### PR TITLE
feat: Add a redactor that uses RapidHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,12 +210,13 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "data_privacy"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "data_privacy_macros",
  "derive_more",
  "mutants",
  "once_cell",
+ "rapidhash",
  "serde",
  "serde_json",
  "xxhash-rust",
@@ -864,6 +865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e65c75143ce5d47c55b510297eeb1182f3c739b6043c537670e9fc18612dae"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +919,12 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ repository = "https://github.com/microsoft/oxidizer"
 
 # local dependencies
 bytesbuf = { path = "crates/bytesbuf", default-features = false, version = "0.1.2" }
-data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.7.0" }
+data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.8.0" }
 data_privacy_macros = { path = "crates/data_privacy_macros", default-features = false, version = "0.7.0" }
 data_privacy_macros_impl = { path = "crates/data_privacy_macros_impl", default-features = false, version = "0.7.0" }
 fundle = { path = "crates/fundle", default-features = false, version = "0.3.0" }
@@ -60,6 +60,7 @@ prettyplease = { version = "0.2.37", default-features = false }
 proc-macro2 = { version = "1.0.103", default-features = false }
 quote = { version = "1.0.42", default-features = false }
 rand = { version = "0.9.2", default-features = false }
+rapidhash = { version = "4.1.1", default-features = false }
 regex = { version = "1.12.2", default-features = false }
 serde = { version = "1.0.228", default-features = false }
 serde_json = { version = "1.0.145", default-features = false }

--- a/crates/data_privacy/CHANGELOG.md
+++ b/crates/data_privacy/CHANGELOG.md
@@ -1,54 +1,30 @@
 # Changelog
 
+## [0.8.0] - 2025-12-10
+
+- ✨ Features
+
+  - Add a redactor that uses RapidHash
+
+- 🔄 Continuous Integration
+
+  - Linting for Cargo.toml files ([#110](https://github.com/microsoft/oxidizer/pull/110))
+  - Add license check for dependencies ([#105](https://github.com/microsoft/oxidizer/pull/105))
+
+- 🧩 Miscellaneous
+
+  - Enable the allow_attribute lint and fix warnings. ([#111](https://github.com/microsoft/oxidizer/pull/111))
+
 ## [0.7.0] - 2025-12-05
+
+- ✨ Features
+
+  - Improve data_privacy UX ([#89](https://github.com/microsoft/oxidizer/pull/89))
 
 - ✔️ Tasks
 
   - Enable the missing_docs compiler lint. ([#102](https://github.com/microsoft/oxidizer/pull/102))
   - enable docs.rs documentation for feature-gated code ([#99](https://github.com/microsoft/oxidizer/pull/99))
-
-- 🧩 Miscellaneous
-
-  - Fix import.
-  - Document more items.
-  - Address missing documentation.
-  - Use inherent method.
-  - Fix after rebase.
-  - Add declassification methods.
-  - Add derive documentation.
-  - Add module docs
-  - Formatter.
-  - Make Redactor non-public.
-  - Make non-public.
-  - Don't make Redactors public.
-  - Add documentation.
-  - Update README.
-  - Format.
-  - Don't make std types redacted, annotate fields with `#[unredacted]` instead.
-  - Disable various tests for miri.
-  - More CI complaints.
-  - Fix CI complaints.
-  - Format again.
-  - Remove `RedactedToString` derive, since it was replaced by blanket trait impl.
-  - Increase coverage.
-  - Fix doc tests.
-  - Format.
-  - Fix clippy
-  - Fix documentation.
-  - Fix more tests and warnings.
-  - Move out integration tests.
-  - Fix some rendering bugs and more UX.
-  - Rename wrapper and improve UX working with DataClasses
-  - Move macros into module for documentation.
-  - Also align data privacy with Rust Guidelines and clean up module structure.
-  - Re-enable tests.
-  - Update main app example and also log entire type.
-  - Fix impl issues and make it work with std.
-  - More design work.
-  - Change #[classified] macro to implement its own derives.
-  - Cleanup before reworking macro
-  - Refactoring plan.
-  - In middle of rework.
 
 ## [0.6.0] - 2025-11-27
 

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "data_privacy"
 description = "Data annotation and redaction system providing a robust way to manipulate sensitive information."
-version = "0.7.0"
+version = "0.8.0"
 readme = "README.md"
 keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
 categories = ["data-structures"]
@@ -26,15 +26,18 @@ allowed_external_types = [
     "serde_core::de::*",
     "serde_core::ser::*",
     "data_privacy_macros::*",
+    "rapidhash::v3::seed::RapidSecrets",
 ]
 
 [features]
 default = ["serde"]
 serde = ["dep:serde"]
 xxh3 = ["dep:xxhash-rust"]
+rapidhash = ["dep:rapidhash"]
 
 [dependencies]
 data_privacy_macros.workspace = true
+rapidhash = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, default-features = false, features = ["derive", "std"] }
 xxhash-rust = { workspace = true, optional = true, features = ["xxh3"] }
 

--- a/crates/data_privacy/src/lib.rs
+++ b/crates/data_privacy/src/lib.rs
@@ -196,6 +196,9 @@ pub use data_class::{DataClass, IntoDataClass};
 pub use macros::{RedactedDebug, RedactedDisplay, classified, taxonomy};
 pub use redacted::{RedactedDebug, RedactedDisplay, RedactedToString};
 pub use redaction_engine::{RedactionEngine, RedactionEngineBuilder};
+#[cfg(feature = "rapidhash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rapidhash")))]
+pub use redactors::rapidhash_redactor;
 #[cfg(feature = "xxh3")]
 #[cfg_attr(docsrs, doc(cfg(feature = "xxh3")))]
 pub use redactors::xxh3_redactor;

--- a/crates/data_privacy/src/redactors/mod.rs
+++ b/crates/data_privacy/src/redactors/mod.rs
@@ -8,8 +8,12 @@ use std::collections::HashMap;
 use std::fmt::Write;
 
 pub mod simple_redactor;
+
 #[cfg(feature = "xxh3")]
 pub mod xxh3_redactor;
+
+#[cfg(feature = "rapidhash")]
+pub mod rapidhash_redactor;
 
 /// Represents types that can redact data.
 pub trait Redactor {
@@ -79,10 +83,40 @@ impl Debug for Redactors {
     }
 }
 
+#[cfg(any(feature = "xxh3", feature = "rapidhash"))]
+#[inline]
+pub fn u64_to_hex_array<const N: usize>(mut value: u64) -> [u8; N] {
+    static HEX_LOWER_CHARS: &[u8; 16] = b"0123456789abcdef";
+
+    let mut buffer = [0u8; N];
+    for e in buffer.iter_mut().rev() {
+        *e = HEX_LOWER_CHARS[(value & 0x0f) as usize];
+        value >>= 4;
+    }
+
+    buffer
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use data_privacy_macros::taxonomy;
+
+    #[cfg(any(feature = "xxh3", feature = "rapidhash"))]
+    #[test]
+    fn test_u64_to_hex_array() {
+        let result = u64_to_hex_array(0x1234_5678_9abc_def0);
+        let expected = b"123456789abcdef0";
+        assert_eq!(result, *expected);
+
+        let result = u64_to_hex_array(0);
+        let expected = b"0000000000000000";
+        assert_eq!(result, *expected);
+
+        let result = u64_to_hex_array(u64::MAX);
+        let expected = b"ffffffffffffffff";
+        assert_eq!(result, *expected);
+    }
 
     struct TestRedactor;
 

--- a/crates/data_privacy/src/redactors/rapidhash_redactor.rs
+++ b/crates/data_privacy/src/redactors/rapidhash_redactor.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! A redactor based on `RapidHash`.
+
+use crate::{DataClass, Redactor};
+use core::fmt::Write;
+use rapidhash::v3::{RapidSecrets, rapidhash_v3_seeded};
+
+/// The length of the redacted output in hex digits.
+pub const REDACTED_LEN: usize = 16;
+
+/// A redactor that replaces the original string with the `RapidHash` hash of the string.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RapidHashRedactor {
+    secrets: RapidSecrets,
+}
+
+impl RapidHashRedactor {
+    /// Creates a new instance with a custom secret.
+    #[must_use]
+    pub fn with_secrets(secrets: RapidSecrets) -> Self {
+        Self { secrets }
+    }
+}
+
+impl Redactor for RapidHashRedactor {
+    fn redact(&self, _: &DataClass, value: &str, output: &mut dyn Write) -> core::fmt::Result {
+        let hash = rapidhash_v3_seeded(value.as_bytes(), &self.secrets);
+        let buffer = crate::redactors::u64_to_hex_array::<REDACTED_LEN>(hash);
+
+        // SAFETY: The buffer is guaranteed to be valid UTF-8 because it only contains hex digits.
+        write!(output, "{}", unsafe { core::str::from_utf8_unchecked(&buffer) })
+    }
+}

--- a/crates/data_privacy/src/redactors/simple_redactor.rs
+++ b/crates/data_privacy/src/redactors/simple_redactor.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 use std::fmt::Write;
 
 /// Mode of operation for the `SimpleRedactor`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SimpleRedactorMode {
     /// Erases the original string.
     Erase,

--- a/crates/data_privacy/src/redactors/xxh3_redactor.rs
+++ b/crates/data_privacy/src/redactors/xxh3_redactor.rs
@@ -15,7 +15,7 @@ pub const REDACTED_LEN: usize = 16;
     non_camel_case_types,
     reason = "Just following the naming conventions of xxHash, silly as they are"
 )]
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct xxH3Redactor {
     secret: Box<[u8]>,
 }
@@ -48,45 +48,15 @@ impl xxH3Redactor {
 impl Redactor for xxH3Redactor {
     fn redact(&self, _: &DataClass, value: &str, output: &mut dyn Write) -> core::fmt::Result {
         let hash = xxh3_64_with_secret(value.as_bytes(), &self.secret);
-        let buffer = u64_to_hex_array(hash);
+        let buffer = crate::redactors::u64_to_hex_array::<REDACTED_LEN>(hash);
 
         // SAFETY: The buffer is guaranteed to be valid UTF-8 because it only contains hex digits.
         write!(output, "{}", unsafe { core::str::from_utf8_unchecked(&buffer) })
     }
 }
 
-#[inline]
-fn u64_to_hex_array(mut value: u64) -> [u8; 16] {
-    static HEX_LOWER_CHARS: &[u8; 16] = b"0123456789abcdef";
-
-    let mut buffer = [0u8; REDACTED_LEN];
-    for e in buffer.iter_mut().rev() {
-        *e = HEX_LOWER_CHARS[(value & 0x0f) as usize];
-        value >>= 4;
-    }
-
-    buffer
-}
-
 #[cfg(test)]
 mod tests {
-    use super::u64_to_hex_array;
-
-    #[test]
-    fn test_u64_to_hex_array() {
-        let result = u64_to_hex_array(0x1234_5678_9abc_def0);
-        let expected = b"123456789abcdef0";
-        assert_eq!(result, *expected);
-
-        let result = u64_to_hex_array(0);
-        let expected = b"0000000000000000";
-        assert_eq!(result, *expected);
-
-        let result = u64_to_hex_array(u64::MAX);
-        let expected = b"ffffffffffffffff";
-        assert_eq!(result, *expected);
-    }
-
     #[test]
     fn test_with_secret_creates_redactor_with_custom_secret() {
         let custom_secret = vec![42; 190];

--- a/crates/data_privacy/tests/rapidhash_redactor.rs
+++ b/crates/data_privacy/tests/rapidhash_redactor.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![expect(missing_docs, reason = "Test code")]
+#![cfg(feature = "rapidhash")]
+
+use data_privacy::DataClass;
+use data_privacy::Redactor;
+use data_privacy::rapidhash_redactor::REDACTED_LEN;
+use data_privacy::rapidhash_redactor::RapidHashRedactor;
+use rapidhash::v3::RapidSecrets;
+
+fn get_test_redactor() -> RapidHashRedactor {
+    let secrets = RapidSecrets::seed(1234);
+    RapidHashRedactor::with_secrets(secrets)
+}
+
+#[test]
+fn test_redact_produces_consistent_output() {
+    let redactor = get_test_redactor();
+    let data_class = DataClass::new("test_taxonomy", "test_class");
+    let input = "sensitive_data";
+
+    let mut output1 = String::new();
+    let mut output2 = String::new();
+
+    redactor.redact(&data_class, input, &mut output1).unwrap();
+    redactor.redact(&data_class, input, &mut output2).unwrap();
+
+    assert_eq!(output1, output2);
+    assert_eq!(output1.len(), REDACTED_LEN);
+}
+
+#[test]
+fn test_redact_output_is_hex_string() {
+    let redactor = get_test_redactor();
+    let data_class = DataClass::new("test_taxonomy", "test_class");
+    let input = "test_input";
+
+    let mut output = String::new();
+    redactor.redact(&data_class, input, &mut output).unwrap();
+
+    assert_eq!(output.len(), REDACTED_LEN);
+    assert!(output.chars().all(|c| c.is_ascii_hexdigit()));
+    assert!(output.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()));
+}
+
+#[test]
+fn test_different_inputs_produce_different_outputs() {
+    let redactor = get_test_redactor();
+    let data_class = DataClass::new("test_taxonomy", "test_class");
+
+    let mut output1 = String::new();
+    let mut output2 = String::new();
+
+    redactor.redact(&data_class, "input1", &mut output1).unwrap();
+    redactor.redact(&data_class, "input2", &mut output2).unwrap();
+
+    assert_ne!(output1, output2);
+}
+
+#[test]
+fn test_different_secrets_produce_different_outputs() {
+    let redactor1 = get_test_redactor();
+    let custom_secrets = RapidSecrets::seed(6789);
+    let redactor2 = RapidHashRedactor::with_secrets(custom_secrets);
+    let data_class = DataClass::new("test_taxonomy", "test_class");
+    let input = "same_input";
+
+    let mut output1 = String::new();
+    let mut output2 = String::new();
+
+    redactor1.redact(&data_class, input, &mut output1).unwrap();
+    redactor2.redact(&data_class, input, &mut output2).unwrap();
+
+    assert_ne!(output1, output2);
+}
+
+#[test]
+fn test_empty_string_input() {
+    let redactor = get_test_redactor();
+    let data_class = DataClass::new("test_taxonomy", "test_class");
+
+    let mut output = String::new();
+    redactor.redact(&data_class, "", &mut output).unwrap();
+
+    assert_eq!(output.len(), REDACTED_LEN);
+    assert!(output.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn test_unicode_input() {
+    let redactor = get_test_redactor();
+    let data_class = DataClass::new("test_taxonomy", "test_class");
+    let input = "こんにちは世界"; // "Hello World" in Japanese
+
+    let mut output = String::new();
+    redactor.redact(&data_class, input, &mut output).unwrap();
+
+    assert_eq!(output.len(), REDACTED_LEN);
+    assert!(output.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn test_clone_produces_identical_redactor() {
+    let custom_secrets = RapidSecrets::seed(2468);
+    let original = RapidHashRedactor::with_secrets(custom_secrets);
+    let cloned = original.clone();
+
+    assert_eq!(original, cloned);
+
+    let data_class = DataClass::new("test_taxonomy", "test_class");
+    let input = "test_input";
+
+    let mut output1 = String::new();
+    let mut output2 = String::new();
+
+    original.redact(&data_class, input, &mut output1).unwrap();
+    cloned.redact(&data_class, input, &mut output2).unwrap();
+
+    assert_eq!(output1, output2);
+}
+
+#[test]
+fn test_data_class_does_not_affect_output() {
+    let redactor = get_test_redactor();
+    let data_class1 = DataClass::new("test_taxonomy", "class1");
+    let data_class2 = DataClass::new("test_taxonomy", "class2");
+    let input = "test_input";
+
+    let mut output1 = String::new();
+    let mut output2 = String::new();
+
+    redactor.redact(&data_class1, input, &mut output1).unwrap();
+    redactor.redact(&data_class2, input, &mut output2).unwrap();
+
+    // The data_class parameter is ignored in the redaction process
+    assert_eq!(output1, output2);
+}


### PR DESCRIPTION
Since RapidHash is faster than xxH3, we should support it.

Also, remove some non-sensical trait implementations for the xxH3Redactor and the SimpleRedactor.
Redactors should not be Ord, PartialOrd, or Hash.
