### PR TITLE
feat(anyspawn): support spawning of blocking work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "anyspawn"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ homepage = "https://github.com/microsoft/oxidizer"
 [workspace.dependencies]
 
 # local dependencies
-anyspawn = { path = "crates/anyspawn", default-features = false, version = "0.4.0" }
+anyspawn = { path = "crates/anyspawn", default-features = false, version = "0.5.0" }
 bytesbuf = { path = "crates/bytesbuf", default-features = false, version = "0.4.2" }
 bytesbuf_io = { path = "crates/bytesbuf_io", default-features = false, version = "0.4.0" }
 cachet = { path = "crates/cachet", default-features = false, version = "0.2.0" }

--- a/crates/anyspawn/CHANGELOG.md
+++ b/crates/anyspawn/CHANGELOG.md
@@ -10,6 +10,7 @@
 - ⚠️ Breaking
 
   - `SpawnCustom` now requires a `spawn_blocking` method. Existing implementors must add this method to compile.
+  - `CustomSpawnerBuilder::layer` now takes two closures — one for futures and one for blocking tasks. Pass an identity closure (`|t| t`) for either side to leave that task kind unchanged.
 
 ## [0.3.0] - 2026-03-27
 

--- a/crates/anyspawn/CHANGELOG.md
+++ b/crates/anyspawn/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## [0.4.0] - 2026-05-12
+## [0.5.0] - 2026-05-12
 
 - ✨ Features
 
@@ -13,6 +13,20 @@
 
   - `SpawnCustom` now requires a `spawn_blocking` method. Existing implementors must add this method to compile.
   - `CustomSpawnerBuilder::layer` now takes two closures — one for futures and one for blocking tasks. Pass an identity closure (`|t| t`) for either side to leave that task kind unchanged.
+
+## [0.4.0] - 2026-05-07
+
+- ✨ Features
+
+  - add `Spawner::spawn_anywhere` for spawning futures built from [`ThreadAware`](thread_aware::ThreadAware) data, with the data relocated before the future is constructed ([#403](https://github.com/microsoft/oxidizer/pull/403)).
+  - publicly export the `SpawnCustom` trait so custom runtimes can be implemented as named types instead of closures ([#403](https://github.com/microsoft/oxidizer/pull/403)).
+  - re-export `thread_aware::closure::ThreadAwareAsyncFnOnce` for ergonomic use alongside `Spawner` ([#403](https://github.com/microsoft/oxidizer/pull/403)).
+
+- ⚠️ Breaking
+
+  - `Spawner::new_custom` now takes a `T: SpawnCustom + Clone` implementation instead of a `Fn(BoxedFuture)` closure. Wrap existing closures in a small struct that implements `SpawnCustom` ([#403](https://github.com/microsoft/oxidizer/pull/403)).
+  - remove `Spawner::new_thread_aware`. Per-core isolation is now expressed by implementing `SpawnCustom` on a `ThreadAware` type and using `Spawner::new_custom`, or via `CustomSpawnerBuilder` ([#403](https://github.com/microsoft/oxidizer/pull/403)).
+  - the set of `allowed_external_types` changed: `thread_aware::affinity::{MemoryAffinity, PinnedAffinity}` are no longer part of the public surface; `thread_aware::affinity::Affinity` and `thread_aware::closure::ThreadAwareAsyncFnOnce` are now exposed instead ([#403](https://github.com/microsoft/oxidizer/pull/403)).
 
 ## [0.3.0] - 2026-03-27
 

--- a/crates/anyspawn/CHANGELOG.md
+++ b/crates/anyspawn/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- ✨ Features
+
+  - add `Spawner::spawn_blocking` for running synchronous, CPU-bound or blocking work on a dedicated thread (Tokio uses [`tokio::task::spawn_blocking`]).
+  - extend the `SpawnCustom` trait with a `spawn_blocking` method, allowing custom runtimes to plug in their own blocking-task execution strategy.
+
+- ⚠️ Breaking
+
+  - `SpawnCustom` now requires a `spawn_blocking` method. Existing implementors must add this method to compile.
+
 ## [0.3.0] - 2026-03-27
 
 - ✨ Features

--- a/crates/anyspawn/CHANGELOG.md
+++ b/crates/anyspawn/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.4.0] - 2026-05-12
+
 - ✨ Features
 
   - add `Spawner::spawn_blocking` for running synchronous, CPU-bound or blocking work on a dedicated thread (Tokio uses [`tokio::task::spawn_blocking`]).

--- a/crates/anyspawn/Cargo.toml
+++ b/crates/anyspawn/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "anyspawn"
 description = "A generic task spawner compatible with any async runtime."
-version = "0.4.0"
+version = "0.5.0"
 readme = "README.md"
 keywords = ["oxidizer", "async", "runtime", "futures"]
 categories = ["asynchronous"]

--- a/crates/anyspawn/README.md
+++ b/crates/anyspawn/README.md
@@ -54,11 +54,11 @@ contention-free, NUMA-friendly task dispatch.
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/anyspawn">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG5RxOwZfGEjeG2_e5NBDlvq5G2UGvhnaHUvnGwpHmIxmYGfgYWSCgmhhbnlzcGF3bmUwLjQuMIJsdGhyZWFkX2F3YXJlZTAuNy4w
- [__link0]: https://docs.rs/anyspawn/0.4.0/anyspawn/?search=Spawner
- [__link1]: https://docs.rs/anyspawn/0.4.0/anyspawn/?search=SpawnCustom
- [__link2]: https://docs.rs/anyspawn/0.4.0/anyspawn/?search=CustomSpawnerBuilder
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG5RxOwZfGEjeG2_e5NBDlvq5G2UGvhnaHUvnGwpHmIxmYGfgYWSCgmhhbnlzcGF3bmUwLjUuMIJsdGhyZWFkX2F3YXJlZTAuNy4w
+ [__link0]: https://docs.rs/anyspawn/0.5.0/anyspawn/?search=Spawner
+ [__link1]: https://docs.rs/anyspawn/0.5.0/anyspawn/?search=SpawnCustom
+ [__link2]: https://docs.rs/anyspawn/0.5.0/anyspawn/?search=CustomSpawnerBuilder
  [__link3]: https://docs.rs/thread_aware/0.7.0/thread_aware/?search=ThreadAware
- [__link4]: https://docs.rs/anyspawn/0.4.0/anyspawn/?search=SpawnCustom
- [__link5]: https://docs.rs/anyspawn/0.4.0/anyspawn/?search=Spawner::new_tokio
- [__link6]: https://docs.rs/anyspawn/0.4.0/anyspawn/?search=Spawner::new_tokio_with_handle
+ [__link4]: https://docs.rs/anyspawn/0.5.0/anyspawn/?search=SpawnCustom
+ [__link5]: https://docs.rs/anyspawn/0.5.0/anyspawn/?search=Spawner::new_tokio
+ [__link6]: https://docs.rs/anyspawn/0.5.0/anyspawn/?search=Spawner::new_tokio_with_handle

--- a/crates/anyspawn/benches/spawner.rs
+++ b/crates/anyspawn/benches/spawner.rs
@@ -7,7 +7,7 @@
     reason = "Benchmarks don't require documentation and should fail fast on errors"
 )]
 
-use anyspawn::{BoxedFuture, SpawnCustom, Spawner};
+use anyspawn::{BoxedBlockingTask, BoxedFuture, SpawnCustom, Spawner};
 use criterion::{Criterion, criterion_group, criterion_main};
 use thread_aware::ThreadAware;
 
@@ -21,6 +21,10 @@ impl SpawnCustom for SmolSpawner {
 
     fn spawn_anywhere(&self, task: Box<dyn thread_aware::closure::ThreadAwareAsyncFnOnce<()>>) {
         self.spawn(task.call_once());
+    }
+
+    fn spawn_blocking(&self, task: BoxedBlockingTask) {
+        std::thread::spawn(task);
     }
 }
 

--- a/crates/anyspawn/examples/custom.rs
+++ b/crates/anyspawn/examples/custom.rs
@@ -50,7 +50,7 @@ async fn main() {
     println!("Got result: {value}");
 
     // Spawn a blocking task
-    let handle = spawner.spawn_blocking(Box::new(|| 1 + 1));
+    let handle = spawner.spawn_blocking(|| 1 + 1);
     let value = handle.await;
     println!("Got result (blocking): {value}");
 

--- a/crates/anyspawn/examples/custom.rs
+++ b/crates/anyspawn/examples/custom.rs
@@ -6,7 +6,7 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use anyspawn::{BoxedFuture, SpawnCustom, Spawner};
+use anyspawn::{BoxedBlockingTask, BoxedFuture, SpawnCustom, Spawner};
 use thread_aware::ThreadAware;
 use thread_aware::affinity::Affinity;
 use thread_aware::closure::ThreadAwareAsyncFnOnce;
@@ -27,6 +27,10 @@ impl SpawnCustom for ThreadPoolSpawner {
     fn spawn_anywhere(&self, task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
         self.spawn(task.call_once());
     }
+
+    fn spawn_blocking(&self, task: BoxedBlockingTask) {
+        std::thread::spawn(task);
+    }
 }
 
 #[tokio::main]
@@ -44,6 +48,11 @@ async fn main() {
     let handle = spawner.spawn(async { 1 + 1 });
     let value = handle.await;
     println!("Got result: {value}");
+
+    // Spawn a blocking task
+    let handle = spawner.spawn_blocking(Box::new(|| 1 + 1));
+    let value = handle.await;
+    println!("Got result (blocking): {value}");
 
     // Wait for background task
     sleep(Duration::from_millis(50));

--- a/crates/anyspawn/examples/otel_context.rs
+++ b/crates/anyspawn/examples/otel_context.rs
@@ -8,17 +8,27 @@
 //! the caller's current context and reattach it inside the spawned future,
 //! so spans, baggage, and other context values propagate automatically.
 
-use anyspawn::{BoxedFuture, CustomSpawnerBuilder};
+use anyspawn::{BoxedBlockingTask, BoxedFuture, CustomSpawnerBuilder};
 use opentelemetry::Context;
 use opentelemetry::context::FutureExt as OtelFutureExt;
 
 #[tokio::main]
 async fn main() {
     let spawner = CustomSpawnerBuilder::tokio()
-        .layer(|task: BoxedFuture| -> BoxedFuture {
-            let cx = Context::current();
-            Box::pin(task.with_context(cx))
-        })
+        .layer(
+            |task: BoxedFuture| -> BoxedFuture {
+                let cx = Context::current();
+                Box::pin(task.with_context(cx))
+            },
+            |task: BoxedBlockingTask| -> BoxedBlockingTask {
+                let cx = Context::current();
+
+                Box::new(move || {
+                    let _guard = cx.attach();
+                    task();
+                })
+            },
+        )
         .name("tokio_with_otel")
         .build();
 
@@ -38,8 +48,20 @@ async fn main() {
             id == "abc-123"
         })
         .await;
-
     assert!(result, "context should have propagated into the spawned task");
+
+    let result = spawner
+        .spawn_blocking(|| {
+            // Inside the spawned task the context is available thanks to
+            // the layer closure above.
+            let cx = Context::current();
+            let id = cx.get::<RequestId>().map_or("<missing>", |r| r.0.as_str());
+            println!("spawned task sees RequestId = {id}");
+            id == "abc-123"
+        })
+        .await;
+    assert!(result, "context should have propagated into the spawned blocking task");
+
     println!("context propagation works!");
 }
 

--- a/crates/anyspawn/examples/thread_aware.rs
+++ b/crates/anyspawn/examples/thread_aware.rs
@@ -11,7 +11,7 @@
 //! In production the data might hold a core-local work queue, metrics
 //! counter, or connection pool instead of a simple index.
 
-use anyspawn::{BoxedFuture, SpawnCustom, Spawner};
+use anyspawn::{BoxedBlockingTask, BoxedFuture, SpawnCustom, Spawner};
 use thread_aware::ThreadAware;
 use thread_aware::affinity::{Affinity, pinned_affinities};
 use thread_aware::closure::ThreadAwareAsyncFnOnce;
@@ -69,5 +69,10 @@ impl SpawnCustom for Scheduler {
 
     fn spawn_anywhere(&self, task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
         self.spawn(task.call_once());
+    }
+
+    fn spawn_blocking(&self, task: BoxedBlockingTask) {
+        println!("{}: executing blocking", self.caption());
+        tokio::task::spawn_blocking(task);
     }
 }

--- a/crates/anyspawn/src/builder.rs
+++ b/crates/anyspawn/src/builder.rs
@@ -167,10 +167,13 @@ impl SpawnCustom for TokioSpawner {
 /// let spawner = CustomSpawnerBuilder::tokio()
 ///     .layer(
 ///         |task: BoxedFuture| -> BoxedFuture {
-///             println!("spawning task");
+///             println!("spawning async task");
 ///             task
 ///         },
-///         |task: BoxedBlockingTask| -> BoxedBlockingTask { task },
+///         |task: BoxedBlockingTask| -> BoxedBlockingTask {
+///             println!("spawning blocking task");
+///             task
+///         },
 ///     )
 ///     .build();
 ///
@@ -290,33 +293,6 @@ impl<S: SpawnCustom + Clone> CustomSpawnerBuilder<S> {
     ///
     /// When multiple layers are added, they run in the order they were
     /// added: the first layer added runs first when the task executes.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # #[cfg(feature = "tokio")]
-    /// # #[tokio::main]
-    /// # async fn main() {
-    /// use anyspawn::{BoxedBlockingTask, BoxedFuture, CustomSpawnerBuilder};
-    ///
-    /// let spawner = CustomSpawnerBuilder::tokio()
-    ///     .layer(
-    ///         |task: BoxedFuture| -> BoxedFuture { task },
-    ///         |task: BoxedBlockingTask| -> BoxedBlockingTask {
-    ///             Box::new(move || {
-    ///                 println!("running blocking task");
-    ///                 task();
-    ///             })
-    ///         },
-    ///     )
-    ///     .build();
-    ///
-    /// let result = spawner.spawn_blocking(|| 42).await;
-    /// assert_eq!(result, 42);
-    /// # }
-    /// # #[cfg(not(feature = "tokio"))]
-    /// # fn main() {}
-    /// ```
     pub fn layer<FL, BL>(self, future_layer: FL, blocking_layer: BL) -> CustomSpawnerBuilder<impl SpawnCustom + Clone>
     where
         FL: Fn(BoxedFuture) -> BoxedFuture + Clone + Send + Sync + 'static,

--- a/crates/anyspawn/src/builder.rs
+++ b/crates/anyspawn/src/builder.rs
@@ -131,28 +131,30 @@ impl SpawnCustom for TokioSpawner {
     }
 }
 
-/// A builder for constructing a [`Spawner`] with layered middleware.
+/// Builds a [`Spawner`] from a base spawner plus zero or more layers.
 ///
-/// Each layer is a pair of closures - one for futures
-/// (`Fn(BoxedFuture) -> BoxedFuture`) and one for blocking tasks
-/// (`Fn(BoxedBlockingTask) -> BoxedBlockingTask`) - that transform spawned
-/// work before it reaches the inner spawner. Layers compose from outside
-/// in: the last added layer runs first when [`Spawner::spawn`] or
-/// [`Spawner::spawn_blocking`] is called.
+/// 1. Pick a base with [`tokio()`](Self::tokio),
+///    [`tokio_with_handle()`](Self::tokio_with_handle), or
+///    [`new()`](Self::new).
+/// 2. Wrap it with any number of [`layer()`](Self::layer) calls.
+/// 3. Call [`build()`](Self::build).
 ///
-/// # Design
+/// A layer is a pair of closures that wrap each spawned task before it
+/// reaches the base spawner: one wraps futures (used by
+/// [`Spawner::spawn`] and [`Spawner::spawn_anywhere`]) and one wraps
+/// blocking tasks (used by [`Spawner::spawn_blocking`]). Pass `|t| t` for
+/// either side to leave that task kind unchanged.
 ///
-/// Use [`new`](Self::new) with any [`SpawnCustom`] base, or the convenience
-/// [`tokio()`](Self::tokio) constructor. Stack middleware with
-/// [`layer()`](Self::layer) and finalize with [`build()`](Self::build).
+/// Layers run in the order they are added: when a task executes, the
+/// first layer added runs first, then the second, and so on, until the
+/// task itself runs.
 ///
 /// # Note
 ///
-/// [`Spawner::new_tokio`] uses a more efficient code path with native Tokio
-/// `JoinHandle`s. The builder's [`tokio()`](Self::tokio) constructor goes
-/// through the custom spawner path (using a oneshot channel for join handles),
-/// which is necessary to support layers but slightly less efficient for
-/// unlayered use.
+/// For a plain Tokio spawner with no layers, prefer [`Spawner::new_tokio`]:
+/// it uses native Tokio `JoinHandle`s directly. The builder's
+/// [`tokio()`](Self::tokio) path uses a oneshot channel for join handles
+/// so that layers can be applied, which is slightly less efficient.
 ///
 /// # Examples
 ///
@@ -276,17 +278,18 @@ impl<S: SpawnCustom + Clone> CustomSpawnerBuilder<S> {
         self
     }
 
-    /// Adds a layer that transforms tasks before they reach the inner
-    /// spawner.
+    /// Wraps each spawned task with a pair of layer closures before it
+    /// reaches the base spawner.
     ///
-    /// `future_layer` receives a [`BoxedFuture`] and returns a
-    /// [`BoxedFuture`]; it is invoked for both [`Spawner::spawn`] and
-    /// [`Spawner::spawn_anywhere`]. `blocking_layer` receives a
-    /// [`BoxedBlockingTask`] and returns a [`BoxedBlockingTask`]; it is
-    /// invoked for [`Spawner::spawn_blocking`]. Pass an identity closure
-    /// (`|t| t`) for either side to leave that task kind unchanged.
+    /// - `future_layer` wraps the future used by [`Spawner::spawn`] and
+    ///   [`Spawner::spawn_anywhere`].
+    /// - `blocking_layer` wraps the closure used by
+    ///   [`Spawner::spawn_blocking`].
     ///
-    /// Layers compose from outside in: the last added layer runs first.
+    /// Pass `|t| t` for either side to leave that task kind unchanged.
+    ///
+    /// When multiple layers are added, they run in the order they were
+    /// added: the first layer added runs first when the task executes.
     ///
     /// # Examples
     ///

--- a/crates/anyspawn/src/builder.rs
+++ b/crates/anyspawn/src/builder.rs
@@ -6,7 +6,7 @@
 use std::fmt::Debug;
 
 use crate::Spawner;
-use crate::custom::{BoxedFuture, SpawnCustom};
+use crate::custom::{BoxedBlockingTask, BoxedFuture, SpawnCustom};
 use thread_aware::ThreadAware;
 use thread_aware::affinity::Affinity;
 use thread_aware::closure::ThreadAwareAsyncFnOnce;
@@ -55,6 +55,13 @@ where
             layer: self.layer.clone(),
         });
         self.inner.spawn_anywhere(layered);
+    }
+
+    fn spawn_blocking(&self, task: BoxedBlockingTask) {
+        // Layers operate on futures, not synchronous closures, so blocking
+        // tasks bypass the layer and are forwarded directly to the inner
+        // spawner.
+        self.inner.spawn_blocking(task);
     }
 }
 
@@ -107,6 +114,17 @@ impl SpawnCustom for TokioSpawner {
 
     fn spawn_anywhere(&self, task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
         self.spawn(task.call_once());
+    }
+
+    fn spawn_blocking(&self, task: BoxedBlockingTask) {
+        match &self.0 {
+            Some(h) => {
+                h.spawn_blocking(task);
+            }
+            None => {
+                ::tokio::task::spawn_blocking(task);
+            }
+        }
     }
 }
 
@@ -328,6 +346,8 @@ mod tests {
             let affinities = thread_aware::affinity::pinned_affinities(&[2]);
             task.relocate(Some(affinities[0]), affinities[1]);
         }
+
+        fn spawn_blocking(&self, _task: BoxedBlockingTask) {}
     }
 
     /// Minimal async task for covering `spawn_anywhere`.
@@ -354,9 +374,10 @@ mod tests {
         layered.relocate(Some(affinities[0]), affinities[1]);
         assert!(RELOCATED.load(Ordering::SeqCst), "Layered must forward relocate to inner");
 
-        // Exercise spawn + spawn_anywhere + layer closure + NoopTask::call_once
+        // Exercise spawn + spawn_anywhere + spawn_blocking + layer closure + NoopTask::call_once
         layered.inner.spawn(Box::pin(async {}));
         layered.inner.spawn_anywhere(Box::new(NoopTask));
+        layered.spawn_blocking(Box::new(|| {}));
         let covered = (layered.layer)(Box::pin(async {}));
         futures::executor::block_on(covered);
         futures::executor::block_on(Box::new(NoopTask).call_once());

--- a/crates/anyspawn/src/builder.rs
+++ b/crates/anyspawn/src/builder.rs
@@ -5,11 +5,12 @@
 
 use std::fmt::Debug;
 
-use crate::Spawner;
-use crate::custom::{BoxedBlockingTask, BoxedFuture, SpawnCustom};
 use thread_aware::ThreadAware;
 use thread_aware::affinity::Affinity;
 use thread_aware::closure::ThreadAwareAsyncFnOnce;
+
+use crate::Spawner;
+use crate::custom::{BoxedBlockingTask, BoxedFuture, SpawnCustom};
 
 /// Internal composition of two layer closures wrapping an inner [`SpawnCustom`].
 ///

--- a/crates/anyspawn/src/builder.rs
+++ b/crates/anyspawn/src/builder.rs
@@ -11,39 +11,45 @@ use thread_aware::ThreadAware;
 use thread_aware::affinity::Affinity;
 use thread_aware::closure::ThreadAwareAsyncFnOnce;
 
-/// Internal composition of a layer closure wrapping an inner [`SpawnCustom`].
+/// Internal composition of two layer closures wrapping an inner [`SpawnCustom`].
 ///
-/// The closure transforms futures before they are forwarded to the inner
-/// spawner. During relocation only the inner spawner is notified; closures
-/// are expected to be stateless (or capture only `Arc`-based state that
-/// does not need relocation).
-struct Layered<F, S> {
-    layer: F,
+/// `future_layer` transforms futures forwarded to [`SpawnCustom::spawn`] and
+/// [`SpawnCustom::spawn_anywhere`]; `blocking_layer` transforms tasks
+/// forwarded to [`SpawnCustom::spawn_blocking`]. The builder supplies an
+/// identity closure for whichever layer kind is not being added. During
+/// relocation only the inner spawner is notified; closures are expected to
+/// be stateless (or capture only `Arc`-based state that does not need
+/// relocation).
+struct Layered<FL, BL, S> {
+    future_layer: FL,
+    blocking_layer: BL,
     inner: S,
 }
 
-impl<F: Clone, S: Clone> Clone for Layered<F, S> {
+impl<FL: Clone, BL: Clone, S: Clone> Clone for Layered<FL, BL, S> {
     fn clone(&self) -> Self {
         Self {
-            layer: self.layer.clone(),
+            future_layer: self.future_layer.clone(),
+            blocking_layer: self.blocking_layer.clone(),
             inner: self.inner.clone(),
         }
     }
 }
 
-impl<F: Send, S: ThreadAware> ThreadAware for Layered<F, S> {
+impl<FL: Send, BL: Send, S: ThreadAware> ThreadAware for Layered<FL, BL, S> {
     fn relocate(&mut self, source: Option<Affinity>, destination: Affinity) {
         self.inner.relocate(source, destination);
     }
 }
 
-impl<F, S> SpawnCustom for Layered<F, S>
+impl<FL, BL, S> SpawnCustom for Layered<FL, BL, S>
 where
-    F: Fn(BoxedFuture) -> BoxedFuture + Clone + Send + Sync + 'static,
+    FL: Fn(BoxedFuture) -> BoxedFuture + Clone + Send + Sync + 'static,
+    BL: Fn(BoxedBlockingTask) -> BoxedBlockingTask + Clone + Send + Sync + 'static,
     S: SpawnCustom + Clone,
 {
     fn spawn(&self, task: BoxedFuture) {
-        self.inner.spawn((self.layer)(task));
+        self.inner.spawn((self.future_layer)(task));
     }
 
     fn spawn_anywhere(&self, task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
@@ -52,16 +58,13 @@ where
         // the captured ThreadAware data is relocated first.
         let layered = Box::new(LayeredTask {
             task,
-            layer: self.layer.clone(),
+            layer: self.future_layer.clone(),
         });
         self.inner.spawn_anywhere(layered);
     }
 
     fn spawn_blocking(&self, task: BoxedBlockingTask) {
-        // Layers operate on futures, not synchronous closures, so blocking
-        // tasks bypass the layer and are forwarded directly to the inner
-        // spawner.
-        self.inner.spawn_blocking(task);
+        self.inner.spawn_blocking((self.blocking_layer)(task));
     }
 }
 
@@ -130,10 +133,12 @@ impl SpawnCustom for TokioSpawner {
 
 /// A builder for constructing a [`Spawner`] with layered middleware.
 ///
-/// Each layer is a closure `Fn(BoxedFuture) -> BoxedFuture` that transforms
-/// the spawned future before it reaches the inner spawner. Layers compose
-/// from outside in: the last added layer runs first when
-/// [`Spawner::spawn`] is called.
+/// Each layer is a pair of closures - one for futures
+/// (`Fn(BoxedFuture) -> BoxedFuture`) and one for blocking tasks
+/// (`Fn(BoxedBlockingTask) -> BoxedBlockingTask`) - that transform spawned
+/// work before it reaches the inner spawner. Layers compose from outside
+/// in: the last added layer runs first when [`Spawner::spawn`] or
+/// [`Spawner::spawn_blocking`] is called.
 ///
 /// # Design
 ///
@@ -155,13 +160,16 @@ impl SpawnCustom for TokioSpawner {
 /// # #[cfg(feature = "tokio")]
 /// # #[tokio::main]
 /// # async fn main() {
-/// use anyspawn::{BoxedFuture, CustomSpawnerBuilder};
+/// use anyspawn::{BoxedBlockingTask, BoxedFuture, CustomSpawnerBuilder};
 ///
 /// let spawner = CustomSpawnerBuilder::tokio()
-///     .layer(|task: BoxedFuture| -> BoxedFuture {
-///         println!("spawning task");
-///         task
-///     })
+///     .layer(
+///         |task: BoxedFuture| -> BoxedFuture {
+///             println!("spawning task");
+///             task
+///         },
+///         |task: BoxedBlockingTask| -> BoxedBlockingTask { task },
+///     )
 ///     .build();
 ///
 /// let result = spawner.spawn(async { 42 }).await;
@@ -268,12 +276,15 @@ impl<S: SpawnCustom + Clone> CustomSpawnerBuilder<S> {
         self
     }
 
-    /// Adds a layer that transforms futures before they reach the inner
+    /// Adds a layer that transforms tasks before they reach the inner
     /// spawner.
     ///
-    /// The closure receives a [`BoxedFuture`] and must return a
-    /// [`BoxedFuture`]. It is invoked for both [`Spawner::spawn`] and
-    /// [`Spawner::spawn_anywhere`].
+    /// `future_layer` receives a [`BoxedFuture`] and returns a
+    /// [`BoxedFuture`]; it is invoked for both [`Spawner::spawn`] and
+    /// [`Spawner::spawn_anywhere`]. `blocking_layer` receives a
+    /// [`BoxedBlockingTask`] and returns a [`BoxedBlockingTask`]; it is
+    /// invoked for [`Spawner::spawn_blocking`]. Pass an identity closure
+    /// (`|t| t`) for either side to leave that task kind unchanged.
     ///
     /// Layers compose from outside in: the last added layer runs first.
     ///
@@ -283,23 +294,35 @@ impl<S: SpawnCustom + Clone> CustomSpawnerBuilder<S> {
     /// # #[cfg(feature = "tokio")]
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use anyspawn::{BoxedFuture, CustomSpawnerBuilder};
+    /// use anyspawn::{BoxedBlockingTask, BoxedFuture, CustomSpawnerBuilder};
     ///
     /// let spawner = CustomSpawnerBuilder::tokio()
-    ///     .layer(|task: BoxedFuture| -> BoxedFuture { task })
+    ///     .layer(
+    ///         |task: BoxedFuture| -> BoxedFuture { task },
+    ///         |task: BoxedBlockingTask| -> BoxedBlockingTask {
+    ///             Box::new(move || {
+    ///                 println!("running blocking task");
+    ///                 task();
+    ///             })
+    ///         },
+    ///     )
     ///     .build();
-    /// # let _ = spawner;
+    ///
+    /// let result = spawner.spawn_blocking(|| 42).await;
+    /// assert_eq!(result, 42);
     /// # }
     /// # #[cfg(not(feature = "tokio"))]
     /// # fn main() {}
     /// ```
-    pub fn layer<F>(self, layer: F) -> CustomSpawnerBuilder<impl SpawnCustom + Clone>
+    pub fn layer<FL, BL>(self, future_layer: FL, blocking_layer: BL) -> CustomSpawnerBuilder<impl SpawnCustom + Clone>
     where
-        F: Fn(BoxedFuture) -> BoxedFuture + Clone + Send + Sync + 'static,
+        FL: Fn(BoxedFuture) -> BoxedFuture + Clone + Send + Sync + 'static,
+        BL: Fn(BoxedBlockingTask) -> BoxedBlockingTask + Clone + Send + Sync + 'static,
     {
         CustomSpawnerBuilder {
             spawner: Layered {
-                layer,
+                future_layer,
+                blocking_layer,
                 inner: self.spawner,
             },
             name: self.name,
@@ -364,21 +387,31 @@ mod tests {
     #[test]
     fn layered_relocate_forwards_to_inner() {
         static RELOCATED: AtomicBool = AtomicBool::new(false);
+        static BLOCKING_LAYER_RAN: AtomicBool = AtomicBool::new(false);
 
         let affinities = thread_aware::affinity::pinned_affinities(&[2]);
         let mut layered = Layered {
-            layer: |task: BoxedFuture| -> BoxedFuture { task },
+            future_layer: |task: BoxedFuture| -> BoxedFuture { task },
+            blocking_layer: |task: BoxedBlockingTask| -> BoxedBlockingTask {
+                BLOCKING_LAYER_RAN.store(true, Ordering::SeqCst);
+                task
+            },
             inner: TrackingSpawner { relocated: &RELOCATED },
         };
 
         layered.relocate(Some(affinities[0]), affinities[1]);
         assert!(RELOCATED.load(Ordering::SeqCst), "Layered must forward relocate to inner");
 
-        // Exercise spawn + spawn_anywhere + spawn_blocking + layer closure + NoopTask::call_once
-        layered.inner.spawn(Box::pin(async {}));
-        layered.inner.spawn_anywhere(Box::new(NoopTask));
+        // Exercise spawn + spawn_anywhere + spawn_blocking + layer closures + NoopTask::call_once
+        layered.spawn(Box::pin(async {}));
+        layered.spawn_anywhere(Box::new(NoopTask));
         layered.spawn_blocking(Box::new(|| {}));
-        let covered = (layered.layer)(Box::pin(async {}));
+        assert!(
+            BLOCKING_LAYER_RAN.load(Ordering::SeqCst),
+            "blocking_layer must run on spawn_blocking"
+        );
+
+        let covered = (layered.future_layer)(Box::pin(async {}));
         futures::executor::block_on(covered);
         futures::executor::block_on(Box::new(NoopTask).call_once());
     }

--- a/crates/anyspawn/src/custom.rs
+++ b/crates/anyspawn/src/custom.rs
@@ -26,6 +26,16 @@ pub trait SpawnCustom: ThreadAware + Sync + 'static {
     /// if needed. Call [`call_once`](ThreadAwareAsyncFnOnce::call_once) to obtain
     /// the future.
     fn spawn_anywhere(&self, task: Box<dyn ThreadAwareAsyncFnOnce<()>>);
+    /// Spawn a blocking (synchronous) task.
+    ///
+    /// Implementations should execute `task` on a thread that is allowed to
+    /// block (e.g., Tokio's blocking thread pool via
+    /// [`tokio::task::spawn_blocking`]) so the async runtime is not stalled.
+    ///
+    /// The task is a type-erased [`FnOnce`] returning `()`; the public
+    /// [`Spawner::spawn_blocking`](crate::Spawner::spawn_blocking) API handles
+    /// the typed result via an internal channel.
+    fn spawn_blocking(&self, task: BoxedBlockingTask);
 }
 
 /// A type-erased, heap-allocated, pinned future that returns `()`.
@@ -33,6 +43,12 @@ pub trait SpawnCustom: ThreadAware + Sync + 'static {
 /// This is the future type that [`SpawnCustom::spawn`] implementations and
 /// layer closures operate on.
 pub type BoxedFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// A type-erased, heap-allocated synchronous closure that returns `()`.
+///
+/// This is the task type that [`SpawnCustom::spawn_blocking`] implementations
+/// operate on.
+pub type BoxedBlockingTask = Box<dyn FnOnce() + Send + 'static>;
 
 /// Wraps [`ThreadAware`] data, a fn pointer, and a result channel as a [`ThreadAwareAsyncFnOnce`].
 ///
@@ -94,6 +110,18 @@ impl CustomSpawner {
         let (tx, rx) = oneshot::channel();
         let task = Box::new(SpawnAnywhereTask { data, f, tx });
         self.spawn.spawn_anywhere(task);
+        rx
+    }
+
+    pub(crate) fn spawn_blocking<T, F>(&self, f: F) -> oneshot::Receiver<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> T + Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        self.spawn.spawn_blocking(Box::new(move || {
+            let _ = tx.send(f());
+        }));
         rx
     }
 }

--- a/crates/anyspawn/src/lib.rs
+++ b/crates/anyspawn/src/lib.rs
@@ -55,7 +55,7 @@ mod handle;
 mod spawner;
 
 pub use builder::CustomSpawnerBuilder;
-pub use custom::{BoxedFuture, SpawnCustom};
+pub use custom::{BoxedBlockingTask, BoxedFuture, SpawnCustom};
 pub use handle::JoinHandle;
 pub use spawner::Spawner;
 pub use thread_aware::closure::ThreadAwareAsyncFnOnce;

--- a/crates/anyspawn/src/spawner.rs
+++ b/crates/anyspawn/src/spawner.rs
@@ -260,6 +260,56 @@ impl Spawner {
             SpawnerKind::Custom(c) => JoinHandle(JoinHandleInner::Custom(c.spawn_anywhere(data, f))),
         }
     }
+
+    /// Spawns a blocking (synchronous) task on the runtime.
+    ///
+    /// Use this for CPU-bound work or calls into blocking APIs that would
+    /// otherwise stall the async executor. The closure `f` runs to completion
+    /// on a thread that is allowed to block; for Tokio this is the blocking
+    /// thread pool managed by [`tokio::task::spawn_blocking`].
+    ///
+    /// Returns a [`JoinHandle`] that can be awaited to retrieve the task's
+    /// result, or dropped to run the task in fire-and-forget mode.
+    ///
+    /// # Panics
+    ///
+    /// Awaiting the returned `JoinHandle` will panic if the spawned task panics.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "tokio")]
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use anyspawn::Spawner;
+    ///
+    /// let spawner = Spawner::new_tokio();
+    /// let value = spawner.spawn_blocking(|| {
+    ///     // expensive synchronous work goes here
+    ///     1 + 1
+    /// }).await;
+    /// assert_eq!(value, 2);
+    /// # }
+    /// # #[cfg(not(feature = "tokio"))]
+    /// # fn main() {}
+    /// ```
+    pub fn spawn_blocking<T, F>(&self, f: F) -> JoinHandle<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> T + Send + 'static,
+    {
+        match &self.0 {
+            #[cfg(feature = "tokio")]
+            SpawnerKind::Tokio(handle) => {
+                let jh = match handle {
+                    Some(h) => h.spawn_blocking(f),
+                    None => ::tokio::task::spawn_blocking(f),
+                };
+                JoinHandle(JoinHandleInner::Tokio(jh))
+            }
+            SpawnerKind::Custom(c) => JoinHandle(JoinHandleInner::Custom(c.spawn_blocking(f))),
+        }
+    }
 }
 
 impl Debug for Spawner {

--- a/crates/anyspawn/src/spawner.rs
+++ b/crates/anyspawn/src/spawner.rs
@@ -284,10 +284,12 @@ impl Spawner {
     /// use anyspawn::Spawner;
     ///
     /// let spawner = Spawner::new_tokio();
-    /// let value = spawner.spawn_blocking(|| {
-    ///     // expensive synchronous work goes here
-    ///     1 + 1
-    /// }).await;
+    /// let value = spawner
+    ///     .spawn_blocking(|| {
+    ///         // expensive synchronous work goes here
+    ///         1 + 1
+    ///     })
+    ///     .await;
     /// assert_eq!(value, 2);
     /// # }
     /// # #[cfg(not(feature = "tokio"))]

--- a/crates/anyspawn/tests/builder.rs
+++ b/crates/anyspawn/tests/builder.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![allow(missing_docs, reason = "test module")]
-// #![cfg(not(miri))]
+#![cfg(not(miri))]
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -60,57 +60,99 @@ async fn builder_layer_counts_invocations() {
     assert_eq!(blocking_count.load(Ordering::SeqCst), 1);
 }
 
+type SharedOrder = Arc<std::sync::Mutex<Vec<&'static str>>>;
+
+/// Builds a layer pair that records `tag` before delegating to the wrapped
+/// task: the future side records to `future_order` and the blocking side to
+/// `blocking_order`. Used to verify that layers execute in the documented
+/// order.
+fn recording_layer(
+    future_order: SharedOrder,
+    blocking_order: SharedOrder,
+    tag: &'static str,
+) -> (
+    impl Fn(BoxedFuture) -> BoxedFuture + Clone + Send + Sync + 'static,
+    impl Fn(BoxedBlockingTask) -> BoxedBlockingTask + Clone + Send + Sync + 'static,
+) {
+    let future_layer = move |task: BoxedFuture| -> BoxedFuture {
+        let order = Arc::clone(&future_order);
+        Box::pin(async move {
+            order.lock().expect("lock poisoned").push(tag);
+            task.await;
+        })
+    };
+    let blocking_layer = move |task: BoxedBlockingTask| -> BoxedBlockingTask {
+        let order = Arc::clone(&blocking_order);
+        Box::new(move || {
+            order.lock().expect("lock poisoned").push(tag);
+            task();
+        })
+    };
+    (future_layer, blocking_layer)
+}
+
 #[tokio::test]
 async fn builder_stacked_layers() {
-    let future_order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
-    let blocking_order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
-    let inner_future = Arc::clone(&future_order);
-    let outer_future = Arc::clone(&future_order);
-    let inner_blocking = Arc::clone(&blocking_order);
-    let outer_blocking = Arc::clone(&blocking_order);
+    // Three layers so the ordering is unambiguous: the documented order
+    // must reproduce the exact add-order, not just any consistent order.
+    let future_order: SharedOrder = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let blocking_order: SharedOrder = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    let (first_f, first_b) = recording_layer(Arc::clone(&future_order), Arc::clone(&blocking_order), "first");
+    let (second_f, second_b) = recording_layer(Arc::clone(&future_order), Arc::clone(&blocking_order), "second");
+    let (third_f, third_b) = recording_layer(Arc::clone(&future_order), Arc::clone(&blocking_order), "third");
 
     let spawner = CustomSpawnerBuilder::tokio()
-        .layer(
-            move |task: BoxedFuture| -> BoxedFuture {
-                let inner = Arc::clone(&inner_future);
-                Box::pin(async move {
-                    inner.lock().unwrap().push("inner");
-                    task.await;
-                })
-            },
-            move |task: BoxedBlockingTask| -> BoxedBlockingTask {
-                let inner = Arc::clone(&inner_blocking);
-                Box::new(move || {
-                    inner.lock().unwrap().push("inner");
-                    task();
-                })
-            },
-        )
-        .layer(
-            move |task: BoxedFuture| -> BoxedFuture {
-                let outer = Arc::clone(&outer_future);
-                Box::pin(async move {
-                    outer.lock().unwrap().push("outer");
-                    task.await;
-                })
-            },
-            move |task: BoxedBlockingTask| -> BoxedBlockingTask {
-                let outer = Arc::clone(&outer_blocking);
-                Box::new(move || {
-                    outer.lock().unwrap().push("outer");
-                    task();
-                })
-            },
-        )
+        .layer(first_f, first_b)
+        .layer(second_f, second_b)
+        .layer(third_f, third_b)
         .build();
 
-    spawner.spawn(async {}).await;
-    spawner.spawn_blocking(|| {}).await;
+    let body_future_order = Arc::clone(&future_order);
+    let body_blocking_order = Arc::clone(&blocking_order);
 
-    // Layers wrap the task outside-in as added: the first-added (innermost
-    // wrapper) layer's pre-task code runs first when the task executes.
-    assert_eq!(*future_order.lock().unwrap(), vec!["inner", "outer"]);
-    assert_eq!(*blocking_order.lock().unwrap(), vec!["inner", "outer"]);
+    spawner
+        .spawn(async move {
+            body_future_order.lock().expect("lock poisoned").push("task");
+        })
+        .await;
+    spawner
+        .spawn_blocking(move || {
+            body_blocking_order.lock().expect("lock poisoned").push("task");
+        })
+        .await;
+
+    // Documented behavior: layers run in the order they were added, then
+    // the task body runs last.
+    assert_eq!(*future_order.lock().unwrap(), vec!["first", "second", "third", "task"]);
+    assert_eq!(*blocking_order.lock().unwrap(), vec!["first", "second", "third", "task"]);
+}
+
+#[tokio::test]
+async fn builder_stacked_layers_spawn_anywhere() {
+    // spawn_anywhere goes through the future layer, so it must observe the
+    // same add-order semantics as spawn().
+    let order: SharedOrder = Arc::new(std::sync::Mutex::new(Vec::new()));
+    // The blocking sink is irrelevant here because spawn_anywhere only
+    // exercises the future layer; pass the same Vec to satisfy the helper.
+    let (first_f, first_b) = recording_layer(Arc::clone(&order), Arc::clone(&order), "first");
+    let (second_f, second_b) = recording_layer(Arc::clone(&order), Arc::clone(&order), "second");
+    let (third_f, third_b) = recording_layer(Arc::clone(&order), Arc::clone(&order), "third");
+
+    let spawner = CustomSpawnerBuilder::tokio()
+        .layer(first_f, first_b)
+        .layer(second_f, second_b)
+        .layer(third_f, third_b)
+        .build();
+
+    // spawn_anywhere takes a fn pointer, so the task body cannot capture
+    // the order Vec. We only assert the layer order here; the existing
+    // `builder_spawn_anywhere_applies_layer` test already covers that
+    // the task body runs after the layer.
+    let result = spawner.spawn_anywhere(0_i32, |x| async move { x + 1 }).await;
+
+    assert_eq!(result, 1);
+    assert_eq!(*order.lock().unwrap(), vec!["first", "second", "third"]);
 }
 
 #[tokio::test]

--- a/crates/anyspawn/tests/builder.rs
+++ b/crates/anyspawn/tests/builder.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use anyspawn::{BoxedFuture, CustomSpawnerBuilder};
+use anyspawn::{BoxedBlockingTask, BoxedFuture, CustomSpawnerBuilder};
 
 #[tokio::test]
 async fn builder_tokio_basic() {
@@ -25,56 +25,95 @@ async fn builder_tokio_with_handle() {
 }
 
 #[tokio::test]
-async fn builder_with_counting_layer() {
-    let count = Arc::new(AtomicUsize::new(0));
-    let count_clone = Arc::clone(&count);
+async fn builder_layer_counts_invocations() {
+    let future_count = Arc::new(AtomicUsize::new(0));
+    let blocking_count = Arc::new(AtomicUsize::new(0));
+    let fc = Arc::clone(&future_count);
+    let bc = Arc::clone(&blocking_count);
 
     let spawner = CustomSpawnerBuilder::tokio()
-        .layer(move |task: BoxedFuture| -> BoxedFuture {
-            count_clone.fetch_add(1, Ordering::SeqCst);
-            task
-        })
+        .layer(
+            move |task: BoxedFuture| -> BoxedFuture {
+                fc.fetch_add(1, Ordering::SeqCst);
+                task
+            },
+            move |task: BoxedBlockingTask| -> BoxedBlockingTask {
+                bc.fetch_add(1, Ordering::SeqCst);
+                task
+            },
+        )
         .build();
 
     let r1 = spawner.spawn(async { 1 }).await;
     let r2 = spawner.spawn(async { 2 }).await;
-    let r3 = spawner.spawn(async { 3 }).await;
+    let r3 = spawner.spawn_blocking(|| 3).await;
 
-    assert_eq!(r1, 1);
-    assert_eq!(r2, 2);
-    assert_eq!(r3, 3);
-    assert_eq!(count.load(Ordering::SeqCst), 3);
+    assert_eq!((r1, r2, r3), (1, 2, 3));
+    // Each layer runs only for its own task kind.
+    assert_eq!(future_count.load(Ordering::SeqCst), 2);
+    assert_eq!(blocking_count.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]
 async fn builder_stacked_layers() {
-    let outer_count = Arc::new(AtomicUsize::new(0));
-    let inner_count = Arc::new(AtomicUsize::new(0));
-
-    let outer_clone = Arc::clone(&outer_count);
-    let inner_clone = Arc::clone(&inner_count);
+    let future_order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+    let blocking_order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+    let inner_future = Arc::clone(&future_order);
+    let outer_future = Arc::clone(&future_order);
+    let inner_blocking = Arc::clone(&blocking_order);
+    let outer_blocking = Arc::clone(&blocking_order);
 
     let spawner = CustomSpawnerBuilder::tokio()
-        .layer(move |task: BoxedFuture| -> BoxedFuture {
-            inner_clone.fetch_add(1, Ordering::SeqCst);
-            task
-        })
-        .layer(move |task: BoxedFuture| -> BoxedFuture {
-            outer_clone.fetch_add(1, Ordering::SeqCst);
-            task
-        })
+        .layer(
+            move |task: BoxedFuture| -> BoxedFuture {
+                let inner = Arc::clone(&inner_future);
+                Box::pin(async move {
+                    inner.lock().unwrap().push("inner");
+                    task.await;
+                })
+            },
+            move |task: BoxedBlockingTask| -> BoxedBlockingTask {
+                let inner = Arc::clone(&inner_blocking);
+                Box::new(move || {
+                    inner.lock().unwrap().push("inner");
+                    task();
+                })
+            },
+        )
+        .layer(
+            move |task: BoxedFuture| -> BoxedFuture {
+                let outer = Arc::clone(&outer_future);
+                Box::pin(async move {
+                    outer.lock().unwrap().push("outer");
+                    task.await;
+                })
+            },
+            move |task: BoxedBlockingTask| -> BoxedBlockingTask {
+                let outer = Arc::clone(&outer_blocking);
+                Box::new(move || {
+                    outer.lock().unwrap().push("outer");
+                    task();
+                })
+            },
+        )
         .build();
 
     spawner.spawn(async {}).await;
+    spawner.spawn_blocking(|| {}).await;
 
-    assert_eq!(outer_count.load(Ordering::SeqCst), 1);
-    assert_eq!(inner_count.load(Ordering::SeqCst), 1);
+    // Layers wrap the task outside-in as added: the first-added (innermost
+    // wrapper) layer's pre-task code runs first when the task executes.
+    assert_eq!(*future_order.lock().unwrap(), vec!["inner", "outer"]);
+    assert_eq!(*blocking_order.lock().unwrap(), vec!["inner", "outer"]);
 }
 
 #[tokio::test]
 async fn builder_passthrough_layer() {
     let spawner = CustomSpawnerBuilder::tokio()
-        .layer(|task: BoxedFuture| -> BoxedFuture { task })
+        .layer(
+            |task: BoxedFuture| -> BoxedFuture { task },
+            |task: BoxedBlockingTask| -> BoxedBlockingTask { task },
+        )
         .build();
 
     let result = spawner.spawn(async { "hello" }).await;
@@ -103,10 +142,13 @@ async fn builder_spawn_anywhere_applies_layer() {
     let count_clone = Arc::clone(&count);
 
     let spawner = CustomSpawnerBuilder::tokio()
-        .layer(move |task: BoxedFuture| -> BoxedFuture {
-            count_clone.fetch_add(1, Ordering::SeqCst);
-            task
-        })
+        .layer(
+            move |task: BoxedFuture| -> BoxedFuture {
+                count_clone.fetch_add(1, Ordering::SeqCst);
+                task
+            },
+            |task: BoxedBlockingTask| -> BoxedBlockingTask { task },
+        )
         .build();
 
     // spawn_anywhere exercises TokioSpawner::spawn_anywhere, Layered::spawn_anywhere,
@@ -125,10 +167,13 @@ async fn builder_relocate_preserves_layer() {
     let count_clone = Arc::clone(&count);
 
     let mut spawner = CustomSpawnerBuilder::tokio()
-        .layer(move |task: BoxedFuture| -> BoxedFuture {
-            count_clone.fetch_add(1, Ordering::SeqCst);
-            task
-        })
+        .layer(
+            move |task: BoxedFuture| -> BoxedFuture {
+                count_clone.fetch_add(1, Ordering::SeqCst);
+                task
+            },
+            |task: BoxedBlockingTask| -> BoxedBlockingTask { task },
+        )
         .build();
 
     let affinities = pinned_affinities(&[2]);

--- a/crates/anyspawn/tests/builder.rs
+++ b/crates/anyspawn/tests/builder.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![allow(missing_docs, reason = "test module")]
-#![cfg(not(miri))]
+// #![cfg(not(miri))]
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -14,6 +14,9 @@ async fn builder_tokio_basic() {
     let spawner = CustomSpawnerBuilder::tokio().build();
     let result = spawner.spawn(async { 42 }).await;
     assert_eq!(result, 42);
+
+    let result = spawner.spawn_blocking(|| 42).await;
+    assert_eq!(result, 42);
 }
 
 #[tokio::test]
@@ -21,6 +24,9 @@ async fn builder_tokio_with_handle() {
     let handle = tokio::runtime::Handle::current();
     let spawner = CustomSpawnerBuilder::tokio_with_handle(handle).build();
     let result = spawner.spawn(async { 99 }).await;
+    assert_eq!(result, 99);
+
+    let result = spawner.spawn_blocking(|| 99).await;
     assert_eq!(result, 99);
 }
 

--- a/crates/anyspawn/tests/builder.rs
+++ b/crates/anyspawn/tests/builder.rs
@@ -162,6 +162,10 @@ async fn builder_custom_spawner_new() {
         fn spawn_anywhere(&self, task: Box<dyn thread_aware::closure::ThreadAwareAsyncFnOnce<()>>) {
             futures::executor::block_on(task.call_once());
         }
+
+        fn spawn_blocking(&self, task: anyspawn::BoxedBlockingTask) {
+            task();
+        }
     }
 
     let spawner = CustomSpawnerBuilder::new(InlineSpawner).name("inline").build();

--- a/crates/anyspawn/tests/relocation.rs
+++ b/crates/anyspawn/tests/relocation.rs
@@ -13,7 +13,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use anyspawn::{BoxedFuture, SpawnCustom, Spawner};
+use anyspawn::{BoxedBlockingTask, BoxedFuture, SpawnCustom, Spawner};
 use thread_aware::ThreadAware;
 use thread_aware::affinity::{self, pinned_affinities};
 use thread_aware::closure::ThreadAwareAsyncFnOnce;
@@ -41,6 +41,10 @@ fn per_process_relocation_preserves_spawn_function() {
 
         fn spawn_anywhere(&self, task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
             self.spawn(task.call_once());
+        }
+
+        fn spawn_blocking(&self, task: BoxedBlockingTask) {
+            std::thread::spawn(task);
         }
     }
 
@@ -86,6 +90,10 @@ fn thread_aware_relocation_invokes_relocated_for_new_core() {
         fn spawn_anywhere(&self, task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
             let fut = task.call_once();
             std::thread::spawn(move || futures::executor::block_on(fut));
+        }
+
+        fn spawn_blocking(&self, task: BoxedBlockingTask) {
+            std::thread::spawn(task);
         }
     }
 
@@ -139,6 +147,10 @@ fn thread_aware_relocated_spawner_dispatches_through_destination() {
 
         fn spawn_anywhere(&self, task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
             self.spawn(task.call_once());
+        }
+
+        fn spawn_blocking(&self, task: BoxedBlockingTask) {
+            std::thread::spawn(task);
         }
     }
 
@@ -199,6 +211,10 @@ fn spawn_anywhere_relocates_task_data() {
             let affinities = pinned_affinities(&[2]);
             task.relocate(Some(affinities[0]), affinities[1]);
             self.spawn(task.call_once());
+        }
+
+        fn spawn_blocking(&self, task: BoxedBlockingTask) {
+            std::thread::spawn(task);
         }
     }
 

--- a/crates/anyspawn/tests/spawner.rs
+++ b/crates/anyspawn/tests/spawner.rs
@@ -6,7 +6,7 @@
 
 //! Tests for `Spawner` implementations.
 
-use anyspawn::{BoxedFuture, SpawnCustom, Spawner};
+use anyspawn::{BoxedBlockingTask, BoxedFuture, SpawnCustom, Spawner};
 use thread_aware::ThreadAware;
 use thread_aware::closure::ThreadAwareAsyncFnOnce;
 
@@ -61,6 +61,10 @@ impl SpawnCustom for ThreadPoolSpawner {
     fn spawn_anywhere(&self, task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
         self.spawn(task.call_once());
     }
+
+    fn spawn_blocking(&self, task: BoxedBlockingTask) {
+        std::thread::spawn(task);
+    }
 }
 
 #[test]
@@ -113,4 +117,26 @@ async fn tokio_spawner_debug() {
     let spawner = Spawner::new_tokio();
     let debug_str = format!("{spawner:?}");
     assert_eq!(debug_str, r#"Spawner("tokio")"#);
+}
+
+#[tokio::test]
+async fn tokio_spawn_blocking() {
+    let spawner = Spawner::new_tokio();
+    let result = spawner.spawn_blocking(|| 21 * 2).await;
+    assert_eq!(result, 42);
+}
+
+#[test]
+fn tokio_with_handle_spawn_blocking() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let spawner = Spawner::new_tokio_with_handle(rt.handle().clone());
+    let result = rt.block_on(spawner.spawn_blocking(|| 7 * 6));
+    assert_eq!(result, 42);
+}
+
+#[test]
+fn custom_spawn_blocking() {
+    let spawner = Spawner::new_custom("threadpool", ThreadPoolSpawner);
+    let result = futures::executor::block_on(spawner.spawn_blocking(|| 100 + 23));
+    assert_eq!(result, 123);
 }


### PR DESCRIPTION
 ## Summary
 
 Adds `spawn_blocking` support to `anyspawn`, enabling tasks to be dispatched to a blocking thread pool through the same abstraction as async tasks.
 
 **This is a breaking change.** Bumps `anyspawn` from `0.4.0` → `0.5.0`.
 
 ## Changes
 
 ### New API
 - **`Spawner::spawn_blocking<T, F>(f) -> impl Future<Output = T>`** — spawns a blocking closure on the runtime's blocking thread pool (Tokio uses 
`tokio::task::spawn_blocking`; custom spawners use a oneshot channel).
 - **`BoxedBlockingTask`** — new public type alias: `Box<dyn FnOnce() + Send + 'static>`.
 
 ### Breaking changes
 - **`SpawnCustom`** trait gains a required `spawn_blocking(&self, task: BoxedBlockingTask)` method. All existing implementations must add this method.
 - **`CustomSpawnerBuilder::layer`** now takes **two** closures: `layer(future_layer, blocking_layer)`. Pass `|t| t` for the side you don't want to wrap.

Tests

 - Added spawn_blocking coverage in tests/spawner.rs.
 - Consolidated duplicated future/blocking builder tests into combined cases in tests/builder.rs (13 tests, all passing).
 - Verified: cargo test, cargo clippy --all-targets -D warnings, just format readme spellcheck all clean.