### PR TITLE
fix(cachet): Fix broken seatbelt dev dependency path

### DIFF
--- a/crates/cachet/Cargo.toml
+++ b/crates/cachet/Cargo.toml
@@ -68,7 +68,7 @@ opentelemetry = { workspace = true, features = [
 ] }
 opentelemetry_sdk = { workspace = true, features = ["logs", "testing"] }
 recoverable = { workspace = true }
-seatbelt = { workspace = true, features = ["retry", "tower-service"] }
+seatbelt = { path = "../seatbelt", features = ["retry", "tower-service"] }
 testing_aids = { path = "../testing_aids" }
 tick = { workspace = true, features = ["test-util", "tokio"] }
 tokio = { workspace = true, features = ["rt"] }


### PR DESCRIPTION
The release pipeline doesn't sort release priority based on dev-deps, but it still checks for those packages before releasing. When Seatbelt was updated to 0.4.5 in #387, it tried to check for the 0.4.5 release before actually releasing it, and got stuck. This PR changes it to a path ref to avoid this issue.