### PR TITLE
ci: make Codecov upload non-blocking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,7 +250,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov-all.info,lcov-no-def.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   pr-title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is needed as the Codecov trial has expired. Hopefully a stop gap until the Codecov payments can be fixed.