### PR TITLE
docs: A few doc-related fixes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bytesbuf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloc_tracker",
  "bytes",
@@ -277,7 +277,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "data_privacy"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "data_privacy_macros",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ repository = "https://github.com/microsoft/oxidizer"
 [workspace.dependencies]
 
 # local dependencies
-bytesbuf = { path = "crates/bytesbuf", default-features = false, version = "0.2.1" }
+bytesbuf = { path = "crates/bytesbuf", default-features = false, version = "0.2.2" }
 bytesbuf_io = { path = "crates/bytesbuf_io", default-features = false, version = "0.1.1" }
-data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.10.0" }
+data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.10.1" }
 data_privacy_macros = { path = "crates/data_privacy_macros", default-features = false, version = "0.9.0" }
 data_privacy_macros_impl = { path = "crates/data_privacy_macros_impl", default-features = false, version = "0.9.0" }
 fundle = { path = "crates/fundle", default-features = false, version = "0.3.0" }

--- a/crates/bytesbuf/CHANGELOG.md
+++ b/crates/bytesbuf/CHANGELOG.md
@@ -10,6 +10,10 @@
 
   - Replace removed doc_auto_cfg feature with doc_cfg ([#178](https://github.com/microsoft/oxidizer/pull/178))
 
+- ✔️ Tasks
+
+  - Bump bytesbuf and bytesbuf_io version numbers to re-trigger publishing ([#188](https://github.com/microsoft/oxidizer/pull/188))
+
 ## [0.2.0] - 2026-01-02
 
 - ✨ Features

--- a/crates/bytesbuf/Cargo.toml
+++ b/crates/bytesbuf/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "bytesbuf"
 description = "Types for creating and manipulating byte sequences."
-version = "0.2.1"
+version = "0.2.2"
 readme = "README.md"
 keywords = ["oxidizer", "buffers", "io", "zero-copy"]
 categories = ["data-structures", "network-programming"]

--- a/crates/bytesbuf/README.md
+++ b/crates/bytesbuf/README.md
@@ -177,7 +177,7 @@ using the fundamental methods that underpin the convenience methods:
 See `examples/bb_slice_by_slice_write.rs` for an example of how to use these methods.
 
 If you do not know exactly how much memory you need in advance, you can extend the [`BytesBuf`][__link35]
-capacity on demand by calling [`BytesBuf::reserve()`][__link36]. You can use [`remaining_capacity()`][__link37]
+capacity on demand by calling [`BytesBuf::reserve`][__link36]. You can use [`remaining_capacity()`][__link37]
 to identify how much unused memory capacity is available.
 
 ```rust
@@ -236,7 +236,7 @@ let final_contents = buf.consume_all();
 ```
 
 If you already have a [`BytesView`][__link41] that you want to write into a [`BytesBuf`][__link42], call
-[`BytesBuf::put_bytes()`][__link43]. This is a highly efficient zero-copy operation
+[`BytesBuf::put_bytes`][__link43]. This is a highly efficient zero-copy operation
 that reuses the memory capacity of the view you are appending.
 
 ```rust
@@ -470,67 +470,67 @@ See the `mem::testing` module for details (requires `test-util` Cargo feature).
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG49D8RruQIE8GwgpxEsyod4nG_0iVUF-Z1CbG8k9bXXtSjKnYWSBgmhieXRlc2J1ZmUwLjIuMQ
- [__link0]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link1]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link10]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::advance
- [__link11]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::first_slice
- [__link12]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::first_slice
- [__link13]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::first_slice
- [__link14]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link15]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::Memory
- [__link16]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::HasMemory
- [__link17]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::HasMemory::memory
- [__link18]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::GlobalPool
- [__link19]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::GlobalPool::new
- [__link2]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link20]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::Memory::reserve
- [__link21]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link22]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link23]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link24]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link25]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::put_num_le
- [__link26]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::put_slice
- [__link27]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::put_byte
- [__link28]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::put_byte_repeated
- [__link29]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::put_bytes
- [__link3]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::get_num_le
- [__link30]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link31]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::first_unfilled_slice
- [__link32]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::advance
- [__link33]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::first_unfilled_slice
- [__link34]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::first_unfilled_slice
- [__link35]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link36]: `BytesBuf::reserve()`
- [__link37]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf::remaining_capacity
- [__link38]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link39]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link4]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::get_byte
- [__link40]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link41]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link42]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link43]: `BytesBuf::put_bytes()`
- [__link44]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::HasMemory
- [__link45]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::HasMemory
- [__link46]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link47]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link48]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::HasMemory
- [__link49]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link5]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::copy_to_slice
- [__link50]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesBuf
- [__link51]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::HasMemory
- [__link52]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::HasMemory
- [__link53]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=mem::GlobalPool
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEGzZ-2Bc0fJD6G7j5NnIMCIG1G7ArxDjgq_0oG2r2CxKzSq0VYWSBgmhieXRlc2J1ZmUwLjIuMg
+ [__link0]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link1]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link10]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::advance
+ [__link11]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::first_slice
+ [__link12]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::first_slice
+ [__link13]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::first_slice
+ [__link14]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link15]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::Memory
+ [__link16]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::HasMemory
+ [__link17]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::HasMemory::memory
+ [__link18]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::GlobalPool
+ [__link19]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::GlobalPool::new
+ [__link2]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link20]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::Memory::reserve
+ [__link21]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link22]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link23]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link24]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link25]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::put_num_le
+ [__link26]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::put_slice
+ [__link27]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::put_byte
+ [__link28]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::put_byte_repeated
+ [__link29]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::put_bytes
+ [__link3]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::get_num_le
+ [__link30]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link31]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::first_unfilled_slice
+ [__link32]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::advance
+ [__link33]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::first_unfilled_slice
+ [__link34]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::first_unfilled_slice
+ [__link35]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link36]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::reserve
+ [__link37]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::remaining_capacity
+ [__link38]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link39]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link4]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::get_byte
+ [__link40]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link41]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link42]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link43]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf::put_bytes
+ [__link44]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::HasMemory
+ [__link45]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::HasMemory
+ [__link46]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link47]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link48]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::HasMemory
+ [__link49]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link5]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::copy_to_slice
+ [__link50]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesBuf
+ [__link51]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::HasMemory
+ [__link52]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::HasMemory
+ [__link53]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=mem::GlobalPool
  [__link54]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
- [__link55]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
+ [__link55]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
  [__link56]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
- [__link57]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
+ [__link57]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
  [__link58]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
  [__link59]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
- [__link6]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::copy_to_uninit_slice
- [__link60]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
+ [__link6]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::copy_to_uninit_slice
+ [__link60]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
  [__link61]: https://doc.rust-lang.org/stable/std/?search=sync::OnceLock
- [__link62]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link7]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::as_read
- [__link8]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView
- [__link9]: https://docs.rs/bytesbuf/0.2.1/bytesbuf/?search=BytesView::first_slice
+ [__link62]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link7]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::as_read
+ [__link8]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView
+ [__link9]: https://docs.rs/bytesbuf/0.2.2/bytesbuf/?search=BytesView::first_slice

--- a/crates/bytesbuf/src/lib.rs
+++ b/crates/bytesbuf/src/lib.rs
@@ -181,7 +181,7 @@
 //! See `examples/bb_slice_by_slice_write.rs` for an example of how to use these methods.
 //!
 //! If you do not know exactly how much memory you need in advance, you can extend the [`BytesBuf`]
-//! capacity on demand by calling [`BytesBuf::reserve()`]. You can use [`remaining_capacity()`]
+//! capacity on demand by calling [`BytesBuf::reserve`]. You can use [`remaining_capacity()`]
 //! to identify how much unused memory capacity is available.
 //!
 //! ```
@@ -249,7 +249,7 @@
 //! ```
 //!
 //! If you already have a [`BytesView`] that you want to write into a [`BytesBuf`], call
-//! [`BytesBuf::put_bytes()`]. This is a highly efficient zero-copy operation
+//! [`BytesBuf::put_bytes`]. This is a highly efficient zero-copy operation
 //! that reuses the memory capacity of the view you are appending.
 //!
 //! ```

--- a/crates/data_privacy/CHANGELOG.md
+++ b/crates/data_privacy/CHANGELOG.md
@@ -1,10 +1,35 @@
 # Changelog
 
-## [0.10.0] - 2025-12-16
+## [0.10.1] - 2026-01-14
+
+- 🐛 Bug Fixes
+
+  - Replace removed doc_auto_cfg feature with doc_cfg ([#178](https://github.com/microsoft/oxidizer/pull/178))
+
+- 📚 Documentation
+
+  - Normalize feature handling for docs.rs ([#153](https://github.com/microsoft/oxidizer/pull/153))
+  - Fix the CI badge ([#154](https://github.com/microsoft/oxidizer/pull/154))
+
+- ✔️ Tasks
+
+  - Replace cargo-rdme by cargo-doc2readme ([#148](https://github.com/microsoft/oxidizer/pull/148))
+
+- 🔄 Continuous Integration
+
+  - Add spell checker ([#158](https://github.com/microsoft/oxidizer/pull/158))
+
+## [0.10.0] - 2025-12-17
 
 - ✨ Features
 
-  - Better serialization and perf.
+  - Better serialization and perf. ([#133](https://github.com/microsoft/oxidizer/pull/133))
+
+- 🐛 Bug Fixes
+
+  - Strip links in readme.md generation because cargo-rdme has problems with link comprehension ([#146](https://github.com/microsoft/oxidizer/pull/146))
+
+## [0.9.0] - 2025-12-16
 
 - 🧩 Miscellaneous
 
@@ -73,7 +98,7 @@
 
 - ✨ Features
 
-  - Make RedactionEngine cloneable. ([#13](https://github.com/microsoft/oxidizer/pull/13))
+  - Make RedactionEngine clonable. ([#13](https://github.com/microsoft/oxidizer/pull/13))
 
 - 📚 Documentation
 

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "data_privacy"
 description = "Data annotation and redaction system providing a robust way to manipulate sensitive information."
-version = "0.10.0"
+version = "0.10.1"
 readme = "README.md"
 keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
 categories = ["data-structures"]

--- a/crates/data_privacy/README.md
+++ b/crates/data_privacy/README.md
@@ -115,7 +115,7 @@ How this all works:
 * The application uses the classified container types to wrap sensitive data throughout the application. This ensures the
   sensitive data is not accidentally exposed through telemetry or other means.
 
-* On startup, the application initializes a [`RedactionEngine`][__link13] via [`RedactionEngine::builder()`][__link14]. The engine is configured
+* On startup, the application initializes a [`RedactionEngine`][__link13] via [`RedactionEngine::builder`][__link14]. The engine is configured
   with redactors for each data class in the taxonomy. The redactors define how to handle sensitive data for that class.
   For example, for a given data class, a redactor may substitute the original data for a hash value, or it may replace it with asterisks.
 
@@ -192,19 +192,19 @@ assert_eq!(output_buffer, "********");
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG4FOBR6whxj8G3U5pc6nDCctG_VrdEzFuyNGG1q0A9c-9HLoYWSBgmxkYXRhX3ByaXZhY3lmMC4xMC4w
- [__link0]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=Classified
- [__link1]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=Redactor
- [__link10]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=classified
- [__link11]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=taxonomy
- [__link12]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=classified
- [__link13]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=RedactionEngine
- [__link14]: `RedactionEngine::builder()`
- [__link2]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=simple_redactor::SimpleRedactor
- [__link3]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=Classified
- [__link4]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=RedactedDebug
- [__link5]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=RedactedDisplay
- [__link6]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=RedactedToString
- [__link7]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=taxonomy
- [__link8]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=DataClass
- [__link9]: https://docs.rs/data_privacy/0.10.0/data_privacy/?search=Classified
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG_vJVWuNQIdLG1RbfSZVNVZ3G8Jil4LnevsRG20YH3-q9jKfYWSBgmxkYXRhX3ByaXZhY3lmMC4xMC4x
+ [__link0]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=Classified
+ [__link1]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=Redactor
+ [__link10]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=classified
+ [__link11]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=taxonomy
+ [__link12]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=classified
+ [__link13]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactionEngine
+ [__link14]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactionEngine::builder
+ [__link2]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=simple_redactor::SimpleRedactor
+ [__link3]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=Classified
+ [__link4]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactedDebug
+ [__link5]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactedDisplay
+ [__link6]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactedToString
+ [__link7]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=taxonomy
+ [__link8]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=DataClass
+ [__link9]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=Classified

--- a/crates/data_privacy/src/lib.rs
+++ b/crates/data_privacy/src/lib.rs
@@ -106,7 +106,7 @@
 //! * The application uses the classified container types to wrap sensitive data throughout the application. This ensures the
 //!   sensitive data is not accidentally exposed through telemetry or other means.
 //!
-//! * On startup, the application initializes a [`RedactionEngine`] via [`RedactionEngine::builder()`]. The engine is configured
+//! * On startup, the application initializes a [`RedactionEngine`] via [`RedactionEngine::builder`]. The engine is configured
 //!   with redactors for each data class in the taxonomy. The redactors define how to handle sensitive data for that class.
 //!   For example, for a given data class, a redactor may substitute the original data for a hash value, or it may replace it with asterisks.
 //!


### PR DESCRIPTION
- Workaround a bug in cargo-doc2readme where it produces bogus links for intra-doc links using () to reference to functions. I've filed a bug against cargo-doc2readme on the subject.

- Extend the release-crate.ps1 script to introduce the --bump option to let you just bump the patch version, the minor version, or the major version. This avoids the need to actually know the current version number, the script figures it out.

- Bumped some crate versions to get the fixed README files published to crates.io.