### PR TITLE
ci: Fix dependabot config to only update for security issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 10
+    # only security updates will be opened automatically
+    open-pull-requests-limit: 0
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,20 +83,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
-            feat
-            fix
-            doc
-            task
-            style
-            perf
-            refactor
-            test
+            build
+            chore
+            ci
             doc
             docs
-            ci
-            chore
+            feat
+            fix
             misc
             miscellaneous
+            perf
+            refactor
+            style
+            task
+            test
 
   mutation-testing:
     runs-on: ${{ matrix.os }}

--- a/scripts/release-crate.ps1
+++ b/scripts/release-crate.ps1
@@ -45,16 +45,16 @@ $script:TypeGroupMapping = @{
 
 # Maps the final group key to a user-friendly header in the changelog.
 $script:HeaderNameMapping = @{
-    'feat'          = '✨ Features';
-    'fix'           = '🐛 Bug Fixes';
-    'perf'          = '⚡ Performance';
-    'task'          = '✔️ Tasks';
-    'refactor'      = '♻️ Code Refactoring';
-    'docs'          = '📚 Documentation';
     'build'         = '🏗️ Build System';
     'ci'            = '🔄 Continuous Integration';
-    'style'         = '🎨 Styling';
+    'docs'          = '📚 Documentation';
+    'feat'          = '✨ Features';
+    'fix'           = '🐛 Bug Fixes';
     'miscellaneous' = '🧩 Miscellaneous';
+    'perf'          = '⚡ Performance';
+    'refactor'      = '♻️ Code Refactoring';
+    'style'         = '🎨 Styling';
+    'task'          = '✔️ Tasks';
 }
 
 # Defines the preferred order for commit type sections in the changelog.


### PR DESCRIPTION
- Dependabot just opened a bunch of PRs, we don't really want that. With this change, we dependebot will only update when there are security issues.

- Cleanup handling of conventional commit prefixes which were inconsistent in the GitHub yaml and in the release-crate script.
