### PR TITLE
chore: update Rust version and fix the build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
 
   # Rust toolchain versions
   RUST_MSRV: "1.88"                                  # used for testing (ensures the MSRV promise is kept)
-  RUST_LATEST: "1.91"                                # used for static analysis & mutation testing
+  RUST_LATEST: "1.92"                                # used for static analysis & mutation testing
   RUST_NIGHTLY: "nightly-2025-11-20"                 # used for coverage and extended analysis
   RUST_NIGHTLY_EXTERNAL_TYPES: "nightly-2025-08-06"  # used for external type exposure checks
 

--- a/crates/tick/src/lib.rs
+++ b/crates/tick/src/lib.rs
@@ -7,7 +7,7 @@
     test,
     allow(
         clippy::arithmetic_side_effects,
-        clippy::unchecked_duration_subtraction,
+        clippy::unchecked_time_subtraction,
         reason = "allow these lints in tests to improve the readability of the tests"
     )
 )]


### PR DESCRIPTION
mis-alignment between internal rust version on OS one causes clippy failures. Fix these by aligning versions. 