### PR TITLE
ci: Add license check for dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ env:
   # Tool versions
   CARGO_AUDIT_VERSION: "0.22.0"
   CARGO_CHECK_EXTERNAL_TYPES_VERSION: "0.3.0"
+  CARGO_DENY_VERSION: "0.18.8"
   CARGO_ENSURE_NO_CYCLIC_DEPS_VERSION: "0.2.0"
   CARGO_ENSURE_NO_DEFAULT_FEATURES_VERSION: "0.2.0"
   CARGO_HACK_VERSION: "0.6.39"
@@ -114,7 +115,7 @@ jobs:
       - name: Install Cargo Tools
         uses: taiki-e/install-action@v2.62.62
         with:
-          tool: cargo-audit@${{ env.CARGO_AUDIT_VERSION }}, cargo-rdme@${{ env.CARGO_RDME_VERSION }}, cargo-workspaces@${{ env.CARGO_WORKSPACES_VERSION }}, cargo-ensure-no-default-features@${{ env.CARGO_ENSURE_NO_DEFAULT_FEATURES_VERSION }}, cargo-ensure-no-cyclic-deps@${{ env.CARGO_ENSURE_NO_CYCLIC_DEPS_VERSION }}
+          tool: cargo-audit@${{ env.CARGO_AUDIT_VERSION }}, cargo-rdme@${{ env.CARGO_RDME_VERSION }}, cargo-workspaces@${{ env.CARGO_WORKSPACES_VERSION }}, cargo-ensure-no-default-features@${{ env.CARGO_ENSURE_NO_DEFAULT_FEATURES_VERSION }}, cargo-ensure-no-cyclic-deps@${{ env.CARGO_ENSURE_NO_CYCLIC_DEPS_VERSION }}, cargo-deny@${{ env.CARGO_DENY_VERSION }}
 
       # execute
       - name: Clippy
@@ -131,6 +132,8 @@ jobs:
         run: cargo ensure-no-default-features
       - name: Cyclic Dependencies
         run: cargo ensure-no-cyclic-deps
+      - name: Dependency Validation
+        run: cargo deny --all-features --workspace --color always check all
 
   extended-analysis:
     if: github.event_name == 'pull_request'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = ["crates/*"]
 edition = "2024"
 rust-version = "1.88"
 authors = ["The Oxidizer Project Authors"]
+license = "MIT"
 license-file = "LICENSE"
 homepage = "https://github.com/microsoft/oxidizer"
 repository = "https://github.com/microsoft/oxidizer"

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ We strive to deliver high-quality code and as such, we've put in place a number 
   have superfluous
   dependencies.
 
+- **Dependency Validation**. We use [`cargo-deny`](https://crates.io/crates/cargo-deny) to ensure our dependencies
+  have acceptable licenses and don't contain known vulnerabilities.
+
 - **PR Title**. Every PR submitted to this repo must follow
   the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
   specification. We use these PR titles as part of our automatic change log generation logic.

--- a/crates/bytesbuf/Cargo.toml
+++ b/crates/bytesbuf/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures", "network-programming"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/data_privacy_macros/Cargo.toml
+++ b/crates/data_privacy_macros/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/data_privacy_macros_impl/Cargo.toml
+++ b/crates/data_privacy_macros_impl/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/fundle/Cargo.toml
+++ b/crates/fundle/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["rust-patterns"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/fundle_macros/Cargo.toml
+++ b/crates/fundle_macros/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["rust-patterns"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/fundle_macros_impl/Cargo.toml
+++ b/crates/fundle_macros_impl/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["rust-patterns"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/ohno/Cargo.toml
+++ b/crates/ohno/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/ohno_macros/Cargo.toml
+++ b/crates/ohno_macros/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/testing_aids/Cargo.toml
+++ b/crates/testing_aids/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/thread_aware/Cargo.toml
+++ b/crates/thread_aware/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/thread_aware_macros/Cargo.toml
+++ b/crates/thread_aware_macros/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/thread_aware_macros_impl/Cargo.toml
+++ b/crates/thread_aware_macros_impl/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures"]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[licenses]
+allow = [
+    # You can add new entries to the list only from "Permissive OSS licenses" on this Microsoft-internal page: https://docs.opensource.microsoft.com/legal/resources/oss-licenses-by-type/.
+    "MIT",
+    "Apache-2.0",
+    "ISC",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "Zlib",
+    "BSL-1.0",
+]
+
+confidence-threshold = 0.8
+unused-allowed-license = "allow"

--- a/scripts/repo-template/Cargo.toml
+++ b/scripts/repo-template/Cargo.toml
@@ -12,6 +12,7 @@ categories = [{{CRATE_CATEGORIES}}]
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
- Make sure all our dependencies have acceptable licenses.

- Add missing 'license` field to our Cargo.toml. Turns out having `license-file` defined isn't enough.