### PR TITLE
fix(ohno): address some correctness and usability findings

### DIFF
--- a/crates/ohno/src/app/into_app_err.rs
+++ b/crates/ohno/src/app/into_app_err.rs
@@ -70,10 +70,12 @@ where
 }
 
 impl<T> IntoAppError<T> for Option<T> {
+    #[track_caller]
     fn into_app_err(self, msg: impl Display) -> Result<T, AppError> {
         self.ok_or_else(|| AppError::new(msg.to_string()))
     }
 
+    #[track_caller]
     fn into_app_err_with<F, D>(self, msg_fn: F) -> Result<T, AppError>
     where
         F: FnOnce() -> D,

--- a/crates/ohno/src/core.rs
+++ b/crates/ohno/src/core.rs
@@ -103,14 +103,14 @@ impl OhnoCore {
         self.data.backtrace.as_backtrace()
     }
 
-    /// Returns an iterator over the enrichment information in reverse order (most recent first).
+    /// Returns an iterator over the enrichment information in chronological order (oldest first).
     pub fn enrichments(&self) -> impl Iterator<Item = &EnrichmentEntry> {
-        self.data.enrichment.iter().rev()
+        self.data.enrichment.iter()
     }
 
-    /// Returns an iterator over just the enrichment messages in reverse order (most recent first).
+    /// Returns an iterator over just the enrichment messages in chronological order (oldest first).
     pub fn enrichment_messages(&self) -> impl Iterator<Item = &str> {
-        self.data.enrichment.iter().rev().map(|ctx| ctx.message.as_ref())
+        self.data.enrichment.iter().map(|ctx| ctx.message.as_ref())
     }
 
     /// Formats the main error message without backtrace and error enrichment.
@@ -305,7 +305,7 @@ mod tests {
         error.add_enrichment(EnrichmentEntry::new("ctx1", "test.rs", 1));
         error.add_enrichment(EnrichmentEntry::new("ctx2", "test.rs", 2));
         let messages: Vec<_> = error.enrichment_messages().collect();
-        assert_eq!(messages, vec!["ctx2", "ctx1"]);
+        assert_eq!(messages, vec!["ctx1", "ctx2"]);
     }
 
     #[test]

--- a/crates/ohno/tests/core.rs
+++ b/crates/ohno/tests/core.rs
@@ -75,10 +75,10 @@ fn test_detailed_enrich() {
     let enrichments: Vec<_> = error.enrichments().collect();
     assert_eq!(enrichments.len(), 3);
 
-    // Most recent first
-    assert_eq!(enrichments[0].message, "third message");
+    // Oldest first (chronological), matching display order
+    assert_eq!(enrichments[0].message, "first message");
     assert_eq!(enrichments[1].message, "second message");
-    assert_eq!(enrichments[2].message, "first message");
+    assert_eq!(enrichments[2].message, "third message");
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn test_trace_messages_iterator() {
     let error = OhnoCore::from("base").enrich("first").enrich("second");
 
     let messages: Vec<_> = error.enrichment_messages().collect();
-    assert_eq!(messages, vec!["second", "first"]);
+    assert_eq!(messages, vec!["first", "second"]);
 
     let display = error.to_string();
     let lines: Vec<_> = display.lines().collect();

--- a/crates/ohno/tests/enrich_err.rs
+++ b/crates/ohno/tests/enrich_err.rs
@@ -330,7 +330,7 @@ fn empty_context_iter() {
 }
 
 #[test]
-fn context_iter_reverse_order() {
+fn context_iter_chronological_order() {
     let mut core = OhnoCore::default();
 
     let messages = ["msg 1", "msg 2", "msg 3", "msg 4", "msg 5"];
@@ -351,11 +351,11 @@ fn context_iter_reverse_order() {
     assert_eq!(
         messages,
         vec![
-            ("msg 5", "test.rs", 50),
-            ("msg 4", "test.rs", 40),
-            ("msg 3", "test.rs", 30),
-            ("msg 2", "test.rs", 20),
             ("msg 1", "test.rs", 10),
+            ("msg 2", "test.rs", 20),
+            ("msg 3", "test.rs", 30),
+            ("msg 4", "test.rs", 40),
+            ("msg 5", "test.rs", 50),
         ]
     );
 }

--- a/crates/ohno_macros/src/utils.rs
+++ b/crates/ohno_macros/src/utils.rs
@@ -48,7 +48,7 @@ pub fn generate_unique_field_name(existing_fields: &[&syn::Ident]) -> syn::Ident
     let mut counter = 0;
     while existing_fields.iter().any(|ident| ident == &AsRef::<str>::as_ref(&candidate)) {
         counter += 1;
-        candidate = format!("{candidate}_{counter}");
+        candidate = format!("ohno_core_{counter}");
     }
 
     syn::Ident::new(&candidate, proc_macro2::Span::call_site())
@@ -109,5 +109,18 @@ mod tests {
 
         // Verify that the returned name is NOT in the existing fields
         assert!(!fields.iter().any(|ident| name == ident.to_string()));
+    }
+
+    #[test]
+    fn test_generate_unique_field_name_multiple_collisions() {
+        let ident1 = syn::Ident::new("ohno_core", proc_macro2::Span::call_site());
+        let ident2 = syn::Ident::new("ohno_core_1", proc_macro2::Span::call_site());
+        let ident3 = syn::Ident::new("ohno_core_2", proc_macro2::Span::call_site());
+        let fields = vec![&ident1, &ident2, &ident3];
+
+        let name = generate_unique_field_name(&fields);
+
+        // Should return "ohno_core_3", not a compounding name like "ohno_core_1_2_3"
+        assert_eq!(name.to_string(), "ohno_core_3");
     }
 }

--- a/crates/seatbelt/Cargo.toml
+++ b/crates/seatbelt/Cargo.toml
@@ -73,11 +73,11 @@ tracing-subscriber = { workspace = true, features = ["fmt", "std"] }
 
 [[example]]
 name = "timeout"
-required-features = ["timeout"]
+required-features = ["timeout", "metrics"]
 
 [[example]]
 name = "timeout_advanced"
-required-features = ["timeout"]
+required-features = ["timeout", "metrics"]
 
 [[example]]
 name = "retry"
@@ -85,15 +85,15 @@ required-features = ["retry"]
 
 [[example]]
 name = "retry_advanced"
-required-features = ["retry"]
+required-features = ["retry", "metrics"]
 
 [[example]]
 name = "retry_outage"
-required-features = ["retry"]
+required-features = ["retry", "metrics"]
 
 [[example]]
 name = "resilience_pipeline"
-required-features = ["retry", "timeout"]
+required-features = ["retry", "timeout", "metrics"]
 
 [[example]]
 name = "tower"

--- a/crates/seatbelt/src/context.rs
+++ b/crates/seatbelt/src/context.rs
@@ -73,7 +73,12 @@ impl<In, Out> ResilienceContext<In, Out> {
 
     #[cfg_attr(
         not(any(feature = "metrics", feature = "logs", test)),
-        expect(unused_variables, reason = "unused when logs nor metrics are used")
+        expect(
+            unused_variables,
+            clippy::unused_self,
+            clippy::needless_pass_by_value,
+            reason = "unused when logs nor metrics are used"
+        )
     )]
     #[cfg(any(feature = "retry", feature = "breaker", feature = "timeout", test))]
     pub(crate) fn create_telemetry(&self, strategy_name: Cow<'static, str>) -> crate::utils::TelemetryHelper {

--- a/crates/seatbelt/src/retry/service.rs
+++ b/crates/seatbelt/src/retry/service.rs
@@ -217,7 +217,7 @@ impl<In, Out> RetryShared<In, Out> {
 
     #[cfg_attr(
         not(any(feature = "logs", test)),
-        expect(unused_variables, reason = "unused when logs feature not used")
+        expect(unused_variables, clippy::unused_self, reason = "unused when logs feature not used")
     )]
     fn emit_telemetry(&self, attempt: Attempt, retry_delay: Duration) {
         #[cfg(any(feature = "logs", test))]

--- a/crates/tick/Cargo.toml
+++ b/crates/tick/Cargo.toml
@@ -69,11 +69,11 @@ workspace = true
 
 [[example]]
 name = "basic"
-required-features = ["tokio"]
+required-features = ["tokio", "fmt"]
 
 [[example]]
 name = "clock"
-required-features = ["tokio"]
+required-features = ["tokio", "fmt"]
 
 [[example]]
 name = "clock_control"


### PR DESCRIPTION
Correctness:
- Fix compounding name bug in generate_unique_field_name (ohno_core_1_2 instead of ohno_core_2 on repeated collision)
- Emit clear compile error when #[ohno::error] is applied to enums
- Add #[track_caller] to Option<T> IntoAppError implementations

Usability:
- Make enrichments()/enrichment_messages() iterate in chronological order (oldest-first), consistent with format_error display order