### PR TITLE
chore: untangle global version of ohno

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
  "data_privacy",
  "http",
  "mutants",
- "ohno 0.3.2",
+ "ohno 0.3.1",
  "pct-str",
  "serde",
  "serde_json",

--- a/crates/templated_uri/Cargo.toml
+++ b/crates/templated_uri/Cargo.toml
@@ -52,7 +52,7 @@ uuid = ["dep:uuid"]
 [dependencies]
 data_privacy.workspace = true
 http.workspace = true
-ohno.workspace = true
+ohno = "0.3.1"
 pct-str = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["std", "derive"], optional = true }
 templated_uri_macros.workspace = true


### PR DESCRIPTION
Recent release of `ohno` caused cascading issues where any crate in this workspace that depends on it need to release a new version with minor bump.

This was reflected when publishing a new version of `http_extensions` that transitively  depends on `templated_uri` which caused the following publishing error:

```
    Updating `CratesIoMirror` index
error: failed to prepare local package for uploading

Caused by:
  failed to select a version for `ohno`.
      ... required by package `templated_uri v0.1.1`
      ... which satisfies dependency `templated_uri = "^0.1.1"` of package `http_extensions v0.3.0 (D:\a\_work\1\s\crates\http_extensions)`
  versions that meet the requirements `^0.3.1` (locked to 0.3.1) are: 0.3.1

  all possible versions conflict with previously selected packages.
```

The solution is not to depend on workspace-defined version but rather keep the version fixed and only bump when necessary.