### PR TITLE
chore: Bump cachet_memory to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ anyspawn = { path = "crates/anyspawn", default-features = false, version = "0.5.
 bytesbuf = { path = "crates/bytesbuf", default-features = false, version = "0.4.2" }
 bytesbuf_io = { path = "crates/bytesbuf_io", default-features = false, version = "0.4.0" }
 cachet = { path = "crates/cachet", default-features = false, version = "0.3.0" }
-cachet_memory = { path = "crates/cachet_memory", default-features = false, version = "0.1.0" }
+cachet_memory = { path = "crates/cachet_memory", default-features = false, version = "0.2.0" }
 cachet_service = { path = "crates/cachet_service", default-features = false, version = "0.1.0" }
 cachet_tier = { path = "crates/cachet_tier", default-features = false, version = "0.1.0" }
 data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.11.0" }

--- a/crates/cachet_memory/Cargo.toml
+++ b/crates/cachet_memory/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "cachet_memory"
 description = "In-memory cache tier backed by Moka for the cachet caching library."
-version = "0.1.0"
+version = "0.2.0"
 readme = "README.md"
 keywords = ["oxidizer", "caching", "concurrency"]
 categories = ["caching", "concurrency"]


### PR DESCRIPTION
Publishes the eviction_policy API that was added after the initial 0.1.0 release.