### PR TITLE
chore(templated_uri): publish 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "templated_uri"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "data_privacy",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ohno = { path = "crates/ohno", default-features = false, version = "0.3.1" }
 ohno_macros = { path = "crates/ohno_macros", default-features = false, version = "0.3.0" }
 recoverable = { path = "crates/recoverable", default-features = false, version = "0.1.1" }
 seatbelt = { path = "crates/seatbelt", default-features = false, version = "0.4.4" }
-templated_uri = { path = "crates/templated_uri", default-features = false, version = "0.1.0" }
+templated_uri = { path = "crates/templated_uri", default-features = false, version = "0.1.1" }
 templated_uri_macros = { path = "crates/templated_uri_macros", default-features = false, version = "0.1.0" }
 templated_uri_macros_impl = { path = "crates/templated_uri_macros_impl", default-features = false, version = "0.1.0" }
 testing_aids = { path = "crates/testing_aids", default-features = false }

--- a/crates/templated_uri/CHANGELOG.md
+++ b/crates/templated_uri/CHANGELOG.md
@@ -1,1 +1,18 @@
 # Changelog
+## [0.1.1] - 2026-04-10
+
+- ✨ Features
+
+  - Support redaction suppression. ([#332](https://github.com/microsoft/oxidizer/pull/332))
+
+- 🐛 Bug Fixes
+
+  - restore const on UriSafeString::from_static ([#328](https://github.com/microsoft/oxidizer/pull/328))
+
+- 📚 Documentation
+
+  - fix BaseUri docs to reflect path prefix support ([#327](https://github.com/microsoft/oxidizer/pull/327))
+
+- ♻️ Code Refactoring
+
+  - use re-exported macros instead of importing templated_uri_macros directly ([#324](https://github.com/microsoft/oxidizer/pull/324))

--- a/crates/templated_uri/Cargo.toml
+++ b/crates/templated_uri/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "templated_uri"
 description = "Standards-compliant URI handling with templating, safety validation, and data classification"
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 keywords = ["oxidizer", "url", "parsing", "templates", "uri"]
 categories = ["encoding", "parser-implementations", "template-engine", "web-programming"]

--- a/crates/templated_uri/README.md
+++ b/crates/templated_uri/README.md
@@ -168,19 +168,19 @@ and servers based on [`hyper`][__link13] like [`reqwest`][__link14].
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEGyftk28CR_jhG9_WxkUHtfBdG9giB010pVAzGwCsTyFCPqO3YWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMS4w
- [__link0]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=uri::Uri
- [__link1]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=BaseUri
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEGyftk28CR_jhG9_WxkUHtfBdG9giB010pVAzGwCsTyFCPqO3YWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMS4x
+ [__link0]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=uri::Uri
+ [__link1]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=BaseUri
  [__link10]: https://docs.rs/http/latest/http/
- [__link11]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=uri::Uri
+ [__link11]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=uri::Uri
  [__link12]: https://docs.rs/http/1.4.0/http/?search=Uri
  [__link13]: https://docs.rs/hyper/latest/hyper/
  [__link14]: https://docs.rs/reqwest/latest/reqwest/
- [__link2]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=BasePath
- [__link3]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=TemplatedPathAndQuery
- [__link4]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=UriSafe
- [__link5]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=UriSafeString
- [__link6]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=UriSafe
- [__link7]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=UriSafeString
+ [__link2]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=BasePath
+ [__link3]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=TemplatedPathAndQuery
+ [__link4]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriSafe
+ [__link5]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriSafeString
+ [__link6]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriSafe
+ [__link7]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriSafeString
  [__link8]: https://datatracker.ietf.org/doc/html/rfc6570
- [__link9]: https://docs.rs/templated_uri/0.1.0/templated_uri/?search=UriParam
+ [__link9]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriParam


### PR DESCRIPTION
- ✨ Features

  - Support redaction suppression. ([#332](https://github.com/microsoft/oxidizer/pull/332))

- 🐛 Bug Fixes

  - restore const on UriSafeString::from_static ([#328](https://github.com/microsoft/oxidizer/pull/328))

- 📚 Documentation

  - fix BaseUri docs to reflect path prefix support ([#327](https://github.com/microsoft/oxidizer/pull/327))

- ♻️ Code Refactoring

  - use re-exported macros instead of importing templated_uri_macros directly ([#324](https://github.com/microsoft/oxidizer/pull/324))
