### PR TITLE
feat(templated_uri)!: rename unredacted macro attribute into `bypass_redaction`

### DIFF
--- a/crates/data_privacy/examples/employees/employee.rs
+++ b/crates/data_privacy/examples/employees/employee.rs
@@ -25,6 +25,6 @@ pub struct Employee {
     pub name: UserName,
     pub address: UserAddress,
     pub id: EmployeeID,
-    #[unredacted]
+    #[bypass_redaction]
     pub age: u32,
 }

--- a/crates/data_privacy/src/macros.rs
+++ b/crates/data_privacy/src/macros.rs
@@ -7,7 +7,7 @@
 /// library's [`Debug`](std::fmt::Debug) trait, but produces redacted output based on the provided [`RedactionEngine`](crate::RedactionEngine).
 /// All fields implementing [`Classified`](crate::Classified) will be automatically redacted according to the engine's policy.
 ///
-/// Fields can be marked with `#[unredacted]` to exclude them from redaction.
+/// Fields can be marked with `#[bypass_redaction]` to exclude them from redaction.
 ///
 /// # Example
 ///
@@ -25,7 +25,7 @@
 /// #[derive(RedactedDebug)]
 /// struct User {
 ///     id: UserId,
-///     #[unredacted]
+///     #[bypass_redaction]
 ///     age: u32,
 /// }
 /// ```
@@ -36,7 +36,7 @@ pub use data_privacy_macros::RedactedDebug;
 /// library's [`Display`](std::fmt::Display) trait, but produces redacted output based on the provided [`RedactionEngine`](crate::RedactionEngine).
 /// All fields implementing [`Classified`](crate::Classified) will be automatically redacted according to the engine's policy.
 ///
-/// Fields can be marked with `#[unredacted]` to exclude them from redaction.
+/// Fields can be marked with `#[bypass_redaction]` to exclude them from redaction.
 ///
 /// # Example
 ///
@@ -54,7 +54,7 @@ pub use data_privacy_macros::RedactedDebug;
 /// #[derive(RedactedDisplay)]
 /// struct User {
 ///     id: UserId,
-///     #[unredacted]
+///     #[bypass_redaction]
 ///     age: u32,
 /// }
 /// ```

--- a/crates/data_privacy/tests/macros.rs
+++ b/crates/data_privacy/tests/macros.rs
@@ -18,7 +18,7 @@ struct EMailAddress(String);
 
 #[derive(Clone, Eq, PartialEq, Hash, RedactedDisplay, RedactedDebug)]
 struct Contact {
-    #[unredacted]
+    #[bypass_redaction]
     name: String,
     email: EMailAddress,
 }

--- a/crates/data_privacy_macros/src/lib.rs
+++ b/crates/data_privacy_macros/src/lib.rs
@@ -30,7 +30,7 @@ pub fn classified(attr_args: proc_macro::TokenStream, item: proc_macro::TokenStr
 }
 
 #[expect(missing_docs, reason = "this is documented in the data_privacy reexport")]
-#[proc_macro_derive(RedactedDebug, attributes(unredacted))]
+#[proc_macro_derive(RedactedDebug, attributes(bypass_redaction))]
 #[cfg_attr(test, mutants::skip)]
 pub fn redacted_debug(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     data_privacy_macros_impl::derive::redacted_debug(input.into())
@@ -39,7 +39,7 @@ pub fn redacted_debug(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 }
 
 #[expect(missing_docs, reason = "this is documented in the data_privacy reexport")]
-#[proc_macro_derive(RedactedDisplay, attributes(unredacted))]
+#[proc_macro_derive(RedactedDisplay, attributes(bypass_redaction))]
 #[cfg_attr(test, mutants::skip)]
 pub fn redacted_display(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     data_privacy_macros_impl::derive::redacted_display(input.into())

--- a/crates/data_privacy_macros_impl/src/derive.rs
+++ b/crates/data_privacy_macros_impl/src/derive.rs
@@ -7,9 +7,9 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, Result, parse2};
 
-/// Check if a field has the `#[unredacted]` attribute
-fn is_unredacted(field: &syn::Field) -> bool {
-    field.attrs.iter().any(|attr| attr.path().is_ident("unredacted"))
+/// Check if a field has the `#[bypass_redaction]` attribute
+fn has_bypass_redaction(field: &syn::Field) -> bool {
+    field.attrs.iter().any(|attr| attr.path().is_ident("bypass_redaction"))
 }
 
 /// Derive the `RedactedDebug` trait for a struct.
@@ -29,11 +29,11 @@ pub fn redacted_debug(input: TokenStream) -> Result<TokenStream> {
                 let field_name = &field.ident;
                 let field_name_str = field_name.as_ref().unwrap().to_string();
                 let field_type = &field.ty;
-                let unredacted = is_unredacted(field);
+                let bypass_redaction = has_bypass_redaction(field);
 
                 let separator = if i == 0 { " " } else { ", " };
 
-                if unredacted {
+                if bypass_redaction {
                     quote! {
                         ::std::write!(f, "{}{}: {:?}", #separator, #field_name_str, &self.#field_name)?;
                     }
@@ -50,7 +50,7 @@ pub fn redacted_debug(input: TokenStream) -> Result<TokenStream> {
             let calls = fields.unnamed.iter().enumerate().map(|(i, field)| {
                 let field_type = &field.ty;
                 let index = syn::Index::from(i);
-                let unredacted = is_unredacted(field);
+                let bypass_redaction = has_bypass_redaction(field);
 
                 let separator = if i > 0 {
                     quote! { ::std::write!(f, ", ")?; }
@@ -58,7 +58,7 @@ pub fn redacted_debug(input: TokenStream) -> Result<TokenStream> {
                     quote! {}
                 };
 
-                let format_call = if unredacted {
+                let format_call = if bypass_redaction {
                     quote! {
                         ::std::write!(f, "{:?}", &self.#index)?;
                     }
@@ -120,11 +120,11 @@ pub fn redacted_display(input: TokenStream) -> Result<TokenStream> {
                 let field_name = &field.ident;
                 let field_name_str = field_name.as_ref().unwrap().to_string();
                 let field_type = &field.ty;
-                let unredacted = is_unredacted(field);
+                let bypass_redaction = has_bypass_redaction(field);
 
                 let separator = if i == 0 { " " } else { ", " };
 
-                if unredacted {
+                if bypass_redaction {
                     quote! {
                         ::std::write!(f, "{}{}: {}", #separator, #field_name_str, &self.#field_name)?;
                     }
@@ -141,7 +141,7 @@ pub fn redacted_display(input: TokenStream) -> Result<TokenStream> {
             let calls = fields.unnamed.iter().enumerate().map(|(i, field)| {
                 let field_type = &field.ty;
                 let index = syn::Index::from(i);
-                let unredacted = is_unredacted(field);
+                let bypass_redaction = has_bypass_redaction(field);
 
                 let separator = if i > 0 {
                     quote! { ::std::write!(f, ", ")?; }
@@ -149,7 +149,7 @@ pub fn redacted_display(input: TokenStream) -> Result<TokenStream> {
                     quote! {}
                 };
 
-                let format_call = if unredacted {
+                let format_call = if bypass_redaction {
                     quote! {
                         ::std::write!(f, "{}", &self.#index)?;
                     }

--- a/crates/data_privacy_macros_impl/tests/derive.rs
+++ b/crates/data_privacy_macros_impl/tests/derive.rs
@@ -30,7 +30,7 @@ fn redacted_debug_single() {
 #[cfg_attr(miri, ignore)]
 fn redacted_debug_multiple() {
     let input = quote! {
-        struct EmailAddress(String, #[unredacted] String);
+        struct EmailAddress(String, #[bypass_redaction] String);
     };
 
     test_derive!(input, redacted_debug);
@@ -42,7 +42,7 @@ fn redacted_debug_multiple_named() {
     let input = quote! {
         struct EmailAddress {
             x: String,
-            #[unredacted]
+            #[bypass_redaction]
             y: String
         }
     };
@@ -86,7 +86,7 @@ fn redacted_display_single() {
 #[cfg_attr(miri, ignore)]
 fn redacted_display_multiple() {
     let input = quote! {
-        struct EmailAddress(String, #[unredacted] String);
+        struct EmailAddress(String, #[bypass_redaction] String);
     };
 
     test_derive!(input, redacted_display);
@@ -98,7 +98,7 @@ fn redacted_display_multiple_named() {
     let input = quote! {
         struct EmailAddress {
             x: String,
-            #[unredacted]
+            #[bypass_redaction]
             y: String
         }
     };

--- a/crates/http_extensions/src/_documentation/recipes.rs
+++ b/crates/http_extensions/src/_documentation/recipes.rs
@@ -184,7 +184,7 @@
 //! use uuid::Uuid;
 //! use templated_uri::templated;
 //!
-//! #[templated(template = "/users/{user_id}/profile", unredacted)]
+//! #[templated(template = "/users/{user_id}/profile", bypass_redaction)]
 //! #[derive(Clone)]
 //! struct UserProfilePath {
 //!     user_id: Uuid,

--- a/crates/http_extensions/src/extensions/extensions_ext.rs
+++ b/crates/http_extensions/src/extensions/extensions_ext.rs
@@ -69,7 +69,7 @@ mod tests {
     fn returns_label_from_templated_target_path_and_query() {
         use templated_uri::{UriSafeString, templated};
 
-        #[templated(template = "/api/{user_id}/posts", label = "user_posts", unredacted)]
+        #[templated(template = "/api/{user_id}/posts", label = "user_posts", bypass_redaction)]
         #[derive(Clone)]
         struct UserPosts {
             user_id: UriSafeString,

--- a/crates/templated_uri/README.md
+++ b/crates/templated_uri/README.md
@@ -168,7 +168,7 @@ and servers based on [`hyper`][__link13] like [`reqwest`][__link14].
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEGyftk28CR_jhG9_WxkUHtfBdG9giB010pVAzGwCsTyFCPqO3YWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMS4y
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG6qPC7Eh-CJnG9oZSv9XpdZjG-MyU_Ev-xW0G3ZSzDcdsXROYWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMS4y
  [__link0]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=uri::Uri
  [__link1]: https://docs.rs/templated_uri/0.1.2/templated_uri/?search=BaseUri
  [__link10]: https://docs.rs/http/latest/http/

--- a/crates/templated_uri/README.md
+++ b/crates/templated_uri/README.md
@@ -59,7 +59,7 @@ For dynamic URIs with variable components, use the templating system:
 ```rust
 use templated_uri::{BaseUri, TemplatedPathAndQuery, Uri, UriSafeString, templated};
 
-#[templated(template = "/users/{user_id}/posts/{post_id}", unredacted)]
+#[templated(template = "/users/{user_id}/posts/{post_id}", bypass_redaction)]
 #[derive(Clone)]
 struct UserPostPath {
     user_id: u32,
@@ -111,7 +111,7 @@ use templated_uri::{UriSafeString, templated};
 #[templated(
     template = "/{org}/users/{user_id}/reports/{report_type}",
     label = "user_report",
-    unredacted
+    bypass_redaction
 )]
 struct ReportPath {
     org: UriSafeString,
@@ -132,7 +132,7 @@ use templated_uri::{UriSafeString, templated};
 #[templated(template = "/{org_id}/user/{user_id}/")]
 #[derive(Clone)]
 struct UserPath {
-    #[unredacted]
+    #[bypass_redaction]
     org_id: UriSafeString,
     user_id: Sensitive<UriSafeString>,
 }

--- a/crates/templated_uri/examples/classified_templating.rs
+++ b/crates/templated_uri/examples/classified_templating.rs
@@ -27,7 +27,7 @@ struct UserId(u32);
 struct UserPath {
     org_id: OrgId,
     user_id: UserId,
-    #[unredacted]
+    #[bypass_redaction]
     item: UriSafeString,
 }
 

--- a/crates/templated_uri/examples/uri_templating.rs
+++ b/crates/templated_uri/examples/uri_templating.rs
@@ -4,7 +4,7 @@
 //! Example demonstrating the basic usage of templated URI in `fetch`
 use templated_uri::{BaseUri, Uri, UriSafeString, templated};
 
-#[templated(template = "/{org_id}/user/{user_id}/{item}", unredacted)]
+#[templated(template = "/{org_id}/user/{user_id}/{item}", bypass_redaction)]
 #[derive(Clone)]
 struct UserPath {
     org_id: UriSafeString,

--- a/crates/templated_uri/src/lib.rs
+++ b/crates/templated_uri/src/lib.rs
@@ -51,7 +51,7 @@
 //! ```rust
 //! use templated_uri::{BaseUri, TemplatedPathAndQuery, Uri, UriSafeString, templated};
 //!
-//! #[templated(template = "/users/{user_id}/posts/{post_id}", unredacted)]
+//! #[templated(template = "/users/{user_id}/posts/{post_id}", bypass_redaction)]
 //! #[derive(Clone)]
 //! struct UserPostPath {
 //!     user_id: u32,
@@ -103,7 +103,7 @@
 //! #[templated(
 //!     template = "/{org}/users/{user_id}/reports/{report_type}",
 //!     label = "user_report",
-//!     unredacted
+//!     bypass_redaction
 //! )]
 //! struct ReportPath {
 //!     org: UriSafeString,
@@ -124,7 +124,7 @@
 //! #[templated(template = "/{org_id}/user/{user_id}/")]
 //! #[derive(Clone)]
 //! struct UserPath {
-//!     #[unredacted]
+//!     #[bypass_redaction]
 //!     org_id: UriSafeString,
 //!     user_id: Sensitive<UriSafeString>,
 //! }

--- a/crates/templated_uri/src/macros.rs
+++ b/crates/templated_uri/src/macros.rs
@@ -59,7 +59,7 @@ pub use templated_uri_macros::UriUnsafeParam;
 ///
 /// ```
 /// # use templated_uri::templated;
-/// #[templated(template = "/topic/{topic_id}", unredacted)]
+/// #[templated(template = "/topic/{topic_id}", bypass_redaction)]
 /// struct ListTopics {
 ///     topic_id: u32,
 /// }
@@ -76,15 +76,15 @@ pub use templated_uri_macros::UriUnsafeParam;
 /// ## Data Privacy
 ///
 /// By default, all fields use `RedactedDisplay` for privacy protection. Use attributes to control:
-/// - `#[templated(template = "...", unredacted)]`: Disable redaction for all fields
-/// - `#[unredacted]`: Disable redaction for a specific field
+/// - `#[templated(template = "...", bypass_redaction)]`: Disable redaction for all fields
+/// - `#[bypass_redaction]`: Disable redaction for a specific field
 ///
 /// ```ignore
 /// # use templated_uri::{templated, UriSafeString};
 /// #[templated(template = "/{org_id}/product/{product_id}")]
 /// struct ProductPath {
 ///     org_id: OrgId,           // Will be redacted
-///     #[unredacted]
+///     #[bypass_redaction]
 ///     product_id: UriSafeString, // Will NOT be redacted
 /// }
 /// ```

--- a/crates/templated_uri/src/templated.rs
+++ b/crates/templated_uri/src/templated.rs
@@ -30,7 +30,7 @@ use crate::{Uri, ValidationError};
 /// ```
 /// use templated_uri::{TemplatedPathAndQuery, UriSafeString, templated};
 ///
-/// #[templated(template = "/{org_id}/user/{user_id}/", unredacted)]
+/// #[templated(template = "/{org_id}/user/{user_id}/", bypass_redaction)]
 /// #[derive(Clone)]
 /// struct UserPath {
 ///     org_id: UriSafeString,
@@ -61,7 +61,7 @@ use crate::{Uri, ValidationError};
 /// #[templated(template = "/{org_id}/user/{user_id}/")]
 /// #[derive(Clone)]
 /// struct UserPath {
-///     #[unredacted]
+///     #[bypass_redaction]
 ///     org_id: UriSafeString,
 ///     user_id: Sensitive<UriSafeString>,
 /// }

--- a/crates/templated_uri/src/uri.rs
+++ b/crates/templated_uri/src/uri.rs
@@ -37,7 +37,7 @@ pub const DATA_CLASS_UNKNOWN_URI: DataClass = DataClass::new(env!("CARGO_PKG_NAM
 /// ```
 /// use templated_uri::{BaseUri, Uri, templated};
 ///
-/// #[templated(template = "/example.com/{param}", unredacted)]
+/// #[templated(template = "/example.com/{param}", bypass_redaction)]
 /// #[derive(Clone)]
 /// struct MyTemplate {
 ///     param: usize,

--- a/crates/templated_uri/tests/templated_uri.rs
+++ b/crates/templated_uri/tests/templated_uri.rs
@@ -36,7 +36,7 @@ struct UserId(UriSafeString);
 #[derive(Clone, UriUnsafeParam)]
 struct PathFragment(String);
 
-#[templated(template = "/{+param}{/param2,param3}{?q1,q2}", unredacted)]
+#[templated(template = "/{+param}{/param2,param3}{?q1,q2}", bypass_redaction)]
 #[derive(Clone)]
 struct PathAndQueryTemplate {
     param: String,
@@ -159,7 +159,7 @@ fn test_uri_taxonomy() {
     );
 }
 
-#[templated(template = "/{org_id}/user/{user_id}/", unredacted)]
+#[templated(template = "/{org_id}/user/{user_id}/", bypass_redaction)]
 #[derive(Clone)]
 struct UserPath {
     org_id: OrgId,
@@ -189,7 +189,7 @@ impl UriUnsafeParam for Action {
     }
 }
 
-#[templated(template = "/{org_id}/user/{user_id}/{+action}/", unredacted)]
+#[templated(template = "/{org_id}/user/{user_id}/{+action}/", bypass_redaction)]
 #[derive(Clone)]
 struct UserActionPath {
     org_id: OrgId,
@@ -242,12 +242,12 @@ fn template_enum() {
 #[derive(Clone)]
 struct MixedRedactionPath {
     org_id: OrgId,
-    #[unredacted]
+    #[bypass_redaction]
     product_id: UriSafeString,
 }
 
 #[test]
-fn test_field_level_unredacted() {
+fn test_field_level_bypass_redaction() {
     let path = MixedRedactionPath {
         org_id: OrgId(UriSafeString::from_static("Acme")),
         product_id: UriSafeString::from_static("product-123"),
@@ -257,11 +257,11 @@ fn test_field_level_unredacted() {
 
     let redaction_engine = RedactionEngine::builder().set_fallback_redactor(SimpleRedactor::new()).build();
 
-    // The org_id should be redacted (classified), but product_id should not (marked as unredacted)
+    // The org_id should be redacted (classified), but product_id should not (marked as bypass_redaction)
     assert_eq!(
         path.to_redacted_string(&redaction_engine),
         "/****/product/product-123/",
-        "Field-level unredacted attribute should prevent redaction for that field only"
+        "Field-level bypass_redaction attribute should prevent redaction for that field only"
     );
 }
 
@@ -269,9 +269,9 @@ fn test_field_level_unredacted() {
 #[derive(Clone)]
 struct SearchPath {
     org_id: OrgId,
-    #[unredacted]
+    #[bypass_redaction]
     query: UriSafeString,
-    #[unredacted]
+    #[bypass_redaction]
     limit: u32,
 }
 
@@ -299,7 +299,7 @@ fn test_redacted_query_params() {
 #[templated(
     template = "/{org_id}/user/{user_id}/reports/{report_type}/{year}/{month}",
     label = "user_monthly_report",
-    unredacted
+    bypass_redaction
 )]
 struct ComplexReportPath {
     org_id: UriSafeString,
@@ -309,7 +309,7 @@ struct ComplexReportPath {
     month: u32,
 }
 
-#[templated(template = "/simple/{id}", unredacted)]
+#[templated(template = "/simple/{id}", bypass_redaction)]
 struct SimplePath {
     id: UriSafeString,
 }
@@ -380,7 +380,7 @@ fn test_target_path_and_query_from_templated() {
 
     use templated_uri::uri::TargetPathAndQuery;
 
-    #[templated(template = "/api/{user_id}/posts", label = "user_posts", unredacted)]
+    #[templated(template = "/api/{user_id}/posts", label = "user_posts", bypass_redaction)]
     #[derive(Clone)]
     struct UserPosts {
         user_id: UriSafeString,
@@ -405,7 +405,7 @@ fn test_target_path_and_query_from_templated() {
     let path_and_query = target_paq.to_path_and_query().unwrap();
     assert_eq!(path_and_query.to_string(), "/api/123/posts");
 
-    // Verify redacted string (unredacted because of unredacted attribute)
+    // Verify redacted string (bypass_redaction because of bypass_redaction attribute)
     let redaction_engine = RedactionEngine::builder().build();
     assert_eq!(target_paq.to_uri_string_redacted(&redaction_engine), "/api/123/posts");
 

--- a/crates/templated_uri/tests/ui/string_in_restricted_position.rs
+++ b/crates/templated_uri/tests/ui/string_in_restricted_position.rs
@@ -6,7 +6,7 @@
 
 use templated_uri::templated;
 
-#[templated(template = "/users/{user_id}", unredacted)]
+#[templated(template = "/users/{user_id}", bypass_redaction)]
 #[derive(Clone)]
 struct UserPath {
     user_id: String,

--- a/crates/templated_uri_macros_impl/src/lib.rs
+++ b/crates/templated_uri_macros_impl/src/lib.rs
@@ -88,7 +88,7 @@ fn filter_original(input: &DeriveInput) -> TokenStream {
 
     match &input.data {
         syn::Data::Struct(s) => {
-            // Filter out templated and unredacted attributes from fields
+            // Filter out templated and bypass_redaction attributes from fields
             let filtered_fields = match &s.fields {
                 syn::Fields::Named(fields) => {
                     let fields: Vec<_> = fields
@@ -112,7 +112,7 @@ fn filter_original(input: &DeriveInput) -> TokenStream {
                             let attrs: Vec<_> = f
                                 .attrs
                                 .iter()
-                                .filter(|attr| !attr.path().is_ident("templated") && !attr.path().is_ident("unredacted"))
+                                .filter(|attr| !attr.path().is_ident("templated") && !attr.path().is_ident("bypass_redaction"))
                                 .collect();
                             let vis = &f.vis;
                             let ty = &f.ty;
@@ -167,7 +167,7 @@ fn filter_attributes(f: &Field) -> Vec<&Attribute> {
     let attrs: Vec<_> = f
         .attrs
         .iter()
-        .filter(|attr| !attr.path().is_ident("templated") && !attr.path().is_ident("unredacted"))
+        .filter(|attr| !attr.path().is_ident("templated") && !attr.path().is_ident("bypass_redaction"))
         .collect();
     attrs
 }
@@ -303,8 +303,8 @@ mod tests {
     }
 
     #[test]
-    fn test_templated_unredacted_uri_impl() {
-        let attr = quote! { template="/example.com/{param}/{+param2}{/param3,param4}", unredacted };
+    fn test_templated_bypass_redaction_uri_impl() {
+        let attr = quote! { template="/example.com/{param}/{+param2}{/param3,param4}", bypass_redaction };
         let item = quote! {
             struct Test {
                 // #[templated(classify=Public)]
@@ -387,12 +387,12 @@ mod tests {
     }
 
     #[test]
-    fn test_field_level_unredacted() {
+    fn test_field_level_bypass_redaction() {
         let attr = quote! { template="/example.com/{param}/{+param2}{/param3,param4}" };
         let item = quote! {
             struct Test {
                 param: String,
-                #[templated(unredacted)]
+                #[templated(bypass_redaction)]
                 param2: UriSafeString,
                 param3: String,
                 param4: String
@@ -469,12 +469,12 @@ mod tests {
     }
 
     #[test]
-    fn test_standalone_unredacted() {
+    fn test_standalone_bypass_redaction() {
         let attr = quote! { template="/example.com/{param}/{+param2}{/param3,param4}" };
         let item = quote! {
             struct Test {
                 param: String,
-                #[unredacted]
+                #[bypass_redaction]
                 param2: UriSafeString,
                 param3: String,
                 param4: String
@@ -1127,18 +1127,18 @@ mod tests {
     fn test_filter_attributes() {
         use syn::Field;
 
-        // Create a field with multiple attributes including templated and unredacted
+        // Create a field with multiple attributes including templated and bypass_redaction
         let field: Field = syn::parse_quote! {
             #[serde(rename = "test")]
-            #[templated(unredacted)]
-            #[unredacted]
+            #[templated(bypass_redaction)]
+            #[bypass_redaction]
             #[doc = "Test field"]
             pub test_field: String
         };
 
         let filtered = super::filter_attributes(&field);
 
-        // Should only keep serde and doc attributes, filtering out templated and unredacted
+        // Should only keep serde and doc attributes, filtering out templated and bypass_redaction
         assert_eq!(filtered.len(), 2);
         assert!(filtered[0].path().is_ident("serde"));
         assert!(filtered[1].path().is_ident("doc"));
@@ -1184,15 +1184,15 @@ mod tests {
     fn test_filter_original_unnamed_fields() {
         use syn::DeriveInput;
 
-        // Create a tuple struct with various attributes including templated and unredacted
+        // Create a tuple struct with various attributes including templated and bypass_redaction
         let input: DeriveInput = syn::parse_quote! {
             #[derive(Debug, Clone)]
             #[templated(template = "/test")]
             pub struct TestTuple(
                 #[serde(rename = "field1")]
-                #[templated(unredacted)]
+                #[templated(bypass_redaction)]
                 pub String,
-                #[unredacted]
+                #[bypass_redaction]
                 #[doc = "Field 2"]
                 pub i32,
                 pub u64
@@ -1212,12 +1212,12 @@ mod tests {
             "Output should not contain templated: {filtered_str}"
         );
 
-        // Should keep serde and doc attributes, but filter out templated and unredacted from fields
+        // Should keep serde and doc attributes, but filter out templated and bypass_redaction from fields
         assert!(filtered_str.contains("serde"), "Output should contain serde: {filtered_str}");
         assert!(filtered_str.contains("doc"), "Output should contain doc: {filtered_str}");
         assert!(
-            !filtered_str.contains("unredacted"),
-            "Output should not contain unredacted: {filtered_str}"
+            !filtered_str.contains("bypass_redaction"),
+            "Output should not contain bypass_redaction: {filtered_str}"
         );
 
         // Should maintain structure as tuple struct

--- a/crates/templated_uri_macros_impl/src/struct_template.rs
+++ b/crates/templated_uri_macros_impl/src/struct_template.rs
@@ -23,7 +23,7 @@ pub struct Opts {
     #[darling(rename = "template")]
     pub input_template: String,
     #[darling(default)]
-    pub unredacted: bool,
+    pub bypass_redaction: bool,
     /// Optional label for telemetry. When provided, this label is used in metrics
     /// instead of the full template string, which is useful for complex templates.
     #[darling(default)]
@@ -35,7 +35,7 @@ pub struct Opts {
 pub struct FieldOpts {
     pub ident: Option<Ident>,
     #[darling(default)]
-    pub unredacted: bool,
+    pub bypass_redaction: bool,
 }
 
 /// Represents the fields of a struct with their options parsed from attributes.
@@ -50,9 +50,9 @@ impl Fields {
             .iter()
             .map(|&f| {
                 let mut opts = FieldOpts::from_field(f)?;
-                // Also check for standalone #[unredacted] attribute
-                if !opts.unredacted {
-                    opts.unredacted = f.attrs.iter().any(|attr| attr.path().is_ident("unredacted"));
+                // Also check for standalone #[bypass_redaction] attribute
+                if !opts.bypass_redaction {
+                    opts.bypass_redaction = f.attrs.iter().any(|attr| attr.path().is_ident("bypass_redaction"));
                 }
                 Ok(opts)
             })
@@ -69,7 +69,7 @@ impl Fields {
     }
 }
 
-// #[proc_macro_derive(TemplatedPathAndQuery, attributes(templated, unredacted))]
+// #[proc_macro_derive(TemplatedPathAndQuery, attributes(templated, bypass_redaction))]
 pub fn struct_template(ident: Ident, data: &DataStruct, attrs: &[Attribute]) -> TokenStream {
     if !matches!(data.fields, syn::Fields::Named(_)) {
         crate::bail!(ident, "#[templated] can only be applied to structs with named fields");
@@ -79,7 +79,7 @@ pub fn struct_template(ident: Ident, data: &DataStruct, attrs: &[Attribute]) -> 
     let struct_name = ident.to_string();
     let Opts {
         input_template,
-        unredacted,
+        bypass_redaction,
         label,
     } = match Opts::from_attributes(attrs) {
         Ok(opts) => opts,
@@ -146,7 +146,7 @@ pub fn struct_template(ident: Ident, data: &DataStruct, attrs: &[Attribute]) -> 
         })
         .collect();
 
-    let redacted_display = construct_redacted_display(&template, &struct_fields, &fields, unredacted);
+    let redacted_display = construct_redacted_display(&template, &struct_fields, &fields, bypass_redaction);
 
     let label_impl = label.as_ref().map_or_else(
         || quote! { ::core::option::Option::None },
@@ -201,14 +201,14 @@ pub fn struct_template(ident: Ident, data: &DataStruct, attrs: &[Attribute]) -> 
     }
 }
 
-fn construct_redacted_display(template: &UriTemplate, struct_fields: &[&Field], fields: &Fields, unredacted: bool) -> TokenStream {
+fn construct_redacted_display(template: &UriTemplate, struct_fields: &[&Field], fields: &Fields, bypass_redaction: bool) -> TokenStream {
     // Build a map from field name to field for lookup
     let field_map: std::collections::HashMap<String, &Field> = struct_fields
         .iter()
         .filter_map(|f| f.ident.as_ref().map(|ident| (ident.to_string(), *f)))
         .collect();
 
-    // Build a map from field name to field options for checking unredacted attribute
+    // Build a map from field name to field options for checking bypass_redaction attribute
     let field_opts_map: std::collections::HashMap<String, &FieldOpts> = fields
         .fields
         .iter()
@@ -247,10 +247,10 @@ fn construct_redacted_display(template: &UriTemplate, struct_fields: &[&Field], 
                     let field_ident = field.ident.as_ref().expect("struct fields must be named");
                     let field_type = &field.ty;
 
-                    // Check if this specific field is marked as unredacted
-                    let field_unredacted = field_opts_map.get(*param_name).is_some_and(|opts| opts.unredacted);
+                    // Check if this specific field is marked as bypass_redaction
+                    let field_bypass_redaction = field_opts_map.get(*param_name).is_some_and(|opts| opts.bypass_redaction);
 
-                    if unredacted || field_unredacted {
+                    if bypass_redaction || field_bypass_redaction {
                         stmts.push(quote! {
                             ::std::write!(f, "{}", self.#field_ident)?;
                         });


### PR DESCRIPTION
Renames the redaction-suppression attribute from `#[unredacted]` / `unredacted` to `#[bypass_redaction]` / `bypass_redaction` across the `templated_uri` macro API.

The new name is intentionally more explicit and slightly more "annoying" to type. This is by design: bypassing redaction is a deliberate, security-relevant choice that should stand out at the call site and prompt the author to think twice before using it. `unredacted` reads as a passive description of state; `bypass_redaction` reads as an active decision.

## Migration

```rust
// Before
#[templated(template = "/{org_id}/user/{user_id}/", unredacted)]
struct UserPath { ... }

// After
#[templated(template = "/{org_id}/user/{user_id}/", bypass_redaction)]
struct UserPath { ... }
```