### PR TITLE
feat: Support redaction suppression.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "data_privacy"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "data_privacy_macros",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cachet = { path = "crates/cachet", default-features = false, version = "0.1.0" }
 cachet_memory = { path = "crates/cachet_memory", default-features = false, version = "0.1.0" }
 cachet_service = { path = "crates/cachet_service", default-features = false, version = "0.1.0" }
 cachet_tier = { path = "crates/cachet_tier", default-features = false, version = "0.1.0" }
-data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.10.1" }
+data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.11.0" }
 data_privacy_macros = { path = "crates/data_privacy_macros", default-features = false, version = "0.9.0" }
 data_privacy_macros_impl = { path = "crates/data_privacy_macros_impl", default-features = false, version = "0.9.0" }
 fundle = { path = "crates/fundle", default-features = false, version = "0.3.0" }

--- a/crates/data_privacy/CHANGELOG.md
+++ b/crates/data_privacy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.11.0] - 2026-03-20
+
+- ✨ Features
+
+  - Support redaction suppression.
+  - Add named-field struct support and trait bounds in #[classified] ([#261](https://github.com/microsoft/oxidizer/pull/261))
+
 ## [0.10.1] - 2026-01-14
 
 - 🐛 Bug Fixes

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "data_privacy"
 description = "Data annotation and redaction system providing a robust way to manipulate sensitive information."
-version = "0.10.1"
+version = "0.11.0"
 readme = "README.md"
 keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
 categories = ["data-structures"]

--- a/crates/data_privacy/README.md
+++ b/crates/data_privacy/README.md
@@ -191,19 +191,19 @@ assert_eq!(output_buffer, "********");
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG3M_vhUtB5gFG-D1ZeP7gWyXGzaYsyQD3GO7GwPXvYMSh3Z2YWSBgmxkYXRhX3ByaXZhY3lmMC4xMC4x
- [__link0]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=Classified
- [__link1]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=Redactor
- [__link10]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=classified
- [__link11]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=taxonomy
- [__link12]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=classified
- [__link13]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactionEngine
- [__link14]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactionEngine::builder
- [__link2]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=simple_redactor::SimpleRedactor
- [__link3]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=Classified
- [__link4]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactedDebug
- [__link5]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactedDisplay
- [__link6]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=RedactedToString
- [__link7]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=taxonomy
- [__link8]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=DataClass
- [__link9]: https://docs.rs/data_privacy/0.10.1/data_privacy/?search=Classified
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG3M_vhUtB5gFG-D1ZeP7gWyXGzaYsyQD3GO7GwPXvYMSh3Z2YWSBgmxkYXRhX3ByaXZhY3lmMC4xMS4w
+ [__link0]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=Classified
+ [__link1]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=Redactor
+ [__link10]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=classified
+ [__link11]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=taxonomy
+ [__link12]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=classified
+ [__link13]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=RedactionEngine
+ [__link14]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=RedactionEngine::builder
+ [__link2]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=simple_redactor::SimpleRedactor
+ [__link3]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=Classified
+ [__link4]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=RedactedDebug
+ [__link5]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=RedactedDisplay
+ [__link6]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=RedactedToString
+ [__link7]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=taxonomy
+ [__link8]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=DataClass
+ [__link9]: https://docs.rs/data_privacy/0.11.0/data_privacy/?search=Classified

--- a/crates/data_privacy/src/lib.rs
+++ b/crates/data_privacy/src/lib.rs
@@ -187,6 +187,8 @@ mod data_class;
 mod macros;
 mod redacted;
 mod redaction_engine;
+mod redaction_engine_builder;
+mod redaction_engine_inner;
 mod redactors;
 mod sensitive;
 
@@ -194,7 +196,8 @@ pub use classified::Classified;
 pub use data_class::{DataClass, IntoDataClass};
 pub use macros::{RedactedDebug, RedactedDisplay, classified, taxonomy};
 pub use redacted::{RedactedDebug, RedactedDisplay, RedactedToString};
-pub use redaction_engine::{RedactionEngine, RedactionEngineBuilder};
+pub use redaction_engine::RedactionEngine;
+pub use redaction_engine_builder::RedactionEngineBuilder;
 #[cfg(feature = "rapidhash")]
 pub use redactors::rapidhash_redactor;
 #[cfg(feature = "xxh3")]

--- a/crates/data_privacy/src/redacted.rs
+++ b/crates/data_privacy/src/redacted.rs
@@ -17,7 +17,7 @@ pub trait RedactedDebug {
     ///
     /// # Errors
     ///
-    /// This function should return [`Err`] if, and only if, the provided [`Formatter`] returns [`Err`]. String redaction is considered an infallible operation;
+    /// This function returns [`Err`] if, and only if, the provided [`Formatter`] returns [`Err`]. String redaction is considered an infallible operation;
     /// this function only returns a [`Result`] because writing to the underlying stream might fail and it must provide a way to propagate the fact that an error
     /// has occurred back up the stack.
     fn fmt(&self, engine: &RedactionEngine, f: &mut Formatter) -> Result;
@@ -35,7 +35,7 @@ pub trait RedactedDisplay {
     ///
     /// # Errors
     ///
-    /// This function should return [`Err`] if, and only if, the provided [`Formatter`] returns [`Err`]. String redaction is considered an infallible operation;
+    /// This function returns [`Err`] if, and only if, the provided [`Formatter`] returns [`Err`]. String redaction is considered an infallible operation;
     /// this function only returns a [`Result`] because writing to the underlying stream might fail and it must provide a way to propagate the fact that an error
     /// has occurred back up the stack.
     fn fmt(&self, engine: &RedactionEngine, f: &mut Formatter) -> Result;

--- a/crates/data_privacy/src/redaction_engine.rs
+++ b/crates/data_privacy/src/redaction_engine.rs
@@ -5,9 +5,8 @@ use core::fmt::Debug;
 use std::fmt::{Display, Formatter, Write};
 use std::sync::Arc;
 
-use data_privacy::IntoDataClass;
-
-use crate::redactors::{Redactor, Redactors};
+use crate::redaction_engine_builder::RedactionEngineBuilder;
+use crate::redaction_engine_inner::RedactionEngineInner;
 use crate::{DataClass, RedactedDebug, RedactedDisplay, RedactedToString};
 
 /// Lets you apply redaction to classified data.
@@ -60,7 +59,7 @@ use crate::{DataClass, RedactedDebug, RedactedDisplay, RedactedToString};
 /// ```
 #[derive(Clone, Default)]
 pub struct RedactionEngine {
-    redactors: Arc<Redactors>,
+    inner: Arc<RedactionEngineInner>,
 }
 
 impl RedactionEngine {
@@ -71,20 +70,28 @@ impl RedactionEngine {
     }
 
     #[must_use]
-    pub(crate) fn new(mut redactors: Redactors) -> Self {
-        redactors.shrink();
-        Self {
-            redactors: Arc::new(redactors),
-        }
+    pub(crate) fn new(mut inner: RedactionEngineInner) -> Self {
+        inner.shrink();
+        Self { inner: Arc::new(inner) }
+    }
+
+    /// Returns whether redaction would take place for the given data class.
+    ///
+    /// Returns `false` only when redaction has been explicitly suppressed for this data class
+    /// via [`RedactionEngineBuilder::suppress_redaction`]. Returns `true` in all other cases,
+    /// including when no specific redactor is registered (since the fallback redactor applies).
+    #[must_use]
+    pub fn would_redact(&self, data_class: &DataClass) -> bool {
+        self.inner.would_redact(data_class)
     }
 
     /// Redacts a value implementing [`RedactedDebug`], sending the results to the output sink.
     ///
     /// # Errors
     ///
-    /// This function should return [`Err`] if, and only if, the provided [`Formatter`] returns [`Err`]. String redaction is considered an infallible operation;
-    /// this function only returns a [`std::fmt::Result`] because writing to the underlying stream might fail and it must provide a way to propagate the fact that an error
-    /// has occurred back up the stack.
+    /// This function returns [`Err`] if, and only if, writing to the provided output sink (which implements [`Write`]) returns [`Err`]. String redaction is considered an infallible operation;
+    /// this function only returns a [`std::fmt::Result`] because writing to the underlying sink might fail and it must provide a way to propagate the fact that an error
+    /// has occurred (as a [`std::fmt::Error`]) back up the stack.
     pub fn redacted_debug(&self, value: &impl RedactedDebug, output: &mut impl Write) -> core::fmt::Result {
         struct DebugFormatter<'a, RD>
         where
@@ -111,9 +118,9 @@ impl RedactionEngine {
     ///
     /// # Errors
     ///
-    /// This function should return [`Err`] if, and only if, the provided [`Formatter`] returns [`Err`]. String redaction is considered an infallible operation;
-    /// this function only returns a [`std::fmt::Result`] because writing to the underlying stream might fail and it must provide a way to propagate the fact that an error
-    /// has occurred back up the stack.
+    /// This function returns [`Err`] if, and only if, writing to the provided output sink (which implements [`Write`]) returns [`Err`]. String redaction is considered an infallible operation;
+    /// this function only returns a [`std::fmt::Result`] because writing to the underlying sink might fail and it must provide a way to propagate the fact that an error
+    /// has occurred (as a [`std::fmt::Error`]) back up the stack.
     pub fn redacted_display(&self, value: &impl RedactedDisplay, output: &mut impl Write) -> core::fmt::Result {
         struct DisplayFormatter<'a, RD>
         where
@@ -145,60 +152,25 @@ impl RedactionEngine {
     ///
     /// # Errors
     ///
-    /// This function should return [`Err`] if, and only if, the provided [`Formatter`] returns [`Err`]. String redaction is considered an infallible operation;
-    /// this function only returns a [`std::fmt::Result`] because writing to the underlying stream might fail and it must provide a way to propagate the fact that an error
-    /// has occurred back up the stack.
+    /// This function returns [`Err`] if, and only if, writing to the provided output sink (which implements [`Write`]) returns [`Err`]. String redaction is considered an infallible operation;
+    /// this function only returns a [`std::fmt::Result`] because writing to the underlying sink might fail and it must provide a way to propagate the fact that an error
+    /// has occurred (as a [`std::fmt::Error`]) back up the stack.
     pub fn redact(&self, data_class: impl AsRef<DataClass>, value: impl AsRef<str>, output: &mut impl Write) -> core::fmt::Result {
-        let redactor = self.redactors.get_or_fallback(data_class.as_ref());
-        redactor.redact(data_class.as_ref(), value.as_ref(), output)
+        let data_class_ref = data_class.as_ref();
+        let value_str = value.as_ref();
+
+        if let Some(redactor) = self.inner.resolve(data_class_ref) {
+            redactor.redact(data_class_ref, value_str, output)
+        } else {
+            // Redaction has been explicitly suppressed for this data class; pass through unmodified,
+            // bypassing both class-specific and fallback redactors.
+            output.write_str(value_str)
+        }
     }
 }
 
 impl Debug for RedactionEngine {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.redactors.fmt(f)
-    }
-}
-
-/// A builder for creating a [`RedactionEngine`].
-#[derive(Debug)]
-pub struct RedactionEngineBuilder {
-    redactors: Redactors,
-}
-
-impl RedactionEngineBuilder {
-    /// Creates a new instance of `RedactionEngineBuilder`.
-    ///
-    /// This is initialized with no registered redactors and a fallback redactor that erases the input.
-    #[must_use]
-    pub(crate) fn new() -> Self {
-        Self {
-            redactors: Redactors::default(),
-        }
-    }
-
-    /// Adds a redactor for a specific data class.
-    ///
-    /// Whenever the redaction engine encounters data of this class, it will use the provided redactor.
-    #[must_use]
-    pub fn add_class_redactor(mut self, data_class: impl IntoDataClass, redactor: impl Redactor + Send + Sync + 'static) -> Self {
-        self.redactors.insert(data_class.into_data_class(), redactor);
-        self
-    }
-
-    /// Adds a redactor that's a fallback for when there is no redactor registered for a particular
-    /// data class.
-    ///
-    /// The default fallback is to use an `ErasingRedactor`, which simply erases the original string.
-    #[must_use]
-    pub fn set_fallback_redactor(mut self, redactor: impl Redactor + Send + Sync + 'static) -> Self {
-        self.redactors.set_fallback(redactor);
-        self
-    }
-
-    /// Builds the `RedactionEngine`.
-    #[must_use]
-    pub fn build(self) -> RedactionEngine {
-        RedactionEngine::new(self.redactors)
+        self.inner.fmt(f)
     }
 }

--- a/crates/data_privacy/src/redaction_engine_builder.rs
+++ b/crates/data_privacy/src/redaction_engine_builder.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::redaction_engine_inner::RedactionEngineInner;
+use crate::{IntoDataClass, RedactionEngine, Redactor};
+
+/// A builder for creating a [`RedactionEngine`].
+#[derive(Debug)]
+pub struct RedactionEngineBuilder {
+    inner: RedactionEngineInner,
+}
+
+impl RedactionEngineBuilder {
+    /// Creates a new instance of `RedactionEngineBuilder`.
+    ///
+    /// This is initialized with no registered redactors and a fallback redactor that erases the input.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: RedactionEngineInner::default(),
+        }
+    }
+
+    /// Adds a redactor for a specific data class.
+    ///
+    /// Whenever the redaction engine encounters data of this class, it will use the provided redactor.
+    ///
+    /// If the same data class was previously suppressed or assigned a different redactor,
+    /// this call overrides that configuration (last call wins).
+    #[must_use]
+    pub fn add_class_redactor(mut self, data_class: impl IntoDataClass, redactor: impl Redactor + Send + Sync + 'static) -> Self {
+        self.inner.insert(data_class, redactor);
+        self
+    }
+
+    /// Adds a redactor that's a fallback for when there is no redactor registered for a particular
+    /// data class.
+    ///
+    /// By default, the fallback uses a [`SimpleRedactor`](crate::simple_redactor::SimpleRedactor) configured with
+    /// [`SimpleRedactorMode::Erase`](crate::simple_redactor::SimpleRedactorMode::Erase), which simply erases the original string.
+    #[must_use]
+    pub fn set_fallback_redactor(mut self, redactor: impl Redactor + Send + Sync + 'static) -> Self {
+        self.inner.set_fallback(redactor);
+        self
+    }
+
+    /// Suppresses redaction for a specific data class.
+    ///
+    /// Data of this class will pass through unmodified, bypassing both class-specific and fallback redactors.
+    ///
+    /// If the same data class was previously assigned a redactor, this call overrides
+    /// that configuration (last call wins).
+    #[must_use]
+    pub fn suppress_redaction(mut self, data_class: impl IntoDataClass) -> Self {
+        self.inner.suppress(data_class);
+        self
+    }
+
+    /// Builds the `RedactionEngine`.
+    #[must_use]
+    pub fn build(self) -> RedactionEngine {
+        RedactionEngine::new(self.inner)
+    }
+}

--- a/crates/data_privacy/src/redaction_engine_inner.rs
+++ b/crates/data_privacy/src/redaction_engine_inner.rs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use core::fmt::Debug;
+
+use rustc_hash::FxHashMap;
+
+use crate::simple_redactor::{SimpleRedactor, SimpleRedactorMode};
+use crate::{DataClass, IntoDataClass, Redactor};
+
+/// Represents the redaction policy for a specific data class.
+pub(crate) enum RedactionPolicy {
+    /// Apply the specified redactor to the data.
+    Redact(Box<dyn Redactor + Send + Sync>),
+    /// Pass through unmodified, bypassing redaction.
+    Suppressed,
+}
+
+pub(crate) struct RedactionEngineInner {
+    redactors: FxHashMap<DataClass, RedactionPolicy>,
+    fallback: Box<dyn Redactor + Send + Sync>,
+}
+
+/// Type holding all redactors registered for different data classes.
+impl RedactionEngineInner {
+    /// Returns the redactor to use for the given data class, or `None` if redaction is suppressed.
+    ///
+    /// Performs a single hash lookup. Returns `None` when the class has been explicitly suppressed,
+    /// `Some(class_redactor)` when a class-specific redactor is registered, or `Some(fallback)` otherwise.
+    #[must_use]
+    pub fn resolve(&self, data_class: &DataClass) -> Option<&(dyn Redactor + Send + Sync)> {
+        match self.redactors.get(data_class) {
+            Some(RedactionPolicy::Redact(redactor)) => Some(redactor.as_ref()),
+            Some(RedactionPolicy::Suppressed) => None,
+            None => Some(self.fallback.as_ref()),
+        }
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.redactors.len()
+    }
+
+    pub fn shrink(&mut self) {
+        self.redactors.shrink_to_fit();
+    }
+
+    pub fn insert(&mut self, data_class: impl IntoDataClass, redactor: impl Redactor + Send + Sync + 'static) {
+        self.redactors
+            .insert(data_class.into_data_class(), RedactionPolicy::Redact(Box::new(redactor)));
+    }
+
+    pub fn suppress(&mut self, data_class: impl IntoDataClass) {
+        self.redactors.insert(data_class.into_data_class(), RedactionPolicy::Suppressed);
+    }
+
+    #[must_use]
+    pub fn would_redact(&self, data_class: &DataClass) -> bool {
+        !matches!(self.redactors.get(data_class), Some(RedactionPolicy::Suppressed))
+    }
+
+    pub fn set_fallback(&mut self, redactor: impl Redactor + Send + Sync + 'static) {
+        self.fallback = Box::new(redactor);
+    }
+}
+
+impl Default for RedactionEngineInner {
+    fn default() -> Self {
+        Self {
+            redactors: FxHashMap::default(),
+            fallback: Box::new(SimpleRedactor::with_mode(SimpleRedactorMode::Erase)),
+        }
+    }
+}
+
+impl Debug for RedactionEngineInner {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_list().entries(self.redactors.keys()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use data_privacy_macros::taxonomy;
+    use rustc_hash::FxBuildHasher;
+
+    use super::*;
+
+    #[taxonomy(test)]
+    enum TestTaxonomy {
+        Sensitive,
+        Insensitive,
+    }
+
+    #[test]
+    fn test_redactor_shrink() {
+        let mut inner = RedactionEngineInner {
+            redactors: FxHashMap::with_capacity_and_hasher(42, FxBuildHasher),
+            ..Default::default()
+        };
+
+        inner.insert(
+            TestTaxonomy::Sensitive.data_class(),
+            SimpleRedactor::with_mode(SimpleRedactorMode::PassthroughAndTag),
+        );
+        inner.insert(
+            TestTaxonomy::Insensitive.data_class(),
+            SimpleRedactor::with_mode(SimpleRedactorMode::Replace('#')),
+        );
+
+        // Check initial size
+        assert_eq!(inner.len(), 2);
+        assert!(inner.redactors.capacity() >= 42, "Initial capacity should be at least 42");
+
+        // Shrink the redactors
+        inner.shrink();
+
+        // Check size after shrinking
+        assert_eq!(inner.len(), 2, "Shrink should not change the number of redactors");
+        assert!(inner.redactors.capacity() < 42, "Capacity should shrink below 42");
+    }
+
+    #[test]
+    fn test_fallback_isnt_redactor() {
+        let fallback_redactor = SimpleRedactor::with_mode(SimpleRedactorMode::Erase);
+        let mut inner = RedactionEngineInner::default();
+        inner.set_fallback(fallback_redactor);
+        assert_eq!(inner.len(), 0);
+    }
+
+    #[test]
+    fn test_suppress_marks_class_as_suppressed() {
+        let mut inner = RedactionEngineInner::default();
+        inner.suppress(TestTaxonomy::Sensitive);
+        assert_eq!(inner.len(), 1);
+        assert!(inner.resolve(&TestTaxonomy::Sensitive.data_class()).is_none());
+    }
+
+    #[test]
+    fn test_would_redact_returns_true_for_unknown_class() {
+        let inner = RedactionEngineInner::default();
+        assert!(inner.would_redact(&TestTaxonomy::Sensitive.data_class()));
+    }
+
+    #[test]
+    fn test_would_redact_returns_true_for_registered_redactor() {
+        let mut inner = RedactionEngineInner::default();
+        inner.insert(TestTaxonomy::Sensitive, SimpleRedactor::new());
+        assert!(inner.would_redact(&TestTaxonomy::Sensitive.data_class()));
+    }
+
+    #[test]
+    fn test_would_redact_returns_false_for_suppressed_class() {
+        let mut inner = RedactionEngineInner::default();
+        inner.suppress(TestTaxonomy::Sensitive);
+        assert!(!inner.would_redact(&TestTaxonomy::Sensitive.data_class()));
+    }
+}

--- a/crates/data_privacy/src/redactors/mod.rs
+++ b/crates/data_privacy/src/redactors/mod.rs
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use core::fmt::Debug;
-use std::fmt::Write;
-
-use rustc_hash::FxHashMap;
-
-use crate::simple_redactor::{SimpleRedactor, SimpleRedactorMode};
-use crate::{DataClass, IntoDataClass};
+mod redactor;
 
 pub mod simple_redactor;
 
@@ -17,73 +11,7 @@ pub mod xxh3_redactor;
 #[cfg(feature = "rapidhash")]
 pub mod rapidhash_redactor;
 
-/// Represents types that can redact data.
-pub trait Redactor {
-    /// Redacts the given value and writes the results to the given output sink.
-    ///
-    /// # Errors
-    ///
-    /// This function should return [`Err`] if, and only if, the provided [`Formatter`](std::fmt::Formatter) returns [`Err`]. String redaction is considered an infallible operation;
-    /// this function only returns a [`std::fmt::Result`] because writing to the underlying stream might fail and it must provide a way to propagate the fact that an error
-    /// has occurred back up the stack.
-    fn redact(&self, data_class: &DataClass, value: &str, output: &mut dyn Write) -> std::fmt::Result;
-}
-
-pub(crate) struct Redactors {
-    redactors: FxHashMap<DataClass, Box<dyn Redactor + Send + Sync>>,
-    fallback: Box<dyn Redactor + Send + Sync>,
-}
-
-/// Type holding all redactors registered for different data classes.
-impl Redactors {
-    #[must_use]
-    pub fn get(&self, data_class: &DataClass) -> Option<&(dyn Redactor + Send + Sync)> {
-        self.redactors.get(data_class).map(AsRef::as_ref)
-    }
-
-    #[must_use]
-    fn fallback(&self) -> &(dyn Redactor + Send + Sync) {
-        self.fallback.as_ref()
-    }
-
-    #[must_use]
-    pub fn get_or_fallback(&self, data_class: &DataClass) -> &(dyn Redactor + Send + Sync) {
-        self.get(data_class).unwrap_or_else(|| self.fallback())
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.redactors.len()
-    }
-
-    pub fn shrink(&mut self) {
-        self.redactors.shrink_to_fit();
-    }
-
-    pub fn insert(&mut self, data_class: impl IntoDataClass, redactor: impl Redactor + Send + Sync + 'static) {
-        self.redactors.insert(data_class.into_data_class(), Box::new(redactor));
-    }
-
-    pub fn set_fallback(&mut self, redactor: impl Redactor + Send + Sync + 'static) {
-        self.fallback = Box::new(redactor);
-    }
-}
-
-impl Default for Redactors {
-    fn default() -> Self {
-        Self {
-            redactors: FxHashMap::default(),
-            fallback: Box::new(SimpleRedactor::with_mode(SimpleRedactorMode::Insert("*".into()))),
-        }
-    }
-}
-
-impl Debug for Redactors {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_list().entries(self.redactors.keys()).finish()
-    }
-}
+pub use redactor::Redactor;
 
 #[cfg(any(feature = "xxh3", feature = "rapidhash"))]
 #[inline]
@@ -101,8 +29,9 @@ pub fn u64_to_hex_array<const N: usize>(mut value: u64) -> [u8; N] {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write;
+
     use data_privacy_macros::taxonomy;
-    use rustc_hash::FxBuildHasher;
 
     use super::*;
 
@@ -125,7 +54,7 @@ mod tests {
     struct TestRedactor;
 
     impl Redactor for TestRedactor {
-        fn redact(&self, _data_class: &DataClass, value: &str, output: &mut dyn Write) -> std::fmt::Result {
+        fn redact(&self, _data_class: &crate::DataClass, value: &str, output: &mut dyn Write) -> std::fmt::Result {
             write!(output, "{value}tomato")
         }
     }
@@ -133,35 +62,6 @@ mod tests {
     #[taxonomy(test)]
     enum TestTaxonomy {
         Sensitive,
-        Insensitive,
-    }
-
-    #[test]
-    fn test_redactor_shrink() {
-        let mut redactors = Redactors {
-            redactors: FxHashMap::with_capacity_and_hasher(42, FxBuildHasher),
-            ..Default::default()
-        };
-
-        redactors.insert(
-            TestTaxonomy::Sensitive.data_class(),
-            SimpleRedactor::with_mode(SimpleRedactorMode::PassthroughAndTag),
-        );
-        redactors.insert(
-            TestTaxonomy::Insensitive.data_class(),
-            SimpleRedactor::with_mode(SimpleRedactorMode::Replace('#')),
-        );
-
-        // Check initial size
-        assert_eq!(redactors.len(), 2);
-        assert!(redactors.redactors.capacity() >= 42, "Initial capacity should be at least 42");
-
-        // Shrink the redactors
-        redactors.shrink();
-
-        // Check size after shrinking
-        assert_eq!(redactors.len(), 2, "Shrink should not change the number of redactors");
-        assert!(redactors.redactors.capacity() < 42, "Capacity should shrink below 42");
     }
 
     #[test]
@@ -171,13 +71,5 @@ mod tests {
         _ = redactor.redact(&TestTaxonomy::Sensitive.data_class(), "test_value", &mut output_buffer);
 
         assert_eq!(output_buffer, "test_valuetomato");
-    }
-
-    #[test]
-    fn test_fallback_isnt_redactor() {
-        let fallback_redactor = SimpleRedactor::with_mode(SimpleRedactorMode::Erase);
-        let mut redactors = Redactors::default();
-        redactors.set_fallback(fallback_redactor);
-        assert_eq!(redactors.len(), 0);
     }
 }

--- a/crates/data_privacy/src/redactors/redactor.rs
+++ b/crates/data_privacy/src/redactors/redactor.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::fmt::Write;
+
+use crate::DataClass;
+
+/// Represents types that can redact data.
+pub trait Redactor {
+    /// Redacts the given value and writes the results to the given output sink.
+    ///
+    /// # Errors
+    ///
+    /// This function returns [`Err`] if, and only if, writing to the provided `output` sink (which implements [`Write`]) returns [`Err`]. String redaction is considered
+    /// an infallible operation; this function only returns a [`std::fmt::Result`] because writing to the underlying output sink might fail and it must provide a way to propagate
+    /// the fact that an error has occurred back up the stack.
+    fn redact(&self, data_class: &DataClass, value: &str, output: &mut dyn Write) -> std::fmt::Result;
+}

--- a/crates/data_privacy/tests/redaction_engine.rs
+++ b/crates/data_privacy/tests/redaction_engine.rs
@@ -350,10 +350,10 @@ fn test_redaction(engine: &RedactionEngine, data_class: &DataClass, input: &str,
 #[test]
 fn new_creates_builder_with_default_values() {
     let engine = RedactionEngine::builder().build();
-    test_redaction(&engine, &DataClass::new("test_taxonomy", "test_class"), "sensitive data", "*");
+    test_redaction(&engine, &DataClass::new("test_taxonomy", "test_class"), "sensitive data", "");
 
     let engine = RedactionEngine::builder().build();
-    test_redaction(&engine, &DataClass::new("test_taxonomy", "test_class"), "sensitive data", "*");
+    test_redaction(&engine, &DataClass::new("test_taxonomy", "test_class"), "sensitive data", "");
 }
 
 #[test]
@@ -372,7 +372,7 @@ fn add_multiple_class_redactors() {
 
     test_redaction(&engine, &data_class1, "sensitive data", "XX");
     test_redaction(&engine, &data_class2, "sensitive data", "YY");
-    test_redaction(&engine, &data_class3, "sensitive data", "*");
+    test_redaction(&engine, &data_class3, "sensitive data", "");
 }
 
 #[test]
@@ -420,4 +420,46 @@ fn debug_trait_implementation() {
     let default_builder = RedactionEngine::builder().build();
     let default_builder_debug_output = format!("{default_builder:?}");
     assert_eq!(default_builder_debug_output, "[]");
+}
+
+#[test]
+fn suppress_redaction_prevents_redaction_for_class() {
+    let engine = RedactionEngine::builder()
+        .add_class_redactor(TestTaxonomy::Sensitive, SimpleRedactor::new())
+        .suppress_redaction(TestTaxonomy::Insensitive)
+        .build();
+
+    assert!(engine.would_redact(&TestTaxonomy::Sensitive.data_class()));
+    assert!(!engine.would_redact(&TestTaxonomy::Insensitive.data_class()));
+}
+
+#[test]
+fn suppress_redaction_results_in_passthrough_output() {
+    let fallback_redactor = SimpleRedactor::with_mode(SimpleRedactorMode::Insert("REDACTED".into()));
+
+    let engine = RedactionEngine::builder()
+        .set_fallback_redactor(fallback_redactor)
+        .suppress_redaction(TestTaxonomy::Insensitive)
+        .build();
+
+    // For a suppressed class, redact() should not apply the fallback redactor
+    // and should instead pass through the original value unchanged.
+    test_redaction(&engine, &TestTaxonomy::Insensitive.data_class(), "sensitive data", "sensitive data");
+}
+
+#[test]
+fn would_redact_returns_true_for_unregistered_class() {
+    let engine = RedactionEngine::builder().build();
+
+    assert!(engine.would_redact(&TestTaxonomy::Sensitive.data_class()));
+}
+
+#[test]
+fn suppress_redaction_overrides_previously_added_redactor() {
+    let engine = RedactionEngine::builder()
+        .add_class_redactor(TestTaxonomy::Sensitive, SimpleRedactor::new())
+        .suppress_redaction(TestTaxonomy::Sensitive)
+        .build();
+
+    assert!(!engine.would_redact(&TestTaxonomy::Sensitive.data_class()));
 }

--- a/crates/templated_uri/src/templated.rs
+++ b/crates/templated_uri/src/templated.rs
@@ -55,6 +55,7 @@ use crate::{Uri, ValidationError};
 /// use data_privacy::{
 ///     Classified, DataClass, RedactedToString, RedactionEngine, RedactionEngineBuilder, Sensitive,
 /// };
+/// use data_privacy::simple_redactor::{SimpleRedactor, SimpleRedactorMode};
 /// use templated_uri::{TemplatedPathAndQuery, UriSafeString, templated};
 ///
 /// #[templated(template = "/{org_id}/user/{user_id}/")]
@@ -71,11 +72,14 @@ use crate::{Uri, ValidationError};
 /// };
 /// assert_eq!(user_path.to_uri_string(), "/acme/user/john_doe/");
 ///
-/// let redaction_engine = RedactionEngine::builder().build();
+/// let asterisk_redactor = SimpleRedactor::with_mode(SimpleRedactorMode::Replace('*'));
+/// let redaction_engine = RedactionEngine::builder()
+///     .set_fallback_redactor(asterisk_redactor)
+///     .build();
 ///
 /// assert_eq!(
 ///     user_path.to_redacted_string(&redaction_engine),
-///     "/acme/user/*/"
+///     "/acme/user/********/"
 /// )
 /// ```
 pub trait TemplatedPathAndQuery: RedactedDisplay + Debug + Sync + Send

--- a/crates/templated_uri/src/uri.rs
+++ b/crates/templated_uri/src/uri.rs
@@ -508,8 +508,8 @@ mod tests {
             .path_and_query(paq_without_trailing_slash.clone())
             .to_redacted_string(&redaction_engine);
         assert_eq!(
-            redacted_uri, "https://example.com/api/v1/*",
-            "redaction should replace the entire path and query with a single asterisk"
+            redacted_uri, "https://example.com/api/v1/",
+            "redaction should erase the entire path and query"
         );
 
         let redacted_uri = Uri::default()
@@ -517,19 +517,19 @@ mod tests {
             .path_and_query(paq_with_trailing_slash.clone())
             .to_redacted_string(&redaction_engine);
         assert_eq!(
-            redacted_uri, "https://example.com/api/v1/*",
-            "redaction should replace the entire path and query with a single asterisk and avoid double slashes"
+            redacted_uri, "https://example.com/api/v1/",
+            "redaction should erase the entire path and query and avoid double slashes"
         );
 
         let redacted_uri = Uri::default()
             .path_and_query(paq_without_trailing_slash)
             .to_redacted_string(&redaction_engine);
-        assert_eq!(redacted_uri, "*");
+        assert_eq!(redacted_uri, "");
 
         let redacted_uri = Uri::default()
             .path_and_query(paq_with_trailing_slash)
             .to_redacted_string(&redaction_engine);
-        assert_eq!(redacted_uri, "*");
+        assert_eq!(redacted_uri, "");
     }
 
     #[test]
@@ -546,8 +546,8 @@ mod tests {
         let mut redacted_debug = String::new();
         redaction_engine.redacted_debug(&uri, &mut redacted_debug).unwrap();
         assert_eq!(
-            redacted_debug, "https://example.com/api/v1/*",
-            "RedactedDebug should redact the path and query with asterisk"
+            redacted_debug, "https://example.com/api/v1/",
+            "RedactedDebug should erase the path and query"
         );
 
         // Test with path and query only (no base URI)
@@ -556,7 +556,7 @@ mod tests {
 
         let mut redacted_debug = String::new();
         redaction_engine.redacted_debug(&uri_no_base, &mut redacted_debug).unwrap();
-        assert_eq!(redacted_debug, "*", "RedactedDebug should redact path-only URI to asterisk");
+        assert_eq!(redacted_debug, "", "RedactedDebug should erase path-only URI");
 
         // Test with base URI only (no path and query)
         let uri_base_only = Uri::default().base_uri(base_uri);
@@ -583,7 +583,7 @@ mod tests {
         let mut redacted_debug = String::new();
         redaction_engine.redacted_debug(&uri_no_slash, &mut redacted_debug).unwrap();
         assert_eq!(
-            redacted_debug, "https://example.com/api/*",
+            redacted_debug, "https://example.com/api/",
             "RedactedDebug should handle paths without leading slash and avoid double slashes"
         );
     }


### PR DESCRIPTION
- Add RedactionEngineBuilder::suppress_redaction() to allow users to specify that redaction should be skipped for a specific data class. This would typically be used for things that are classified as public for example.

- Add RedactionEngine::would_redact() to allow users to check if a specific data class would be redacted or not. This enables fast path optimizations for non-redacted data.