### PR TITLE
feat: Better serialization and perf.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,21 +262,23 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "data_privacy"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "data_privacy_macros",
  "derive_more",
  "mutants",
  "once_cell",
  "rapidhash",
+ "rustc-hash",
  "serde",
+ "serde_core",
  "serde_json",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "data_privacy_macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "data_privacy_macros_impl",
  "mutants",
@@ -284,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "data_privacy_macros_impl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "insta",
  "mutants",
@@ -1186,6 +1188,12 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ repository = "https://github.com/microsoft/oxidizer"
 
 # local dependencies
 bytesbuf = { path = "crates/bytesbuf", default-features = false, version = "0.1.2" }
-data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.9.0" }
-data_privacy_macros = { path = "crates/data_privacy_macros", default-features = false, version = "0.8.0" }
-data_privacy_macros_impl = { path = "crates/data_privacy_macros_impl", default-features = false, version = "0.8.0" }
+data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.10.0" }
+data_privacy_macros = { path = "crates/data_privacy_macros", default-features = false, version = "0.9.0" }
+data_privacy_macros_impl = { path = "crates/data_privacy_macros_impl", default-features = false, version = "0.9.0" }
 fundle = { path = "crates/fundle", default-features = false, version = "0.3.0" }
 fundle_macros = { path = "crates/fundle_macros", default-features = false, version = "0.3.0" }
 fundle_macros_impl = { path = "crates/fundle_macros_impl", default-features = false, version = "0.3.0" }
@@ -68,8 +68,9 @@ quote = { version = "1.0.42", default-features = false }
 rand = { version = "0.9.2", default-features = false }
 rapidhash = { version = "4.1.1", default-features = false }
 regex = { version = "1.12.2", default-features = false }
+rustc-hash = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.228", default-features = false }
-serde_core = { version = "1.0.224", default-features = false }
+serde_core = { version = "1.0.228", default-features = false }
 serde_json = { version = "1.0.145", default-features = false }
 smallvec = { version = "1.15.1", default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }

--- a/crates/data_privacy/CHANGELOG.md
+++ b/crates/data_privacy/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [0.9.0] - 2025-12-16
+## [0.10.0] - 2025-12-16
+
+- ✨ Features
+
+  - Better serialization and perf.
 
 - 🧩 Miscellaneous
 
-  - Make it to_redacted_string to avoid annoying downstream conflicts.
+  - Make it to_redacted_string to avoid annoying downstream conflicts. ([#143](https://github.com/microsoft/oxidizer/pull/143))
 
 ## [0.8.0] - 2025-12-10
 

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "data_privacy"
 description = "Data annotation and redaction system providing a robust way to manipulate sensitive information."
-version = "0.9.0"
+version = "0.10.0"
 readme = "README.md"
 keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
 categories = ["data-structures"]
@@ -22,7 +22,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
-    "serde::*",
     "serde_core::de::*",
     "serde_core::ser::*",
     "data_privacy_macros::*",
@@ -31,21 +30,22 @@ allowed_external_types = [
 
 [features]
 default = ["serde"]
-serde = ["dep:serde"]
-xxh3 = ["dep:xxhash-rust"]
 rapidhash = ["dep:rapidhash"]
+serde = ["dep:serde_core"]
+xxh3 = ["dep:xxhash-rust"]
 
 [dependencies]
 data_privacy_macros.workspace = true
 rapidhash = { workspace = true, optional = true }
-serde = { workspace = true, optional = true, default-features = false, features = ["derive", "std"] }
+rustc-hash = { workspace = true, features = ["std"] }
+serde_core = { workspace = true, optional = true, default-features = false, features = ["std"] }
 xxhash-rust = { workspace = true, optional = true, features = ["xxh3"] }
 
 [dev-dependencies]
 derive_more = { workspace = true, features = ["constructor", "from"] }
 mutants.workspace = true
 once_cell = { workspace = true, features = ["std"] }
-serde = { workspace = true, features = ["derive", "std"] }
+serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
 
 [lints]

--- a/crates/data_privacy/src/classified.rs
+++ b/crates/data_privacy/src/classified.rs
@@ -51,8 +51,9 @@ use crate::DataClass;
 /// }
 ///
 /// impl Classified for ClassifiedPerson {
-///     fn data_class(&self) -> DataClass {
-///         DataClass::new("example_taxonomy", "classified_person")
+///     fn data_class(&self) -> &DataClass {
+///         static DATA_CLASS: DataClass = DataClass::new("example_taxonomy", "classified_person");
+///         &DATA_CLASS
 ///     }
 /// }
 ///
@@ -64,5 +65,5 @@ use crate::DataClass;
 pub trait Classified {
     /// Returns the data class of the classified data.
     #[must_use]
-    fn data_class(&self) -> DataClass;
+    fn data_class(&self) -> &DataClass;
 }

--- a/crates/data_privacy/src/data_class.rs
+++ b/crates/data_privacy/src/data_class.rs
@@ -4,26 +4,35 @@
 use core::fmt::Display;
 use std::borrow::Cow;
 
+#[cfg(feature = "serde")]
+use serde_core::{Deserialize, Deserializer, Serialize, Serializer, de};
+
 /// The identity of a well-known data class.
 ///
 /// Each data class has a name, which is unique in the context of a specific named taxonomy.
+///
+/// # Serialization
+///
+/// Serializing a `DataClass` produces a string in the format `taxonomy/name`.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DataClass {
     taxonomy: Cow<'static, str>,
     name: Cow<'static, str>,
 }
 
-impl AsRef<Self> for DataClass {
-    fn as_ref(&self) -> &Self {
-        self
-    }
-}
-
 impl DataClass {
     /// Creates a new data class instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `taxonomy` or `name` are not valid ASCII identifiers. Valid identifiers must
+    /// start with `_` or an ASCII letter, followed by zero or more `_`, ASCII letters, or ASCII
+    /// digits (e.g., `foo`, `_bar`, `Baz123`)
     #[must_use]
     pub const fn new(taxonomy: &'static str, name: &'static str) -> Self {
+        assert!(is_valid_identifier(taxonomy), "taxonomy is not a valid identifier");
+        assert!(is_valid_identifier(name), "name is not a valid identifier");
+
         Self {
             taxonomy: Cow::Borrowed(taxonomy),
             name: Cow::Borrowed(name),
@@ -49,6 +58,12 @@ impl Display for DataClass {
     }
 }
 
+impl AsRef<Self> for DataClass {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 /// Helper for converting a type into a [`DataClass`].
 pub trait IntoDataClass {
     /// Converts `self` into a [`DataClass`].
@@ -58,5 +73,230 @@ pub trait IntoDataClass {
 impl IntoDataClass for DataClass {
     fn into_data_class(self) -> DataClass {
         self
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for DataClass {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for DataClass {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct DataClassVisitor;
+
+        impl de::Visitor<'_> for DataClassVisitor {
+            type Value = DataClass;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("a string in taxonomy/name format")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                let (taxonomy, name) = v
+                    .split_once('/')
+                    .ok_or_else(|| de::Error::custom("expecting taxonomy/name format"))?;
+
+                if !is_valid_identifier(taxonomy) {
+                    return Err(de::Error::custom("invalid taxonomy identifier"));
+                }
+
+                if !is_valid_identifier(name) {
+                    return Err(de::Error::custom("invalid name identifier"));
+                }
+
+                Ok(DataClass {
+                    taxonomy: Cow::Owned(taxonomy.to_owned()),
+                    name: Cow::Owned(name.to_owned()),
+                })
+            }
+        }
+
+        deserializer.deserialize_str(DataClassVisitor)
+    }
+}
+
+/// Checks if a byte is a valid ASCII start character for a Rust identifier.
+const fn is_valid_ascii_ident_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+/// Checks if a byte is a valid ASCII continuation character for a Rust identifier.
+const fn is_valid_ascii_ident_continue(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+/// Validates that a string is a valid Rust identifier (ASCII only).
+///
+/// This supports standard ASCII identifiers: `foo`, `_bar`, `Baz123`
+///
+/// Valid identifiers must:
+/// - Start with `_` or an ASCII letter (a-z, A-Z)
+/// - Continue with zero or more `_`, ASCII letters, or ASCII digits (0-9)
+///
+/// This function is `const` and can be used in both const and runtime contexts.
+#[cfg_attr(test, mutants::skip)] // leads to build timeouts in mutant tests
+const fn is_valid_identifier(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+
+    // Validate first character
+    if !is_valid_ascii_ident_start(bytes[0]) {
+        return false;
+    }
+
+    // Validate remaining characters
+    let mut i = 1;
+    while i < bytes.len() {
+        if !is_valid_ascii_ident_continue(bytes[i]) {
+            return false;
+        }
+        i += 1;
+    }
+
+    true
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        let dc = DataClass::new("contoso", "customer_identifier");
+        let serialized = serde_json::to_string(&dc).expect("failed to serialize");
+        assert_eq!(serialized, "\"contoso/customer_identifier\"");
+    }
+
+    #[test]
+    fn test_deserialize_valid() {
+        let serialized = "\"contoso/customer_identifier\"";
+        let dc: DataClass = serde_json::from_str(serialized).expect("failed to deserialize");
+        assert_eq!(dc.taxonomy(), "contoso");
+        assert_eq!(dc.name(), "customer_identifier");
+    }
+
+    #[test]
+    fn test_deserialize_invalid_format_no_slash() {
+        let serialized = "\"contoso_customer_identifier\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("expecting taxonomy/name format"));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_format_empty_taxonomy() {
+        let serialized = "\"/customer_identifier\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("invalid taxonomy identifier"));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_format_empty_name() {
+        let serialized = "\"contoso/\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("invalid name identifier"));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_taxonomy() {
+        let serialized = "\"a-b/c\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("invalid taxonomy identifier"));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_name() {
+        let serialized = "\"a/b-c\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("invalid name identifier"));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_type() {
+        let serialized = "123";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.is_data());
+    }
+
+    #[test]
+    fn test_deserialize_expecting_message() {
+        let serialized = "false";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("a string in taxonomy/name format"));
+    }
+
+    #[test]
+    fn test_is_valid_identifier_valid() {
+        let _ = DataClass::new("a", "a");
+        let _ = DataClass::new("a1", "a");
+        let _ = DataClass::new("a_b", "a");
+        let _ = DataClass::new("_a", "a");
+        let _ = DataClass::new("A", "a");
+        let _ = DataClass::new("A1", "a");
+        let _ = DataClass::new("A_B", "a");
+        let _ = DataClass::new("_A", "a");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_is_valid_identifier_invalid_empty() {
+        let _ = DataClass::new("", "a");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_is_valid_identifier_invalid_starts_with_number() {
+        let _ = DataClass::new("1a", "a");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_is_valid_identifier_invalid_contains_invalid_char() {
+        let _ = DataClass::new("a-b", "a");
+    }
+
+    #[test]
+    fn test_is_valid_identifier_invalid_hash() {
+        // Hash character is not valid in identifiers
+        let serialized = "\"r#type/data\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("invalid taxonomy identifier"));
+    }
+
+    #[test]
+    fn test_unicode_identifiers_emoji_invalid() {
+        // Emoji are not XID_Start or XID_Continue, should be invalid
+        let serialized = "\"test/🦀data\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("invalid name identifier"));
+    }
+
+    #[test]
+    fn test_unicode_invalid_start_with_digit() {
+        // Even with Unicode, can't start with a digit
+        let serialized = "\"1μετρο/data\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("invalid taxonomy identifier"));
+    }
+
+    #[test]
+    fn test_unicode_invalid_whitespace() {
+        // Whitespace is not XID_Continue
+        let serialized = "\"hello world/data\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("invalid taxonomy identifier"));
+    }
+
+    #[test]
+    fn test_unicode_invalid_punctuation() {
+        // Most punctuation is not XID_Continue (except underscore)
+        let serialized = "\"hello-world/data\"";
+        let err = serde_json::from_str::<DataClass>(serialized).unwrap_err();
+        assert!(err.to_string().contains("invalid taxonomy identifier"));
     }
 }

--- a/crates/data_privacy/src/redactors/mod.rs
+++ b/crates/data_privacy/src/redactors/mod.rs
@@ -4,7 +4,7 @@
 use crate::simple_redactor::{SimpleRedactor, SimpleRedactorMode};
 use crate::{DataClass, IntoDataClass};
 use core::fmt::Debug;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fmt::Write;
 
 pub mod simple_redactor;
@@ -28,7 +28,7 @@ pub trait Redactor {
 }
 
 pub(crate) struct Redactors {
-    redactors: HashMap<DataClass, Box<dyn Redactor + Send + Sync>>,
+    redactors: FxHashMap<DataClass, Box<dyn Redactor + Send + Sync>>,
     fallback: Box<dyn Redactor + Send + Sync>,
 }
 
@@ -71,7 +71,7 @@ impl Redactors {
 impl Default for Redactors {
     fn default() -> Self {
         Self {
-            redactors: HashMap::new(),
+            redactors: FxHashMap::default(),
             fallback: Box::new(SimpleRedactor::with_mode(SimpleRedactorMode::Insert("*".into()))),
         }
     }
@@ -86,7 +86,7 @@ impl Debug for Redactors {
 #[cfg(any(feature = "xxh3", feature = "rapidhash"))]
 #[inline]
 pub fn u64_to_hex_array<const N: usize>(mut value: u64) -> [u8; N] {
-    static HEX_LOWER_CHARS: &[u8; 16] = b"0123456789abcdef";
+    const HEX_LOWER_CHARS: &[u8; 16] = b"0123456789abcdef";
 
     let mut buffer = [0u8; N];
     for e in buffer.iter_mut().rev() {
@@ -101,6 +101,7 @@ pub fn u64_to_hex_array<const N: usize>(mut value: u64) -> [u8; N] {
 mod tests {
     use super::*;
     use data_privacy_macros::taxonomy;
+    use rustc_hash::FxBuildHasher;
 
     #[cfg(any(feature = "xxh3", feature = "rapidhash"))]
     #[test]
@@ -135,7 +136,7 @@ mod tests {
     #[test]
     fn test_redactor_shrink() {
         let mut redactors = Redactors {
-            redactors: HashMap::with_capacity(42),
+            redactors: FxHashMap::with_capacity_and_hasher(42, FxBuildHasher),
             ..Default::default()
         };
 

--- a/crates/data_privacy/src/redactors/simple_redactor.rs
+++ b/crates/data_privacy/src/redactors/simple_redactor.rs
@@ -67,7 +67,8 @@ impl SimpleRedactor {
 impl Redactor for SimpleRedactor {
     #[cfg_attr(test, mutants::skip)]
     fn redact(&self, data_class: &DataClass, value: &str, output: &mut dyn Write) -> core::fmt::Result {
-        static ASTERISKS: &str = "********************************";
+        const ASTERISKS: &str =
+            "************************************************************************************************************************";
 
         match &self.mode {
             SimpleRedactorMode::Erase => {
@@ -93,7 +94,10 @@ impl Redactor for SimpleRedactor {
                 if *c == '*' && len < ASTERISKS.len() {
                     write!(output, "{}", &ASTERISKS[0..len])
                 } else {
-                    write!(output, "{}", c.to_string().repeat(len))
+                    for _ in 0..len {
+                        output.write_char(*c)?;
+                    }
+                    Ok(())
                 }
             }
 
@@ -103,7 +107,11 @@ impl Redactor for SimpleRedactor {
                 if *c == '*' && len < ASTERISKS.len() {
                     write!(output, "<{data_class}:{}>", &ASTERISKS[0..len])
                 } else {
-                    write!(output, "<{data_class}:{}>", (*c.to_string()).repeat(len))
+                    write!(output, "<{data_class}:")?;
+                    for _ in 0..len {
+                        output.write_char(*c)?;
+                    }
+                    output.write_char('>')
                 }
             }
 

--- a/crates/data_privacy/src/sensitive.rs
+++ b/crates/data_privacy/src/sensitive.rs
@@ -5,6 +5,9 @@ use crate::{Classified, DataClass, RedactedDebug, RedactedDisplay, RedactionEngi
 use core::fmt::{Debug, Display, Formatter};
 use data_privacy::IntoDataClass;
 
+/// Size of the stack-allocated buffer used for formatting before falling back to heap allocation.
+const STACK_BUFFER_SIZE: usize = 128;
+
 /// A wrapper that dynamically classifies a value with a specific data class.
 ///
 /// Use this wrapper in places where the data class of a value cannot be determined statically. When the data class is known
@@ -62,8 +65,8 @@ impl<T> Sensitive<T> {
 }
 
 impl<T> Classified for Sensitive<T> {
-    fn data_class(&self) -> DataClass {
-        self.data_class.clone()
+    fn data_class(&self) -> &DataClass {
+        &self.data_class
     }
 }
 
@@ -73,12 +76,12 @@ where
 {
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "Converting from u64 to usize, value is known to be <= 128"
+        reason = "Converting from u64 to usize, value is known to be <= STACK_BUFFER_SIZE"
     )]
     fn fmt(&self, engine: &RedactionEngine, f: &mut Formatter) -> std::fmt::Result {
         let v = &self.value;
 
-        let mut local_buf = [0u8; 128];
+        let mut local_buf = [0u8; STACK_BUFFER_SIZE];
         let amount = {
             let mut cursor = std::io::Cursor::new(&mut local_buf[..]);
             if std::io::Write::write_fmt(&mut cursor, format_args!("{v:?}")).is_ok() {
@@ -106,12 +109,12 @@ where
 {
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "Converting from u64 to usize, value is known to be <= 128"
+        reason = "Converting from u64 to usize, value is known to be <= STACK_BUFFER_SIZE"
     )]
     fn fmt(&self, engine: &RedactionEngine, f: &mut Formatter) -> std::fmt::Result {
         let v = &self.value;
 
-        let mut local_buf = [0u8; 128];
+        let mut local_buf = [0u8; STACK_BUFFER_SIZE];
         let amount = {
             let mut cursor = std::io::Cursor::new(&mut local_buf[..]);
             if std::io::Write::write_fmt(&mut cursor, format_args!("{v}")).is_ok() {

--- a/crates/data_privacy/tests/classified.rs
+++ b/crates/data_privacy/tests/classified.rs
@@ -11,8 +11,9 @@ struct ClassifiedExample {
 }
 
 impl Classified for ClassifiedExample {
-    fn data_class(&self) -> DataClass {
-        DataClass::new("example", "classified_example")
+    fn data_class(&self) -> &DataClass {
+        static DATA_CLASS: DataClass = DataClass::new("example", "classified_example");
+        &DATA_CLASS
     }
 }
 

--- a/crates/data_privacy_macros/CHANGELOG.md
+++ b/crates/data_privacy_macros/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [0.8.0] - 2025-12-16
+## [0.9.0] - 2025-12-16
+
+- ✨ Features
+
+  - Better serialization and perf.
 
 - 🔄 Continuous Integration
 
@@ -9,6 +13,7 @@
 
 - 🧩 Miscellaneous
 
+  - Make it to_redacted_string to avoid annoying downstream conflicts. ([#143](https://github.com/microsoft/oxidizer/pull/143))
   - Enable the allow_attribute lint and fix warnings. ([#111](https://github.com/microsoft/oxidizer/pull/111))
 
 ## [0.7.0] - 2025-12-05

--- a/crates/data_privacy_macros/Cargo.toml
+++ b/crates/data_privacy_macros/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "data_privacy_macros"
 description = "Macros for the data_privacy crate."
-version = "0.8.0"
+version = "0.9.0"
 readme = "README.md"
 keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
 categories = ["data-structures"]

--- a/crates/data_privacy_macros_impl/CHANGELOG.md
+++ b/crates/data_privacy_macros_impl/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [0.8.0] - 2025-12-16
+## [0.9.0] - 2025-12-16
+
+- ✨ Features
+
+  - Better serialization and perf.
 
 - 🔄 Continuous Integration
 
@@ -9,6 +13,7 @@
 
 - 🧩 Miscellaneous
 
+  - Make it to_redacted_string to avoid annoying downstream conflicts. ([#143](https://github.com/microsoft/oxidizer/pull/143))
   - Enable the allow_attribute lint and fix warnings. ([#111](https://github.com/microsoft/oxidizer/pull/111))
 
 ## [0.7.0] - 2025-12-05

--- a/crates/data_privacy_macros_impl/Cargo.toml
+++ b/crates/data_privacy_macros_impl/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "data_privacy_macros_impl"
 description = "Macros for the data_privacy crate."
-version = "0.8.0"
+version = "0.9.0"
 readme = "README.md"
 keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
 categories = ["data-structures"]

--- a/crates/data_privacy_macros_impl/src/taxonomy.rs
+++ b/crates/data_privacy_macros_impl/src/taxonomy.rs
@@ -39,7 +39,8 @@ impl Parse for MacroArgs {
 #[expect(
     missing_docs,
     clippy::missing_errors_doc,
-    reason = "this is documented in the data_privacy reexport"
+    clippy::too_many_lines,
+    reason = "this is documented in the data_privacy reexport; function length is acceptable for macro code generation"
 )]
 pub fn taxonomy(attr_args: TokenStream, item: TokenStream) -> SynResult<TokenStream> {
     let macro_args = MacroArgs::parse(attr_args)?;
@@ -146,9 +147,21 @@ pub fn taxonomy(attr_args: TokenStream, item: TokenStream) -> SynResult<TokenStr
             }
         }
 
+        impl ::core::cmp::PartialEq<&#data_privacy_path::DataClass> for #enum_name {
+            fn eq(&self, other: &&#data_privacy_path::DataClass) -> core::primitive::bool {
+                self.data_class() == **other
+            }
+        }
+
         impl ::core::cmp::PartialEq<#enum_name> for #data_privacy_path::DataClass {
             fn eq(&self, other: &#enum_name) -> core::primitive::bool {
                 other == self
+            }
+        }
+
+        impl ::core::cmp::PartialEq<#enum_name> for &#data_privacy_path::DataClass {
+            fn eq(&self, other: &#enum_name) -> core::primitive::bool {
+                *other == **self
             }
         }
 

--- a/crates/data_privacy_macros_impl/tests/snapshots/classified__success.snap
+++ b/crates/data_privacy_macros_impl/tests/snapshots/classified__success.snap
@@ -1,47 +1,39 @@
 ---
 source: crates/data_privacy_macros_impl/tests/classified.rs
-assertion_line: 92
 expression: pretty
 ---
 struct EmailAddress(String);
 impl ::data_privacy::Classified for EmailAddress {
-    fn data_class(&self) -> ::data_privacy::DataClass {
-        ExampleTaxonomy::PersonallyIdentifiableInformation.data_class()
+    fn data_class(&self) -> &::data_privacy::DataClass {
+        ExampleTaxonomy::PersonallyIdentifiableInformation.as_ref()
     }
 }
 impl ::core::fmt::Debug for EmailAddress {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_fmt(
-            format_args!(
-                "<CLASSIFIED:{}/{}>", data_privacy::Classified::data_class(self)
-                .taxonomy(), data_privacy::Classified::data_class(self).name()
-            ),
-        )
+        let dc = <Self as ::data_privacy::Classified>::data_class(self);
+        write!(f, "<CLASSIFIED:{}/{}>", dc.taxonomy(), dc.name())
     }
 }
 impl ::core::fmt::Display for EmailAddress {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_fmt(
-            format_args!(
-                "<CLASSIFIED:{}/{}>", data_privacy::Classified::data_class(self)
-                .taxonomy(), data_privacy::Classified::data_class(self).name()
-            ),
-        )
+        let dc = <Self as ::data_privacy::Classified>::data_class(self);
+        write!(f, "<CLASSIFIED:{}/{}>", dc.taxonomy(), dc.name())
     }
 }
 impl ::data_privacy::RedactedDebug for EmailAddress {
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "Converting from u64 to usize, value is known to be <= 128"
+        reason = "Converting from u64 to usize, value is known to be <= STACK_BUFFER_SIZE"
     )]
     fn fmt(
         &self,
         engine: &::data_privacy::RedactionEngine,
         output: &mut ::std::fmt::Formatter<'_>,
     ) -> ::core::fmt::Result {
-        use data_privacy::Classified;
+        const STACK_BUFFER_SIZE: usize = 128;
         let v = &self.0;
-        let mut local_buf = [0u8; 128];
+        let dc = <Self as ::data_privacy::Classified>::data_class(self);
+        let mut local_buf = [0u8; STACK_BUFFER_SIZE];
         let amount = {
             let mut cursor = ::std::io::Cursor::new(&mut local_buf[..]);
             if ::std::io::Write::write_fmt(&mut cursor, format_args!("{v:?}")).is_ok() {
@@ -52,25 +44,26 @@ impl ::data_privacy::RedactedDebug for EmailAddress {
         };
         if amount <= local_buf.len() {
             let s = unsafe { ::core::str::from_utf8_unchecked(&local_buf[..amount]) };
-            engine.redact(&self.data_class(), s, output)
+            engine.redact(dc, s, output)
         } else {
-            engine.redact(&self.data_class(), format!("{v:?}"), output)
+            engine.redact(dc, format!("{v:?}"), output)
         }
     }
 }
 impl ::data_privacy::RedactedDisplay for EmailAddress {
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "Converting from u64 to usize, value is known to be <= 128"
+        reason = "Converting from u64 to usize, value is known to be <= STACK_BUFFER_SIZE"
     )]
     fn fmt(
         &self,
         engine: &::data_privacy::RedactionEngine,
         output: &mut ::std::fmt::Formatter,
     ) -> ::core::fmt::Result {
-        use data_privacy::Classified;
+        const STACK_BUFFER_SIZE: usize = 128;
         let v = &self.0;
-        let mut local_buf = [0u8; 128];
+        let dc = <Self as ::data_privacy::Classified>::data_class(self);
+        let mut local_buf = [0u8; STACK_BUFFER_SIZE];
         let amount = {
             let mut cursor = ::std::io::Cursor::new(&mut local_buf[..]);
             if ::std::io::Write::write_fmt(&mut cursor, format_args!("{v}")).is_ok() {
@@ -81,9 +74,9 @@ impl ::data_privacy::RedactedDisplay for EmailAddress {
         };
         if amount <= local_buf.len() {
             let s = unsafe { ::core::str::from_utf8_unchecked(&local_buf[..amount]) };
-            engine.redact(&self.data_class(), s, output)
+            engine.redact(dc, s, output)
         } else {
-            engine.redact(&self.data_class(), format!("{v}"), output)
+            engine.redact(dc, format!("{v}"), output)
         }
     }
 }

--- a/crates/data_privacy_macros_impl/tests/snapshots/taxonomy__success.snap
+++ b/crates/data_privacy_macros_impl/tests/snapshots/taxonomy__success.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/data_privacy_macros_impl/tests/taxonomy.rs
-assertion_line: 159
 expression: pretty
 ---
 enum GovTaxonomy {
@@ -43,9 +42,19 @@ impl ::core::cmp::PartialEq<::data_privacy::DataClass> for GovTaxonomy {
         self.data_class() == *other
     }
 }
+impl ::core::cmp::PartialEq<&::data_privacy::DataClass> for GovTaxonomy {
+    fn eq(&self, other: &&::data_privacy::DataClass) -> core::primitive::bool {
+        self.data_class() == **other
+    }
+}
 impl ::core::cmp::PartialEq<GovTaxonomy> for ::data_privacy::DataClass {
     fn eq(&self, other: &GovTaxonomy) -> core::primitive::bool {
         other == self
+    }
+}
+impl ::core::cmp::PartialEq<GovTaxonomy> for &::data_privacy::DataClass {
+    fn eq(&self, other: &GovTaxonomy) -> core::primitive::bool {
+        *other == **self
     }
 }
 #[doc("Really secret data")]


### PR DESCRIPTION
- Improve serialization of the DataClass type. It's now serialized as a simple string rather than a clumsy map.

- Use serde_core instead of serde for improved build times.

- Change the Classified trait's data_class method to return a &DataClass rather than a DataClass.
This avoids the need to clone the DataClass in many places, improving performance (since DataClass has two Cow to clone).

- Use FxHashMap to hold the redactors to get much better hash lookup perf. We don't need DoS protection since the hash keys are entirely internal.