### PR TITLE
feat(templated_uri): support Option<T> fields for RFC 6570 undefined …

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -369,3 +369,4 @@ infallible
 unescaped
 spawners
 unlayered
+UFCS

--- a/crates/templated_uri/CHANGELOG.md
+++ b/crates/templated_uri/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- ✨ Features
+
+  - Support `Option<T>` fields in `#[templated]` structs for RFC 6570 undefined variable semantics. When a field is `None`, it is omitted from the rendered URI, including any associated prefix or separator.
+
 ## [0.2.0] - 2026-05-11
 
 - ⚠️ Breaking

--- a/crates/templated_uri/README.md
+++ b/crates/templated_uri/README.md
@@ -154,12 +154,43 @@ fragments are stripped by the `http` crate and ignored by HTTP clients.
 Template variables must implement [`Escape`][__link10] (except for reserved expansions,
 which use [`Raw`][__link11]) to ensure the resulting URI is valid.
 
+### Undefined Values (`Option<T>`)
+
+Per [RFC 6570 section 2.3][__link12], template
+variables may be *undefined*. Use `Option<T>` to model this: a `None` value is treated
+as undefined and the variable (along with its prefix or separator) is omitted from the
+rendered URI.
+
+```rust
+use templated_uri::{EscapedString, PathAndQueryTemplate, templated};
+
+#[templated(template = "/items{?query,limit}", unredacted)]
+struct ItemSearch {
+    query: EscapedString,
+    limit: Option<u32>,
+}
+
+// With limit defined:
+let path = ItemSearch {
+    query: EscapedString::from_static("rust"),
+    limit: Some(10),
+};
+assert_eq!(path.render(), "/items?query=rust&limit=10");
+
+// With limit undefined:
+let path = ItemSearch {
+    query: EscapedString::from_static("rust"),
+    limit: None,
+};
+assert_eq!(path.render(), "/items?query=rust");
+```
+
 ## Integration with HTTP Ecosystem
 
 This crate seamlessly integrates with the broader Rust HTTP ecosystem by re-exporting
-and building upon the standard [`http`][__link12] crate types. The resulting [`Uri`][__link13] can be converted
-to an [`http::Uri`][__link14] for use with HTTP clients
-and servers based on [`hyper`][__link15] like [`reqwest`][__link16].
+and building upon the standard [`http`][__link13] crate types. The resulting [`Uri`][__link14] can be converted
+to an [`http::Uri`][__link15] for use with HTTP clients
+and servers based on [`hyper`][__link16] like [`reqwest`][__link17].
 
 
 <hr/>
@@ -167,16 +198,17 @@ and servers based on [`hyper`][__link15] like [`reqwest`][__link16].
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG0T5raMqLWlbG_bHSLqi9-LvG1FXJK0aJXSgG8Whs0b10fq3YWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMi4w
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG63iTBJYMadJG6nseEEoATCvG3YJS_EajemqG70n7pjeggIrYWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMi4w
  [__link0]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Uri
  [__link1]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=BaseUri
  [__link10]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Escape
  [__link11]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Raw
- [__link12]: https://docs.rs/http/latest/http/
- [__link13]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Uri
- [__link14]: https://docs.rs/http/1.4.0/http/?search=Uri
- [__link15]: https://docs.rs/hyper/latest/hyper/
- [__link16]: https://docs.rs/reqwest/latest/reqwest/
+ [__link12]: https://datatracker.ietf.org/doc/html/rfc6570#section-2.3
+ [__link13]: https://docs.rs/http/latest/http/
+ [__link14]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Uri
+ [__link15]: https://docs.rs/http/1.4.0/http/?search=Uri
+ [__link16]: https://docs.rs/hyper/latest/hyper/
+ [__link17]: https://docs.rs/reqwest/latest/reqwest/
  [__link2]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=BaseUri
  [__link3]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=BasePath
  [__link4]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=PathAndQueryTemplate

--- a/crates/templated_uri/src/lib.rs
+++ b/crates/templated_uri/src/lib.rs
@@ -146,6 +146,37 @@
 //! Template variables must implement [`Escape`] (except for reserved expansions,
 //! which use [`Raw`]) to ensure the resulting URI is valid.
 //!
+//! ## Undefined Values (`Option<T>`)
+//!
+//! Per [RFC 6570 section 2.3](https://datatracker.ietf.org/doc/html/rfc6570#section-2.3), template
+//! variables may be *undefined*. Use `Option<T>` to model this: a `None` value is treated
+//! as undefined and the variable (along with its prefix or separator) is omitted from the
+//! rendered URI.
+//!
+//! ```rust
+//! use templated_uri::{EscapedString, PathAndQueryTemplate, templated};
+//!
+//! #[templated(template = "/items{?query,limit}", unredacted)]
+//! struct ItemSearch {
+//!     query: EscapedString,
+//!     limit: Option<u32>,
+//! }
+//!
+//! // With limit defined:
+//! let path = ItemSearch {
+//!     query: EscapedString::from_static("rust"),
+//!     limit: Some(10),
+//! };
+//! assert_eq!(path.render(), "/items?query=rust&limit=10");
+//!
+//! // With limit undefined:
+//! let path = ItemSearch {
+//!     query: EscapedString::from_static("rust"),
+//!     limit: None,
+//! };
+//! assert_eq!(path.render(), "/items?query=rust");
+//! ```
+//!
 //! # Integration with HTTP Ecosystem
 //!
 //! This crate seamlessly integrates with the broader Rust HTTP ecosystem by re-exporting

--- a/crates/templated_uri/src/macros.rs
+++ b/crates/templated_uri/src/macros.rs
@@ -71,6 +71,27 @@ pub use templated_uri_macros::Raw;
 /// - `{/param1,param2}`: Path segment expansion (`/value1/value2`)
 /// - `{?param1,param2}`: Query parameter expansion (`?param1=value1&param2=value2`)
 ///
+/// ## Undefined Values (`Option<T>`)
+///
+/// Fields may be wrapped in `Option<T>` to represent RFC 6570 *undefined* variables.
+/// When a field is `None`, the variable and its associated prefix/separator are omitted.
+///
+/// The inner type `T` must satisfy the same trait bounds the macro requires for any
+/// non-optional field in the same position: `T: Escape` for restricted expansions
+/// (`{var}`, `{/var}`, `{?var}`, `{;var}`, `{.var}`), `T: Raw` for reserved expansions
+/// (`{+var}`), and `T: RedactedDisplay` unless the field carries `#[unredacted]` (or
+/// the struct does). For example, `Option<String>` works for `{+var}` but not for `{var}`,
+/// because `String` implements `Raw` but not `Escape`.
+///
+/// ```rust
+/// # use templated_uri::{templated, EscapedString};
+/// #[templated(template = "/search{?query,limit}", unredacted)]
+/// struct Search {
+///     query: EscapedString,
+///     limit: Option<u32>,
+/// }
+/// ```
+///
 /// ## Data Privacy
 ///
 /// By default, all fields use `RedactedDisplay` for privacy protection. Use attributes to control:

--- a/crates/templated_uri/tests/compile_tests.rs
+++ b/crates/templated_uri/tests/compile_tests.rs
@@ -10,4 +10,5 @@ use trybuild::TestCases;
 fn compile_fail_tests() {
     let t = TestCases::new();
     t.compile_fail("tests/ui/string_in_restricted_position.rs");
+    t.compile_fail("tests/ui/option_string_in_restricted_position.rs");
 }

--- a/crates/templated_uri/tests/templated_uri.rs
+++ b/crates/templated_uri/tests/templated_uri.rs
@@ -5,10 +5,8 @@
 
 use std::fmt::Display;
 
-#[cfg(feature = "uuid")]
-use data_privacy::Sensitive;
 use data_privacy::simple_redactor::SimpleRedactor;
-use data_privacy::{RedactedToString, RedactionEngine, classified, taxonomy};
+use data_privacy::{RedactedToString, RedactionEngine, Sensitive, classified, taxonomy};
 use templated_uri::{BaseUri, Escape, EscapedString, PathAndQueryTemplate, Raw, Uri, templated};
 
 // Local taxonomy for testing purposes, mimicking microsoft_enterprise_data_taxonomy
@@ -434,4 +432,508 @@ fn test_uri_path_from_template() {
     // Verify it can be used in a Uri
     let uri = Uri::from(target_paq);
     assert_eq!(uri.to_string().declassify_ref(), "/api/123/posts");
+}
+
+// ======== RFC 6570 undefined values (Option<T>) tests ========
+
+#[templated(template = "/foo{?topic_id}", unredacted)]
+#[derive(Clone)]
+struct ListTopics {
+    topic_id: Option<u32>,
+}
+
+#[test]
+fn optional_query_param_some() {
+    let path = ListTopics { topic_id: Some(42) };
+    assert_eq!(path.render(), "/foo?topic_id=42");
+}
+
+#[test]
+fn optional_query_param_none() {
+    let path = ListTopics { topic_id: None };
+    assert_eq!(path.render(), "/foo");
+}
+
+#[templated(template = "/search{?query,limit,offset}", unredacted)]
+#[derive(Clone)]
+struct SearchQuery {
+    query: EscapedString,
+    limit: Option<u32>,
+    offset: Option<u32>,
+}
+
+#[test]
+fn optional_query_mixed_all_some() {
+    let path = SearchQuery {
+        query: EscapedString::from_static("rust"),
+        limit: Some(10),
+        offset: Some(20),
+    };
+    assert_eq!(path.render(), "/search?query=rust&limit=10&offset=20");
+}
+
+#[test]
+fn optional_query_mixed_some_none() {
+    let path = SearchQuery {
+        query: EscapedString::from_static("rust"),
+        limit: Some(10),
+        offset: None,
+    };
+    assert_eq!(path.render(), "/search?query=rust&limit=10");
+}
+
+#[test]
+fn optional_query_mixed_all_none() {
+    let path = SearchQuery {
+        query: EscapedString::from_static("rust"),
+        limit: None,
+        offset: None,
+    };
+    assert_eq!(path.render(), "/search?query=rust");
+}
+
+// Optional-first ordering: `{?opt,req}` with `opt=None` must still attach the `?` prefix
+// to the required value (i.e., not lose the group prefix when the first member is undefined).
+// This exercises the `__first` tracking in the order required-after-optional rather than
+// the more common optional-after-required.
+#[templated(template = "/items{?opt,req}", unredacted)]
+#[derive(Clone)]
+struct OptionalFirstThenRequired {
+    opt: Option<u32>,
+    req: u32,
+}
+
+#[test]
+fn optional_first_then_required_some() {
+    let path = OptionalFirstThenRequired { opt: Some(1), req: 2 };
+    assert_eq!(path.render(), "/items?opt=1&req=2");
+}
+
+#[test]
+fn optional_first_then_required_none_attaches_prefix_to_required() {
+    let path = OptionalFirstThenRequired { opt: None, req: 2 };
+    // `opt` is undefined, so the `?` prefix must hop to `req`. The naive bug would
+    // drop the prefix entirely and produce `/itemsreq=2` or `/items&req=2`.
+    assert_eq!(path.render(), "/items?req=2");
+}
+
+#[templated(template = "/items{?x,y}", unredacted)]
+#[derive(Clone)]
+struct AllOptionalQuery {
+    x: Option<u32>,
+    y: Option<u32>,
+}
+
+#[test]
+fn optional_query_all_optional_both_some() {
+    let path = AllOptionalQuery {
+        x: Some(1024),
+        y: Some(768),
+    };
+    assert_eq!(path.render(), "/items?x=1024&y=768");
+}
+
+#[test]
+fn optional_query_all_optional_first_none() {
+    // RFC 6570: {?undef,y} → ?y=768
+    let path = AllOptionalQuery { x: None, y: Some(768) };
+    assert_eq!(path.render(), "/items?y=768");
+}
+
+#[test]
+fn optional_query_all_optional_second_none() {
+    // RFC 6570: {?x,undef} → ?x=1024
+    let path = AllOptionalQuery { x: Some(1024), y: None };
+    assert_eq!(path.render(), "/items?x=1024");
+}
+
+#[test]
+fn optional_query_all_optional_both_none() {
+    let path = AllOptionalQuery { x: None, y: None };
+    assert_eq!(path.render(), "/items");
+}
+
+#[templated(template = "/{x}", unredacted)]
+#[derive(Clone)]
+struct SimpleOptional {
+    x: Option<EscapedString>,
+}
+
+#[test]
+fn optional_simple_expansion_some() {
+    let path = SimpleOptional {
+        x: Some(EscapedString::from_static("hello")),
+    };
+    assert_eq!(path.render(), "/hello");
+}
+
+#[test]
+fn optional_simple_expansion_none() {
+    // RFC 6570: O{undef}X → OX — the variable disappears
+    let path = SimpleOptional { x: None };
+    assert_eq!(path.render(), "/");
+}
+
+#[templated(template = "/prefix{/a,b}", unredacted)]
+#[derive(Clone)]
+struct PathExpansionOptional {
+    a: EscapedString,
+    b: Option<EscapedString>,
+}
+
+#[test]
+fn optional_path_expansion_some() {
+    let path = PathExpansionOptional {
+        a: EscapedString::from_static("x"),
+        b: Some(EscapedString::from_static("y")),
+    };
+    assert_eq!(path.render(), "/prefix/x/y");
+}
+
+#[test]
+fn optional_path_expansion_none() {
+    let path = PathExpansionOptional {
+        a: EscapedString::from_static("x"),
+        b: None,
+    };
+    assert_eq!(path.render(), "/prefix/x");
+}
+
+#[templated(template = "/data{?required}{&opt}", unredacted)]
+#[derive(Clone)]
+struct QueryContinuationOptional {
+    required: u32,
+    opt: Option<u32>,
+}
+
+#[test]
+fn optional_query_continuation_some() {
+    let path = QueryContinuationOptional { required: 1, opt: Some(2) };
+    assert_eq!(path.render(), "/data?required=1&opt=2");
+}
+
+#[test]
+fn optional_query_continuation_none() {
+    let path = QueryContinuationOptional { required: 1, opt: None };
+    assert_eq!(path.render(), "/data?required=1");
+}
+
+#[templated(template = "/{x,y}", unredacted)]
+#[derive(Clone)]
+struct SimpleMultiOptional {
+    x: Option<EscapedString>,
+    y: Option<EscapedString>,
+}
+
+#[test]
+fn optional_simple_multi_both_some() {
+    let path = SimpleMultiOptional {
+        x: Some(EscapedString::from_static("a")),
+        y: Some(EscapedString::from_static("b")),
+    };
+    assert_eq!(path.render(), "/a,b");
+}
+
+#[test]
+fn optional_simple_multi_first_none() {
+    let path = SimpleMultiOptional {
+        x: None,
+        y: Some(EscapedString::from_static("b")),
+    };
+    assert_eq!(path.render(), "/b");
+}
+
+#[test]
+fn optional_simple_multi_second_none() {
+    let path = SimpleMultiOptional {
+        x: Some(EscapedString::from_static("a")),
+        y: None,
+    };
+    assert_eq!(path.render(), "/a");
+}
+
+#[test]
+fn optional_simple_multi_both_none() {
+    let path = SimpleMultiOptional { x: None, y: None };
+    assert_eq!(path.render(), "/");
+}
+
+// Test that Some("") (empty string) is NOT treated as undefined — it's a defined empty value.
+// RFC 6570 section 3.2.2: ?{x,empty} → ?1024,  vs  ?{x,undef} → ?1024
+#[templated(template = "/?{x,y}", unredacted)]
+#[derive(Clone)]
+struct SimpleMultiEmptyVsUndef {
+    x: EscapedString,
+    y: Option<EscapedString>,
+}
+
+#[test]
+fn optional_some_empty_vs_none_simple() {
+    // Defined empty value: separator is kept, value is empty → trailing comma
+    let some_empty = SimpleMultiEmptyVsUndef {
+        x: EscapedString::from_static("1024"),
+        y: Some(EscapedString::from_static("")),
+    };
+    assert_eq!(some_empty.render(), "/?1024,");
+
+    // Undefined: variable AND separator are omitted
+    let none = SimpleMultiEmptyVsUndef {
+        x: EscapedString::from_static("1024"),
+        y: None,
+    };
+    assert_eq!(none.render(), "/?1024");
+}
+
+#[test]
+fn optional_some_empty_vs_none() {
+    let some_empty = ListTopics { topic_id: Some(0) };
+    assert_eq!(some_empty.render(), "/foo?topic_id=0");
+
+    let none = ListTopics { topic_id: None };
+    assert_eq!(none.render(), "/foo");
+}
+
+// Test Option with reserved expansion {+var}
+#[templated(template = "/{+path}", unredacted)]
+#[derive(Clone)]
+struct OptionalReserved {
+    path: Option<String>,
+}
+
+#[test]
+fn optional_reserved_expansion_some() {
+    let path = OptionalReserved {
+        path: Some("a/b/c".to_string()),
+    };
+    assert_eq!(path.render(), "/a/b/c");
+}
+
+#[test]
+fn optional_reserved_expansion_none() {
+    let path = OptionalReserved { path: None };
+    assert_eq!(path.render(), "/");
+}
+
+// Test Option with classified/redacted fields
+#[templated(template = "/{org_id}/items{?filter}")]
+#[derive(Clone)]
+struct RedactedOptionalPath {
+    org_id: OrgId,
+    #[unredacted]
+    filter: Option<EscapedString>,
+}
+
+#[test]
+fn optional_redacted_display_some() {
+    let path = RedactedOptionalPath {
+        org_id: OrgId(EscapedString::from_static("Acme")),
+        filter: Some(EscapedString::from_static("active")),
+    };
+
+    assert_eq!(path.render(), "/Acme/items?filter=active");
+
+    let redaction_engine = RedactionEngine::builder().set_fallback_redactor(SimpleRedactor::new()).build();
+    assert_eq!(
+        path.to_redacted_string(&redaction_engine),
+        "/****/items?filter=active",
+        "org_id should be redacted, filter should not"
+    );
+}
+
+#[test]
+fn optional_redacted_display_none() {
+    let path = RedactedOptionalPath {
+        org_id: OrgId(EscapedString::from_static("Acme")),
+        filter: None,
+    };
+
+    assert_eq!(path.render(), "/Acme/items");
+
+    let redaction_engine = RedactionEngine::builder().set_fallback_redactor(SimpleRedactor::new()).build();
+    assert_eq!(
+        path.to_redacted_string(&redaction_engine),
+        "/****/items",
+        "undefined filter should be omitted from redacted display too"
+    );
+}
+
+// Test Option<Sensitive<T>>
+#[templated(template = "/users{?user_id}")]
+#[derive(Clone)]
+struct OptionalSensitiveField {
+    user_id: Option<Sensitive<EscapedString>>,
+}
+
+#[test]
+fn optional_sensitive_some() {
+    let path = OptionalSensitiveField {
+        user_id: Some(Sensitive::new(EscapedString::from_static("secret_user"), Uri::DATA_CLASS)),
+    };
+    assert_eq!(path.render(), "/users?user_id=secret_user");
+
+    let redaction_engine = RedactionEngine::builder().set_fallback_redactor(SimpleRedactor::new()).build();
+    assert_eq!(
+        path.to_redacted_string(&redaction_engine),
+        "/users?user_id=***********",
+        "Sensitive value should be redacted"
+    );
+}
+
+#[test]
+fn optional_sensitive_none() {
+    let path = OptionalSensitiveField { user_id: None };
+    assert_eq!(path.render(), "/users");
+
+    let redaction_engine = RedactionEngine::builder().set_fallback_redactor(SimpleRedactor::new()).build();
+    assert_eq!(
+        path.to_redacted_string(&redaction_engine),
+        "/users",
+        "None value should be omitted from redacted display"
+    );
+}
+
+// Verifies that `#[unredacted]` actually relaxes the `RedactedDisplay` trait bound to
+// just `Display`. `DisplayOnly` deliberately does not implement `RedactedDisplay`, so
+// the `redacted_display_group_with_optional` codegen MUST take the `Display`-only branch
+// for the marked fields. Flipping `unredacted || field_unredacted` to `&&` in the macro
+// would route through `<DisplayOnly as RedactedDisplay>::fmt(...)`, which doesn't exist —
+// causing this file to fail compilation. That's the precise semantic invariant the test
+// pins down: `#[unredacted]` allows `Display`-only types in templates.
+#[derive(Clone)]
+struct DisplayOnly(&'static str);
+
+impl Display for DisplayOnly {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+impl templated_uri::Escape for DisplayOnly {
+    fn escape(&self) -> templated_uri::Escaped<impl Display> {
+        templated_uri::Escaped::from_static(self.0)
+    }
+}
+
+#[templated(template = "/items{?required_id,opt_id}")]
+#[derive(Clone)]
+struct UnredactedDisplayOnlyOptional {
+    #[unredacted]
+    required_id: DisplayOnly,
+    #[unredacted]
+    opt_id: Option<DisplayOnly>,
+}
+
+#[test]
+fn optional_field_unredacted_required_uses_display_only_trait_bound() {
+    // `opt_id = None` so the optional-aware path is taken with only `required_id`.
+    let path = UnredactedDisplayOnlyOptional {
+        required_id: DisplayOnly("req"),
+        opt_id: None,
+    };
+    let redaction_engine = RedactionEngine::builder().set_fallback_redactor(SimpleRedactor::new()).build();
+    assert_eq!(path.to_redacted_string(&redaction_engine), "/items?required_id=req");
+}
+
+#[test]
+fn optional_field_unredacted_optional_uses_display_only_trait_bound() {
+    // `opt_id = Some(...)` covers the optional-field branch.
+    let path = UnredactedDisplayOnlyOptional {
+        required_id: DisplayOnly("req"),
+        opt_id: Some(DisplayOnly("opt")),
+    };
+    let redaction_engine = RedactionEngine::builder().set_fallback_redactor(SimpleRedactor::new()).build();
+    assert_eq!(path.to_redacted_string(&redaction_engine), "/items?required_id=req&opt_id=opt");
+}
+
+// Test that template() and format_template() are unchanged by Option usage
+#[test]
+fn optional_template_metadata_unchanged() {
+    let path = AllOptionalQuery { x: None, y: None };
+    assert_eq!(path.template(), "/items{?x,y}");
+    assert_eq!(path.format_template(), "/items?x={x}&y={y}");
+    assert_eq!(format!("{path:?}"), r#"AllOptionalQuery("/items{?x,y}")"#);
+}
+
+// ======== Matrix params `{;a,b}` (RFC 6570 section 3.2.7) ========
+#[templated(template = "/items{;a,b}", unredacted)]
+#[derive(Clone)]
+struct MatrixOptional {
+    a: Option<EscapedString>,
+    b: Option<EscapedString>,
+}
+
+#[test]
+fn optional_matrix_both_some() {
+    let path = MatrixOptional {
+        a: Some(EscapedString::from_static("x")),
+        b: Some(EscapedString::from_static("y")),
+    };
+    assert_eq!(path.render(), "/items;a=x;b=y");
+}
+
+#[test]
+fn optional_matrix_first_none() {
+    // RFC 6570: undefined first variable → prefix attaches to second
+    let path = MatrixOptional {
+        a: None,
+        b: Some(EscapedString::from_static("y")),
+    };
+    assert_eq!(path.render(), "/items;b=y");
+}
+
+#[test]
+fn optional_matrix_second_none() {
+    let path = MatrixOptional {
+        a: Some(EscapedString::from_static("x")),
+        b: None,
+    };
+    assert_eq!(path.render(), "/items;a=x");
+}
+
+#[test]
+fn optional_matrix_both_none() {
+    let path = MatrixOptional { a: None, b: None };
+    assert_eq!(path.render(), "/items");
+}
+
+// ======== Label-style `{.a,b}` (RFC 6570 section 3.2.5) ========
+#[templated(template = "/file{.ext1,ext2}", unredacted)]
+#[derive(Clone)]
+struct LabelOptional {
+    ext1: Option<EscapedString>,
+    ext2: Option<EscapedString>,
+}
+
+#[test]
+fn optional_label_both_some() {
+    let path = LabelOptional {
+        ext1: Some(EscapedString::from_static("tar")),
+        ext2: Some(EscapedString::from_static("gz")),
+    };
+    assert_eq!(path.render(), "/file.tar.gz");
+}
+
+#[test]
+fn optional_label_first_none() {
+    // RFC 6570: undefined first variable → label dot attaches to second
+    let path = LabelOptional {
+        ext1: None,
+        ext2: Some(EscapedString::from_static("gz")),
+    };
+    assert_eq!(path.render(), "/file.gz");
+}
+
+#[test]
+fn optional_label_second_none() {
+    let path = LabelOptional {
+        ext1: Some(EscapedString::from_static("tar")),
+        ext2: None,
+    };
+    assert_eq!(path.render(), "/file.tar");
+}
+
+#[test]
+fn optional_label_both_none() {
+    let path = LabelOptional { ext1: None, ext2: None };
+    assert_eq!(path.render(), "/file");
 }

--- a/crates/templated_uri/tests/ui/option_string_in_restricted_position.rs
+++ b/crates/templated_uri/tests/ui/option_string_in_restricted_position.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Using `Option<String>` in a restricted template position (`{param}`) must fail
+//! to compile because `String` does not implement `Escape`.
+//!
+//! The extra blank lines below shift both diagnostic line numbers (the `#[templated]`
+//! attribute and the `Option<String>` field) to 2-digit values. rustc pads line-number
+//! columns in a diagnostic block to the width of the widest reference; keeping both
+//! references at the same digit count produces stable column alignment in the
+//! `.stderr` regardless of how rustc decides to pad.
+
+use templated_uri::templated;
+
+#[templated(template = "/users/{user_id}", unredacted)]
+#[derive(Clone)]
+struct UserPath {
+    user_id: Option<String>,
+}
+
+fn main() {}

--- a/crates/templated_uri/tests/ui/option_string_in_restricted_position.stderr
+++ b/crates/templated_uri/tests/ui/option_string_in_restricted_position.stderr
@@ -1,0 +1,36 @@
+error[E0277]: the trait bound `String: templated_uri::Escape` is not satisfied
+  --> tests/ui/option_string_in_restricted_position.rs:15:1
+   |
+15 | #[templated(template = "/users/{user_id}", unredacted)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `templated_uri::Escape` is not implemented for `String`
+...
+18 |     user_id: Option<String>,
+   |                     ------ required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `templated_uri::Escape`:
+             Escaped<Cow<'static, str>>
+             IpAddr
+             NonZero<u128>
+             NonZero<u16>
+             NonZero<u32>
+             NonZero<u64>
+             NonZero<u8>
+             NonZero<usize>
+           and $N others
+
+error[E0277]: the trait bound `String: templated_uri::Escape` is not satisfied
+  --> tests/ui/option_string_in_restricted_position.rs:18:21
+   |
+18 |     user_id: Option<String>,
+   |                     ^^^^^^ the trait `templated_uri::Escape` is not implemented for `String`
+   |
+   = help: the following other types implement trait `templated_uri::Escape`:
+             Escaped<Cow<'static, str>>
+             IpAddr
+             NonZero<u128>
+             NonZero<u16>
+             NonZero<u32>
+             NonZero<u64>
+             NonZero<u8>
+             NonZero<usize>
+           and $N others

--- a/crates/templated_uri_macros_impl/CHANGELOG.md
+++ b/crates/templated_uri_macros_impl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- ✨ Features
+
+  - Support `Option<T>` fields in `#[templated]` structs for RFC 6570 undefined variable semantics.
+
 ## [0.2.0] - 2026-05-11
 
 - ⚠️ Breaking

--- a/crates/templated_uri_macros_impl/src/lib.rs
+++ b/crates/templated_uri_macros_impl/src/lib.rs
@@ -218,6 +218,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Inline snapshot of generated codegen exceeds the threshold by design"
+    )]
     fn test_templated_uri_impl() {
         let attr = quote! { template="/example.com/{param}/{+param2}{/param3,param4}" };
         let item = quote! {
@@ -248,11 +252,44 @@ mod tests {
                 ::core::option::Option::None
             }
             fn render(&self) -> ::std::string::String {
-                let param = ::templated_uri::Escape::escape(&self.param);
-                let param2 = ::templated_uri::Raw::raw(&self.param2);
-                let param3 = ::templated_uri::Escape::escape(&self.param3);
-                let param4 = ::templated_uri::Escape::escape(&self.param4);
-                ::std::format!("/example.com/{param}/{param2}/{param3}/{param4}")
+                let mut __out = ::std::string::String::with_capacity(16usize);
+                __out.push_str("/example.com/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.param)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Raw::raw(& self.param2)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!(
+                            "{}", ::templated_uri::Escape::escape(& self.param3)
+                        ),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!(
+                            "{}", ::templated_uri::Escape::escape(& self.param4)
+                        ),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out
             }
             fn to_path_and_query(
                 &self,
@@ -304,6 +341,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Inline snapshot of generated codegen exceeds the threshold by design"
+    )]
     fn test_templated_unredacted_uri_impl() {
         let attr = quote! { template="/example.com/{param}/{+param2}{/param3,param4}", unredacted };
         let item = quote! {
@@ -337,11 +378,44 @@ mod tests {
                 ::core::option::Option::None
             }
             fn render(&self) -> ::std::string::String {
-                let param = ::templated_uri::Escape::escape(&self.param);
-                let param2 = ::templated_uri::Raw::raw(&self.param2);
-                let param3 = ::templated_uri::Escape::escape(&self.param3);
-                let param4 = ::templated_uri::Escape::escape(&self.param4);
-                ::std::format!("/example.com/{param}/{param2}/{param3}/{param4}")
+                let mut __out = ::std::string::String::with_capacity(16usize);
+                __out.push_str("/example.com/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.param)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Raw::raw(& self.param2)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!(
+                            "{}", ::templated_uri::Escape::escape(& self.param3)
+                        ),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!(
+                            "{}", ::templated_uri::Escape::escape(& self.param4)
+                        ),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out
             }
             fn to_path_and_query(
                 &self,
@@ -389,6 +463,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Inline snapshot of generated codegen exceeds the threshold by design"
+    )]
     fn test_field_level_unredacted() {
         let attr = quote! { template="/example.com/{param}/{+param2}{/param3,param4}" };
         let item = quote! {
@@ -420,11 +498,44 @@ mod tests {
                 ::core::option::Option::None
             }
             fn render(&self) -> ::std::string::String {
-                let param = ::templated_uri::Escape::escape(&self.param);
-                let param2 = ::templated_uri::Raw::raw(&self.param2);
-                let param3 = ::templated_uri::Escape::escape(&self.param3);
-                let param4 = ::templated_uri::Escape::escape(&self.param4);
-                ::std::format!("/example.com/{param}/{param2}/{param3}/{param4}")
+                let mut __out = ::std::string::String::with_capacity(16usize);
+                __out.push_str("/example.com/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.param)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Raw::raw(& self.param2)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!(
+                            "{}", ::templated_uri::Escape::escape(& self.param3)
+                        ),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!(
+                            "{}", ::templated_uri::Escape::escape(& self.param4)
+                        ),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out
             }
             fn to_path_and_query(
                 &self,
@@ -472,6 +583,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Inline snapshot of generated codegen exceeds the threshold by design"
+    )]
     fn test_standalone_unredacted() {
         let attr = quote! { template="/example.com/{param}/{+param2}{/param3,param4}" };
         let item = quote! {
@@ -503,11 +618,44 @@ mod tests {
                 ::core::option::Option::None
             }
             fn render(&self) -> ::std::string::String {
-                let param = ::templated_uri::Escape::escape(&self.param);
-                let param2 = ::templated_uri::Raw::raw(&self.param2);
-                let param3 = ::templated_uri::Escape::escape(&self.param3);
-                let param4 = ::templated_uri::Escape::escape(&self.param4);
-                ::std::format!("/example.com/{param}/{param2}/{param3}/{param4}")
+                let mut __out = ::std::string::String::with_capacity(16usize);
+                __out.push_str("/example.com/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.param)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Raw::raw(& self.param2)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!(
+                            "{}", ::templated_uri::Escape::escape(& self.param3)
+                        ),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!(
+                            "{}", ::templated_uri::Escape::escape(& self.param4)
+                        ),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out
             }
             fn to_path_and_query(
                 &self,
@@ -555,6 +703,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Inline snapshot of generated codegen exceeds the threshold by design"
+    )]
     fn test_query_param_is_kv_expansion() {
         let attr = quote! { template="/api/{resource}{?page,limit}" };
         let item = quote! {
@@ -584,10 +736,38 @@ mod tests {
                 ::core::option::Option::None
             }
             fn render(&self) -> ::std::string::String {
-                let resource = ::templated_uri::Escape::escape(&self.resource);
-                let page = ::templated_uri::Escape::escape(&self.page);
-                let limit = ::templated_uri::Escape::escape(&self.limit);
-                ::std::format!("/api/{resource}?page={page}&limit={limit}")
+                let mut __out = ::std::string::String::with_capacity(18usize);
+                __out.push_str("/api/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!(
+                            "{}", ::templated_uri::Escape::escape(& self.resource)
+                        ),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("?");
+                __out.push_str("page");
+                __out.push_str("=");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.page)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out.push_str("&");
+                __out.push_str("limit");
+                __out.push_str("=");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.limit)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                __out
             }
             fn to_path_and_query(
                 &self,
@@ -628,6 +808,417 @@ mod tests {
         }
         impl From<QueryTest> for ::templated_uri::PathAndQuery {
             fn from(value: QueryTest) -> Self {
+                ::templated_uri::PathAndQuery::from_template(value)
+            }
+        }
+        "#);
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Inline snapshot of generated codegen exceeds the threshold by design"
+    )]
+    fn test_optional_field_codegen() {
+        // Mixes a required-only group `{id}` with a query group `{?filter,limit}` that
+        // contains an `Option<u32>`. Locks in:
+        //   * the all-required render path (flat `push_str` / `write!` for `{id}`),
+        //   * the optional-aware render path with `__first` tracking for `{?filter,limit}`,
+        //   * the matching `RedactedDisplay` paths,
+        //   * `if let Some(ref __val) = self.limit` extraction of the inner `u32`.
+        let attr = quote! { template="/items/{id}{?filter,limit}" };
+        let item = quote! {
+            struct OptionalTest {
+                id: u32,
+                filter: String,
+                limit: Option<u32>
+            }
+        };
+
+        let output_pretty = pretty_parse(attr, item);
+        assert_snapshot!(output_pretty, @r#"
+        struct OptionalTest {
+            id: u32,
+            filter: String,
+            limit: Option<u32>,
+        }
+        impl ::templated_uri::PathAndQueryTemplate for OptionalTest {
+            fn template(&self) -> &'static core::primitive::str {
+                "/items/{id}{?filter,limit}"
+            }
+            fn format_template(&self) -> &'static core::primitive::str {
+                "/items/{id}?filter={filter}&limit={limit}"
+            }
+            fn label(&self) -> ::core::option::Option<&'static core::primitive::str> {
+                ::core::option::Option::None
+            }
+            fn render(&self) -> ::std::string::String {
+                let mut __out = ::std::string::String::with_capacity(22usize);
+                __out.push_str("/items/");
+                ::std::fmt::Write::write_fmt(
+                        &mut __out,
+                        ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.id)),
+                    )
+                    .expect(
+                        "Display impls for templated URI parameter values are expected to be infallible",
+                    );
+                {
+                    let mut __first = true;
+                    {
+                        let __val = &self.filter;
+                        if __first {
+                            __out.push_str("?");
+                        } else {
+                            __out.push_str("&");
+                        }
+                        __out.push_str("filter");
+                        __out.push_str("=");
+                        ::std::fmt::Write::write_fmt(
+                                &mut __out,
+                                ::core::format_args!(
+                                    "{}", ::templated_uri::Escape::escape(__val)
+                                ),
+                            )
+                            .expect(
+                                "Display impls for templated URI parameter values are expected to be infallible",
+                            );
+                        __first = false;
+                    }
+                    if let ::core::option::Option::Some(ref __val) = self.limit {
+                        if __first {
+                            __out.push_str("?");
+                        } else {
+                            __out.push_str("&");
+                        }
+                        __out.push_str("limit");
+                        __out.push_str("=");
+                        ::std::fmt::Write::write_fmt(
+                                &mut __out,
+                                ::core::format_args!(
+                                    "{}", ::templated_uri::Escape::escape(__val)
+                                ),
+                            )
+                            .expect(
+                                "Display impls for templated URI parameter values are expected to be infallible",
+                            );
+                        __first = false;
+                    }
+                }
+                __out
+            }
+            fn to_path_and_query(
+                &self,
+            ) -> ::std::result::Result<
+                ::templated_uri::http::uri::PathAndQuery,
+                ::templated_uri::UriError,
+            > {
+                Ok(
+                    ::templated_uri::http::uri::PathAndQuery::try_from(
+                        ::templated_uri::PathAndQueryTemplate::render(self),
+                    )?,
+                )
+            }
+        }
+        impl ::std::fmt::Debug for OptionalTest {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.debug_tuple("OptionalTest").field(&"/items/{id}{?filter,limit}").finish()
+            }
+        }
+        impl ::data_privacy::RedactedDisplay for OptionalTest {
+            fn fmt(
+                &self,
+                engine: &::data_privacy::RedactionEngine,
+                f: &mut ::std::fmt::Formatter,
+            ) -> ::std::fmt::Result {
+                f.write_str("/items/")?;
+                <u32 as ::data_privacy::RedactedDisplay>::fmt(&self.id, engine, f)?;
+                {
+                    let mut __first = true;
+                    {
+                        if __first {
+                            f.write_str("?")?;
+                        } else {
+                            f.write_str("&")?;
+                        }
+                        f.write_str("filter")?;
+                        f.write_str("=")?;
+                        <String as ::data_privacy::RedactedDisplay>::fmt(
+                            &self.filter,
+                            engine,
+                            f,
+                        )?;
+                        __first = false;
+                    }
+                    if let ::core::option::Option::Some(ref __val) = self.limit {
+                        if __first {
+                            f.write_str("?")?;
+                        } else {
+                            f.write_str("&")?;
+                        }
+                        f.write_str("limit")?;
+                        f.write_str("=")?;
+                        <u32 as ::data_privacy::RedactedDisplay>::fmt(__val, engine, f)?;
+                        __first = false;
+                    }
+                }
+                ::std::result::Result::Ok(())
+            }
+        }
+        impl From<OptionalTest> for ::templated_uri::PathAndQuery {
+            fn from(value: OptionalTest) -> Self {
+                ::templated_uri::PathAndQuery::from_template(value)
+            }
+        }
+        "#);
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Inline snapshot of generated codegen exceeds the threshold by design"
+    )]
+    fn test_optional_field_with_unredacted_codegen() {
+        // Pins down the `unredacted || field_unredacted` semantics inside the
+        // optional-aware redacted-display path. With a `#[unredacted]` field, the
+        // generated code MUST call `::std::write!(f, "{}", self.field)` (Display),
+        // not the `RedactedDisplay::fmt` trait path. Flipping the `||` to `&&` in
+        // `redacted_display_group_with_optional` produces a different TokenStream
+        // and this snapshot diff will catch it.
+        let attr = quote! { template = "/items{?filter,limit}" };
+        let item = quote! {
+            struct OptionalUnredactedTest {
+                #[unredacted]
+                filter: String,
+                #[unredacted]
+                limit: Option<u32>,
+            }
+        };
+
+        let output_pretty = pretty_parse(attr, item);
+        assert_snapshot!(output_pretty, @r#"
+        struct OptionalUnredactedTest {
+            filter: String,
+            limit: Option<u32>,
+        }
+        impl ::templated_uri::PathAndQueryTemplate for OptionalUnredactedTest {
+            fn template(&self) -> &'static core::primitive::str {
+                "/items{?filter,limit}"
+            }
+            fn format_template(&self) -> &'static core::primitive::str {
+                "/items?filter={filter}&limit={limit}"
+            }
+            fn label(&self) -> ::core::option::Option<&'static core::primitive::str> {
+                ::core::option::Option::None
+            }
+            fn render(&self) -> ::std::string::String {
+                let mut __out = ::std::string::String::with_capacity(21usize);
+                __out.push_str("/items");
+                {
+                    let mut __first = true;
+                    {
+                        let __val = &self.filter;
+                        if __first {
+                            __out.push_str("?");
+                        } else {
+                            __out.push_str("&");
+                        }
+                        __out.push_str("filter");
+                        __out.push_str("=");
+                        ::std::fmt::Write::write_fmt(
+                                &mut __out,
+                                ::core::format_args!(
+                                    "{}", ::templated_uri::Escape::escape(__val)
+                                ),
+                            )
+                            .expect(
+                                "Display impls for templated URI parameter values are expected to be infallible",
+                            );
+                        __first = false;
+                    }
+                    if let ::core::option::Option::Some(ref __val) = self.limit {
+                        if __first {
+                            __out.push_str("?");
+                        } else {
+                            __out.push_str("&");
+                        }
+                        __out.push_str("limit");
+                        __out.push_str("=");
+                        ::std::fmt::Write::write_fmt(
+                                &mut __out,
+                                ::core::format_args!(
+                                    "{}", ::templated_uri::Escape::escape(__val)
+                                ),
+                            )
+                            .expect(
+                                "Display impls for templated URI parameter values are expected to be infallible",
+                            );
+                        __first = false;
+                    }
+                }
+                __out
+            }
+            fn to_path_and_query(
+                &self,
+            ) -> ::std::result::Result<
+                ::templated_uri::http::uri::PathAndQuery,
+                ::templated_uri::UriError,
+            > {
+                Ok(
+                    ::templated_uri::http::uri::PathAndQuery::try_from(
+                        ::templated_uri::PathAndQueryTemplate::render(self),
+                    )?,
+                )
+            }
+        }
+        impl ::std::fmt::Debug for OptionalUnredactedTest {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.debug_tuple("OptionalUnredactedTest").field(&"/items{?filter,limit}").finish()
+            }
+        }
+        impl ::data_privacy::RedactedDisplay for OptionalUnredactedTest {
+            fn fmt(
+                &self,
+                engine: &::data_privacy::RedactionEngine,
+                f: &mut ::std::fmt::Formatter,
+            ) -> ::std::fmt::Result {
+                f.write_str("/items")?;
+                {
+                    let mut __first = true;
+                    {
+                        if __first {
+                            f.write_str("?")?;
+                        } else {
+                            f.write_str("&")?;
+                        }
+                        f.write_str("filter")?;
+                        f.write_str("=")?;
+                        ::std::write!(f, "{}", self.filter)?;
+                        __first = false;
+                    }
+                    if let ::core::option::Option::Some(ref __val) = self.limit {
+                        if __first {
+                            f.write_str("?")?;
+                        } else {
+                            f.write_str("&")?;
+                        }
+                        f.write_str("limit")?;
+                        f.write_str("=")?;
+                        ::std::write!(f, "{}", __val)?;
+                        __first = false;
+                    }
+                }
+                ::std::result::Result::Ok(())
+            }
+        }
+        impl From<OptionalUnredactedTest> for ::templated_uri::PathAndQuery {
+            fn from(value: OptionalUnredactedTest) -> Self {
+                ::templated_uri::PathAndQuery::from_template(value)
+            }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_optional_reference_field_codegen() {
+        // For `Option<&T>`, `Some(ref __val)` binds `__val: &&T`. The macro must peel one
+        // reference so the generated trait calls resolve against `T: Escape`/`T: RedactedDisplay`
+        // rather than the much rarer `&T` impls. This snapshot pins down:
+        //   * the render path emits `Escape::escape(*__val)` (not `__val`),
+        //   * the redacted-display path emits `<str as RedactedDisplay>::fmt(*__val, ...)`
+        //     with the inner reference peeled from the UFCS receiver type.
+        let attr = quote! { template = "/items{?name}" };
+        let item = quote! {
+            struct ReferenceOptional {
+                name: Option<&'static str>,
+            }
+        };
+
+        let output_pretty = pretty_parse(attr, item);
+        assert_snapshot!(output_pretty, @r#"
+        struct ReferenceOptional {
+            name: Option<&'static str>,
+        }
+        impl ::templated_uri::PathAndQueryTemplate for ReferenceOptional {
+            fn template(&self) -> &'static core::primitive::str {
+                "/items{?name}"
+            }
+            fn format_template(&self) -> &'static core::primitive::str {
+                "/items?name={name}"
+            }
+            fn label(&self) -> ::core::option::Option<&'static core::primitive::str> {
+                ::core::option::Option::None
+            }
+            fn render(&self) -> ::std::string::String {
+                let mut __out = ::std::string::String::with_capacity(12usize);
+                __out.push_str("/items");
+                {
+                    let mut __first = true;
+                    if let ::core::option::Option::Some(ref __val) = self.name {
+                        if __first {
+                            __out.push_str("?");
+                        } else {
+                            __out.push_str("&");
+                        }
+                        __out.push_str("name");
+                        __out.push_str("=");
+                        ::std::fmt::Write::write_fmt(
+                                &mut __out,
+                                ::core::format_args!(
+                                    "{}", ::templated_uri::Escape::escape(* __val)
+                                ),
+                            )
+                            .expect(
+                                "Display impls for templated URI parameter values are expected to be infallible",
+                            );
+                        __first = false;
+                    }
+                }
+                __out
+            }
+            fn to_path_and_query(
+                &self,
+            ) -> ::std::result::Result<
+                ::templated_uri::http::uri::PathAndQuery,
+                ::templated_uri::UriError,
+            > {
+                Ok(
+                    ::templated_uri::http::uri::PathAndQuery::try_from(
+                        ::templated_uri::PathAndQueryTemplate::render(self),
+                    )?,
+                )
+            }
+        }
+        impl ::std::fmt::Debug for ReferenceOptional {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.debug_tuple("ReferenceOptional").field(&"/items{?name}").finish()
+            }
+        }
+        impl ::data_privacy::RedactedDisplay for ReferenceOptional {
+            fn fmt(
+                &self,
+                engine: &::data_privacy::RedactionEngine,
+                f: &mut ::std::fmt::Formatter,
+            ) -> ::std::fmt::Result {
+                f.write_str("/items")?;
+                {
+                    let mut __first = true;
+                    if let ::core::option::Option::Some(ref __val) = self.name {
+                        if __first {
+                            f.write_str("?")?;
+                        } else {
+                            f.write_str("&")?;
+                        }
+                        f.write_str("name")?;
+                        f.write_str("=")?;
+                        <str as ::data_privacy::RedactedDisplay>::fmt(*__val, engine, f)?;
+                        __first = false;
+                    }
+                }
+                ::std::result::Result::Ok(())
+            }
+        }
+        impl From<ReferenceOptional> for ::templated_uri::PathAndQuery {
+            fn from(value: ReferenceOptional) -> Self {
                 ::templated_uri::PathAndQuery::from_template(value)
             }
         }

--- a/crates/templated_uri_macros_impl/src/struct_template.rs
+++ b/crates/templated_uri_macros_impl/src/struct_template.rs
@@ -15,7 +15,10 @@ use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 use syn::{Attribute, DataStruct, Field};
 
-use crate::template_parser::{TemplatePart, UriTemplate};
+use crate::template_parser::{ParamGroup, TemplatePart, UriTemplate};
+
+type FieldMap<'a> = std::collections::HashMap<String, &'a Field>;
+type FieldOptsMap<'a> = std::collections::HashMap<String, &'a FieldOpts>;
 
 #[derive(Debug, FromAttributes)]
 #[darling(attributes(templated))]
@@ -128,24 +131,7 @@ pub fn struct_template(ident: Ident, data: &DataStruct, attrs: &[Attribute]) -> 
         .map(|p| p.name.to_owned())
         .collect();
 
-    let is_restricted = |p: &Ident| !unrestricted_params.contains(&p.to_string());
-
-    let collect_params: Vec<_> = struct_fields
-        .iter()
-        .map(|f| {
-            let ident = f.ident.as_ref().expect("struct fields must be named");
-            let is_restricted = is_restricted(ident);
-            let ty_span = f.ty.span();
-
-            // Restricted fields use .escape(), unrestricted use .raw()
-            if is_restricted {
-                quote_spanned! { ty_span => let #ident = ::templated_uri::Escape::escape(&self.#ident); }
-            } else {
-                quote_spanned! { ty_span => let #ident = ::templated_uri::Raw::raw(&self.#ident); }
-            }
-        })
-        .collect();
-
+    let render_body = construct_render(&template, &struct_fields, &unrestricted_params);
     let redacted_display = construct_redacted_display(&template, &struct_fields, &fields, unredacted);
 
     let label_impl = label.as_ref().map_or_else(
@@ -168,9 +154,7 @@ pub fn struct_template(ident: Ident, data: &DataStruct, attrs: &[Attribute]) -> 
             }
 
             fn render(&self) -> ::std::string::String {
-                #(#collect_params)*
-
-                ::std::format!(#format_template)
+                #render_body
             }
 
             fn to_path_and_query(&self) -> ::std::result::Result<::templated_uri::http::uri::PathAndQuery, ::templated_uri::UriError> {
@@ -200,15 +184,262 @@ pub fn struct_template(ident: Ident, data: &DataStruct, attrs: &[Attribute]) -> 
     }
 }
 
-fn construct_redacted_display(template: &UriTemplate, struct_fields: &[&Field], fields: &Fields, unredacted: bool) -> TokenStream {
-    // Build a map from field name to field for lookup
-    let field_map: std::collections::HashMap<String, &Field> = struct_fields
+/// Checks whether `ty` is syntactically `Option<T>` (or `std::option::Option<T>`, etc.)
+/// and returns the inner type `T`.
+///
+/// This is the standard approach used by serde, clap, and other derive macros.
+/// It won't detect type aliases for `Option`, which is a known and accepted limitation.
+fn extract_option_inner(ty: &syn::Type) -> Option<&syn::Type> {
+    let syn::Type::Path(type_path) = ty else {
+        return None;
+    };
+    let last_segment = type_path.path.segments.last()?;
+    if last_segment.ident != "Option" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments else {
+        return None;
+    };
+    if args.args.len() != 1 {
+        return None;
+    }
+    let syn::GenericArgument::Type(inner_ty) = &args.args[0] else {
+        return None;
+    };
+    Some(inner_ty)
+}
+
+/// Generates the body of the `render()` method.
+///
+/// Walks the parsed template parts and emits `Write::write_fmt` calls (via UFCS,
+/// to avoid bringing `fmt::Write` into the caller's scope), handling RFC 6570
+/// undefined-value semantics for `Option<T>` fields.
+fn construct_render(template: &UriTemplate, struct_fields: &[&Field], unrestricted_params: &HashSet<String>) -> TokenStream {
+    let field_map: FieldMap<'_> = struct_fields
         .iter()
         .filter_map(|f| f.ident.as_ref().map(|ident| (ident.to_string(), *f)))
         .collect();
 
-    // Build a map from field name to field options for checking unredacted attribute
-    let field_opts_map: std::collections::HashMap<String, &FieldOpts> = fields
+    // Pre-allocate the rendered-URI buffer using a static heuristic computed from the
+    // template parts. See `render_capacity_hint` for the precise semantics; it may
+    // slightly over-allocate when a group's parameters are all `None` at runtime, which
+    // is far cheaper than the realloc chain a fresh `String::new()` would incur.
+    let initial_capacity = render_capacity_hint(template);
+
+    let statements: Vec<TokenStream> = template
+        .template_parts()
+        .iter()
+        .flat_map(|part| match part {
+            TemplatePart::Content(content) => {
+                vec![quote! { __out.push_str(#content); }]
+            }
+            TemplatePart::ParamGroup(group) => construct_render_group(group, &field_map, unrestricted_params),
+        })
+        .collect();
+
+    quote! {
+        let mut __out = ::std::string::String::with_capacity(#initial_capacity);
+        #(#statements)*
+        __out
+    }
+}
+
+/// Compile-time capacity heuristic for the `String` buffer that holds a rendered URI.
+///
+/// The returned size counts every byte the macro can statically *name*:
+///
+/// - Static `Content` segments are always present.
+/// - Each parameter group's fixed literals (prefix, separators between values, and the
+///   `key=` literal for key/value expansions like `{?a}` and `{;a}`).
+///
+/// Parameter values themselves are not counted because their runtime size is unknown.
+/// The heuristic does **not** discount per-parameter literals attached to `Option<T>`
+/// fields, so when a group's optional values are all `None` at runtime, the buffer
+/// over-allocates by a few bytes (typically one prefix byte plus the key length plus
+/// `=`). That small over-attribution is harmless: a strict lower bound would require
+/// threading field metadata into this function, and the worst-case waste is bounded
+/// by a few bytes per group, well below a single allocator slab.
+fn render_capacity_hint(template: &UriTemplate) -> usize {
+    template
+        .template_parts()
+        .iter()
+        .map(|part| match part {
+            TemplatePart::Content(content) => content.len(),
+            TemplatePart::ParamGroup(group) => {
+                let prefix_len = group.prefix().map_or(0, str::len);
+                let param_names = group.param_names();
+                // Every RFC 6570 separator emitted by `ParamKind::separator()` (`,`, `;`,
+                // `&`, `.`, `/`) is exactly 1 byte, so the separator-byte count equals the
+                // number of separators. If the vocabulary ever grows a multi-byte member,
+                // multiply by `group.separator().len()` and add a unit test for it.
+                let separators_len = param_names.len().saturating_sub(1);
+                let kv_len = if group.is_kv() {
+                    // Each value gets `key=` prepended.
+                    param_names.iter().map(|n| n.len() + 1).sum::<usize>()
+                } else {
+                    0
+                };
+                prefix_len + separators_len + kv_len
+            }
+        })
+        .sum()
+}
+
+/// Returns true if any parameter in `param_names` is backed by an `Option<T>` field.
+fn group_has_any_optional(param_names: &[&str], field_map: &FieldMap<'_>) -> bool {
+    param_names
+        .iter()
+        .any(|name| field_map.get(*name).is_some_and(|f| extract_option_inner(&f.ty).is_some()))
+}
+
+/// Returns the `(emit_delim, emit_kv)` token-stream pair used inside the optional-aware
+/// `__first`-tracked code paths in both `render_group_with_optional` and
+/// `redacted_display_group_with_optional`.
+///
+/// `write_lit` is a closure that emits the writer-specific statement for writing a
+/// single string literal: `__out.push_str(s)` for render, `f.write_str(s)?` for the
+/// `RedactedDisplay` impl. Factoring this here keeps both code paths in lockstep so
+/// future operator tweaks can't drift between `render()` and `RedactedDisplay::fmt`.
+fn emit_optional_delim_and_kv(
+    prefix: &str,
+    separator: &str,
+    key: Option<&str>,
+    write_lit: impl Fn(&str) -> TokenStream,
+) -> (TokenStream, TokenStream) {
+    let emit_delim = if prefix.is_empty() {
+        let sep = write_lit(separator);
+        quote! { if !__first { #sep } }
+    } else {
+        let pfx = write_lit(prefix);
+        let sep = write_lit(separator);
+        quote! { if __first { #pfx } else { #sep } }
+    };
+    let emit_kv = key.map_or_else(TokenStream::new, |k| {
+        let key_tok = write_lit(k);
+        let eq_tok = write_lit("=");
+        quote! { #key_tok #eq_tok }
+    });
+    (emit_delim, emit_kv)
+}
+
+/// Generates render code for a single parameter group (e.g. `{?x,y}`, `{/a,b}`, `{x}`).
+///
+/// Dispatches to the all-required fast path or the optional-aware path depending on
+/// whether the group contains any `Option<T>` field.
+fn construct_render_group(group: &ParamGroup, field_map: &FieldMap<'_>, unrestricted_params: &HashSet<String>) -> Vec<TokenStream> {
+    if group_has_any_optional(group.param_names(), field_map) {
+        render_group_with_optional(group, field_map, unrestricted_params)
+    } else {
+        render_group_all_required(group, field_map, unrestricted_params)
+    }
+}
+
+/// Render path for groups whose parameters are all required.
+///
+/// Emits a flat sequence of `push_str` and `write!` statements. No `__first`
+/// tracking is needed because every parameter contributes a value.
+fn render_group_all_required(group: &ParamGroup, field_map: &FieldMap<'_>, unrestricted_params: &HashSet<String>) -> Vec<TokenStream> {
+    let prefix = group.prefix().unwrap_or_default();
+    let separator = group.separator();
+    let is_kv = group.is_kv();
+    let param_names = group.param_names();
+
+    let mut stmts = Vec::new();
+    for (i, param_name) in param_names.iter().enumerate() {
+        let delim = if i == 0 { prefix } else { separator };
+        if !delim.is_empty() {
+            stmts.push(quote! { __out.push_str(#delim); });
+        }
+        if is_kv {
+            let key = *param_name;
+            stmts.push(quote! { __out.push_str(#key); __out.push_str("="); });
+        }
+        let field = field_map.get(*param_name).expect("field should exist (validated earlier)");
+        let field_ident = field.ident.as_ref().expect("struct fields must be named");
+        let ty_span = field.ty.span();
+        if unrestricted_params.contains(*param_name) {
+            stmts.push(quote_spanned! { ty_span => ::std::fmt::Write::write_fmt(&mut __out, ::core::format_args!("{}", ::templated_uri::Raw::raw(&self.#field_ident))).expect("Display impls for templated URI parameter values are expected to be infallible"); });
+        } else {
+            stmts.push(
+                quote_spanned! { ty_span => ::std::fmt::Write::write_fmt(&mut __out, ::core::format_args!("{}", ::templated_uri::Escape::escape(&self.#field_ident))).expect("Display impls for templated URI parameter values are expected to be infallible"); },
+            );
+        }
+    }
+    stmts
+}
+
+/// Render path for groups containing at least one `Option<T>` parameter.
+///
+/// Emits a `__first`-tracked block per RFC 6570 section 3.2: when a variable is
+/// undefined (`None`), its prefix or separator is also omitted so that the
+/// first *defined* variable receives the prefix and subsequent defined
+/// variables receive the separator.
+fn render_group_with_optional(group: &ParamGroup, field_map: &FieldMap<'_>, unrestricted_params: &HashSet<String>) -> Vec<TokenStream> {
+    let prefix = group.prefix().unwrap_or_default();
+    let separator = group.separator();
+    let is_kv = group.is_kv();
+    let param_names = group.param_names();
+
+    let mut inner_stmts = Vec::new();
+    inner_stmts.push(quote! { let mut __first = true; });
+
+    for param_name in param_names {
+        let field = field_map.get(*param_name).expect("field should exist (validated earlier)");
+        let field_ident = field.ident.as_ref().expect("struct fields must be named");
+        let optional_inner = extract_option_inner(&field.ty);
+        let ty_span = optional_inner.map_or_else(|| field.ty.span(), syn::spanned::Spanned::span);
+
+        // For `Option<&T>` the `Some(ref __val)` binding produces `__val: &&T`. Pass `*__val`
+        // (which is `&T`) to the trait method so resolution sees the intended receiver type.
+        let inner_is_reference = optional_inner.is_some_and(|ty| matches!(ty, syn::Type::Reference(_)));
+        let val_arg = if inner_is_reference {
+            quote! { *__val }
+        } else {
+            quote! { __val }
+        };
+
+        let escape_expr = if unrestricted_params.contains(*param_name) {
+            quote_spanned! { ty_span => ::templated_uri::Raw::raw(#val_arg) }
+        } else {
+            quote_spanned! { ty_span => ::templated_uri::Escape::escape(#val_arg) }
+        };
+
+        let key_for_kv = is_kv.then_some(*param_name);
+        let (emit_delim, emit_kv) = emit_optional_delim_and_kv(prefix, separator, key_for_kv, |s| quote! { __out.push_str(#s); });
+
+        let body = quote! {
+            #emit_delim
+            #emit_kv
+            ::std::fmt::Write::write_fmt(&mut __out, ::core::format_args!("{}", #escape_expr)).expect("Display impls for templated URI parameter values are expected to be infallible");
+            __first = false;
+        };
+
+        if optional_inner.is_some() {
+            inner_stmts.push(quote! {
+                if let ::core::option::Option::Some(ref __val) = self.#field_ident {
+                    #body
+                }
+            });
+        } else {
+            inner_stmts.push(quote! {
+                {
+                    let __val = &self.#field_ident;
+                    #body
+                }
+            });
+        }
+    }
+
+    vec![quote! { { #(#inner_stmts)* } }]
+}
+
+fn construct_redacted_display(template: &UriTemplate, struct_fields: &[&Field], fields: &Fields, unredacted: bool) -> TokenStream {
+    let field_map: FieldMap<'_> = struct_fields
+        .iter()
+        .filter_map(|f| f.ident.as_ref().map(|ident| (ident.to_string(), *f)))
+        .collect();
+
+    let field_opts_map: FieldOptsMap<'_> = fields
         .fields
         .iter()
         .filter_map(|f| f.ident.as_ref().map(|ident| (ident.to_string(), f)))
@@ -219,53 +450,200 @@ fn construct_redacted_display(template: &UriTemplate, struct_fields: &[&Field], 
         .iter()
         .flat_map(|part| match part {
             TemplatePart::Content(content) => {
-                // For static content, just write it to the formatter
                 vec![quote! { f.write_str(#content)?; }]
             }
-            TemplatePart::ParamGroup(group) => {
-                let prefix = group.prefix().unwrap_or_default();
-                let separator = group.separator();
-                let is_kv = group.is_kv();
-                let param_names = group.param_names();
-
-                let mut stmts = Vec::new();
-                for (i, param_name) in param_names.iter().enumerate() {
-                    // Emit prefix (first param) or separator (subsequent params)
-                    let delim = if i == 0 { prefix } else { separator };
-                    if !delim.is_empty() {
-                        stmts.push(quote! { f.write_str(#delim)?; });
-                    }
-
-                    // Emit key= for KV expansions (e.g. ?key=value, ;key=value)
-                    if is_kv {
-                        let key = *param_name;
-                        stmts.push(quote! { f.write_str(#key)?; f.write_str("=")?; });
-                    }
-
-                    let field = field_map.get(*param_name).expect("Field should exist (validated earlier)");
-                    let field_ident = field.ident.as_ref().expect("struct fields must be named");
-                    let field_type = &field.ty;
-
-                    // Check if this specific field is marked as unredacted
-                    let field_unredacted = field_opts_map.get(*param_name).is_some_and(|opts| opts.unredacted);
-
-                    if unredacted || field_unredacted {
-                        stmts.push(quote! {
-                            ::std::write!(f, "{}", self.#field_ident)?;
-                        });
-                    } else {
-                        stmts.push(quote! {
-                            <#field_type as ::data_privacy::RedactedDisplay>::fmt(&self.#field_ident, engine, f)?;
-                        });
-                    }
-                }
-                stmts
-            }
+            TemplatePart::ParamGroup(group) => construct_redacted_display_group(group, &field_map, &field_opts_map, unredacted),
         })
         .collect();
 
     quote! {
         #(#statements)*
         ::std::result::Result::Ok(())
+    }
+}
+
+/// Generates redacted-display code for a single parameter group.
+///
+/// Dispatches to the all-required fast path or the optional-aware path depending on
+/// whether the group contains any `Option<T>` field.
+fn construct_redacted_display_group(
+    group: &ParamGroup,
+    field_map: &FieldMap<'_>,
+    field_opts_map: &FieldOptsMap<'_>,
+    unredacted: bool,
+) -> Vec<TokenStream> {
+    if group_has_any_optional(group.param_names(), field_map) {
+        redacted_display_group_with_optional(group, field_map, field_opts_map, unredacted)
+    } else {
+        redacted_display_group_all_required(group, field_map, field_opts_map, unredacted)
+    }
+}
+
+/// Redacted-display path for groups whose parameters are all required.
+fn redacted_display_group_all_required(
+    group: &ParamGroup,
+    field_map: &FieldMap<'_>,
+    field_opts_map: &FieldOptsMap<'_>,
+    unredacted: bool,
+) -> Vec<TokenStream> {
+    let prefix = group.prefix().unwrap_or_default();
+    let separator = group.separator();
+    let is_kv = group.is_kv();
+    let param_names = group.param_names();
+
+    let mut stmts = Vec::new();
+    for (i, param_name) in param_names.iter().enumerate() {
+        let delim = if i == 0 { prefix } else { separator };
+        if !delim.is_empty() {
+            stmts.push(quote! { f.write_str(#delim)?; });
+        }
+        if is_kv {
+            let key = *param_name;
+            stmts.push(quote! { f.write_str(#key)?; f.write_str("=")?; });
+        }
+        let field = field_map.get(*param_name).expect("field should exist (validated earlier)");
+        let field_ident = field.ident.as_ref().expect("struct fields must be named");
+        let field_type = &field.ty;
+        let field_unredacted = field_opts_map.get(*param_name).is_some_and(|opts| opts.unredacted);
+
+        if unredacted || field_unredacted {
+            stmts.push(quote! { ::std::write!(f, "{}", self.#field_ident)?; });
+        } else {
+            stmts.push(quote! { <#field_type as ::data_privacy::RedactedDisplay>::fmt(&self.#field_ident, engine, f)?; });
+        }
+    }
+    stmts
+}
+
+/// Redacted-display path for groups containing at least one `Option<T>` parameter.
+///
+/// Mirrors `render_group_with_optional`: undefined values are skipped along with
+/// their prefix/separator using `__first` tracking.
+fn redacted_display_group_with_optional(
+    group: &ParamGroup,
+    field_map: &FieldMap<'_>,
+    field_opts_map: &FieldOptsMap<'_>,
+    unredacted: bool,
+) -> Vec<TokenStream> {
+    let prefix = group.prefix().unwrap_or_default();
+    let separator = group.separator();
+    let is_kv = group.is_kv();
+    let param_names = group.param_names();
+
+    let mut inner_stmts = Vec::new();
+    inner_stmts.push(quote! { let mut __first = true; });
+
+    for param_name in param_names {
+        let field = field_map.get(*param_name).expect("field should exist (validated earlier)");
+        let field_ident = field.ident.as_ref().expect("struct fields must be named");
+        let optional_inner = extract_option_inner(&field.ty);
+        let field_unredacted = field_opts_map.get(*param_name).is_some_and(|opts| opts.unredacted);
+
+        let key_for_kv = is_kv.then_some(*param_name);
+        let (emit_delim, emit_kv) = emit_optional_delim_and_kv(prefix, separator, key_for_kv, |s| quote! { f.write_str(#s)?; });
+
+        if let Some(inner_type) = optional_inner {
+            // For `Option<&T>` the `Some(ref __val)` binding produces `__val: &&T`. Peel
+            // the AST `Type::Reference` and dereference once so the generated trait call
+            // resolves against `T: RedactedDisplay`, not the less useful `&T: RedactedDisplay`.
+            let (self_ty, val_arg) = match inner_type {
+                syn::Type::Reference(reference) => {
+                    let elem = &*reference.elem;
+                    (quote! { #elem }, quote! { *__val })
+                }
+                _ => (quote! { #inner_type }, quote! { __val }),
+            };
+            let display_value = if unredacted || field_unredacted {
+                quote! { ::std::write!(f, "{}", #val_arg)?; }
+            } else {
+                quote! { <#self_ty as ::data_privacy::RedactedDisplay>::fmt(#val_arg, engine, f)?; }
+            };
+
+            inner_stmts.push(quote! {
+                if let ::core::option::Option::Some(ref __val) = self.#field_ident {
+                    #emit_delim
+                    #emit_kv
+                    #display_value
+                    __first = false;
+                }
+            });
+        } else {
+            let display_value = if unredacted || field_unredacted {
+                quote! { ::std::write!(f, "{}", self.#field_ident)?; }
+            } else {
+                let field_type = &field.ty;
+                quote! { <#field_type as ::data_privacy::RedactedDisplay>::fmt(&self.#field_ident, engine, f)?; }
+            };
+
+            inner_stmts.push(quote! {
+                {
+                    #emit_delim
+                    #emit_kv
+                    #display_value
+                    __first = false;
+                }
+            });
+        }
+    }
+
+    vec![quote! { { #(#inner_stmts)* } }]
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    use super::extract_option_inner;
+
+    #[test]
+    fn extract_option_inner_some_for_simple_option() {
+        let ty: syn::Type = parse_quote! { Option<u32> };
+        let inner = extract_option_inner(&ty).expect("Option<u32> should match");
+        let inner_str = quote::quote! { #inner }.to_string();
+        assert_eq!(inner_str, "u32");
+    }
+
+    #[test]
+    fn extract_option_inner_some_for_qualified_option() {
+        // Both `std::option::Option<T>` and `core::option::Option<T>` are accepted by
+        // matching only on the last path segment.
+        let ty: syn::Type = parse_quote! { std::option::Option<String> };
+        let inner = extract_option_inner(&ty).expect("qualified Option should match");
+        let inner_str = quote::quote! { #inner }.to_string();
+        assert_eq!(inner_str, "String");
+    }
+
+    #[test]
+    fn extract_option_inner_none_for_non_path_type() {
+        // `&Option<u32>` is `Type::Reference`, not `Type::Path` — must short-circuit.
+        let ty: syn::Type = parse_quote! { &Option<u32> };
+        assert!(extract_option_inner(&ty).is_none());
+    }
+
+    #[test]
+    fn extract_option_inner_none_for_non_option_path() {
+        let ty: syn::Type = parse_quote! { Vec<u32> };
+        assert!(extract_option_inner(&ty).is_none());
+    }
+
+    #[test]
+    fn extract_option_inner_none_for_bare_option_without_generics() {
+        // Bare `Option` parses with `PathArguments::None`, not `AngleBracketed`.
+        let ty: syn::Type = parse_quote! { Option };
+        assert!(extract_option_inner(&ty).is_none());
+    }
+
+    #[test]
+    fn extract_option_inner_none_for_option_with_two_type_args() {
+        // Malformed `Option<T, U>` — the length check rejects it.
+        let ty: syn::Type = parse_quote! { Option<u32, String> };
+        assert!(extract_option_inner(&ty).is_none());
+    }
+
+    #[test]
+    fn extract_option_inner_none_for_option_with_lifetime_arg() {
+        // `Option<'a>` parses but the generic arg is a `Lifetime`, not a `Type`.
+        let ty: syn::Type = parse_quote! { Option<'a> };
+        assert!(extract_option_inner(&ty).is_none());
     }
 }


### PR DESCRIPTION
…values

Per RFC 6570 §2.3, template variables may be undefined. Allow Option<T> fields in `#[templated]` structs to model this: `None` causes the variable and its associated prefix or separator to be omitted from the rendered URI, while `Some(value)` (including empty strings) renders normally.

Both `render()` and the `RedactedDisplay` impl are regenerated to walk the parsed template parts with `__first` tracking so that prefix and separator placement stays correct across all RFC 6570 operators (`{x}`, `{+x}`, `{/x,y}`, `{?x,y}`, `{&x}`, `{;x,y}`).

Includes 18 new behavioural tests covering each operator family plus a trybuild compile-fail test ensuring `Option<T>` still propagates the inner-type span on `Escape` trait-bound errors.