### PR TITLE
chore: Improve our crate's repository property.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ rust-version = "1.88"
 authors = ["The Oxidizer Project Authors"]
 license = "MIT"
 homepage = "https://github.com/microsoft/oxidizer"
-repository = "https://github.com/microsoft/oxidizer"
 
 # Adhere to the following rules when adding dependencies:
 # * All dependencies specified here need to have default-features turned off - individual crates can enable the

--- a/crates/anyspawn/Cargo.toml
+++ b/crates/anyspawn/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/anyspawn"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/automation/Cargo.toml
+++ b/crates/automation/Cargo.toml
@@ -10,7 +10,6 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/bytesbuf/Cargo.toml
+++ b/crates/bytesbuf/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 libc.workspace = true

--- a/crates/bytesbuf_io/Cargo.toml
+++ b/crates/bytesbuf_io/Cargo.toml
@@ -19,7 +19,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf_io"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["bytesbuf::*", "ohno::*", "futures_core::stream::Stream"]

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/data_privacy_macros/Cargo.toml
+++ b/crates/data_privacy_macros/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy_macros"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["data_privacy_macros::*"]

--- a/crates/data_privacy_macros_impl/Cargo.toml
+++ b/crates/data_privacy_macros_impl/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy_macros_impl"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [

--- a/crates/fundle/Cargo.toml
+++ b/crates/fundle/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fundle"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["fundle_macros::*"]

--- a/crates/fundle_macros/Cargo.toml
+++ b/crates/fundle_macros/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fundle_macros"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/fundle_macros_impl/Cargo.toml
+++ b/crates/fundle_macros_impl/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fundle_macros_impl"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["proc_macro2::*", "syn::error::*"]

--- a/crates/layered/Cargo.toml
+++ b/crates/layered/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/layered"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ohno/Cargo.toml
+++ b/crates/ohno/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/ohno"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["ohno_macros::*"]

--- a/crates/ohno_macros/Cargo.toml
+++ b/crates/ohno_macros/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/ohno_macros"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/recoverable/Cargo.toml
+++ b/crates/recoverable/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/recoverable"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/seatbelt/Cargo.toml
+++ b/crates/seatbelt/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/seatbelt"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [

--- a/crates/testing_aids/Cargo.toml
+++ b/crates/testing_aids/Cargo.toml
@@ -13,7 +13,6 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
 
 [dependencies]
 futures = { workspace = true, features = ["executor"] }

--- a/crates/thread_aware/Cargo.toml
+++ b/crates/thread_aware/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["thread_aware_macros::ThreadAware"]

--- a/crates/thread_aware_macros/Cargo.toml
+++ b/crates/thread_aware_macros/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware_macros"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/thread_aware_macros_impl/Cargo.toml
+++ b/crates/thread_aware_macros_impl/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware_macros_impl"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [

--- a/crates/tick/Cargo.toml
+++ b/crates/tick/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/tick"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [

--- a/crates/uniflight/Cargo.toml
+++ b/crates/uniflight/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/uniflight"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [

--- a/scripts/crate-template/Cargo.toml
+++ b/scripts/crate-template/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/{{CRATE_NAME}}"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Turns out the repository property in a crate's metadata doesn't
just have to point to a repo's root. It can point directly to a
specific subdirectory. So we can leverage that such that clicking
on the repo link on crates.io will bring the user straight to
the right place in our repo.