### PR TITLE
refactor(templated_uri): use re-exported macros instead of importing …

### DIFF
--- a/crates/templated_uri/examples/classified_templating.rs
+++ b/crates/templated_uri/examples/classified_templating.rs
@@ -4,8 +4,7 @@
 //! Example demonstrating how to use existing classification taxonomy with templated paths in `fetch`,
 
 use data_privacy::{RedactedToString, RedactionEngine, classified, taxonomy};
-use templated_uri::{BaseUri, Uri, UriParam, UriSafeString};
-use templated_uri_macros::templated;
+use templated_uri::{BaseUri, Uri, UriParam, UriSafeString, templated};
 
 // Example taxonomy for demonstration purposes
 #[taxonomy(example_taxonomy)]

--- a/crates/templated_uri/examples/uri_templating.rs
+++ b/crates/templated_uri/examples/uri_templating.rs
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 
 //! Example demonstrating the basic usage of templated URI in `fetch`
-use templated_uri::{BaseUri, Uri, UriSafeString};
-use templated_uri_macros::templated;
+use templated_uri::{BaseUri, Uri, UriSafeString, templated};
 
 #[templated(template = "/{org_id}/user/{user_id}/{item}", unredacted)]
 #[derive(Clone)]

--- a/crates/templated_uri/tests/templated_uri.rs
+++ b/crates/templated_uri/tests/templated_uri.rs
@@ -11,8 +11,7 @@ use data_privacy::simple_redactor::SimpleRedactor;
 use data_privacy::{RedactedToString, RedactionEngine, classified, taxonomy};
 #[cfg(feature = "uuid")]
 use templated_uri::uri::DATA_CLASS_UNKNOWN_URI;
-use templated_uri::{BaseUri, TemplatedPathAndQuery, Uri, UriParam, UriSafeString, UriUnsafeParam};
-use templated_uri_macros::templated;
+use templated_uri::{BaseUri, TemplatedPathAndQuery, Uri, UriParam, UriSafeString, UriUnsafeParam, templated};
 
 // Local taxonomy for testing purposes, mimicking microsoft_enterprise_data_taxonomy
 #[taxonomy(test_taxonomy)]


### PR DESCRIPTION
…macro crate directly

Update examples and tests to import `templated` from `templated_uri` instead of `templated_uri_macros`, so users don't need to depend on the macro crate directly.