### PR TITLE
ci: switch wild linker to wild-linker/action@0.8.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -113,4 +113,4 @@ runs:
 
     - name: Install Wild Linker
       if: inputs.enable-wild-linker == 'true'
-      uses: davidlattimore/wild-action@0.7.0
+      uses: wild-linker/action@0.8.0


### PR DESCRIPTION
The action moved from davidlattimore/wild-action to the wild-linker org (see https://github.com/wild-linker/action). Pin to 0.8.0.