### PR TITLE
Few automation/CI improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.89
+          toolchain: 1.88
       - name: Install Cargo Tools
         uses: taiki-e/install-action@v2
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.89
+          toolchain: 1.88
           components: clippy, rustfmt
       - name: Install Rust Nightly
         uses: actions-rs/toolchain@v1
@@ -54,7 +54,7 @@ jobs:
       - name: Install Cargo Tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-audit@0.21.2, cargo-udeps@0.1.57
+          tool: cargo-audit@0.21.2, cargo-udeps@0.1.57, cargo-rdme@1.4.8, cargo-workspaces@0.4.0
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Audit
@@ -65,6 +65,8 @@ jobs:
         run: cargo doc --no-deps --workspace --all-features
       - name: Udeps
         run: cargo +nightly udeps --all-features --workspace
+      - name: Readme
+        run: cargo workspaces exec cargo rdme --check --no-fail-on-warnings
       - name: Miri
         run: cargo +nightly miri test --all-features --workspace
 
@@ -78,7 +80,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.89
+          toolchain: 1.88
           components: clippy, rustfmt
       - name: Install Cargo Tools
         uses: taiki-e/install-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,15 @@ members = [
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.89"
-authors = ["Oxidizer Team <ox-team@microsoft.com>"]
+rust-version = "1.88"
+authors = ["The Oxidizer Project Authors"]
 license-file = "LICENSE.txt"
-readme = "README.md"
 homepage = "https://github.com/microsoft/oxidizer"
 repository = "https://github.com/microsoft/oxidizer"
-keywords = ["Rust", "microservices"]
-categories = ["sdk", "framework", "library"]
 
+# all dependencies are listed with default-features = false, individual crates add the features they need
 [workspace.dependencies]
-# workspace dependencies
+# local dependencies
 data_privacy_macros = { path = "crates/data_privacy_macros", default-features = false  }
 
 # external dependencies

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Project
+# The Oxidizer Project
+
+[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 
 This repository contains a set of libraries that should eventually help with building performant services in Rust.
 At this stage, these libraries should be treated as experimental as we figure out the correct shape that best suits
@@ -21,8 +25,8 @@ or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any addi
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  precision: 1
+  round: down
+  range: 100..100
+  status:
+    project:
+      default:
+        target: 97
+        threshold: 0
+        base: auto

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -5,15 +5,16 @@
 name = "data_privacy"
 description = "Data annotation and redaction system providing a robust way to manipulate sensitive information."
 version = "0.1.0"
+readme = "README.md"
+keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
+categories = ["data-structures"]
+
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license-file.workspace = true
-readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-keywords.workspace = true
-categories.workspace = true
 
 [dependencies]
 data_privacy_macros.workspace = true

--- a/crates/data_privacy/README.md
+++ b/crates/data_privacy/README.md
@@ -6,6 +6,8 @@
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 
+<!-- cargo-rdme start -->
+
 Mechanisms to classify, manipulate, and redact sensitive data.
 
 Commercial software often needs to handle sensitive data, such as personally identifiable information (PII).
@@ -59,12 +61,12 @@ contains the name of the taxonomy and the name of the data class.
 
 ## Classified Containers
 
-Types that implement the `Classified` trait are said to be classified containers. They encapsulate
+Types that implement the [`Classified`] trait are said to be classified containers. They encapsulate
 an instance of another type. Although containers can be created by hand, they are most commonly created
 using the `taxonomy` attribute. See the documentation for the attribute to learn how you define your own
 taxonomy and all its data classes.
 
-Classified containers implement the `Debug` trait if the data they hold implements the trait. However,
+Classified containers implement the [`Debug`] trait if the data they hold implements the trait. However,
 the data produced by the `Debug` trait is redacted, so it does not accidentally expose the sensitive data.
 
 Applications use the classified container types around application
@@ -157,3 +159,5 @@ fn try_out() {
     assert_eq!(output_buffer, "********");
 }
 ```
+
+<!-- cargo-rdme end -->

--- a/crates/data_privacy/src/lib.rs
+++ b/crates/data_privacy/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![expect(rustdoc::redundant_explicit_links, reason = "Needed to support cargo-rdme link mapping.")]
+
 //! Mechanisms to classify, manipulate, and redact sensitive data.
 //!
 //! Commercial software often needs to handle sensitive data, such as personally identifiable information (PII).
@@ -40,23 +42,23 @@
 //!
 //! This crate is built around two traits:
 //!
-//! * The [`Classified`] trait is used to mark types that hold sensitive data. The trait exposes
+//! * The [`Classified`](crate::Classified) trait is used to mark types that hold sensitive data. The trait exposes
 //!   explicit mechanisms to access the data in a safe and auditable way.
 //!
-//! * The [`Redactor`] trait defines the logic needed by an individual redactor. This crate provides a
-//!   few implementations of this trait, such as [`SimpleRedactor`], but others can
+//! * The [`Redactor`](crate::Redactor) trait defines the logic needed by an individual redactor. This crate provides a
+//!   few implementations of this trait, such as [`SimpleRedactor`](crate::SimpleRedactor), but others can
 //!   be implemented and used by applications as well.
 //!
 //! # Data Classes
 //!
-//! A [`DataClass`] is a struct that represents a single data class within a taxonomy. The struct
+//! A [`DataClass`](crate::DataClass) is a struct that represents a single data class within a taxonomy. The struct
 //! contains the name of the taxonomy and the name of the data class.
 //!
 //! # Classified Containers
 //!
 //! Types that implement the [`Classified`] trait are said to be classified containers. They encapsulate
 //! an instance of another type. Although containers can be created by hand, they are most commonly created
-//! using the [`taxonomy`] attribute. See the documentation for the attribute to learn how you define your own
+//! using the [`taxonomy`](crate::taxonomy) attribute. See the documentation for the attribute to learn how you define your own
 //! taxonomy and all its data classes.
 //!
 //! Classified containers implement the [`Debug`] trait if the data they hold implements the trait. However,
@@ -66,20 +68,20 @@
 //! data types to indicate instances of those types hold sensitive data. Although applications typically
 //! define their own taxonomies of data classes, this crate defines three well-known data classes:
 //!
-//! * [`Sensitive<T>`](common_taxonomy::Sensitive) which can be used for taxonomy-agnostic classification in libraries.
-//! * [`UnknownSensitivity<T>`](common_taxonomy::UnknownSensitivity) which holds data without a known classification.
-//! * [`Insensitive<T>`](common_taxonomy::Insensitive) which holds data that explicitly has no classification.
+//! * [`Sensitive<T>`](crate::common_taxonomy::Sensitive) which can be used for taxonomy-agnostic classification in libraries.
+//! * [`UnknownSensitivity<T>`](crate::common_taxonomy::UnknownSensitivity) which holds data without a known classification.
+//! * [`Insensitive<T>`](crate::common_taxonomy::Insensitive) which holds data that explicitly has no classification.
 //!
 //! # Theory of Operation
 //!
 //! How this all works:
 //!
-//! * An application defines its own taxonomy using the [`taxonomy`] macro, which generates classified container types.
+//! * An application defines its own taxonomy using the [`taxonomy`](crate::taxonomy) macro, which generates classified container types.
 //!
 //! * The application uses the classified container types to wrap sensitive data throughout the application. This ensures the
 //!   sensitive data is not accidentally exposed through telemetry or other means.
 //!
-//! * On startup, the application initializes a [`RedactionEngine`] using the [`RedactionEngineBuilder`] type. The engine is configured with
+//! * On startup, the application initializes a [`RedactionEngine`](crate::RedactionEngine) using the [`RedactionEngineBuilder`](crate::RedactionEngineBuilder) type. The engine is configured with
 //!   redactors for each data class in the taxonomy. The redactors define how to handle sensitive data for that class. For example, for
 //!   a given data class, a redactor may substitute the original data for a hash value, or it may replace it with asterisks.
 //!

--- a/crates/data_privacy_macros/Cargo.toml
+++ b/crates/data_privacy_macros/Cargo.toml
@@ -5,15 +5,16 @@
 name = "data_privacy_macros"
 description = "Procedural macros for data privacy."
 version = "0.1.0"
+readme = "README.md"
+keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
+categories = ["data-structures"]
+
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license-file.workspace = true
-readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-keywords.workspace = true
-categories.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/data_privacy_macros/README.md
+++ b/crates/data_privacy_macros/README.md
@@ -6,4 +6,10 @@
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 
-This crate contains macros to support the [`data_privacy`](https://docs.rs/data_privacy) crate.
+<!-- cargo-rdme start -->
+
+This crate exposes macros to generate data taxonomies.
+
+See the documentation for the [`data_privacy`](https://docs.rs/data_privacy) crate for details.
+
+<!-- cargo-rdme end -->

--- a/crates/data_privacy_macros/src/lib.rs
+++ b/crates/data_privacy_macros/src/lib.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Exposes a macro to generate data taxonomies.
+//! This crate exposes macros to generate data taxonomies.
+//!
+//! See the documentation for the [`data_privacy`](https://docs.rs/data_privacy) crate for details.
 
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;


### PR DESCRIPTION
- Auto-generated crate-level README file using cargo-rdme.

- Add CI gate to make sure README files are up to date, per cargo-rdme.

- Use per-crate keywords and categories.

- Add badges to the top-level README file.