### PR TITLE
fix(ohno): rollback #312

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,3 +1,4 @@
+307
 →
 0.X.Y
 100k
@@ -247,7 +248,6 @@ SLAs
 smallvec
 spawner
 startup
-std's
 stderr
 stdlib
 stdout
@@ -269,7 +269,6 @@ tdnf
 testability
 timestamp
 timestamps
-TODO
 Tokio
 Tokio's
 toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,6 @@ dependencies = [
  "futures",
  "mutants",
  "ohno_macros",
- "ptr_meta",
  "regex",
  "thiserror",
  "tokio",
@@ -1431,12 +1430,6 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "ptr_meta"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,6 @@ pin-project-lite = { version = "0.2.13", default-features = false }
 pretty_assertions = { version = "1.4.1", default-features = false }
 prettyplease = { version = "0.2.37", default-features = false }
 proc-macro2 = { version = "1.0.103", default-features = false }
-ptr_meta = { version = "0.3.1", default-features = false }
 quote = { version = "1.0.42", default-features = false }
 rapidhash = { version = "4.1.1", default-features = false }
 regex = { version = "1.12.2", default-features = false }

--- a/crates/ohno/Cargo.toml
+++ b/crates/ohno/Cargo.toml
@@ -28,7 +28,6 @@ test-util = []
 
 [dependencies]
 ohno_macros.workspace = true
-ptr_meta.workspace = true
 typeid.workspace = true
 
 [dev-dependencies]

--- a/crates/ohno/src/core.rs
+++ b/crates/ohno/src/core.rs
@@ -184,12 +184,7 @@ where
         if is_string_error(&value) {
             Self::from_source(Source::Transparent(value.into().into()))
         } else {
-            let boxed: Box<dyn StdError + Send + Sync> = value.into();
-            if is_boxed_string_error(&*boxed) {
-                Self::from_source(Source::Transparent(boxed.into()))
-            } else {
-                Self::from_source(Source::Error(boxed.into()))
-            }
+            Self::from_source(Source::Error(value.into().into()))
         }
     }
 }
@@ -203,31 +198,6 @@ const STR_TYPE_IDS: [typeid::ConstTypeId; 3] = [
 fn is_string_error<T>(_: &T) -> bool {
     let typeid_of_t = typeid::of::<T>();
     STR_TYPE_IDS.iter().any(|&id| id == typeid_of_t)
-}
-
-/// Checks at runtime whether a type-erased error is std's private `StringError`
-/// by comparing its vtable against the known `StringError` vtable.
-///
-/// This behavior is not guaranteed to be stable across Rust versions, so there might be cases where
-/// `StringError` is not detected and gets treated as a normal error source.
-///
-/// TODO: switch to [`std::ptr::metadata`](https://doc.rust-lang.org/std/ptr/fn.metadata.html) once
-/// it becomes stable: https://github.com/rust-lang/rust/issues/81513
-fn is_boxed_string_error(err: &(dyn StdError + Send + Sync + 'static)) -> bool {
-    static STRING_VTABLE: std::sync::LazyLock<ptr_meta::DynMetadata<dyn StdError + Send + Sync + 'static>> =
-        std::sync::LazyLock::new(|| {
-            let err: Box<dyn StdError + Send + Sync + 'static> = "probe".into();
-            ptr_meta::metadata(&raw const *err)
-        });
-
-    // errors constructed from `Cow` have a different vtable
-    static COW_STRING_VTABLE: std::sync::LazyLock<ptr_meta::DynMetadata<dyn StdError + Send + Sync + 'static>> =
-        std::sync::LazyLock::new(|| {
-            let err: Box<dyn StdError + Send + Sync + 'static> = Cow::Borrowed("probe").into();
-            ptr_meta::metadata(&raw const *err)
-        });
-
-    ptr_meta::metadata(err) == *STRING_VTABLE || ptr_meta::metadata(err) == *COW_STRING_VTABLE
 }
 
 /// Helper struct for formatting error messages in a consistent way.
@@ -291,55 +261,14 @@ mod tests {
         if let Source::Transparent(source) = &error.data.source {
             assert_eq!(source.to_string(), "msg");
         }
-        assert!(matches!(&error.data.source, Source::Transparent(_)), "{:?}", error.data.source);
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)] // miri does not guarantee vtable deduplication
-    #[expect(clippy::redundant_type_annotations, reason = "this test intentionally uses explicit annotations")]
-    fn from_boxed_string_error() {
-        let err: &'static str = "a boxed string error";
-        let boxed: Box<dyn StdError + Send + Sync> = err.into();
-        let error = OhnoCore::from(boxed);
-        assert!(error.source().is_none(), "{:?}", error.data.source);
-        let Source::Transparent(source) = &error.data.source else {
-            panic!("expected transparent source: found {:?}", error.data.source);
-        };
-        assert_eq!(source.to_string(), "a boxed string error");
-
-        let err: String = "a boxed owned string error".to_string();
-        let boxed: Box<dyn StdError + Send + Sync> = err.into();
-        let error = OhnoCore::from(boxed);
-        assert!(error.source().is_none(), "{:?}", error.data.source);
-        let Source::Transparent(source) = &error.data.source else {
-            panic!("expected transparent source: found {:?}", error.data.source);
-        };
-        assert_eq!(source.to_string(), "a boxed owned string error");
-
-        let err: Cow<'static, str> = Cow::Borrowed("a boxed cow string error");
-        let boxed: Box<dyn StdError + Send + Sync> = err.into();
-        let error = OhnoCore::from(boxed);
-        assert!(error.source().is_none(), "{:?}", error.data.source);
-        let Source::Transparent(source) = &error.data.source else {
-            panic!("expected transparent source: found {:?}", error.data.source);
-        };
-        assert_eq!(source.to_string(), "a boxed cow string error");
-    }
-
-    #[test]
-    fn test_from_boxed_io_error() {
-        let io_error = std::io::Error::other("io error");
-        let boxed: Box<dyn StdError + Send + Sync> = Box::new(io_error);
-        let error = OhnoCore::from(boxed);
-        assert!(matches!(error.data.source, Source::Error(_)), "{:?}", error.data.source);
-        assert!(error.source().unwrap().downcast_ref::<std::io::Error>().is_some());
+        assert!(matches!(&error.data.source, Source::Transparent(_)), "expected transparent source");
     }
 
     #[test]
     fn test_caused_by_without_backtrace() {
         let io_error = std::io::Error::other("io error");
         let error = OhnoCore::without_backtrace(io_error);
-        assert!(matches!(error.data.source, Source::Error(_)), "{:?}", error.data.source);
+        assert!(matches!(error.data.source, Source::Error(_)));
         assert!(!error.has_backtrace());
         assert!(error.source().unwrap().downcast_ref::<std::io::Error>().is_some());
     }
@@ -348,15 +277,25 @@ mod tests {
     fn test_caused_by() {
         let io_error = std::io::Error::other("io error");
         let error = OhnoCore::from(io_error);
-        assert!(matches!(error.data.source, Source::Error(_)), "{:?}", error.data.source);
+        assert!(matches!(error.data.source, Source::Error(_)));
         assert!(error.source().unwrap().downcast_ref::<std::io::Error>().is_some());
     }
+
+    #[test]
+    fn test_from_boxed_error() {
+        let io_error = std::io::Error::other("io error");
+        let boxed: Box<dyn StdError + Send + Sync> = Box::new(io_error);
+        let error = OhnoCore::from(boxed);
+        assert!(matches!(error.data.source, Source::Error(_)));
+        assert!(error.source().unwrap().downcast_ref::<std::io::Error>().is_some());
+    }
+
     #[test]
     fn test_from_boxed_error_2() {
         let io_error = std::io::Error::other("io error");
         let boxed: Box<dyn StdError + Send + Sync> = Box::new(io_error);
         let error: OhnoCore = boxed.into();
-        assert!(matches!(error.data.source, Source::Error(_)), "{:?}", error.data.source);
+        assert!(matches!(error.data.source, Source::Error(_)));
         assert!(error.source().unwrap().downcast_ref::<std::io::Error>().is_some());
     }
 
@@ -399,7 +338,7 @@ mod tests {
         let io_error = std::io::Error::other("io error");
         let boxed: Box<dyn StdError + Send + Sync> = Box::new(io_error);
         let error: OhnoCore = boxed.into();
-        assert!(matches!(error.data.source, Source::Error(_)), "{:?}", error.data.source);
+        assert!(matches!(error.data.source, Source::Error(_)));
         assert!(error.source().unwrap().downcast_ref::<std::io::Error>().is_some());
     }
 
@@ -441,25 +380,5 @@ mod tests {
         assert!(is_string_error(&Cow::Borrowed("a string slice")));
         assert!(is_string_error(&Cow::<'static, str>::Owned(String::from("a string"))));
         assert!(!is_string_error(&std::io::Error::other("an io error")));
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)] // miri does not guarantee vtable deduplication
-    #[expect(clippy::redundant_type_annotations, reason = "this test intentionally uses explicit annotations")]
-    fn is_boxed_string_error_test() {
-        let err: &'static str = "a string slice";
-        let string_err: Box<dyn StdError + Send + Sync> = err.into();
-        assert!(is_boxed_string_error(&*string_err), "{string_err:?}");
-
-        let err: String = "a string".to_string();
-        let string_err: Box<dyn StdError + Send + Sync> = err.into();
-        assert!(is_boxed_string_error(&*string_err), "{string_err:?}");
-
-        let err: Cow<'static, str> = "a cow string".into();
-        let string_err: Box<dyn StdError + Send + Sync> = err.into();
-        assert!(is_boxed_string_error(&*string_err), "{string_err:?}");
-
-        let io_err: Box<dyn StdError + Send + Sync> = Box::new(std::io::Error::other("io"));
-        assert!(!is_boxed_string_error(&*io_err), "{io_err:?}");
     }
 }

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -8,7 +8,6 @@
     expect(rustdoc::broken_intra_doc_links, reason = "AppError is only available with the 'app-err' feature")
 )]
 #![expect(clippy::doc_markdown, reason = "AppError in header doesn't look good with backticks")]
-#![forbid(unsafe_code)]
 
 //! High-quality error handling for Rust.
 //!


### PR DESCRIPTION
tests show that this workaround doesn't really work for release builds

```
failures:
    core::tests::from_boxed_string_error

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 28 filtered out; finished in 0.00s

──── STDERR:             ohno core::tests::from_boxed_string_error

thread 'core::tests::from_boxed_string_error' (8632) panicked at crates\ohno\src\core.rs:304:9:
Error("a boxed string error")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

        FAIL [   0.012s] ohno core::tests::is_boxed_string_error_test
──── STDOUT:             ohno core::tests::is_boxed_string_error_test

running 1 test
test core::tests::is_boxed_string_error_test ... FAILED
```