### PR TITLE
fix(cachet): lower tick dependency from ^0.2.2 to >=0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cachet"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloc_tracker",
  "anyspawn",

--- a/crates/cachet/CHANGELOG.md
+++ b/crates/cachet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1] - 2026-05-14
+
+- 🐛 Bug Fixes
+
+  - Fix tick dependency requirement from `^0.2.2` to `^0.2.1` (tick 0.2.2 was never published)
+
 ## [0.2.0] - 2026-05-06
 
 - ✔️ Tasks

--- a/crates/cachet/Cargo.toml
+++ b/crates/cachet/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "cachet"
 description = "A composable, customizable multi-tier caching library with rich feature support."
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 keywords = ["oxidizer", "caching", "concurrency"]
 categories = ["caching", "concurrency"]
@@ -60,7 +60,7 @@ pin-project-lite = { workspace = true }
 postcard = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 thread_aware = { workspace = true }
-tick = { workspace = true, features = [] }
+tick = { path = "../tick", default-features = false, version = ">=0.2.1, <0.4.0", features = [] }
 tracing = { workspace = true, optional = true }
 uniflight = { workspace = true }
 

--- a/crates/cachet/README.md
+++ b/crates/cachet/README.md
@@ -264,23 +264,23 @@ Event name: `cache.event` with fields `cache.name`, `cache.operation`,
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/cachet">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG1DRY_ouWcOzG58PK1HRUDW5G5JDU0oAlprIG37b8vyW3Z6AYWSHgmhieXRlc2J1ZmUwLjQuMoJmY2FjaGV0ZTAuMi4wgm1jYWNoZXRfbWVtb3J5ZTAuMS4wgm5jYWNoZXRfc2VydmljZWUwLjEuMIJrY2FjaGV0X3RpZXJlMC4xLjCCZHRpY2tlMC4zLjCCaXVuaWZsaWdodGUwLjEuMA
- [__link0]: https://docs.rs/cachet/0.2.0/cachet/?search=TimeToRefresh
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbUNFj-i5Zw7Mbnw8rUdFQNbkbkkNTSgCWmsgbftvy_JbdnoBhZIeCaGJ5dGVzYnVmZTAuNC4ygmZjYWNoZXRlMC4yLjGCbWNhY2hldF9tZW1vcnllMC4xLjCCbmNhY2hldF9zZXJ2aWNlZTAuMS4wgmtjYWNoZXRfdGllcmUwLjEuMIJkdGlja2UwLjMuMIJpdW5pZmxpZ2h0ZTAuMS4w
+ [__link0]: https://docs.rs/cachet/0.2.1/cachet/?search=TimeToRefresh
  [__link1]: https://crates.io/crates/uniflight/0.1.0
  [__link10]: https://docs.rs/cachet_tier/0.1.0/cachet_tier/?search=CacheTier
- [__link11]: https://docs.rs/cachet/0.2.0/cachet/?search=InsertPolicy
- [__link12]: https://docs.rs/cachet/0.2.0/cachet/?search=TimeToRefresh
+ [__link11]: https://docs.rs/cachet/0.2.1/cachet/?search=InsertPolicy
+ [__link12]: https://docs.rs/cachet/0.2.1/cachet/?search=TimeToRefresh
  [__link13]: https://docs.rs/cachet_tier/0.1.0/cachet_tier/?search=Error
  [__link14]: https://crates.io/crates/cachet_tier/0.1.0
  [__link15]: https://crates.io/crates/cachet_memory/0.1.0
  [__link16]: https://docs.rs/moka
  [__link17]: https://crates.io/crates/cachet_service/0.1.0
  [__link18]: https://docs.rs/bytesbuf/0.4.2/bytesbuf/?search=BytesView
- [__link2]: https://docs.rs/cachet/0.2.0/cachet/?search=CacheBuilder::stampede_protection
+ [__link2]: https://docs.rs/cachet/0.2.1/cachet/?search=CacheBuilder::stampede_protection
  [__link3]: https://docs.rs/cachet_tier/0.1.0/cachet_tier/?search=CacheTier
  [__link4]: https://docs.rs/cachet_tier/0.1.0/cachet_tier/?search=DynamicCache
- [__link5]: https://docs.rs/cachet/0.2.0/cachet/?search=InsertPolicy
+ [__link5]: https://docs.rs/cachet/0.2.1/cachet/?search=InsertPolicy
  [__link6]: https://docs.rs/tick/0.3.0/tick/?search=Clock
- [__link7]: https://docs.rs/cachet/0.2.0/cachet/?search=Cache
- [__link8]: https://docs.rs/cachet/0.2.0/cachet/?search=CacheBuilder
+ [__link7]: https://docs.rs/cachet/0.2.1/cachet/?search=Cache
+ [__link8]: https://docs.rs/cachet/0.2.1/cachet/?search=CacheBuilder
  [__link9]: https://docs.rs/cachet_tier/0.1.0/cachet_tier/?search=CacheEntry


### PR DESCRIPTION
tick 0.2.2 was never published to the OxidizerDependencies registry, causing cachet 0.2.0 consumers to fail resolution. This patch release widens the tick requirement to >=0.2.1,<0.4.0 so that tick 0.2.1 (which exists in the registry) satisfies the constraint.