### PR TITLE
task: A few fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  MSRV: "1.88"        # used for testing, ensures the MSRV promise is kept
+  RUST_LATEST: "1.90" # used for static analysis, mutation testing, and coverage
 
 jobs:
   testing:
@@ -22,7 +24,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: ${{ env.MSRV }}
       - name: Install Cargo Tools
         uses: taiki-e/install-action@v2
         with:
@@ -44,7 +46,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: ${{ env.RUST_LATEST }}
           components: clippy, rustfmt
       - name: Install Rust Nightly
         uses: actions-rs/toolchain@v1
@@ -87,6 +89,12 @@ jobs:
             perf
             refactor
             test
+            doc
+            docs
+            ci
+            chore
+            misc
+            miscellaneous
 
   mutation-testing:
     runs-on: ${{ matrix.os }}
@@ -98,7 +106,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: ${{ env.RUST_LATEST }}
           components: clippy, rustfmt
       - name: Install Cargo Tools
         uses: taiki-e/install-action@v2

--- a/crates/data_privacy/README.md
+++ b/crates/data_privacy/README.md
@@ -1,10 +1,11 @@
-<div style="text-align: center">
+<div align="center">
  <img src="./logo.png" alt="Data Privacy Logo" width="128">
 
 # Data Privacy
 
 [![crate.io](https://img.shields.io/crates/v/data_privacy.svg)](https://crates.io/crates/data_privacy)
 [![docs.rs](https://docs.rs/data_privacy/badge.svg)](https://docs.rs/data_privacy)
+[![MSRV](https://img.shields.io/crates/msrv/data_privacy)](https://crates.io/crates/data_privacy)
 [![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)

--- a/crates/data_privacy_macros/README.md
+++ b/crates/data_privacy_macros/README.md
@@ -1,10 +1,11 @@
-<div style="text-align: center">
+<div align="center">
  <img src="./logo.png" alt="Data Privacy Macros Logo" width="128">
 
 # Data Privacy Macros
 
 [![crate.io](https://img.shields.io/crates/v/data_privacy_macros.svg)](https://crates.io/crates/data_privacy_macros)
 [![docs.rs](https://docs.rs/data_privacy_macros/badge.svg)](https://docs.rs/data_privacy_macros)
+[![MSRV](https://img.shields.io/crates/msrv/data_privacy_macros)](https://crates.io/crates/data_privacy_macros)
 [![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)

--- a/scripts/repo-template/README.md
+++ b/scripts/repo-template/README.md
@@ -1,10 +1,11 @@
-<div style="text-align: center">
+<div align="center">
  <img src="./logo.png" alt="{{CRATE_NAME_UPPER}} Logo" width="128">
 
 # {{CRATE_NAME_UPPER}}
 
 [![crate.io](https://img.shields.io/crates/v/{{CRATE_NAME}}.svg)](https://crates.io/crates/{{CRATE_NAME}})
 [![docs.rs](https://docs.rs/{{CRATE_NAME}}/badge.svg)](https://docs.rs/{{CRATE_NAME}})
+[![MSRV](https://img.shields.io/crates/msrv/{{CRATE_NAME}})](https://crates.io/crates/{{CRATE_NAME}})
 [![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)


### PR DESCRIPTION
- Update README centering tag, since GitHub filters out the CSS text-align property. Go back to the original way of centering.

- Add badges to the readme files to report the MSRV

- Update GitHub Actions workflow to use both MSRV and latest stable Rust versions. MSRV is used for testing to ensure the MSRV promise is kept, and latest stable is used for static analysis, mutation testing, and coverage.