### PR TITLE
chore(templated_uri): adopt latest ohno and release new version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "templated_uri"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "data_privacy",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ohno = { path = "crates/ohno", default-features = false, version = "0.3.2" }
 ohno_macros = { path = "crates/ohno_macros", default-features = false, version = "0.3.0" }
 recoverable = { path = "crates/recoverable", default-features = false, version = "0.1.2" }
 seatbelt = { path = "crates/seatbelt", default-features = false, version = "0.4.4" }
-templated_uri = { path = "crates/templated_uri", default-features = false, version = "0.1.1" }
+templated_uri = { path = "crates/templated_uri", default-features = false, version = "0.1.2" }
 templated_uri_macros = { path = "crates/templated_uri_macros", default-features = false, version = "0.1.0" }
 templated_uri_macros_impl = { path = "crates/templated_uri_macros_impl", default-features = false, version = "0.1.0" }
 testing_aids = { path = "crates/testing_aids", default-features = false }

--- a/crates/templated_uri/CHANGELOG.md
+++ b/crates/templated_uri/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [0.1.2] - 2026-04-16
+
+- ✨ Features
+
+  - add support for `ErrorLabel` and bump `ohno` version
+
 ## [0.1.1] - 2026-04-10
 
 - ✨ Features

--- a/crates/templated_uri/Cargo.toml
+++ b/crates/templated_uri/Cargo.toml
@@ -36,6 +36,8 @@ allowed_external_types = [
     "templated_uri_macros::UriUnsafeParam",
     "ohno::enrichable::Enrichable",
     "ohno::error_ext::ErrorExt",
+    "ohno::error_label::ErrorLabel",
+    "ohno::error_label::Labeled",
     "serde_core::de::*",
     "serde_core::ser::*",
     "uuid::Uuid",

--- a/crates/templated_uri/Cargo.toml
+++ b/crates/templated_uri/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "templated_uri"
 description = "Standards-compliant URI handling with templating, safety validation, and data classification"
-version = "0.1.1"
+version = "0.1.2"
 readme = "README.md"
 keywords = ["oxidizer", "url", "parsing", "templates", "uri"]
 categories = ["encoding", "parser-implementations", "template-engine", "web-programming"]

--- a/crates/templated_uri/README.md
+++ b/crates/templated_uri/README.md
@@ -168,19 +168,19 @@ and servers based on [`hyper`][__link13] like [`reqwest`][__link14].
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEGyftk28CR_jhG9_WxkUHtfBdG9giB010pVAzGwCsTyFCPqO3YWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMS4x
- [__link0]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=uri::Uri
- [__link1]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=BaseUri
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEGyftk28CR_jhG9_WxkUHtfBdG9giB010pVAzGwCsTyFCPqO3YWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMS4y
+ [__link0]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=uri::Uri
+ [__link1]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=BaseUri
  [__link10]: https://docs.rs/http/latest/http/
- [__link11]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=uri::Uri
+ [__link11]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=uri::Uri
  [__link12]: https://docs.rs/http/1.4.0/http/?search=Uri
  [__link13]: https://docs.rs/hyper/latest/hyper/
  [__link14]: https://docs.rs/reqwest/latest/reqwest/
- [__link2]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=BasePath
- [__link3]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=TemplatedPathAndQuery
- [__link4]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriSafe
- [__link5]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriSafeString
- [__link6]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriSafe
- [__link7]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriSafeString
+ [__link2]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=BasePath
+ [__link3]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=TemplatedPathAndQuery
+ [__link4]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=UriSafe
+ [__link5]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=UriSafeString
+ [__link6]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=UriSafe
+ [__link7]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=UriSafeString
  [__link8]: https://datatracker.ietf.org/doc/html/rfc6570
- [__link9]: https://docs.rs/templated_uri/0.1.1/templated_uri/?search=UriParam
+ [__link9]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=UriParam

--- a/crates/templated_uri/src/base_uri.rs
+++ b/crates/templated_uri/src/base_uri.rs
@@ -366,7 +366,7 @@ impl BaseUri {
     /// ```
     pub fn from_http_uri(uri: &http::Uri) -> Result<Self, ValidationError> {
         let (Some(scheme), Some(authority)) = (uri.scheme(), uri.authority()) else {
-            return Err(ValidationError::caused_by("URI must have both scheme and authority components"));
+            return Err(ValidationError::invalid_uri("URI must have both scheme and authority components"));
         };
 
         // Use only the path component - query and fragment are not part of a base URI.

--- a/crates/templated_uri/src/base_uri/base_path.rs
+++ b/crates/templated_uri/src/base_uri/base_path.rs
@@ -23,10 +23,10 @@ impl BasePath {
     fn validate_path_format(&self) -> Result<(), ValidationError> {
         let path_str = self.inner.as_str();
         if self.inner.query().is_some() {
-            return Err(ValidationError::caused_by("the path must not contain a query string"));
+            return Err(ValidationError::invalid_uri("the path must not contain a query string"));
         }
         if !(path_str.starts_with('/') && path_str.ends_with('/')) {
-            return Err(ValidationError::caused_by("the path must start and end with a slash"));
+            return Err(ValidationError::invalid_uri("the path must start and end with a slash"));
         }
 
         Ok(())

--- a/crates/templated_uri/src/base_uri/origin.rs
+++ b/crates/templated_uri/src/base_uri/origin.rs
@@ -42,7 +42,7 @@ impl Origin {
 
         // Validate that the scheme is either HTTP or HTTPS
         if scheme != Scheme::HTTP && scheme != Scheme::HTTPS {
-            return Err(ValidationError::caused_by(format!(
+            return Err(ValidationError::invalid_uri(format!(
                 "unsupported scheme: {scheme}, only HTTP and HTTPS schemes are supported",
             )));
         }
@@ -132,10 +132,10 @@ impl std::str::FromStr for Origin {
     /// (missing scheme, unsupported scheme, or invalid authority).
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let uri: http::Uri = s.parse().map_err(ValidationError::from)?;
-        let scheme = uri.scheme().ok_or_else(|| ValidationError::caused_by("missing scheme"))?.clone();
+        let scheme = uri.scheme().ok_or_else(|| ValidationError::invalid_uri("missing scheme"))?.clone();
         let authority = uri
             .authority()
-            .ok_or_else(|| ValidationError::caused_by("missing authority"))?
+            .ok_or_else(|| ValidationError::invalid_uri("missing authority"))?
             .clone();
         Self::new(scheme, authority)
     }

--- a/crates/templated_uri/src/error.rs
+++ b/crates/templated_uri/src/error.rs
@@ -14,7 +14,7 @@ const LABEL_URI_HTTP_ERROR: ErrorLabel = ErrorLabel::from_static("uri_http_error
 /// This error type is returned when URI parsing or validation fails,
 /// typically due to malformed syntax or invalid URI components. It can wrap
 /// errors from the `http` crate, such as `InvalidUri` and `InvalidUriParts`,
-/// and exposes them via the `source()` method as `http::Error` when available.
+/// and exposes them via the `source()` method.
 #[ohno::error]
 #[from(http::Error(label: LABEL_URI_HTTP_ERROR))]
 #[from(InvalidUri(label: LABEL_URI_INVALID))]

--- a/crates/templated_uri/src/error.rs
+++ b/crates/templated_uri/src/error.rs
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::borrow::Cow;
+
 use http::uri::{InvalidUri, InvalidUriParts};
+use ohno::{ErrorLabel, Labeled};
+
+const LABEL_URI_INVALID: ErrorLabel = ErrorLabel::from_static("uri_invalid");
+const LABEL_URI_HTTP_ERROR: ErrorLabel = ErrorLabel::from_static("uri_http_error");
 
 /// Represents errors that occur during URI validation.
 ///
@@ -10,20 +16,22 @@ use http::uri::{InvalidUri, InvalidUriParts};
 /// errors from the `http` crate, such as `InvalidUri` and `InvalidUriParts`,
 /// and exposes them via the `source()` method as `http::Error` when available.
 #[ohno::error]
-#[from(http::Error)]
-pub struct ValidationError;
+#[from(http::Error(label: LABEL_URI_HTTP_ERROR))]
+#[from(InvalidUri(label: LABEL_URI_INVALID))]
+#[from(InvalidUriParts(label: LABEL_URI_INVALID))]
+pub struct ValidationError {
+    label: ErrorLabel,
+}
 
-/// `InvalidUri` is a flavor of `http::Error`
-impl From<InvalidUri> for ValidationError {
-    fn from(err: InvalidUri) -> Self {
-        Self::from(http::Error::from(err))
+impl ValidationError {
+    pub(crate) fn invalid_uri(message: impl Into<Cow<'static, str>>) -> Self {
+        Self::caused_by(LABEL_URI_INVALID, message.into())
     }
 }
 
-/// `InvalidUriParts` is a flavor of `http::Error`
-impl From<InvalidUriParts> for ValidationError {
-    fn from(err: InvalidUriParts) -> Self {
-        Self::from(http::Error::from(err))
+impl Labeled for ValidationError {
+    fn label(&self) -> &ErrorLabel {
+        &self.label
     }
 }
 
@@ -31,33 +39,33 @@ impl From<InvalidUriParts> for ValidationError {
 mod tests {
     use std::error::Error;
 
+    use ohno::{ErrorLabel, Labeled};
+
     use super::ValidationError;
 
     #[test]
     fn test_error_display() {
-        let error = ValidationError::caused_by("Test validation error");
+        let error = ValidationError::caused_by(ErrorLabel::from_static("test"), "Test validation error");
         let display = error.to_string();
         assert!(display.starts_with("Test validation error"), "Unexpected message: {display}");
     }
 
     #[test]
     fn test_source() {
-        let error = ValidationError::caused_by("Test validation error");
+        let error = ValidationError::caused_by(ErrorLabel::from_static("test"), "Test validation error");
         assert!(error.source().is_none());
     }
 
     #[test]
     fn test_from_invalid_uri() {
         // Create an invalid URI error
-        let invalid_uri_result = "http://[::1:invalid".parse::<http::Uri>();
-        assert!(invalid_uri_result.is_err());
-
-        let invalid_uri = invalid_uri_result.unwrap_err();
+        let invalid_uri = "http://[::1:invalid".parse::<http::Uri>().unwrap_err();
         let validation_error = ValidationError::from(invalid_uri);
 
         // Verify the error can be displayed
         let display = validation_error.to_string();
         assert!(!display.is_empty(), "Error should have a non-empty display");
+        assert_eq!(validation_error.label(), "uri_invalid");
 
         // Verify it has a source
         assert!(validation_error.source().is_some(), "Should have a source error");
@@ -76,6 +84,7 @@ mod tests {
         let display = validation_error.to_string();
         assert!(!display.is_empty(), "Error should have a non-empty display");
         assert!(validation_error.source().is_some(), "Should have a source error");
+        assert_eq!(validation_error.label(), "uri_http_error");
     }
 
     #[test]
@@ -97,5 +106,6 @@ mod tests {
         let display = validation_error.to_string();
         assert!(!display.is_empty(), "Error should have a non-empty display");
         assert!(validation_error.source().is_some(), "Should have a source error");
+        assert_eq!(validation_error.label(), "uri_invalid");
     }
 }

--- a/crates/templated_uri/src/uri.rs
+++ b/crates/templated_uri/src/uri.rs
@@ -363,7 +363,7 @@ impl TryFrom<Uri> for TargetPathAndQuery {
     fn try_from(uri: Uri) -> Result<Self, Self::Error> {
         uri.to_path_and_query()?
             .map(Self::from_path_and_query)
-            .ok_or_else(|| ValidationError::caused_by("URI does not have a path and query component"))
+            .ok_or_else(|| ValidationError::invalid_uri("URI does not have a path and query component"))
     }
 }
 
@@ -377,7 +377,7 @@ impl TryFrom<Uri> for PathAndQuery {
     type Error = ValidationError;
     fn try_from(uri: Uri) -> Result<Self, Self::Error> {
         uri.to_path_and_query()?
-            .ok_or_else(|| ValidationError::caused_by("URI does not have a path and query component"))
+            .ok_or_else(|| ValidationError::invalid_uri("URI does not have a path and query component"))
     }
 }
 


### PR DESCRIPTION
- bump `ohno` version
- support for `ErrorLabel`