### PR TITLE
feat(bytesbuf): clamp minimum reservation size in BytesBufWriter

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,4 +1,4 @@
-304
+306
 →
 0.X.Y
 100k
@@ -143,8 +143,10 @@ Interop
 interoperability
 interoperate
 jitter
+JSON
 IOCP
 IP
+KiB
 Kubernetes
 libc
 libs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,11 @@ If you only touch one crate, you may use `just package=crate_name command` to na
 
 - Run `just format` to format code.
 - Run `just readme` to regenerate crate-level readme files.
+- Run `just spellcheck` to check spelling in code comments and docs.
+
+## Spelling
+
+The spell checker dictionary is in the `.spelling` file, one word per line in arbitrary order.
 
 ## Changelogs
 


### PR DESCRIPTION
## Summary

`BytesBufWriter` (the `std::io::Write` adapter for `BytesBuf`) previously reserved only the exact number of bytes requested on each `write()` call. Since `Write` is designed for piece-by-piece writing in small increments, this caused excessive memory allocations - each tiny write triggered its own reservation.

## Changes

The writer now uses a two-tier minimum reservation strategy via a new `ensure_sufficient_capacity()` method:

- **Empty buffer, small payload (<=4 KiB):** reserve 4 KiB. We assume total data will be modest, avoiding waste for small payloads (e.g. short JSON error responses, where over-reserving could open a door to resource exhaustion).
- **Otherwise:** reserve at least 64 KiB (or the payload size if larger). Once data crosses the 4 KiB boundary we are likely dealing with a large payload, so we take big bites to reduce allocation frequency.

The reservation logic is factored out of `write()` into `ensure_sufficient_capacity()` on `BytesBufWriter`, keeping the `Write` impl clean and providing a natural home for the design rationale documentation.

## Testing

Three new tests covering:
- Empty buffer with small write -> 4 KiB reservation
- Empty buffer with large write (>4 KiB) -> 64 KiB reservation
- Non-empty buffer needing more capacity -> 64 KiB reservation

Closes #271