### PR TITLE
fix(thread_aware): Move source registration up so we prevent race condition

### DIFF
--- a/crates/thread_aware/src/cell/mod.rs
+++ b/crates/thread_aware/src/cell/mod.rs
@@ -490,6 +490,12 @@ impl<T, S: Strategy> ThreadAware for Arc<T, S> {
     fn relocated(self, source: MemoryAffinity, destination: PinnedAffinity) -> Self {
         let mut guard = self.storage.write().expect("Failed to acquire write lock");
 
+        if let MemoryAffinity::Pinned(source) = source {
+        if guard.get_clone(source).is_none() {
+            guard.replace(source, sync::Arc::clone(&self.value));
+        }
+    }
+
         let (value, new_factory) = if let Some(value) = guard.get_clone(destination) {
             (value, self.factory)
         } else {
@@ -530,15 +536,6 @@ impl<T, S: Strategy> ThreadAware for Arc<T, S> {
 
             (value, factory)
         };
-
-        if let MemoryAffinity::Pinned(source) = source {
-            // Only restore the value to the source slot when source and destination differ.
-            // If they are the same slot, the replacement above already stored the new value
-            // there; overwriting it here would corrupt storage with the stale pre-relocation value.
-            if source != destination {
-                guard.replace(source, self.value);
-            }
-        }
 
         drop(guard);
 

--- a/crates/thread_aware/src/cell/tests.rs
+++ b/crates/thread_aware/src/cell/tests.rs
@@ -488,3 +488,23 @@ fn test_relocated_source_equals_destination_does_not_corrupt_storage() {
         "subsequent relocation must not see stale pre-relocation value from storage"
     );
 }
+
+#[test]
+fn factory_runs_once_per_affinity_when_source_eq_destination() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static CALLS: AtomicUsize = AtomicUsize::new(0);
+    let arc = PerCore::new(|| {
+        CALLS.fetch_add(1, Ordering::Relaxed);
+        0u32
+    });
+    assert_eq!(CALLS.load(Ordering::Relaxed), 1);
+
+    let here = pinned_affinities(&[1])[0];
+    let _ = arc.clone().relocated(here.into(), here);
+    let _ = arc.clone().relocated(here.into(), here);
+
+    // Without the fix this is 3 (factory re-runs each time source slot is empty
+    // at destination-lookup time).
+    assert_eq!(CALLS.load(Ordering::Relaxed), 1);
+}


### PR DESCRIPTION
This prevents a race condition when source equals destination.