### PR TITLE
docs: Fix the CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 # The Oxidizer Project
 
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 </div>
 

--- a/crates/README.j2
+++ b/crates/README.j2
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="{{ crate | title }} Logo" width="96">
+ <img src="./logo.png" alt="{{ crate | replace("_", " ") | title }} Logo" width="96">
 
-# {{ crate | title | lower }}
+# {{ crate | replace("_", " ") | title }}
 
 [![crate.io](https://img.shields.io/crates/v/{{ crate }}.svg)](https://crates.io/crates/{{ crate }})
 [![docs.rs](https://docs.rs/{{ crate }}/badge.svg)](https://docs.rs/{{ crate }})
 [![MSRV](https://img.shields.io/crates/msrv/{{ crate }})](https://crates.io/crates/{{ crate }})
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -17,7 +17,7 @@
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/{{crate | title | lower}}">source code</a>.
 </sub>
 
 {{ links }}

--- a/crates/automation/README.md
+++ b/crates/automation/README.md
@@ -1,14 +1,11 @@
 # Automation
 
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 
 An unpublished crate for shared code used for writing Rust scripts
 
-
-<div style="font-size: 75%" ><hr/>
-
-This crate was developed as part of [The Oxidizer Project](https://github.com/microsoft/oxidizer).
-
-</div>
-
+<hr/>
+<sub>
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+</sub>

--- a/crates/bytesbuf/README.md
+++ b/crates/bytesbuf/README.md
@@ -1,12 +1,12 @@
 <div align="center">
  <img src="./logo.png" alt="Bytesbuf Logo" width="96">
 
-# bytesbuf
+# Bytesbuf
 
 [![crate.io](https://img.shields.io/crates/v/bytesbuf.svg)](https://crates.io/crates/bytesbuf)
 [![docs.rs](https://docs.rs/bytesbuf/badge.svg)](https://docs.rs/bytesbuf)
 [![MSRV](https://img.shields.io/crates/msrv/bytesbuf)](https://crates.io/crates/bytesbuf)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -536,10 +536,10 @@ processing in your code:
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEG-dp_C9D4-jCG9tBl5F7M1bDG3mj9J-QdGxQGyUWhRYQiuECYXKEG5yAxXVX-INyGwACB9YZn6BLG5mUwiQgcGNZGyIa4-qKJXxMYWSBgmhieXRlc2J1ZmUwLjEuMg
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG5yAxXVX-INyGwACB9YZn6BLG5mUwiQgcGNZGyIa4-qKJXxMYWSBgmhieXRlc2J1ZmUwLjEuMg
  [__link0]: https://docs.rs/bytesbuf/0.1.2/bytesbuf/?search=BytesView
  [__link1]: https://docs.rs/bytesbuf/0.1.2/bytesbuf/?search=BytesView
  [__link10]: https://docs.rs/bytesbuf/0.1.2/bytesbuf/?search=HasMemory

--- a/crates/data_privacy/README.md
+++ b/crates/data_privacy/README.md
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="Data_Privacy Logo" width="96">
+ <img src="./logo.png" alt="Data Privacy Logo" width="96">
 
-# data_privacy
+# Data Privacy
 
 [![crate.io](https://img.shields.io/crates/v/data_privacy.svg)](https://crates.io/crates/data_privacy)
 [![docs.rs](https://docs.rs/data_privacy/badge.svg)](https://docs.rs/data_privacy)
 [![MSRV](https://img.shields.io/crates/msrv/data_privacy)](https://crates.io/crates/data_privacy)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -189,10 +189,10 @@ assert_eq!(output_buffer, "********");
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEG-dp_C9D4-jCG9tBl5F7M1bDG3mj9J-QdGxQGyUWhRYQiuECYXKEG60g5Zo_p4DxG7thIbirEmXiG-Rmydk-fpIuG-OodFo7tu4EYWSBgmxkYXRhX3ByaXZhY3lmMC4xMC4w
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG60g5Zo_p4DxG7thIbirEmXiG-Rmydk-fpIuG-OodFo7tu4EYWSBgmxkYXRhX3ByaXZhY3lmMC4xMC4w
  [__link0]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=Classified
  [__link1]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=Redactor
  [__link10]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=classified

--- a/crates/data_privacy_macros/README.md
+++ b/crates/data_privacy_macros/README.md
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="Data_Privacy_Macros Logo" width="96">
+ <img src="./logo.png" alt="Data Privacy Macros Logo" width="96">
 
-# data_privacy_macros
+# Data Privacy Macros
 
 [![crate.io](https://img.shields.io/crates/v/data_privacy_macros.svg)](https://crates.io/crates/data_privacy_macros)
 [![docs.rs](https://docs.rs/data_privacy_macros/badge.svg)](https://docs.rs/data_privacy_macros)
 [![MSRV](https://img.shields.io/crates/msrv/data_privacy_macros)](https://crates.io/crates/data_privacy_macros)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -18,7 +18,7 @@ Macros for the [`data_privacy`][__link0] crate.
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy_macros">source code</a>.
 </sub>
 
  [__link0]: https://docs.rs/data_privacy

--- a/crates/data_privacy_macros_impl/README.md
+++ b/crates/data_privacy_macros_impl/README.md
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="Data_Privacy_Macros_Impl Logo" width="96">
+ <img src="./logo.png" alt="Data Privacy Macros Impl Logo" width="96">
 
-# data_privacy_macros_impl
+# Data Privacy Macros Impl
 
 [![crate.io](https://img.shields.io/crates/v/data_privacy_macros_impl.svg)](https://crates.io/crates/data_privacy_macros_impl)
 [![docs.rs](https://docs.rs/data_privacy_macros_impl/badge.svg)](https://docs.rs/data_privacy_macros_impl)
 [![MSRV](https://img.shields.io/crates/msrv/data_privacy_macros_impl)](https://crates.io/crates/data_privacy_macros_impl)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -18,7 +18,7 @@ Macros for the [`data_privacy`][__link0] crate.
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy_macros_impl">source code</a>.
 </sub>
 
  [__link0]: https://docs.rs/data_privacy

--- a/crates/fundle/README.md
+++ b/crates/fundle/README.md
@@ -1,12 +1,12 @@
 <div align="center">
  <img src="./logo.png" alt="Fundle Logo" width="96">
 
-# fundle
+# Fundle
 
 [![crate.io](https://img.shields.io/crates/v/fundle.svg)](https://crates.io/crates/fundle)
 [![docs.rs](https://docs.rs/fundle/badge.svg)](https://docs.rs/fundle)
 [![MSRV](https://img.shields.io/crates/msrv/fundle)](https://crates.io/crates/fundle)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -100,6 +100,6 @@ The name `fundle::bundle` comes from the “Take Your Daughter to Work Day” ep
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/fundle">source code</a>.
 </sub>
 

--- a/crates/fundle_macros/README.md
+++ b/crates/fundle_macros/README.md
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="Fundle_Macros Logo" width="96">
+ <img src="./logo.png" alt="Fundle Macros Logo" width="96">
 
-# fundle_macros
+# Fundle Macros
 
 [![crate.io](https://img.shields.io/crates/v/fundle_macros.svg)](https://crates.io/crates/fundle_macros)
 [![docs.rs](https://docs.rs/fundle_macros/badge.svg)](https://docs.rs/fundle_macros)
 [![MSRV](https://img.shields.io/crates/msrv/fundle_macros)](https://crates.io/crates/fundle_macros)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -59,7 +59,7 @@ Generates `Clone`, `From<T: AsRef<Logger>>`, `Deref`, and `DerefMut`.
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/fundle_macros">source code</a>.
 </sub>
 
  [__link0]: https://docs.rs/fundle

--- a/crates/fundle_macros_impl/README.md
+++ b/crates/fundle_macros_impl/README.md
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="Fundle_Macros_Impl Logo" width="96">
+ <img src="./logo.png" alt="Fundle Macros Impl Logo" width="96">
 
-# fundle_macros_impl
+# Fundle Macros Impl
 
 [![crate.io](https://img.shields.io/crates/v/fundle_macros_impl.svg)](https://crates.io/crates/fundle_macros_impl)
 [![docs.rs](https://docs.rs/fundle_macros_impl/badge.svg)](https://docs.rs/fundle_macros_impl)
 [![MSRV](https://img.shields.io/crates/msrv/fundle_macros_impl)](https://crates.io/crates/fundle_macros_impl)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -18,7 +18,7 @@ Macros for the [`fundle`][__link0] crate.
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/fundle_macros_impl">source code</a>.
 </sub>
 
  [__link0]: https://docs.rs/fundle

--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -1,12 +1,12 @@
 <div align="center">
  <img src="./logo.png" alt="Ohno Logo" width="96">
 
-# ohno
+# Ohno
 
 [![crate.io](https://img.shields.io/crates/v/ohno.svg)](https://crates.io/crates/ohno)
 [![docs.rs](https://docs.rs/ohno/badge.svg)](https://docs.rs/ohno)
 [![MSRV](https://img.shields.io/crates/msrv/ohno)](https://crates.io/crates/ohno)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -234,10 +234,10 @@ fn open_file(path: &str) -> Result<String, MyError> {
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEG-dp_C9D4-jCG9tBl5F7M1bDG3mj9J-QdGxQGyUWhRYQiuECYXKEGzgWfI8NISQyG6axg1O2rjQfGxzhzaW2WjRzG3owvcD8UYPxYWSCgmRvaG5vZTAuMi4wgmtvaG5vX21hY3Jvc2UwLjIuMA
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEGzgWfI8NISQyG6axg1O2rjQfGxzhzaW2WjRzG3owvcD8UYPxYWSCgmRvaG5vZTAuMi4wgmtvaG5vX21hY3Jvc2UwLjIuMA
  [__link0]: https://docs.rs/ohno/0.2.0/ohno/?search=ErrorExt
  [__link1]: https://docs.rs/ohno/0.2.0/ohno/?search=OhnoCore
  [__link10]: https://docs.rs/ohno_macros/0.2.0/ohno_macros/?search=enrich_err

--- a/crates/ohno_macros/README.md
+++ b/crates/ohno_macros/README.md
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="Ohno_Macros Logo" width="96">
+ <img src="./logo.png" alt="Ohno Macros Logo" width="96">
 
-# ohno_macros
+# Ohno Macros
 
 [![crate.io](https://img.shields.io/crates/v/ohno_macros.svg)](https://crates.io/crates/ohno_macros)
 [![docs.rs](https://docs.rs/ohno_macros/badge.svg)](https://docs.rs/ohno_macros)
 [![MSRV](https://img.shields.io/crates/msrv/ohno_macros)](https://crates.io/crates/ohno_macros)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -23,7 +23,7 @@ Macros for the [`ohno`][__link0] crate.
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno_macros">source code</a>.
 </sub>
 
  [__link0]: https://docs.rs/ohno

--- a/crates/testing_aids/README.md
+++ b/crates/testing_aids/README.md
@@ -1,14 +1,11 @@
 # Testing_Aids
 
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 
 An unpublished crate containing testing utilities for use within this repo.
 
-
-<div style="font-size: 75%" ><hr/>
-
-This crate was developed as part of [The Oxidizer Project](https://github.com/microsoft/oxidizer).
-
-</div>
-
+<hr/>
+<sub>
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+</sub>

--- a/crates/thread_aware/README.md
+++ b/crates/thread_aware/README.md
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="Thread_Aware Logo" width="96">
+ <img src="./logo.png" alt="Thread Aware Logo" width="96">
 
-# thread_aware
+# Thread Aware
 
 [![crate.io](https://img.shields.io/crates/v/thread_aware.svg)](https://crates.io/crates/thread_aware)
 [![docs.rs](https://docs.rs/thread_aware/badge.svg)](https://docs.rs/thread_aware)
 [![MSRV](https://img.shields.io/crates/msrv/thread_aware)](https://crates.io/crates/thread_aware)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -146,10 +146,10 @@ impl Service {
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEG-dp_C9D4-jCG9tBl5F7M1bDG3mj9J-QdGxQGyUWhRYQiuECYXKEGxWHjFPHVfBQG3G58H2zodoBG5x8pW8Bc5imG8o5LL8tl2DqYWSCgmx0aHJlYWRfYXdhcmVlMC42LjCCc3RocmVhZF9hd2FyZV9tYWNyb3NlMC42LjA
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEGxWHjFPHVfBQG3G58H2zodoBG5x8pW8Bc5imG8o5LL8tl2DqYWSCgmx0aHJlYWRfYXdhcmVlMC42LjCCc3RocmVhZF9hd2FyZV9tYWNyb3NlMC42LjA
  [__link0]: https://docs.rs/thread_aware_macros/0.6.0/thread_aware_macros/?search=ThreadAware
  [__link1]: https://doc.rust-lang.org/stable/std/clone/trait.Clone.html
  [__link10]: https://docs.rs/thread_aware_macros/0.6.0/thread_aware_macros/?search=ThreadAware

--- a/crates/thread_aware_macros/README.md
+++ b/crates/thread_aware_macros/README.md
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="Thread_Aware_Macros Logo" width="96">
+ <img src="./logo.png" alt="Thread Aware Macros Logo" width="96">
 
-# thread_aware_macros
+# Thread Aware Macros
 
 [![crate.io](https://img.shields.io/crates/v/thread_aware_macros.svg)](https://crates.io/crates/thread_aware_macros)
 [![docs.rs](https://docs.rs/thread_aware_macros/badge.svg)](https://docs.rs/thread_aware_macros)
 [![MSRV](https://img.shields.io/crates/msrv/thread_aware_macros)](https://crates.io/crates/thread_aware_macros)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -23,7 +23,7 @@ Macros for the [`thread_aware`][__link0] crate.
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware_macros">source code</a>.
 </sub>
 
  [__link0]: https://docs.rs/thread_aware

--- a/crates/thread_aware_macros_impl/README.md
+++ b/crates/thread_aware_macros_impl/README.md
@@ -1,12 +1,12 @@
 <div align="center">
- <img src="./logo.png" alt="Thread_Aware_Macros_Impl Logo" width="96">
+ <img src="./logo.png" alt="Thread Aware Macros Impl Logo" width="96">
 
-# thread_aware_macros_impl
+# Thread Aware Macros Impl
 
 [![crate.io](https://img.shields.io/crates/v/thread_aware_macros_impl.svg)](https://crates.io/crates/thread_aware_macros_impl)
 [![docs.rs](https://docs.rs/thread_aware_macros_impl/badge.svg)](https://docs.rs/thread_aware_macros_impl)
 [![MSRV](https://img.shields.io/crates/msrv/thread_aware_macros_impl)](https://crates.io/crates/thread_aware_macros_impl)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -18,7 +18,7 @@ Macros for the [`thread_aware`][__link0] crate.
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware_macros_impl">source code</a>.
 </sub>
 
  [__link0]: https://docs.rs/thread_aware

--- a/crates/tick/README.md
+++ b/crates/tick/README.md
@@ -1,12 +1,12 @@
 <div align="center">
  <img src="./logo.png" alt="Tick Logo" width="96">
 
-# tick
+# Tick
 
 [![crate.io](https://img.shields.io/crates/v/tick.svg)](https://crates.io/crates/tick)
 [![docs.rs](https://docs.rs/tick/badge.svg)](https://docs.rs/tick)
 [![MSRV](https://img.shields.io/crates/msrv/tick)](https://crates.io/crates/tick)
-[![CI](https://github.com/microsoft/oxidizer/workflows/main/badge.svg)](https://github.com/microsoft/oxidizer/actions)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
 [![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 <a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
@@ -201,10 +201,10 @@ contain additional examples of how to use the time primitives.
 
 <hr/>
 <sub>
-This crate was developed as part of <a href="../..">The Oxidizer Project</a>.
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/tick">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEG-dp_C9D4-jCG9tBl5F7M1bDG3mj9J-QdGxQGyUWhRYQiuECYXKEG0YUhb-K8ea7G_NBN2_hIoeEGzhuGMMPiDz8G_nmDjrJF1TjYWSBgmR0aWNrZTAuMS4w
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG0YUhb-K8ea7G_NBN2_hIoeEGzhuGMMPiDz8G_nmDjrJF1TjYWSBgmR0aWNrZTAuMS4w
  [__link0]: https://docs.rs/tick/0.1.0/tick/?search=ClockControl
  [__link1]: https://docs.rs/tick/0.1.0/tick/?search=Clock
  [__link10]: https://docs.rs/tick/0.1.0/tick/runtime/index.html


### PR DESCRIPTION
- Previously, the CI badge would show "failed" if a PR happens to not be building and it was the last thing built in the repo. Now, the badge reflects the state the last time changes were pushed into the repo, which is always guaranteed to be working given our gates.