### PR TITLE
feat(bytesbuf_io): release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "bytesbuf_io"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytesbuf",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://github.com/microsoft/oxidizer"
 # local dependencies
 anyspawn = { path = "crates/anyspawn", default-features = false, version = "0.1.0" }
 bytesbuf = { path = "crates/bytesbuf", default-features = false, version = "0.3.0" }
-bytesbuf_io = { path = "crates/bytesbuf_io", default-features = false, version = "0.2.0" }
+bytesbuf_io = { path = "crates/bytesbuf_io", default-features = false, version = "0.3.0" }
 data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.10.1" }
 data_privacy_macros = { path = "crates/data_privacy_macros", default-features = false, version = "0.9.0" }
 data_privacy_macros_impl = { path = "crates/data_privacy_macros_impl", default-features = false, version = "0.9.0" }

--- a/crates/bytesbuf_io/CHANGELOG.md
+++ b/crates/bytesbuf_io/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.0] - 2026-02-16
+
+- ✔️ Tasks
+
+  - Improve our crate's repository property. ([#246](https://github.com/microsoft/oxidizer/pull/246))
+
+- 🔄 Continuous Integration
+
+  - automatically publish release notes ([#247](https://github.com/microsoft/oxidizer/pull/247))
+
 ## [0.2.0] - 2026-01-28
 
 - 📚 Documentation

--- a/crates/bytesbuf_io/Cargo.toml
+++ b/crates/bytesbuf_io/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "bytesbuf_io"
 description = "Asynchronous I/O abstractions expressed via `bytesbuf` types."
-version = "0.2.0"
+version = "0.3.0"
 readme = "README.md"
 keywords = ["oxidizer", "io", "zero-copy", "performance", "async"]
 categories = [

--- a/crates/bytesbuf_io/README.md
+++ b/crates/bytesbuf_io/README.md
@@ -35,9 +35,9 @@ types that produce or consume streams of bytes. These are in the `testing` modul
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf_io">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG8wC2qKB5vPMG5c8vZ8ulsvSGwSlXV9Pnjr5GyAAXY8thjNKYWSBgmtieXRlc2J1Zl9pb2UwLjIuMA
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG8wC2qKB5vPMG5c8vZ8ulsvSGwSlXV9Pnjr5GyAAXY8thjNKYWSBgmtieXRlc2J1Zl9pb2UwLjMuMA
  [__link0]: https://docs.io/bytesbuf
- [__link1]: https://docs.rs/bytesbuf_io/0.2.0/bytesbuf_io/?search=Read
- [__link2]: https://docs.rs/bytesbuf_io/0.2.0/bytesbuf_io/?search=Write
+ [__link1]: https://docs.rs/bytesbuf_io/0.3.0/bytesbuf_io/?search=Read
+ [__link2]: https://docs.rs/bytesbuf_io/0.3.0/bytesbuf_io/?search=Write
  [__link3]: https://docs.io/bytesbuf
- [__link4]: https://docs.rs/bytesbuf_io/0.2.0/bytesbuf_io/?search=Read
+ [__link4]: https://docs.rs/bytesbuf_io/0.3.0/bytesbuf_io/?search=Read


### PR DESCRIPTION
To publish a version that uses `bytesbuf 0.3.0`.

[Additional context in Teams](https://teams.microsoft.com/l/message/19:9236a6e90a494d08a9d382ede3a3432c@thread.tacv2/1771227538416?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=a4f716cc-3291-4989-a4bb-a66143117f4f&parentMessageId=1771227538416&teamName=Oxidizer&channelName=Builds%20%EF%BC%86%20Infrastructure&createdTime=1771227538416)