### PR TITLE
feat(http_extensions)!: rename RequestHandler::execute to RequestHandler::execute_request

### DIFF
--- a/crates/http_extensions/README.md
+++ b/crates/http_extensions/README.md
@@ -139,7 +139,7 @@ impl<S: RequestHandler> Service<HttpRequest> for LoggingMiddleware<S> {
 
     async fn execute(&self, request: HttpRequest) -> Self::Out {
         println!("Processing request to: {}", request.uri());
-        let response = self.inner.execute(request).await?;
+        let response = self.inner.execute_request(request).await?;
         println!("Response status: {}", response.status());
         Ok(response)
     }
@@ -169,7 +169,7 @@ for future requests. This makes the crate particularly efficient for high-throug
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/http_extensions">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG3LPHG9fwZLvG6-sWflLbuqmGw7XLgkwT8lqG42aoC3iq2gqYWSFgmVieXRlc2YxLjExLjGCaGJ5dGVzYnVmZTAuNC4ygmRodHRwZTEuNC4wgmlodHRwX2JvZHllMS4wLjGCb2h0dHBfZXh0ZW5zaW9uc2UwLjIuMQ
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG63IEWc1GJC0G77QlPrMKvbGG8zS57JKTIvkGwgSbidtYwwRYWSFgmVieXRlc2YxLjExLjGCaGJ5dGVzYnVmZTAuNC4ygmRodHRwZTEuNC4wgmlodHRwX2JvZHllMS4wLjGCb2h0dHBfZXh0ZW5zaW9uc2UwLjIuMQ
  [__link0]: https://crates.io/crates/http/1.4.0
  [__link1]: https://docs.rs/http_extensions/0.2.1/http_extensions/type.HttpRequest.html
  [__link10]: https://docs.rs/http_extensions/0.2.1/http_extensions/?search=StatusExt

--- a/crates/http_extensions/examples/custom_server.rs
+++ b/crates/http_extensions/examples/custom_server.rs
@@ -79,7 +79,7 @@ async fn serve_with_hyper<T: RequestHandler + 'static>(service: T, body_builder:
                 let request = request.map(|incoming| map_incoming_to_http_body(incoming, &body_builder));
                 let service_cloned = Arc::clone(&service_cloned);
 
-                async move { service_cloned.execute(request).await }
+                async move { service_cloned.execute_request(request).await }
             });
 
             // Configure the hyper server connection

--- a/crates/http_extensions/src/http_request_builder.rs
+++ b/crates/http_extensions/src/http_request_builder.rs
@@ -439,7 +439,7 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
         let handler = self.request_handler;
 
         match self.build() {
-            Ok(request) => Either::Left(handler.execute(request)),
+            Ok(request) => Either::Left(handler.execute_request(request)),
             Err(err) => Either::Right(ready(Err(err))),
         }
     }

--- a/crates/http_extensions/src/lib.rs
+++ b/crates/http_extensions/src/lib.rs
@@ -148,7 +148,7 @@
 //!
 //!     async fn execute(&self, request: HttpRequest) -> Self::Out {
 //!         println!("Processing request to: {}", request.uri());
-//!         let response = self.inner.execute(request).await?;
+//!         let response = self.inner.execute_request(request).await?;
 //!         println!("Response status: {}", response.status());
 //!         Ok(response)
 //!     }

--- a/crates/http_extensions/src/request_handler.rs
+++ b/crates/http_extensions/src/request_handler.rs
@@ -34,20 +34,20 @@ use crate::{HttpRequest, HttpResponse, Result};
 ///
 ///     async fn execute(&self, request: HttpRequest) -> Self::Out {
 ///         // do some custom processing and call the inner handler
-///         self.0.execute(request).await
+///         self.0.execute_request(request).await
 ///     }
 /// }
 /// ```
 pub trait RequestHandler: Send + Sync + sealed::Sealed {
     /// Processes an HTTP request and returns a response.
-    fn execute(&self, request: HttpRequest) -> impl Future<Output = Result<HttpResponse>> + Send;
+    fn execute_request(&self, request: HttpRequest) -> impl Future<Output = Result<HttpResponse>> + Send;
 }
 
 impl<S> RequestHandler for S
 where
     S: Service<HttpRequest, Out = Result<HttpResponse>>,
 {
-    fn execute(&self, request: HttpRequest) -> impl Future<Output = S::Out> + Send {
+    fn execute_request(&self, request: HttpRequest) -> impl Future<Output = S::Out> + Send {
         Service::execute(self, request)
     }
 }

--- a/crates/http_extensions/src/request_handler.rs
+++ b/crates/http_extensions/src/request_handler.rs
@@ -22,18 +22,22 @@ use crate::{HttpRequest, HttpResponse, Result};
 ///
 /// # Examples
 ///
+/// Implement [`Service`] (not `RequestHandler` directly) to create middleware.
+/// Use `RequestHandler` as a trait bound on the inner service to constrain it
+/// to request-handler–compatible types without spelling out the full
+/// `Service<HttpRequest, Out = Result<HttpResponse>>` bound. Call
+/// [`execute_request`](RequestHandler::execute_request) to delegate:
+///
 /// ```rust
 /// # use http_extensions::{HttpRequest, HttpResponse, RequestHandler, Result};
 /// # use layered::Service;
 /// struct MyHandler<S>(S);
 ///
-/// // My handler wraps another service constrained to `RequestHandler`
-/// // and implements the `Service` trait with particular input and output types.
 /// impl<S: RequestHandler> Service<HttpRequest> for MyHandler<S> {
 ///     type Out = Result<HttpResponse>;
 ///
 ///     async fn execute(&self, request: HttpRequest) -> Self::Out {
-///         // do some custom processing and call the inner handler
+///         // Custom processing, then delegate to the inner handler.
 ///         self.0.execute_request(request).await
 ///     }
 /// }

--- a/crates/http_extensions/src/request_handler_ext.rs
+++ b/crates/http_extensions/src/request_handler_ext.rs
@@ -3,15 +3,15 @@
 
 use layered::{DynamicService, DynamicServiceExt, Service};
 
-use crate::{HttpRequest, HttpResponse, Result};
+use crate::{HttpRequest, HttpResponse, RequestHandler, Result};
 
 /// Extension trait for [`RequestHandler`][crate::RequestHandler] that provides type erasure.
-pub trait RequestHandlerExt: crate::RequestHandler + 'static {
+pub trait RequestHandlerExt: RequestHandler + 'static {
     /// Converts this handler into a type-erased [`DynamicService`].
     fn into_dynamic_service(self) -> DynamicService<HttpRequest, Result<HttpResponse>>;
 }
 
-impl<T: crate::RequestHandler + 'static> RequestHandlerExt for T {
+impl<T: RequestHandler + 'static> RequestHandlerExt for T {
     fn into_dynamic_service(self) -> DynamicService<HttpRequest, Result<HttpResponse>> {
         ServiceAdapter(self).into_dynamic()
     }
@@ -21,7 +21,7 @@ impl<T: crate::RequestHandler + 'static> RequestHandlerExt for T {
 #[derive(Debug)]
 struct ServiceAdapter<T>(T);
 
-impl<T: crate::RequestHandler> Service<HttpRequest> for ServiceAdapter<T> {
+impl<T: RequestHandler> Service<HttpRequest> for ServiceAdapter<T> {
     type Out = crate::Result<HttpResponse>;
 
     fn execute(&self, input: HttpRequest) -> impl Future<Output = Self::Out> + Send {

--- a/crates/http_extensions/src/request_handler_ext.rs
+++ b/crates/http_extensions/src/request_handler_ext.rs
@@ -25,7 +25,7 @@ impl<T: crate::RequestHandler> Service<HttpRequest> for ServiceAdapter<T> {
     type Out = crate::Result<HttpResponse>;
 
     fn execute(&self, input: HttpRequest) -> impl Future<Output = Self::Out> + Send {
-        self.0.execute(input)
+        self.0.execute_request(input)
     }
 }
 


### PR DESCRIPTION
`RequestHandler::execute` clashes with `Service::execute`

This is breaking change, but we are releasing new major version anyway.