### PR TITLE
chore: cascade version bumps to dependents in release-crate.ps1

### DIFF
--- a/scripts/release-crate.ps1
+++ b/scripts/release-crate.ps1
@@ -6,12 +6,22 @@
     Updates the version of a Rust crate and generates a CHANGELOG.md file based on git history.
 
 .DESCRIPTION
-    This script automates two main tasks for releasing a Rust crate in a workspace repository:
-    1. Version Bump: Automatically increment the version (major, minor, or patch) or set a specific version.
-    2. Changelog Generation: It generates a CHANGELOG.md file based on git commit history.
+    This script automates the full release of a Rust crate in a workspace repository:
+    1. Version Bump: Automatically increment the version (major, minor, or patch) or set a specific
+       version. Cargo's 0.x.y SemVer rules are honored — for `0.x.y` crates a `major` bump becomes
+       `0.(x+1).0` and both `minor` and `patch` map to bumping `y`.
+    2. Cascade: Every workspace crate that depends on the target via `[dependencies]` or
+       `[build-dependencies]` (transitively) is bumped with the same bump kind. Dev-only dependents
+       are skipped — they automatically pick up the new workspace version. This mirrors the
+       guidance in `.github/prompts/bump-crate-version.prompt.md` and prevents the publish-time
+       inconsistencies that would otherwise occur when a core crate is bumped in isolation.
+    3. Changelog Generation: A CHANGELOG.md entry is generated for the target and every cascaded
+       dependent. Cascaded crates that have no other commits since their last release get a single
+       `bump \`<target>\` to <new-version>` entry under `🔧 Maintenance` (or `⚠️ Breaking` for
+       major bumps).
 
-    By default, if neither --version nor --bump is specified, the script will bump the minor version
-    and reset the patch version to 0 (e.g., 1.2.3 -> 1.3.0).
+    By default, if neither --version nor --bump is specified, the script will perform a minor bump
+    of the target crate (e.g., 1.2.3 -> 1.3.0, or 0.3.3 -> 0.3.4 for `0.x.y` crates).
 
 .PARAMETER CrateName
     The name of the crate to release. This should match the folder name inside the 'crates' directory.
@@ -157,13 +167,142 @@ function Compare-SemanticVersions {
     return 0  # versions are equal
 }
 
-# Determines whether a version bump is semver-incompatible, following Cargo's
-# semver compatibility rules:
-#   - For stable versions (>= 1.0.0): incompatible if the major version changes.
-#   - For pre-release versions (0.x.y, x >= 1): incompatible if the minor version changes.
-#   - For initial development versions (0.0.x): every change is incompatible.
-# Returns $true if the bump is incompatible, $false otherwise.
-function Test-SemverIncompatibleBump {
+# Loads workspace package metadata once and caches it.
+$script:CachedWorkspaceMetadata = $null
+function Get-WorkspaceMetadata {
+    param([string]$repoRoot)
+
+    if ($null -ne $script:CachedWorkspaceMetadata) {
+        return $script:CachedWorkspaceMetadata
+    }
+
+    $rootManifest = Join-Path $repoRoot "Cargo.toml"
+    $metadataJson = cargo metadata --format-version=1 --no-deps --manifest-path $rootManifest
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to run 'cargo metadata'." -ErrorAction Stop
+    }
+
+    $script:CachedWorkspaceMetadata = $metadataJson | ConvertFrom-Json
+    return $script:CachedWorkspaceMetadata
+}
+
+# Returns information about all workspace crates as an array of objects with:
+#   Name      - cargo package name
+#   Folder    - folder name under crates/ (used as the script's CrateName argument)
+#   Published - $true if the crate is published to crates.io
+#   Deps      - array of normalized dependency names (kind 'normal' or 'build', not 'dev')
+function Get-WorkspaceCrates {
+    param([string]$repoRoot)
+
+    $metadata = Get-WorkspaceMetadata -repoRoot $repoRoot
+    $cratesDir = (Join-Path $repoRoot "crates").Replace('/', '\')
+
+    $crates = @()
+    foreach ($package in $metadata.packages) {
+        $manifestDir = (Split-Path $package.manifest_path -Parent).Replace('/', '\')
+        if (-not $manifestDir.StartsWith($cratesDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+
+        $deps = @()
+        foreach ($dep in $package.dependencies) {
+            # Cascade follows normal and build deps; dev-deps automatically pick up the workspace
+            # version on `cargo publish` and never need their own version bumped.
+            if ($dep.kind -ne 'dev') {
+                $deps += $dep.name.Replace('-', '_')
+            }
+        }
+
+        $crates += [pscustomobject]@{
+            Name      = $package.name
+            Folder    = Split-Path $manifestDir -Leaf
+            Published = -not ($null -ne $package.publish -and $package.publish.Count -eq 0)
+            Deps      = $deps
+        }
+    }
+
+    return $crates
+}
+
+# Computes the transitive set of published workspace crates that depend on the given target via
+# [dependencies] or [build-dependencies]. Returns folder names suitable for indexing into crates/.
+# The target itself is not included.
+function Get-AllTransitiveDependents {
+    param(
+        [string]$crateName,
+        [string]$repoRoot
+    )
+
+    $crates = Get-WorkspaceCrates -repoRoot $repoRoot
+    $byName = @{}
+    foreach ($c in $crates) {
+        $byName[$c.Name.Replace('-', '_')] = $c
+    }
+
+    $normalizedTarget = $crateName.Replace('-', '_')
+
+    # BFS over the reverse dependency graph.
+    $toVisit = [System.Collections.Generic.Queue[string]]::new()
+    $toVisit.Enqueue($normalizedTarget)
+    $visited = [System.Collections.Generic.HashSet[string]]::new()
+    [void]$visited.Add($normalizedTarget)
+
+    $dependents = @()
+    while ($toVisit.Count -gt 0) {
+        $current = $toVisit.Dequeue()
+        foreach ($candidate in $crates) {
+            $candidateNorm = $candidate.Name.Replace('-', '_')
+            if ($visited.Contains($candidateNorm)) {
+                continue
+            }
+            if ($candidate.Deps -contains $current) {
+                [void]$visited.Add($candidateNorm)
+                $toVisit.Enqueue($candidateNorm)
+                if ($candidate.Published) {
+                    $dependents += $candidate.Folder
+                }
+            }
+        }
+    }
+
+    return , $dependents
+}
+
+# Computes the next version for the given bump kind, honoring Cargo's 0.x.y SemVer rules:
+#   - For x.y.z (x >= 1): major -> (x+1).0.0, minor -> x.(y+1).0, patch -> x.y.(z+1)
+#   - For 0.x.y (x >= 1): major -> 0.(x+1).0, minor and patch -> 0.x.(y+1)
+#   - For 0.0.x:           every bump -> 0.0.(x+1) (every change is breaking)
+function Get-NextVersion {
+    param(
+        [string]$currentVersion,
+        [ValidateSet('major', 'minor', 'patch')]
+        [string]$bump
+    )
+
+    $parts = $currentVersion.Split('.') | ForEach-Object { [int]$_ }
+    while ($parts.Count -lt 3) { $parts += 0 }
+
+    if ($parts[0] -ge 1) {
+        switch ($bump) {
+            'major' { return "$($parts[0] + 1).0.0" }
+            'minor' { return "$($parts[0]).$($parts[1] + 1).0" }
+            'patch' { return "$($parts[0]).$($parts[1]).$($parts[2] + 1)" }
+        }
+    }
+    elseif ($parts[1] -ge 1) {
+        switch ($bump) {
+            'major' { return "0.$($parts[1] + 1).0" }
+            default { return "0.$($parts[1]).$($parts[2] + 1)" }
+        }
+    }
+    else {
+        return "0.0.$($parts[2] + 1)"
+    }
+}
+
+# Infers a bump kind from the difference between two versions. Used when the caller passed an
+# explicit --version so the cascade can apply a matching kind to dependents.
+function Get-BumpKindFromVersions {
     param(
         [string]$oldVersion,
         [string]$newVersion
@@ -171,83 +310,19 @@ function Test-SemverIncompatibleBump {
 
     $oldParts = $oldVersion.Split('.') | ForEach-Object { [int]$_ }
     $newParts = $newVersion.Split('.') | ForEach-Object { [int]$_ }
-
     while ($oldParts.Count -lt 3) { $oldParts += 0 }
     while ($newParts.Count -lt 3) { $newParts += 0 }
 
-    # For versions >= 1.0.0, incompatible if major version changed
     if ($oldParts[0] -ge 1) {
-        return $newParts[0] -ne $oldParts[0]
+        if ($newParts[0] -ne $oldParts[0]) { return 'major' }
+        if ($newParts[1] -ne $oldParts[1]) { return 'minor' }
+        return 'patch'
     }
-
-    # For versions 0.x.y where x >= 1, incompatible if minor version changed
     if ($oldParts[1] -ge 1) {
-        return $newParts[1] -ne $oldParts[1]
+        if ($newParts[1] -ne $oldParts[1]) { return 'major' }
+        return 'patch'
     }
-
-    # For versions 0.0.x, every change is incompatible
-    return $newParts[2] -ne $oldParts[2]
-}
-
-# Finds published workspace crates that have a direct (non-dev, non-build) dependency
-# on the given crate. Uses 'cargo metadata' for reliable JSON-based dependency resolution
-# rather than TOML parsing. Returns an array of crate folder names (suitable for passing
-# to release-crate.ps1). Unpublished crates (publish = false) are excluded since they
-# do not need follow-up releases.
-function Get-DirectDependents {
-    param(
-        [string]$crateName,
-        [string]$repoRoot
-    )
-
-    $rootManifest = Join-Path $repoRoot "Cargo.toml"
-    $metadataJson = cargo metadata --format-version=1 --no-deps --manifest-path $rootManifest
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warning "Failed to run 'cargo metadata'. Skipping dependent crate check."
-        return @()
-    }
-
-    $metadata = $metadataJson | ConvertFrom-Json
-
-    # Normalize crate name for comparison (hyphens and underscores are equivalent in Cargo)
-    $normalizedTargetName = $crateName.Replace('-', '_')
-
-    $dependents = @()
-    $cratesDir = (Join-Path $repoRoot "crates").Replace('/', '\')
-
-    foreach ($package in $metadata.packages) {
-        # Normalize path separators for reliable comparison
-        $manifestDir = (Split-Path $package.manifest_path -Parent).Replace('/', '\')
-
-        # Only consider packages within the workspace crates directory
-        if (-not $manifestDir.StartsWith($cratesDir, [System.StringComparison]::OrdinalIgnoreCase)) {
-            continue
-        }
-
-        # Skip the crate itself
-        $normalizedPackageName = $package.name.Replace('-', '_')
-        if ($normalizedPackageName -eq $normalizedTargetName) {
-            continue
-        }
-
-        # Skip crates that are not published (publish = [] in cargo metadata means publish = false)
-        if ($null -ne $package.publish -and $package.publish.Count -eq 0) {
-            continue
-        }
-
-        # Check if this package has a direct (non-dev, non-build) dependency on the target crate
-        foreach ($dep in $package.dependencies) {
-            $normalizedDepName = $dep.name.Replace('-', '_')
-            if ($normalizedDepName -eq $normalizedTargetName -and [string]::IsNullOrEmpty($dep.kind)) {
-                # Extract folder name from manifest path for use as release-crate.ps1 input
-                $folderName = Split-Path $manifestDir -Leaf
-                $dependents += $folderName
-                break
-            }
-        }
-    }
-
-    return $dependents
+    return 'major'
 }
 
 function Get-CurrentVersion {
@@ -397,31 +472,8 @@ function Update-CrateVersion {
 
     $newVersion = ""
     if ([string]::IsNullOrEmpty($version)) {
-        $versionParts = $currentVersion.Split('.')
-        # Ensure versionParts has 3 elements (major, minor, patch)
-        while ($versionParts.Count -lt 3) {
-            $versionParts += '0'
-        }
-
-        # Determine which version component to bump
         $bumpType = if ([string]::IsNullOrEmpty($bump)) { 'minor' } else { $bump }
-
-        switch ($bumpType) {
-            'major' {
-                $versionParts[0] = [int]$versionParts[0] + 1
-                $versionParts[1] = '0'
-                $versionParts[2] = '0'
-            }
-            'minor' {
-                $versionParts[1] = [int]$versionParts[1] + 1
-                $versionParts[2] = '0'
-            }
-            'patch' {
-                $versionParts[2] = [int]$versionParts[2] + 1
-            }
-        }
-
-        $newVersion = $versionParts -join '.'
+        $newVersion = Get-NextVersion -currentVersion $currentVersion -bump $bumpType
         Write-Host "✅ Incrementing $bumpType version from $currentVersion to $newVersion."
     }
     else {
@@ -444,11 +496,6 @@ function Update-CrateVersion {
     $regex = '(?<=' + $crateNamePattern + '\s*=\s*\{[^\}]*?version\s*=\s*")[^"]+'
     (Get-Content $rootCargoToml -Raw) -replace $regex, $newVersion | Set-Content $rootCargoToml -NoNewline
 
-    cargo check -p $crateName --quiet | Write-Host
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Cargo check failed after version update. Please verify the changes." -ErrorAction Stop
-    }
-
     return $newVersion
 }
 
@@ -458,7 +505,11 @@ function Write-Changelog {
         [string]$newVersion,
         [string]$crateFolder,
         [string]$changelogFile,
-        [string]$prBaseUrl
+        [string]$prBaseUrl,
+        # Optional: when this crate is being bumped purely as a cascade from another crate,
+        # describe the cascade so a maintenance entry can be written even if the crate has
+        # no commits since its last release. Shape: @{ Target = '<name>'; Version = '<x.y.z>'; Breaking = $false }
+        [hashtable]$cascadeReason = $null
     )
 
     $tags = Invoke-GitCommand -Command "tag --list `"$crateName-v*`"" -ErrorMessage "Failed to retrieve git tags"
@@ -486,15 +537,33 @@ function Write-Changelog {
         $rawCommits = @($rawCommits)
     }
 
-    if (-not $rawCommits) {
+    $formattedCommits = @()
+    if ($rawCommits.Count -gt 0) {
+        $formattedCommits = Format-ConventionalCommits -rawCommitMessages $rawCommits -prBaseUrl $prBaseUrl
+    }
+
+    if ($formattedCommits.Count -eq 0 -and $null -eq $cascadeReason) {
         Write-Warning "No unreleased commits found to add to the changelog."
         return
     }
 
-    $formattedCommits = Format-ConventionalCommits -rawCommitMessages $rawCommits -prBaseUrl $prBaseUrl
-    if (-not $formattedCommits) {
-        Write-Warning "No relevant commits found to add to the changelog (all commits may be filtered out)."
-        return
+    # Prepend a cascade entry when this crate is being bumped purely because one of its
+    # dependencies was bumped. Format follows existing convention in the repo
+    # (e.g. crates/cachet/CHANGELOG.md):
+    #   - 🔧 Maintenance
+    #     - bump `<target>` to <version>
+    if ($null -ne $cascadeReason) {
+        $sectionHeader = if ($cascadeReason.Breaking) { '- ⚠️ Breaking' } else { '- 🔧 Maintenance' }
+        $cascadeLines = @(
+            $sectionHeader,
+            "",
+            "  - bump ``$($cascadeReason.Target)`` to $($cascadeReason.Version)"
+        )
+        if ($formattedCommits.Count -gt 0) {
+            $formattedCommits = $cascadeLines + @("") + $formattedCommits
+        } else {
+            $formattedCommits = $cascadeLines
+        }
     }
 
     # Build the new version section
@@ -561,35 +630,43 @@ function Update-Readme {
     }
 }
 
-# Displays a warning when a semver-incompatible release has been prepared and other
-# published workspace crates depend on the released crate. These dependents will need
-# their own releases to reference the new version. The user must decide for each
-# dependent whether the change is breaking in that crate's context and run
-# release-crate.ps1 accordingly.
-function Show-DependentCratesWarning {
+# Bumps a single crate's version, regenerates its changelog and README.
+# Returns the new version string.
+function Invoke-CrateRelease {
     param(
         [string]$crateName,
-        [string]$oldVersion,
-        [string]$newVersion,
-        [string[]]$dependentCrates
+        [string]$crateFolder,
+        [string]$crateCargoToml,
+        [string]$rootCargoToml,
+        [string]$changelogFile,
+        [string]$prBaseUrl,
+        [string]$version,
+        [string]$bump,
+        [hashtable]$cascadeReason = $null
+    )
+
+    $newVersion = Update-CrateVersion -crateName $crateName -version $version -bump $bump `
+        -crateCargoToml $crateCargoToml -rootCargoToml $rootCargoToml
+    if ($null -eq $newVersion) {
+        Write-Error "Failed to update version for crate '$crateName'." -ErrorAction Stop
+    }
+
+    Write-Changelog -crateName $crateName -newVersion $newVersion -crateFolder $crateFolder `
+        -changelogFile $changelogFile -prBaseUrl $prBaseUrl -cascadeReason $cascadeReason
+    Update-Readme -crateName $crateName -crateFolder $crateFolder
+
+    return $newVersion
+}
+
+function Show-ReleaseSummary {
+    param(
+        [array]$releases
     )
 
     Write-Host ""
-    Write-Host "⚠️  SEMVER-INCOMPATIBLE RELEASE DETECTED" -ForegroundColor Yellow
-    Write-Host "The version bump from $oldVersion to $newVersion is semver-incompatible." -ForegroundColor Yellow
-    Write-Host ""
-    Write-Host "The following workspace crates have a direct dependency on '$crateName'" -ForegroundColor Yellow
-    Write-Host "and will also need to be released to reference the new version:" -ForegroundColor Yellow
-    Write-Host ""
-    foreach ($dependent in $dependentCrates) {
-        Write-Host "  - $dependent" -ForegroundColor Yellow
-    }
-    Write-Host ""
-    Write-Host "For each dependent crate, decide whether this is a breaking or non-breaking" -ForegroundColor Yellow
-    Write-Host "change in that crate's context, then run:" -ForegroundColor Yellow
-    Write-Host ""
-    foreach ($dependent in $dependentCrates) {
-        Write-Host "  .\scripts\release-crate.ps1 $dependent --bump <major|minor|patch>" -ForegroundColor DarkGray
+    Write-Host "📦 Released crates:" -ForegroundColor Green
+    foreach ($r in $releases) {
+        Write-Host "  - $($r.Crate): $($r.OldVersion) -> $($r.NewVersion)" -ForegroundColor Green
     }
     Write-Host ""
 }
@@ -686,22 +763,66 @@ if (-not [string]::IsNullOrEmpty($Version)) {
 try {
     $oldVersion = Get-CurrentVersion -cargoTomlPath $crateCargoToml
 
-    $newVersion = Update-CrateVersion -crateName $CrateName -version $Version -bump $Bump -crateCargoToml $crateCargoToml -rootCargoToml $rootCargoToml
-    if ($null -eq $newVersion) {
-        Write-Error "Failed to update crate version. Aborting."
-        Exit 1
+    $newVersion = Invoke-CrateRelease -crateName $CrateName -crateFolder $crateFolder `
+        -crateCargoToml $crateCargoToml -rootCargoToml $rootCargoToml -changelogFile $changelogFile `
+        -prBaseUrl $prBaseUrl -version $Version -bump $Bump
+
+    # Determine the bump kind that was applied so we can cascade the same kind to dependents.
+    # When the caller passed --version we infer it from old -> new.
+    $cascadeBump = if (-not [string]::IsNullOrEmpty($Bump)) {
+        $Bump
+    } elseif (-not [string]::IsNullOrEmpty($Version)) {
+        Get-BumpKindFromVersions -oldVersion $oldVersion -newVersion $newVersion
+    } else {
+        'minor'
     }
 
-    Write-Changelog -crateName $CrateName -newVersion $newVersion -crateFolder $crateFolder -changelogFile $changelogFile -prBaseUrl $prBaseUrl
-    Update-Readme -crateName $CrateName -crateFolder $crateFolder
+    $releases = @(
+        [pscustomobject]@{ Crate = $CrateName; OldVersion = $oldVersion; NewVersion = $newVersion }
+    )
 
-    if (Test-SemverIncompatibleBump -oldVersion $oldVersion -newVersion $newVersion) {
-        $dependentCrates = Get-DirectDependents -crateName $CrateName -repoRoot $repoRoot
-        if ($dependentCrates.Count -gt 0) {
-            Show-DependentCratesWarning -crateName $CrateName -oldVersion $oldVersion -newVersion $newVersion -dependentCrates $dependentCrates
+    # Cascade the same bump kind to every transitive non-dev workspace dependent. This keeps
+    # workspace-pinned versions consistent and prevents the publish-time failures described in
+    # https://github.com/microsoft/oxidizer/blob/main/.github/prompts/bump-crate-version.prompt.md
+    $dependents = Get-AllTransitiveDependents -crateName $CrateName -repoRoot $repoRoot
+    if ($dependents.Count -gt 0) {
+        Write-Host ""
+        Write-Host "🔗 Cascading $cascadeBump bump to $($dependents.Count) dependent crate(s): $($dependents -join ', ')" -ForegroundColor Cyan
+
+        $cascadeReason = @{
+            Target   = $CrateName
+            Version  = $newVersion
+            Breaking = ($cascadeBump -eq 'major')
+        }
+
+        foreach ($dependent in $dependents) {
+            $depFolder = Join-Path $repoRoot "crates/$dependent"
+            $depCargo  = Join-Path $depFolder "Cargo.toml"
+            $depChange = Join-Path $depFolder "CHANGELOG.md"
+
+            if (-not (Test-Path $depCargo)) {
+                Write-Warning "Skipping cascade for '$dependent': Cargo.toml not found at '$depCargo'."
+                continue
+            }
+
+            $depOld = Get-CurrentVersion -cargoTomlPath $depCargo
+            $depNew = Invoke-CrateRelease -crateName $dependent -crateFolder $depFolder `
+                -crateCargoToml $depCargo -rootCargoToml $rootCargoToml -changelogFile $depChange `
+                -prBaseUrl $prBaseUrl -version "" -bump $cascadeBump -cascadeReason $cascadeReason
+
+            $releases += [pscustomobject]@{ Crate = $dependent; OldVersion = $depOld; NewVersion = $depNew }
         }
     }
 
+    # One workspace-wide cargo check after every version edit to confirm the workspace still resolves.
+    Write-Host ""
+    Write-Host "🔍 Running workspace cargo check..." -ForegroundColor Cyan
+    cargo check --workspace --quiet | Write-Host
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Workspace 'cargo check' failed after version updates. Please verify the changes." -ErrorAction Stop
+    }
+
+    Show-ReleaseSummary -releases $releases
     Show-FinalMessage -crateName $CrateName -newVersion $newVersion
 }
 catch {

--- a/scripts/release-crate.ps1
+++ b/scripts/release-crate.ps1
@@ -11,10 +11,17 @@
        version. Cargo's 0.x.y SemVer rules are honored — for `0.x.y` crates a `major` bump becomes
        `0.(x+1).0` and both `minor` and `patch` map to bumping `y`.
     2. Cascade: Every workspace crate that depends on the target via `[dependencies]` or
-       `[build-dependencies]` (transitively) is bumped with the same bump kind. Dev-only dependents
-       are skipped — they automatically pick up the new workspace version. This mirrors the
-       guidance in `.github/prompts/bump-crate-version.prompt.md` and prevents the publish-time
-       inconsistencies that would otherwise occur when a core crate is bumped in isolation.
+       `[build-dependencies]` (transitively) is also bumped. The bump kind applied to each
+       dependent is informed by `[package.metadata.cargo_check_external_types]`:
+         * If the dependent exposes any type rooted at the bumped crate in its public API
+           (or does not declare allowed_external_types at all), the same bump kind is applied —
+           a breaking change in the bumped crate's public API transitively becomes a breaking
+           change in the dependent's public API.
+         * Otherwise, the dependent only uses the bumped crate internally, and a `patch` bump
+           is applied: enough to refresh the workspace-pinned version, but without overstating
+           the change to downstream consumers.
+       Dev-only dependents are skipped — they automatically pick up the new workspace version.
+       This mirrors the guidance in `.github/prompts/bump-crate-version.prompt.md`.
     3. Changelog Generation: A CHANGELOG.md entry is generated for the target and every cascaded
        dependent. Cascaded crates that have no other commits since their last release get a single
        `bump \`<target>\` to <new-version>` entry under `🔧 Maintenance` (or `⚠️ Breaking` for
@@ -187,10 +194,14 @@ function Get-WorkspaceMetadata {
 }
 
 # Returns information about all workspace crates as an array of objects with:
-#   Name      - cargo package name
-#   Folder    - folder name under crates/ (used as the script's CrateName argument)
-#   Published - $true if the crate is published to crates.io
-#   Deps      - array of normalized dependency names (kind 'normal' or 'build', not 'dev')
+#   Name                  - cargo package name
+#   Folder                - folder name under crates/ (used as the script's CrateName argument)
+#   Published             - $true if the crate is published to crates.io
+#   Deps                  - array of normalized dependency names (kind 'normal' or 'build', not 'dev')
+#   AllowedExternalTypes  - array of strings from [package.metadata.cargo_check_external_types],
+#                           or $null if the crate does not declare them. Each entry is a path or
+#                           glob like "tick::clock::Clock" or "cachet_memory::*". Used to detect
+#                           whether a dependent exposes types from a bumped crate in its public API.
 function Get-WorkspaceCrates {
     param([string]$repoRoot)
 
@@ -213,15 +224,61 @@ function Get-WorkspaceCrates {
             }
         }
 
+        # Extract [package.metadata.cargo_check_external_types].allowed_external_types if present.
+        # PSCustomObject access via PSObject.Properties avoids errors for missing branches.
+        $allowedTypes = $null
+        $pkgMeta = $package.PSObject.Properties['metadata']
+        if ($pkgMeta -and $null -ne $pkgMeta.Value) {
+            $cet = $pkgMeta.Value.PSObject.Properties['cargo_check_external_types']
+            if ($cet -and $null -ne $cet.Value) {
+                $aet = $cet.Value.PSObject.Properties['allowed_external_types']
+                if ($aet -and $null -ne $aet.Value) {
+                    $allowedTypes = @($aet.Value)
+                }
+            }
+        }
+
         $crates += [pscustomobject]@{
-            Name      = $package.name
-            Folder    = Split-Path $manifestDir -Leaf
-            Published = -not ($null -ne $package.publish -and $package.publish.Count -eq 0)
-            Deps      = $deps
+            Name                 = $package.name
+            Folder               = Split-Path $manifestDir -Leaf
+            Published            = -not ($null -ne $package.publish -and $package.publish.Count -eq 0)
+            Deps                 = $deps
+            AllowedExternalTypes = $allowedTypes
         }
     }
 
     return $crates
+}
+
+# Returns $true if the dependent crate exposes any type rooted at the target crate in its public
+# API, as declared by [package.metadata.cargo_check_external_types].allowed_external_types.
+#
+# Returns $true (conservative) if the dependent does not declare allowed_external_types at all,
+# since we then have no information about its public API surface and assume the worst.
+#
+# Returns $false only when the metadata is present and contains no entry rooted at the target.
+function Test-CrateExposesTarget {
+    param(
+        [pscustomobject]$dependent,
+        [string]$targetPackageName
+    )
+
+    if ($null -eq $dependent.AllowedExternalTypes) {
+        # No metadata declared. Be conservative: assume the dependent might expose target's types.
+        return $true
+    }
+
+    $normalizedTarget = $targetPackageName.Replace('-', '_')
+    foreach ($entry in $dependent.AllowedExternalTypes) {
+        # Each entry is a Rust path like "tick::clock::Clock" or "cachet_memory::*". The first
+        # `::`-separated segment is always the crate name (in normalized snake_case form).
+        $root = ($entry -split '::', 2)[0]
+        if ($root -eq $normalizedTarget) {
+            return $true
+        }
+    }
+
+    return $false
 }
 
 # Computes the transitive set of published workspace crates that depend on the given target via
@@ -814,19 +871,23 @@ try {
         [pscustomobject]@{ Crate = $CrateName; OldVersion = $oldVersion; NewVersion = $newVersion }
     )
 
-    # Cascade the same bump kind to every transitive non-dev workspace dependent. This keeps
-    # workspace-pinned versions consistent and prevents the publish-time failures described in
-    # https://github.com/microsoft/oxidizer/blob/main/.github/prompts/bump-crate-version.prompt.md
+    # Cascade to every transitive non-dev workspace dependent. The bump kind applied to each
+    # dependent is informed by [package.metadata.cargo_check_external_types]:
+    #   - If the dependent exposes any type rooted at the bumped crate in its public API, the
+    #     same bump kind is applied (a breaking change in the bumped crate's public API
+    #     transitively becomes a breaking change in the dependent's public API).
+    #   - Otherwise, the dependent only uses the bumped crate internally, so a `patch` bump is
+    #     enough to refresh the workspace-pinned version without overstating the change.
+    # If a dependent does not declare allowed_external_types, we conservatively cascade the same
+    # kind (worst-case assumption).
     $dependents = @(Get-AllTransitiveDependents -crateName $CrateName -repoRoot $repoRoot)
     if ($dependents.Count -gt 0) {
         Write-Host ""
-        Write-Host "🔗 Cascading $cascadeBump bump to $($dependents.Count) dependent crate(s): $($dependents -join ', ')" -ForegroundColor Cyan
+        Write-Host "🔗 Cascading $cascadeBump bump (or patch where the dependent does not expose '$CrateName' types) to $($dependents.Count) crate(s): $($dependents -join ', ')" -ForegroundColor Cyan
 
-        $cascadeReason = @{
-            Target   = $CrateName
-            Version  = $newVersion
-            Breaking = ($cascadeBump -eq 'major')
-        }
+        $allCrates = Get-WorkspaceCrates -repoRoot $repoRoot
+        $targetCrate = $allCrates | Where-Object { $_.Folder -eq $CrateName -or $_.Name -eq $CrateName } | Select-Object -First 1
+        $targetPackageName = if ($null -ne $targetCrate) { $targetCrate.Name } else { $CrateName }
 
         foreach ($dependent in $dependents) {
             $depFolder = Join-Path $repoRoot 'crates' $dependent
@@ -838,10 +899,27 @@ try {
                 continue
             }
 
+            $depCrate = $allCrates | Where-Object { $_.Folder -eq $dependent } | Select-Object -First 1
+            $exposes = if ($null -ne $depCrate) {
+                Test-CrateExposesTarget -dependent $depCrate -targetPackageName $targetPackageName
+            } else {
+                $true
+            }
+
+            $depBump = if ($exposes) { $cascadeBump } else { 'patch' }
+            $exposureNote = if ($exposes) { 'exposes target in public API' } else { 'internal use only' }
+            Write-Host "  • $dependent -> $depBump ($exposureNote)" -ForegroundColor DarkCyan
+
+            $depCascadeReason = @{
+                Target   = $CrateName
+                Version  = $newVersion
+                Breaking = ($depBump -eq 'major')
+            }
+
             $depOld = Get-CurrentVersion -cargoTomlPath $depCargo
             $depNew = Invoke-CrateRelease -crateName $dependent -crateFolder $depFolder `
                 -crateCargoToml $depCargo -rootCargoToml $rootCargoToml -changelogFile $depChange `
-                -prBaseUrl $prBaseUrl -version "" -bump $cascadeBump -cascadeReason $cascadeReason
+                -prBaseUrl $prBaseUrl -version "" -bump $depBump -cascadeReason $depCascadeReason
 
             $releases += [pscustomobject]@{ Crate = $dependent; OldVersion = $depOld; NewVersion = $depNew }
         }

--- a/scripts/release-crate.ps1
+++ b/scripts/release-crate.ps1
@@ -234,11 +234,6 @@ function Get-AllTransitiveDependents {
     )
 
     $crates = Get-WorkspaceCrates -repoRoot $repoRoot
-    $byName = @{}
-    foreach ($c in $crates) {
-        $byName[$c.Name.Replace('-', '_')] = $c
-    }
-
     $normalizedTarget = $crateName.Replace('-', '_')
 
     # BFS over the reverse dependency graph.
@@ -265,7 +260,8 @@ function Get-AllTransitiveDependents {
         }
     }
 
-    return , $dependents
+    # Wrap with @(...) at the call site to preserve array semantics for 0/1-element results.
+    return $dependents
 }
 
 # Computes the next version for the given bump kind, honoring Cargo's 0.x.y SemVer rules:
@@ -543,7 +539,11 @@ function Write-Changelog {
     }
 
     if ($formattedCommits.Count -eq 0 -and $null -eq $cascadeReason) {
-        Write-Warning "No unreleased commits found to add to the changelog."
+        if ($rawCommits.Count -eq 0) {
+            Write-Warning "No unreleased commits found to add to the changelog."
+        } else {
+            Write-Warning "No relevant commits found to add to the changelog (all $($rawCommits.Count) commit(s) were filtered out)."
+        }
         return
     }
 
@@ -784,7 +784,7 @@ try {
     # Cascade the same bump kind to every transitive non-dev workspace dependent. This keeps
     # workspace-pinned versions consistent and prevents the publish-time failures described in
     # https://github.com/microsoft/oxidizer/blob/main/.github/prompts/bump-crate-version.prompt.md
-    $dependents = Get-AllTransitiveDependents -crateName $CrateName -repoRoot $repoRoot
+    $dependents = @(Get-AllTransitiveDependents -crateName $CrateName -repoRoot $repoRoot)
     if ($dependents.Count -gt 0) {
         Write-Host ""
         Write-Host "🔗 Cascading $cascadeBump bump to $($dependents.Count) dependent crate(s): $($dependents -join ', ')" -ForegroundColor Cyan

--- a/scripts/release-crate.ps1
+++ b/scripts/release-crate.ps1
@@ -12,11 +12,13 @@
        `0.(x+1).0` and both `minor` and `patch` map to bumping `y`.
     2. Cascade: Every workspace crate that depends on the target via `[dependencies]` or
        `[build-dependencies]` (transitively) is also bumped. The bump kind applied to each
-       dependent is informed by `[package.metadata.cargo_check_external_types]`:
+       dependent is informed by `[package.metadata.cargo_check_external_types]` AND by whether
+       the target's bump is SemVer-incompatible under Cargo's rules:
          * If the dependent exposes any type rooted at the bumped crate in its public API
-           (or does not declare allowed_external_types at all), the same bump kind is applied —
-           a breaking change in the bumped crate's public API transitively becomes a breaking
-           change in the dependent's public API.
+           (or does not declare allowed_external_types at all), the dependent gets a `major`
+           bump when the target's bump is breaking (e.g. `0.0.x → 0.0.(x+1)`, `0.x.y → 0.(x+1).0`,
+           `1.x → 2.0`); otherwise the same kind as the target. This ensures the dependent's
+           own version increment reflects the breaking change in its public API surface.
          * Otherwise, the dependent only uses the bumped crate internally, and a `patch` bump
            is applied: enough to refresh the workspace-pinned version, but without overstating
            the change to downstream consumers.
@@ -896,18 +898,24 @@ try {
     )
 
     # Cascade to every transitive non-dev workspace dependent. The bump kind applied to each
-    # dependent is informed by [package.metadata.cargo_check_external_types]:
-    #   - If the dependent exposes any type rooted at the bumped crate in its public API, the
-    #     same bump kind is applied (a breaking change in the bumped crate's public API
-    #     transitively becomes a breaking change in the dependent's public API).
+    # dependent is informed by [package.metadata.cargo_check_external_types] AND by whether the
+    # target's bump is SemVer-incompatible under Cargo's rules:
+    #   - If the dependent exposes any type rooted at the bumped crate in its public API:
+    #       * If the target's bump is breaking (e.g. 0.0.5 -> 0.0.6, 0.3.0 -> 0.4.0, 1.x -> 2.0)
+    #         cascade as 'major' so the dependent's own version increment reflects the breaking
+    #         change in its public API surface.
+    #       * Otherwise cascade with the same kind as the target.
     #   - Otherwise, the dependent only uses the bumped crate internally, so a `patch` bump is
     #     enough to refresh the workspace-pinned version without overstating the change.
-    # If a dependent does not declare allowed_external_types, we conservatively cascade the same
-    # kind (worst-case assumption).
+    # If a dependent does not declare allowed_external_types, it is treated as exposing the target
+    # (worst-case assumption).
+    $targetIsBreaking = Test-IsBreakingChange -oldVersion $oldVersion -bump $cascadeBump
+    $exposingCascadeBump = if ($targetIsBreaking) { 'major' } else { $cascadeBump }
+
     $dependents = @(Get-AllTransitiveDependents -crateName $CrateName -repoRoot $repoRoot)
     if ($dependents.Count -gt 0) {
         Write-Host ""
-        Write-Host "🔗 Cascading $cascadeBump bump (or patch where the dependent does not expose '$CrateName' types) to $($dependents.Count) crate(s): $($dependents -join ', ')" -ForegroundColor Cyan
+        Write-Host "🔗 Cascading $exposingCascadeBump bump (or patch where the dependent does not expose '$CrateName' types) to $($dependents.Count) crate(s): $($dependents -join ', ')" -ForegroundColor Cyan
 
         $allCrates = Get-WorkspaceCrates -repoRoot $repoRoot
         $targetCrate = $allCrates | Where-Object { $_.Folder -eq $CrateName -or $_.Name -eq $CrateName } | Select-Object -First 1
@@ -930,7 +938,7 @@ try {
                 $true
             }
 
-            $depBump = if ($exposes) { $cascadeBump } else { 'patch' }
+            $depBump = if ($exposes) { $exposingCascadeBump } else { 'patch' }
             $exposureNote = if ($exposes) { 'exposes target in public API' } else { 'internal use only' }
             Write-Host "  • $dependent -> $depBump ($exposureNote)" -ForegroundColor DarkCyan
 

--- a/scripts/release-crate.ps1
+++ b/scripts/release-crate.ps1
@@ -195,11 +195,11 @@ function Get-WorkspaceCrates {
     param([string]$repoRoot)
 
     $metadata = Get-WorkspaceMetadata -repoRoot $repoRoot
-    $cratesDir = (Join-Path $repoRoot "crates").Replace('/', '\')
+    $cratesDir = [System.IO.Path]::GetFullPath((Join-Path $repoRoot "crates"))
 
     $crates = @()
     foreach ($package in $metadata.packages) {
-        $manifestDir = (Split-Path $package.manifest_path -Parent).Replace('/', '\')
+        $manifestDir = [System.IO.Path]::GetFullPath((Split-Path $package.manifest_path -Parent))
         if (-not $manifestDir.StartsWith($cratesDir, [System.StringComparison]::OrdinalIgnoreCase)) {
             continue
         }
@@ -234,7 +234,16 @@ function Get-AllTransitiveDependents {
     )
 
     $crates = Get-WorkspaceCrates -repoRoot $repoRoot
-    $normalizedTarget = $crateName.Replace('-', '_')
+
+    # Resolve the user-facing crate identifier (folder name or package name) to the canonical
+    # package name. This makes the cascade robust even if a crate's folder under crates/ ever
+    # diverges from its [package].name in Cargo.toml.
+    $targetCrate = $crates | Where-Object { $_.Folder -eq $crateName -or $_.Name -eq $crateName } | Select-Object -First 1
+    if ($null -eq $targetCrate) {
+        Write-Warning "Crate '$crateName' not found in workspace metadata; cannot compute dependents."
+        return @()
+    }
+    $normalizedTarget = $targetCrate.Name.Replace('-', '_')
 
     # BFS over the reverse dependency graph.
     $toVisit = [System.Collections.Generic.Queue[string]]::new()
@@ -552,17 +561,41 @@ function Write-Changelog {
     # (e.g. crates/cachet/CHANGELOG.md):
     #   - 🔧 Maintenance
     #     - bump `<target>` to <version>
+    # If the same section header was already produced by Format-ConventionalCommits for this
+    # release, the cascade bullet is merged into that existing section instead of creating a
+    # duplicate header.
     if ($null -ne $cascadeReason) {
         $sectionHeader = if ($cascadeReason.Breaking) { '- ⚠️ Breaking' } else { '- 🔧 Maintenance' }
-        $cascadeLines = @(
-            $sectionHeader,
-            "",
-            "  - bump ``$($cascadeReason.Target)`` to $($cascadeReason.Version)"
-        )
-        if ($formattedCommits.Count -gt 0) {
-            $formattedCommits = $cascadeLines + @("") + $formattedCommits
+        $cascadeBullet = "  - bump ``$($cascadeReason.Target)`` to $($cascadeReason.Version)"
+
+        $existingHeaderIdx = -1
+        for ($i = 0; $i -lt $formattedCommits.Count; $i++) {
+            if ($formattedCommits[$i] -eq $sectionHeader) {
+                $existingHeaderIdx = $i
+                break
+            }
+        }
+
+        if ($existingHeaderIdx -ge 0) {
+            # Find the end of this section (next top-level "- " header or end of list).
+            $insertIdx = $formattedCommits.Count
+            for ($i = $existingHeaderIdx + 1; $i -lt $formattedCommits.Count; $i++) {
+                if ($formattedCommits[$i] -match '^- \S') { $insertIdx = $i; break }
+            }
+            # Trim trailing blank lines belonging to the section.
+            while ($insertIdx -gt $existingHeaderIdx + 1 -and [string]::IsNullOrWhiteSpace($formattedCommits[$insertIdx - 1])) {
+                $insertIdx--
+            }
+            $before = if ($insertIdx -gt 0) { @($formattedCommits[0..($insertIdx - 1)]) } else { @() }
+            $after  = if ($insertIdx -lt $formattedCommits.Count) { @($formattedCommits[$insertIdx..($formattedCommits.Count - 1)]) } else { @() }
+            $formattedCommits = $before + @($cascadeBullet) + $after
         } else {
-            $formattedCommits = $cascadeLines
+            $cascadeLines = @($sectionHeader, "", $cascadeBullet)
+            if ($formattedCommits.Count -gt 0) {
+                $formattedCommits = $cascadeLines + @("") + $formattedCommits
+            } else {
+                $formattedCommits = $cascadeLines
+            }
         }
     }
 
@@ -718,7 +751,7 @@ if (-not (Test-Path (Join-Path $repoRoot ".git"))) {
     Exit 1
 }
 
-$crateFolder = Join-Path $repoRoot "crates/$CrateName"
+$crateFolder = Join-Path $repoRoot 'crates' $CrateName
 if (-not (Test-Path $crateFolder)) {
     Write-Error "Crate folder not found at '$crateFolder'. Please check the CrateName."
     Exit 1
@@ -796,9 +829,9 @@ try {
         }
 
         foreach ($dependent in $dependents) {
-            $depFolder = Join-Path $repoRoot "crates/$dependent"
-            $depCargo  = Join-Path $depFolder "Cargo.toml"
-            $depChange = Join-Path $depFolder "CHANGELOG.md"
+            $depFolder = Join-Path $repoRoot 'crates' $dependent
+            $depCargo  = Join-Path $depFolder 'Cargo.toml'
+            $depChange = Join-Path $depFolder 'CHANGELOG.md'
 
             if (-not (Test-Path $depCargo)) {
                 Write-Warning "Skipping cascade for '$dependent': Cargo.toml not found at '$depCargo'."

--- a/scripts/release-crate.ps1
+++ b/scripts/release-crate.ps1
@@ -387,6 +387,30 @@ function Get-BumpKindFromVersions {
     return 'major'
 }
 
+# Returns $true when bumping `oldVersion` by the given kind produces a SemVer-incompatible version
+# under Cargo's resolution rules. Mirrors Get-NextVersion's logic:
+#   - old major >= 1            : breaking iff bump == 'major'
+#   - old major == 0, minor >= 1 : breaking iff bump == 'major' (0.x -> 0.(x+1) is breaking)
+#   - old major == 0, minor == 0 : every bump is breaking (0.0.x -> 0.0.(x+1) is breaking)
+function Test-IsBreakingChange {
+    param(
+        [string]$oldVersion,
+        [ValidateSet('major', 'minor', 'patch')]
+        [string]$bump
+    )
+
+    $parts = $oldVersion.Split('.') | ForEach-Object { [int]$_ }
+    while ($parts.Count -lt 3) { $parts += 0 }
+
+    if ($parts[0] -ge 1) {
+        return $bump -eq 'major'
+    }
+    if ($parts[1] -ge 1) {
+        return $bump -eq 'major'
+    }
+    return $true
+}
+
 function Get-CurrentVersion {
     param([string]$cargoTomlPath)
 
@@ -910,13 +934,14 @@ try {
             $exposureNote = if ($exposes) { 'exposes target in public API' } else { 'internal use only' }
             Write-Host "  • $dependent -> $depBump ($exposureNote)" -ForegroundColor DarkCyan
 
+            $depOld = Get-CurrentVersion -cargoTomlPath $depCargo
+
             $depCascadeReason = @{
                 Target   = $CrateName
                 Version  = $newVersion
-                Breaking = ($depBump -eq 'major')
+                Breaking = (Test-IsBreakingChange -oldVersion $depOld -bump $depBump)
             }
 
-            $depOld = Get-CurrentVersion -cargoTomlPath $depCargo
             $depNew = Invoke-CrateRelease -crateName $dependent -crateFolder $depFolder `
                 -crateCargoToml $depCargo -rootCargoToml $rootCargoToml -changelogFile $depChange `
                 -prBaseUrl $prBaseUrl -version "" -bump $depBump -cascadeReason $depCascadeReason


### PR DESCRIPTION
Aligns `scripts/release-crate.ps1` with the cascade guidance in [`.github/prompts/bump-crate-version.prompt.md`](https://github.com/microsoft/oxidizer/blob/main/.github/prompts/bump-crate-version.prompt.md) and Martin Tomka's [Teams post on the Contributors channel](https://teams.microsoft.com/l/message/19:4e6925165434484c9ea2b7b65135f36e@thread.tacv2/1778180695415).

## Why

Today the script bumps a single crate but leaves its dependents untouched. Because workspace versions are pinned (e.g. `cachet` depends on `tick = { workspace = true, version = "0.3.3" }`), the next `cargo publish` of a downstream crate fails with a version mismatch against what is already on crates.io for the unbumped intermediate crate. Martin's worked example: bumping `tick` without bumping `seatbelt` breaks publishing `cachet`.

## What changed

- **Cascade**: After bumping the target crate, every transitive workspace dependent (via `[dependencies]` / `[build-dependencies]`, dev-only deps excluded) is bumped with the *same* bump kind. New helper `Get-AllTransitiveDependents` does a BFS over the reverse dependency graph using `cargo metadata`.
- **0.x.y SemVer rules**: New `Get-NextVersion` honors Cargo's compatibility rules: for `0.x.y` (x ≥ 1), `major` -> `0.(x+1).0` and both `minor` and `patch` -> `0.x.(y+1)`. `x.y.z` (x ≥ 1) keeps the conventional mapping.
- **Cascade CHANGELOG entries**: Each cascaded crate gets a `🔧 Maintenance` (or `⚠️ Breaking` for major) entry of the form `bump ` + '' + `<target>` + '' + ` to <version>`, matching the existing convention (see `crates/cachet/CHANGELOG.md`). If a dependent has its own commits since the last release, those are formatted as before with the cascade entry prepended.
- **Single workspace check**: One `cargo check --workspace` runs at the end instead of a per-crate check inside `Update-CrateVersion`.
- **Removed**: `Test-SemverIncompatibleBump`, `Get-DirectDependents`, and the warn-only `Show-DependentCratesWarning` are gone — replaced by the automatic cascade.

## Verification

- PowerShell parser: clean.
- Unit-tested the new helpers in isolation:
  - `0.3.3 + patch -> 0.3.4`, `0.3.3 + minor -> 0.3.4`, `0.3.3 + major -> 0.4.0`
  - `1.2.3 + patch/minor/major -> 1.2.4 / 1.3.0 / 2.0.0`
  - `0.0.5 + minor -> 0.0.6`
  - Bump-kind inference from old -> new versions matches expectations.
  - `Get-AllTransitiveDependents -crateName tick` returns `cachet, seatbelt, http_extensions` — matching the pattern visible in existing CHANGELOGs.