### PR TITLE
fix: clock on tokio stops working after relocation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -223,6 +223,7 @@ OpenSource
 openssl-devel
 OpenTelemetry
 parameterless
+parameterized
 parser
 passthrough
 performant

--- a/crates/tick/Cargo.toml
+++ b/crates/tick/Cargo.toml
@@ -35,7 +35,10 @@ test-util = []
 # Serialization support for serde
 serde = ["dep:serde_core"]
 # Integration with tokio runtime
-tokio = ["dep:tokio"]
+tokio = ["dep:tokio", "rt-shared"]
+# Enables primitives for runtimes that drive the clock from a single shared driver task,
+# such as multi-threaded async runtimes (e.g. Tokio). Enables `InactiveClock::new_shared`.
+rt-shared = []
 # Exposes APIs for formatting of SystemTime
 fmt = ["dep:jiff"]
 

--- a/crates/tick/src/clock.rs
+++ b/crates/tick/src/clock.rs
@@ -229,13 +229,10 @@ impl Clock {
         const TIMER_RESOLUTION: Duration = Duration::from_millis(10);
 
         // The Tokio clock is driven by a single background task that advances a shared timer
-        // set. Per-core relocation would create independent timer storage on the destination
-        // thread that this driver never advances, so we construct the clock state with
-        // relocation disabled. Unlike [`InactiveClock::activate`], this does not go through the
-        // thread-per-core activation path.
-        let state = ClockState::new_system_global();
-        let clock = Self::new(state.clone());
-        let mut driver = crate::runtime::ClockDriver::new(state);
+        // set. We use the `Shared` inactive-clock variant which intentionally does not support
+        // cloning or per-core relocation, since both would create configurations the single
+        // background driver could not advance correctly.
+        let (clock, mut driver) = crate::runtime::InactiveClock::new_shared().activate();
 
         let join_handle = tokio::spawn(async move {
             loop {

--- a/crates/tick/src/clock.rs
+++ b/crates/tick/src/clock.rs
@@ -95,6 +95,12 @@ use crate::timers::TimerKey;
 ///   [`ClockControl`][crate::ClockControl] controls time for all clocks derived from it, even
 ///   across threads.
 ///
+/// - **Tokio clocks** (created via [`Clock::new_tokio()`]): Relocation is a no-op. The Tokio clock
+///   is driven by a single background task that advances a shared set of timers, so all clones
+///   share the same timer storage regardless of which thread they are on. Per-core relocation
+///   would create independent timer storage on the destination thread that the background driver
+///   does not advance, so relocation is intentionally suppressed.
+///
 /// For thread-per-core setups, the typical pattern is to clone an
 /// [`InactiveClock`][crate::runtime::InactiveClock], relocate each clone to its target thread,
 /// and then activate it. See the [`runtime`][crate::runtime] module for details.
@@ -222,7 +228,14 @@ impl Clock {
         /// background task that drives timer advancement in Tokio.
         const TIMER_RESOLUTION: Duration = Duration::from_millis(10);
 
-        let (clock, mut driver) = crate::runtime::InactiveClock::default().activate();
+        // The Tokio clock is driven by a single background task that advances a shared timer
+        // set. Per-core relocation would create independent timer storage on the destination
+        // thread that this driver never advances, so we construct the clock state with
+        // relocation disabled. Unlike [`InactiveClock::activate`], this does not go through the
+        // thread-per-core activation path.
+        let state = ClockState::new_system_global();
+        let clock = Self::new(state.clone());
+        let mut driver = crate::runtime::ClockDriver::new(state);
 
         let join_handle = tokio::spawn(async move {
             loop {
@@ -571,6 +584,16 @@ mod tests {
     #[tokio::test]
     async fn tokio_ensure_timers_advancing() {
         let clock = Clock::new_tokio();
+        clock.delay(Duration::from_millis(15)).await;
+    }
+
+    #[cfg_attr(miri, ignore)] // The logic we call talks to the real OS, which Miri cannot do.
+    #[tokio::test]
+    async fn tokio_ensure_timers_advancing_after_relocate() {
+        // Relocation must be a no-op for Tokio clocks: the background driver task drives a
+        // shared timer set, so a relocated clone must still observe timers being advanced.
+        let affinities = pinned_affinities(&[2]);
+        let clock = Clock::new_tokio().relocated(affinities[0].into(), affinities[1]);
         clock.delay(Duration::from_millis(15)).await;
     }
 

--- a/crates/tick/src/runtime/clock_driver.rs
+++ b/crates/tick/src/runtime/clock_driver.rs
@@ -21,7 +21,7 @@ pub struct ClockDriver {
 }
 
 impl ClockDriver {
-    pub(super) const fn new(state: ClockState) -> Self {
+    pub(crate) const fn new(state: ClockState) -> Self {
         Self { state }
     }
 
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn advance_timers_ok() {
-        let timers = SynchronizedTimers::new();
+        let timers = SynchronizedTimers::new_isolated();
         let when = Instant::now();
         timers.with_timers::<_, ()>(|timers| {
             timers.register(when, Waker::noop().clone());

--- a/crates/tick/src/runtime/clock_driver.rs
+++ b/crates/tick/src/runtime/clock_driver.rs
@@ -21,7 +21,7 @@ pub struct ClockDriver {
 }
 
 impl ClockDriver {
-    pub(crate) const fn new(state: ClockState) -> Self {
+    pub(super) const fn new(state: ClockState) -> Self {
         Self { state }
     }
 

--- a/crates/tick/src/runtime/inactive_clock.rs
+++ b/crates/tick/src/runtime/inactive_clock.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::marker::PhantomData;
+
 use thread_aware::ThreadAware;
 use thread_aware::affinity::{MemoryAffinity, PinnedAffinity};
 
@@ -8,11 +10,36 @@ use crate::Clock;
 use crate::runtime::clock_driver::ClockDriver;
 use crate::state::ClockState;
 
+/// Marker for an [`InactiveClock`] backed by per-core isolated timer storage.
+///
+/// This is the default mode. Clones can be relocated to different threads via
+/// [`ThreadAware::relocated`], producing independent timer storage per core. Suitable for
+/// thread-per-core runtimes.
+#[derive(Debug, Default, Clone, Copy)]
+#[non_exhaustive]
+pub struct Isolated;
+
+/// Marker for an [`InactiveClock`] backed by a single shared timer set.
+///
+/// Created via [`InactiveClock::new_shared`]. The resulting `InactiveClock<Shared>`
+/// intentionally does **not** implement [`Clone`] or [`ThreadAware`]: there is exactly one
+/// shared timer set advanced by exactly one driver, so cloning or relocation would create
+/// configurations the driver could not advance correctly.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Shared;
+
 /// An inactive clock that must be activated before time operations can be performed.
 ///
 /// This type represents a clock in an inactive state that cannot perform any time-related
-/// operations until activated. It can be safely cloned and moved across threads, making it
-/// suitable for initialization in multi-threaded environments.
+/// operations until activated. It is parameterized by a mode marker (`S`):
+///
+/// - [`Isolated`] (default) — per-core timer storage. The inactive clock can be cloned and
+///   relocated across threads, with each thread getting an independent timer set on
+///   activation.
+/// - [`Shared`] — a single shared timer set advanced by a single driver. Use
+///   [`InactiveClock::new_shared`] to construct one. Does not implement [`Clone`] or
+///   [`ThreadAware`].
 ///
 /// To begin using the clock, call [`InactiveClock::activate`] to get a working [`Clock`] instance and
 /// its associated [`ClockDriver`]. The driver is responsible for advancing timers and must
@@ -39,28 +66,57 @@ use crate::state::ClockState;
 /// [`relocate`](thread_aware::ThreadAware::relocated) each clone to its target thread before
 /// activation. Relocation creates per-core timer storage, so each thread gets an independent set
 /// of timers with no cross-thread lock contention.
-#[derive(Debug, Clone)]
-pub struct InactiveClock {
+#[derive(Debug)]
+pub struct InactiveClock<S = Isolated> {
     state: ClockState,
+    _marker: PhantomData<fn() -> S>,
 }
 
-impl Default for InactiveClock {
+impl Clone for InactiveClock<Isolated> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl Default for InactiveClock<Isolated> {
     fn default() -> Self {
         Self {
             state: ClockState::new_system(),
+            _marker: PhantomData,
         }
     }
 }
 
-impl ThreadAware for InactiveClock {
+impl ThreadAware for InactiveClock<Isolated> {
     fn relocated(self, source: MemoryAffinity, destination: PinnedAffinity) -> Self {
         Self {
             state: self.state.relocated(source, destination),
+            _marker: PhantomData,
         }
     }
 }
 
-impl InactiveClock {
+#[cfg(any(feature = "tokio", test))]
+impl InactiveClock<Shared> {
+    /// Creates an [`InactiveClock`] backed by a single shared timer set.
+    ///
+    /// The returned value is intentionally not [`Clone`] and does not implement
+    /// [`ThreadAware`]: a `Shared` clock has exactly one timer set that must be advanced by
+    /// exactly one [`ClockDriver`]. This is the construction mode used by
+    /// [`Clock::new_tokio`][crate::Clock::new_tokio].
+    #[must_use]
+    pub fn new_shared() -> Self {
+        Self {
+            state: ClockState::new_system_shared(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S> InactiveClock<S> {
     /// Activates the clock for time operations.
     ///
     /// Consumes this inactive clock and returns a working [`Clock`] instance along with
@@ -82,10 +138,11 @@ impl InactiveClock {
 }
 
 #[cfg(any(feature = "test-util", test))]
-impl From<crate::ClockControl> for InactiveClock {
+impl From<crate::ClockControl> for InactiveClock<Isolated> {
     fn from(control: crate::ClockControl) -> Self {
         Self {
             state: ClockState::ClockControl(control),
+            _marker: PhantomData,
         }
     }
 }
@@ -93,17 +150,29 @@ impl From<crate::ClockControl> for InactiveClock {
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod tests {
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+
     use super::*;
     use crate::ClockControl;
 
     #[test]
     fn assert_types() {
-        static_assertions::assert_impl_all!(InactiveClock: Send, Sync);
+        assert_impl_all!(InactiveClock: Send, Sync, Clone);
+        assert_impl_all!(InactiveClock<Shared>: Send, Sync);
+        assert_not_impl_any!(InactiveClock<Shared>: Clone);
     }
 
     #[test]
     fn activate_ok() {
         let inactive_clock = InactiveClock::default();
+        let (clock, driver) = inactive_clock.activate();
+        assert!(matches!(clock.clock_state(), ClockState::System(_)));
+        assert!(matches!(&driver.state, &ClockState::System(_)));
+    }
+
+    #[test]
+    fn activate_shared_ok() {
+        let inactive_clock = InactiveClock::new_shared();
         let (clock, driver) = inactive_clock.activate();
         assert!(matches!(clock.clock_state(), ClockState::System(_)));
         assert!(matches!(&driver.state, &ClockState::System(_)));

--- a/crates/tick/src/runtime/inactive_clock.rs
+++ b/crates/tick/src/runtime/inactive_clock.rs
@@ -34,10 +34,10 @@ pub struct Shared;
 /// This type represents a clock in an inactive state that cannot perform any time-related
 /// operations until activated. It is parameterized by a mode marker (`S`):
 ///
-/// - [`Isolated`] (default) — per-core timer storage. The inactive clock can be cloned and
+/// - [`Isolated`] (default): per-core timer storage. The inactive clock can be cloned and
 ///   relocated across threads, with each thread getting an independent timer set on
 ///   activation.
-/// - [`Shared`] — a single shared timer set advanced by a single driver. Use
+/// - [`Shared`]: a single shared timer set advanced by a single driver. Use
 ///   [`InactiveClock::new_shared`] to construct one. Does not implement [`Clone`] or
 ///   [`ThreadAware`].
 ///
@@ -99,7 +99,7 @@ impl ThreadAware for InactiveClock<Isolated> {
     }
 }
 
-#[cfg(any(feature = "tokio", test))]
+#[cfg(any(feature = "rt-shared", test))]
 impl InactiveClock<Shared> {
     /// Creates an [`InactiveClock`] backed by a single shared timer set.
     ///

--- a/crates/tick/src/runtime/mod.rs
+++ b/crates/tick/src/runtime/mod.rs
@@ -69,4 +69,4 @@ mod inactive_clock;
 
 pub use clock_driver::ClockDriver;
 pub use clock_gone::ClockGone;
-pub use inactive_clock::InactiveClock;
+pub use inactive_clock::{InactiveClock, Isolated, Shared};

--- a/crates/tick/src/state.rs
+++ b/crates/tick/src/state.rs
@@ -35,7 +35,7 @@ impl ClockState {
     /// by a single global driver task (e.g. the Tokio-driven clock created by
     /// [`Clock::new_tokio`][crate::Clock::new_tokio]). [`ThreadAware::relocated`] is a no-op for
     /// this variant.
-    #[cfg(any(feature = "tokio", test))]
+    #[cfg(any(feature = "rt-shared", test))]
     pub fn new_system_shared() -> Self {
         Self::System(SynchronizedTimers::new_shared())
     }
@@ -80,7 +80,7 @@ pub(crate) enum SynchronizedTimers {
     /// A single shared timer set. [`ThreadAware::relocated`] is a no-op, so all clones observe
     /// the same timers regardless of thread affinity. Used by clocks driven by a single global
     /// driver task (e.g. the Tokio-driven clock created by [`Clock::new_tokio`][crate::Clock::new_tokio]).
-    #[cfg(any(feature = "tokio", test))]
+    #[cfg(any(feature = "rt-shared", test))]
     Shared(std::sync::Arc<Mutex<Timers>>),
 
     /// Per-core isolated timer storage. [`ThreadAware::relocated`] creates a fresh timer set on
@@ -92,7 +92,7 @@ pub(crate) enum SynchronizedTimers {
 impl ThreadAware for SynchronizedTimers {
     fn relocated(self, source: MemoryAffinity, destination: PinnedAffinity) -> Self {
         match self {
-            #[cfg(any(feature = "tokio", test))]
+            #[cfg(any(feature = "rt-shared", test))]
             Self::Shared(_) => self,
             Self::Isolated(timers) => Self::Isolated(timers.relocated(source, destination)),
         }
@@ -104,7 +104,7 @@ impl SynchronizedTimers {
         Self::Isolated(thread_aware::Arc::new(|| Mutex::new(Timers::default())))
     }
 
-    #[cfg(any(feature = "tokio", test))]
+    #[cfg(any(feature = "rt-shared", test))]
     pub fn new_shared() -> Self {
         Self::Shared(std::sync::Arc::new(Mutex::new(Timers::default())))
     }
@@ -114,7 +114,7 @@ impl SynchronizedTimers {
         F: FnOnce(&mut Timers) -> R,
     {
         let mut timers = match self {
-            #[cfg(any(feature = "tokio", test))]
+            #[cfg(any(feature = "rt-shared", test))]
             Self::Shared(timers) => timers.lock().expect("timers lock poisoned"),
             Self::Isolated(timers) => timers.lock().expect("timers lock poisoned"),
         };
@@ -129,7 +129,7 @@ impl SynchronizedTimers {
     #[cfg_attr(test, mutants::skip)] // causes test timeout
     pub fn is_unique(&self) -> bool {
         match self {
-            #[cfg(any(feature = "tokio", test))]
+            #[cfg(any(feature = "rt-shared", test))]
             Self::Shared(timers) => std::sync::Arc::strong_count(timers) == 1,
             Self::Isolated(timers) => thread_aware::Arc::strong_count(timers) == 1,
         }

--- a/crates/tick/src/state.rs
+++ b/crates/tick/src/state.rs
@@ -31,12 +31,13 @@ impl ClockState {
         Self::System(SynchronizedTimers::new_isolated())
     }
 
-    /// Creates a `System` clock state backed by a globally shared (non-isolated) timer set.
-    /// Used by Tokio-driven clocks where a single background task drives the timers, so
-    /// [`ThreadAware::relocated`] must be a no-op.
+    /// Creates a `System` clock state backed by a single shared timer set. Used by clocks driven
+    /// by a single global driver task (e.g. the Tokio-driven clock created by
+    /// [`Clock::new_tokio`][crate::Clock::new_tokio]). [`ThreadAware::relocated`] is a no-op for
+    /// this variant.
     #[cfg(any(feature = "tokio", test))]
-    pub fn new_system_global() -> Self {
-        Self::System(SynchronizedTimers::new_global())
+    pub fn new_system_shared() -> Self {
+        Self::System(SynchronizedTimers::new_shared())
     }
 }
 
@@ -80,7 +81,7 @@ pub(crate) enum SynchronizedTimers {
     /// the same timers regardless of thread affinity. Used by clocks driven by a single global
     /// driver task (e.g. the Tokio-driven clock created by [`Clock::new_tokio`][crate::Clock::new_tokio]).
     #[cfg(any(feature = "tokio", test))]
-    Global(std::sync::Arc<Mutex<Timers>>),
+    Shared(std::sync::Arc<Mutex<Timers>>),
 
     /// Per-core isolated timer storage. [`ThreadAware::relocated`] creates a fresh timer set on
     /// the destination core, enabling thread-per-core runtimes to operate on independent timers
@@ -92,7 +93,7 @@ impl ThreadAware for SynchronizedTimers {
     fn relocated(self, source: MemoryAffinity, destination: PinnedAffinity) -> Self {
         match self {
             #[cfg(any(feature = "tokio", test))]
-            Self::Global(_) => self,
+            Self::Shared(_) => self,
             Self::Isolated(timers) => Self::Isolated(timers.relocated(source, destination)),
         }
     }
@@ -104,8 +105,8 @@ impl SynchronizedTimers {
     }
 
     #[cfg(any(feature = "tokio", test))]
-    pub fn new_global() -> Self {
-        Self::Global(std::sync::Arc::new(Mutex::new(Timers::default())))
+    pub fn new_shared() -> Self {
+        Self::Shared(std::sync::Arc::new(Mutex::new(Timers::default())))
     }
 
     pub(super) fn with_timers<F, R>(&self, f: F) -> R
@@ -114,7 +115,7 @@ impl SynchronizedTimers {
     {
         let mut timers = match self {
             #[cfg(any(feature = "tokio", test))]
-            Self::Global(timers) => timers.lock().expect("timers lock poisoned"),
+            Self::Shared(timers) => timers.lock().expect("timers lock poisoned"),
             Self::Isolated(timers) => timers.lock().expect("timers lock poisoned"),
         };
         f(&mut timers)
@@ -129,7 +130,7 @@ impl SynchronizedTimers {
     pub fn is_unique(&self) -> bool {
         match self {
             #[cfg(any(feature = "tokio", test))]
-            Self::Global(timers) => std::sync::Arc::strong_count(timers) == 1,
+            Self::Shared(timers) => std::sync::Arc::strong_count(timers) == 1,
             Self::Isolated(timers) => thread_aware::Arc::strong_count(timers) == 1,
         }
     }

--- a/crates/tick/src/state.rs
+++ b/crates/tick/src/state.rs
@@ -28,7 +28,15 @@ impl ThreadAware for ClockState {
 
 impl ClockState {
     pub fn new_system() -> Self {
-        Self::System(SynchronizedTimers::new())
+        Self::System(SynchronizedTimers::new_isolated())
+    }
+
+    /// Creates a `System` clock state backed by a globally shared (non-isolated) timer set.
+    /// Used by Tokio-driven clocks where a single background task drives the timers, so
+    /// [`ThreadAware::relocated`] must be a no-op.
+    #[cfg(any(feature = "tokio", test))]
+    pub fn new_system_global() -> Self {
+        Self::System(SynchronizedTimers::new_global())
     }
 }
 
@@ -59,44 +67,53 @@ impl ClockState {
     }
 }
 
+// The mutex here is not accessed on a hot path. Timers are accessed only when:
+//
+// 1. A new timer is registered.
+// 2. A timer is unregistered.
+// 3. Timers are evaluated. Timer evaluation is very fast when there are no timers to fire. If
+//    there are timers to fire, the time to evaluate them is proportional to the number of timers
+//    that are ready to fire, and taking the lock is not the bottleneck.
 #[derive(Debug, Clone)]
-pub(crate) struct SynchronizedTimers {
-    // The mutex here is not accessed on a hot path. Timers are accessed only when:
-    //
-    // 1. A new timer is registered.
-    // 2. A timer is unregistered.
-    // 3. Timers are evaluated. Timer evaluation is very fast when there are no timers to fire. If
-    //    there are timers to fire, the time to evaluate them is proportional to the number of timers
-    //    that are ready to fire, and taking the lock is not the bottleneck.
-    //
-    // We have performed a [benchmark](https://o365exchange.visualstudio.com/O365%20Core/_git/ox-sdk?path=/crates/tick/benches/clock_bench.rs)
-    // that compares the performance of this code by replacing the `Mutex`
-    // with `RefCell`. The `RefCell` variant is around 7% faster. In practice, in real applications,
-    // the difference is negligible. The real performance improvement comes from isolating the `Clock` to each thread.
-    // This reduces lock contention and provides linear scalability.
-    timers: thread_aware::Arc<Mutex<Timers>, PerCore>,
+pub(crate) enum SynchronizedTimers {
+    /// A single shared timer set. [`ThreadAware::relocated`] is a no-op, so all clones observe
+    /// the same timers regardless of thread affinity. Used by clocks driven by a single global
+    /// driver task (e.g. the Tokio-driven clock created by [`Clock::new_tokio`][crate::Clock::new_tokio]).
+    Global(std::sync::Arc<Mutex<Timers>>),
+
+    /// Per-core isolated timer storage. [`ThreadAware::relocated`] creates a fresh timer set on
+    /// the destination core, enabling thread-per-core runtimes to operate on independent timers
+    /// with no cross-thread lock contention.
+    Isolated(thread_aware::Arc<Mutex<Timers>, PerCore>),
 }
 
 impl ThreadAware for SynchronizedTimers {
     fn relocated(self, source: MemoryAffinity, destination: PinnedAffinity) -> Self {
-        Self {
-            timers: self.timers.relocated(source, destination),
+        match self {
+            Self::Global(_) => self,
+            Self::Isolated(timers) => Self::Isolated(timers.relocated(source, destination)),
         }
     }
 }
 
 impl SynchronizedTimers {
-    pub fn new() -> Self {
-        Self {
-            timers: thread_aware::Arc::new(|| Mutex::new(Timers::default())),
-        }
+    pub fn new_isolated() -> Self {
+        Self::Isolated(thread_aware::Arc::new(|| Mutex::new(Timers::default())))
+    }
+
+    #[cfg(any(feature = "tokio", test))]
+    pub fn new_global() -> Self {
+        Self::Global(std::sync::Arc::new(Mutex::new(Timers::default())))
     }
 
     pub(super) fn with_timers<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&mut Timers) -> R,
     {
-        let mut timers = self.timers.lock().expect("timers lock poisoned");
+        let mut timers = match self {
+            Self::Global(timers) => timers.lock().expect("timers lock poisoned"),
+            Self::Isolated(timers) => timers.lock().expect("timers lock poisoned"),
+        };
         f(&mut timers)
     }
 
@@ -107,7 +124,10 @@ impl SynchronizedTimers {
 
     #[cfg_attr(test, mutants::skip)] // causes test timeout
     pub fn is_unique(&self) -> bool {
-        thread_aware::Arc::strong_count(&self.timers) == 1
+        match self {
+            Self::Global(timers) => std::sync::Arc::strong_count(timers) == 1,
+            Self::Isolated(timers) => thread_aware::Arc::strong_count(timers) == 1,
+        }
     }
 }
 

--- a/crates/tick/src/state.rs
+++ b/crates/tick/src/state.rs
@@ -79,6 +79,7 @@ pub(crate) enum SynchronizedTimers {
     /// A single shared timer set. [`ThreadAware::relocated`] is a no-op, so all clones observe
     /// the same timers regardless of thread affinity. Used by clocks driven by a single global
     /// driver task (e.g. the Tokio-driven clock created by [`Clock::new_tokio`][crate::Clock::new_tokio]).
+    #[cfg(any(feature = "tokio", test))]
     Global(std::sync::Arc<Mutex<Timers>>),
 
     /// Per-core isolated timer storage. [`ThreadAware::relocated`] creates a fresh timer set on
@@ -90,6 +91,7 @@ pub(crate) enum SynchronizedTimers {
 impl ThreadAware for SynchronizedTimers {
     fn relocated(self, source: MemoryAffinity, destination: PinnedAffinity) -> Self {
         match self {
+            #[cfg(any(feature = "tokio", test))]
             Self::Global(_) => self,
             Self::Isolated(timers) => Self::Isolated(timers.relocated(source, destination)),
         }
@@ -111,6 +113,7 @@ impl SynchronizedTimers {
         F: FnOnce(&mut Timers) -> R,
     {
         let mut timers = match self {
+            #[cfg(any(feature = "tokio", test))]
             Self::Global(timers) => timers.lock().expect("timers lock poisoned"),
             Self::Isolated(timers) => timers.lock().expect("timers lock poisoned"),
         };
@@ -125,6 +128,7 @@ impl SynchronizedTimers {
     #[cfg_attr(test, mutants::skip)] // causes test timeout
     pub fn is_unique(&self) -> bool {
         match self {
+            #[cfg(any(feature = "tokio", test))]
             Self::Global(timers) => std::sync::Arc::strong_count(timers) == 1,
             Self::Isolated(timers) => thread_aware::Arc::strong_count(timers) == 1,
         }


### PR DESCRIPTION
found a bug when testing the clock on tokio