### PR TITLE
chore: suppress Dependabot minor/patch version bump PRs for Cargo deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,20 @@ updates:
   commit-message:
     prefix: "chore: "
   ignore:
-    # ignore minor updates for tokio as they are semver compatible
-    - dependency-name: "tokio"
-      versions: ["1.x"]
-    # ignore patch updates for all dependencies
+    # Ignore all minor and patch updates — security updates are handled separately
+    # by Dependabot security alerts and are not affected by these ignore rules.
+    #
+    # Ideally we would use versioning-strategy: increase-if-necessary to allow
+    # minor bumps that only touch Cargo.lock (respecting Cargo's 0.x semver
+    # conventions). However, Cargo only supports "auto" and "lockfile-only" —
+    # see https://github.com/dependabot/dependabot-core/issues/4009
+    # If that issue is resolved, replace these ignore rules with:
+    #   versioning-strategy: increase-if-necessary
+    #   ignore patch updates only
     - dependency-name: "*"
-      update-types: ["version-update:semver-patch"]
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-patch"
 
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Code in this repository should follow the guidelines specified in the [Microsoft Rust Guidelines](https://microsoft.github.io/rust-guidelines/agents/all.txt).
 
+## Branching
+
+Never commit directly to `main`. Always create a feature branch, push it, and open a pull request.
+
 ## README Files
 
 Crate README files are auto-generated via `just readme`. Do not manually update them.


### PR DESCRIPTION
## Problem

Dependabot creates noisy PRs for non-major version bumps of Cargo dependencies. For example, [PR #347](https://github.com/microsoft/oxidizer/pull/347) bumped `uuid` from 1.22.0 to 1.23.0 — a minor version bump where the existing caret range `"1.21"` (meaning `>=1.21.0, <2.0.0`) already covers 1.23.0. There is no reason for Dependabot to modify `Cargo.toml` in this case.

## Solution

Ignore all `semver-minor` and `semver-patch` Cargo dependency updates. Only major version bumps and security vulnerability fixes will create PRs.

### What still creates PRs

- **Major version bumps** (e.g., `1.x` → `2.0`, `0.x` → `1.0`)
- **Security vulnerability fixes** — Dependabot security updates are a [separate system](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates) driven by GitHub Security Advisories. They are **not affected** by `ignore` rules and will continue to create PRs for any dependency with a known vulnerability.

### Known limitation: 0.x breaking changes are also suppressed

In Rust, `0.1.x` → `0.2.x` is a breaking change, but Dependabot classifies it as `semver-minor`. There is no way to configure Dependabot to understand Rust's 0.x convention.

This is a real tradeoff — 39 of 70 external dependencies (56%) are at 0.x versions. The ideal solution would be `versioning-strategy: increase-if-necessary`, which would only modify `Cargo.toml` when the current caret range doesn't cover the new version (naturally respecting Cargo's 0.x semantics). **However, Cargo only supports `auto` and `lockfile-only` for `versioning-strategy`** — see [dependabot-core#4009](https://github.com/dependabot/dependabot-core/issues/4009).

A comment is left in `dependabot.yml` linking to that issue so a future maintainer can switch to `increase-if-necessary` if/when it becomes available.

### Why we accept this tradeoff

1. **Security is still covered.** Dependabot security updates bypass ignore rules entirely.
2. **The alternative is worse.** Allowing `semver-minor` through means every minor bump for all 70 deps creates a PR — the exact problem we're solving.
3. **Major 0.x transitions still arrive.** A `0.x` → `1.0` bump is `semver-major` and still creates a PR.
4. **Awareness through other channels.** Breaking changes in actively-used 0.x crates are typically discovered through release announcements and CI breakage during routine development.

### Other changes

- Removed the `tokio`-specific ignore rule — now covered by the wildcard.
- Added a branching convention note to `AGENTS.md`: never commit directly to main.

## Testing

Configuration-only change. No code or tests affected.