### PR TITLE
ci(main): temporarily force delta.skip=false to unblock PRs stuck on matrix status checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,14 +74,14 @@ jobs:
           exclude_not_affected=$(impact -f cargo-excludes --affected)
           exclude_not_required=$(impact -f cargo-excludes --required)
 
-          # `required` is the superset (required ⊇ affected ⊇ modified). If it
-          # has no impacted crates, nothing is impacted and downstream
-          # source-scoped jobs can be skipped entirely.
-          if [[ -z "$(impact -f names --required)" ]]; then
-            skip=true
-          else
-            skip=false
-          fi
+          # Workaround: branch protection requires matrix-expanded status check
+          # contexts (e.g. `testing (ubuntu-latest)`), but GitHub Actions does
+          # not expand the matrix for a job whose top-level `if:` evaluates to
+          # false — only a single skipped check is posted under the bare job
+          # name. Until the required-checks fan-in lands and the ruleset is
+          # migrated, force `skip=false` so every matrix job actually runs and
+          # posts the per-OS contexts the ruleset is waiting for.
+          skip=false
 
           {
             echo "exclude_not_modified=$exclude_not_modified"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,34 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
+
+          # Temporary workaround (see PR #434): the entire delta job is
+          # treated as a no-op. We still run `cargo delta snapshot/impact`
+          # below on PRs so we notice if the tool itself breaks, but we
+          # discard its opinion and emit constant `skip=false` plus empty
+          # excludes. This is needed because:
+          #
+          #   1. Branch protection on `main` requires matrix-expanded
+          #      contexts like `testing (ubuntu-latest)`. When a matrix
+          #      job's top-level `if:` evaluates to false, GitHub Actions
+          #      does not expand the matrix and only posts a single skipped
+          #      check under the bare job name, so those required contexts
+          #      stay in "Expected — Waiting for status to be reported"
+          #      forever.
+          #
+          #   2. `cargo-excludes` emits the workspace *complement* of the
+          #      selected tier. When `--required` is empty (e.g. doc-only
+          #      PRs that `.delta.toml` excludes), every tier's complement
+          #      excludes the entire workspace, which would make downstream
+          #      `cargo --workspace --exclude ...` invocations select zero
+          #      packages and fail. Forcing empty excludes makes downstream
+          #      jobs run the full workspace, which is correct (if not
+          #      minimal) for every PR.
+          #
+          # The proper fix is the `required-checks` fan-in (PR #435) and a
+          # ruleset migration; once that lands this whole block can return
+          # to honoring `cargo delta`'s computed outputs.
+
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             # push to main (or any non-PR trigger) -> full backstop: no excludes.
             {
@@ -70,24 +98,18 @@ jobs:
             cargo delta -c .delta.toml impact --baseline "$baseline" --current "$current" "$@"
           }
 
-          exclude_not_modified=$(impact -f cargo-excludes --modified)
-          exclude_not_affected=$(impact -f cargo-excludes --affected)
-          exclude_not_required=$(impact -f cargo-excludes --required)
-
-          # Workaround: branch protection requires matrix-expanded status check
-          # contexts (e.g. `testing (ubuntu-latest)`), but GitHub Actions does
-          # not expand the matrix for a job whose top-level `if:` evaluates to
-          # false — only a single skipped check is posted under the bare job
-          # name. Until the required-checks fan-in lands and the ruleset is
-          # migrated, force `skip=false` so every matrix job actually runs and
-          # posts the per-OS contexts the ruleset is waiting for.
-          skip=false
+          # Run impact for its side effect of exercising the tool; outputs are
+          # intentionally discarded while the workaround is in effect.
+          impact -f cargo-excludes --modified  >/dev/null
+          impact -f cargo-excludes --affected  >/dev/null
+          impact -f cargo-excludes --required  >/dev/null
+          impact -f names          --required  >/dev/null
 
           {
-            echo "exclude_not_modified=$exclude_not_modified"
-            echo "exclude_not_affected=$exclude_not_affected"
-            echo "exclude_not_required=$exclude_not_required"
-            echo "skip=$skip"
+            echo "exclude_not_modified="
+            echo "exclude_not_affected="
+            echo "exclude_not_required="
+            echo "skip=false"
           } | tee -a "$GITHUB_OUTPUT"
 
   testing:


### PR DESCRIPTION
## What

Temporarily treat the `delta` job as a no-op: still invoke `cargo delta`
(snapshot + impact) on PRs so the tool itself is exercised and we notice
regressions, but discard its computed outputs and emit constant
`skip=false` with empty `exclude_not_*` strings. Downstream
`cargo --workspace ${{ needs.delta.outputs.exclude_* }}` invocations
collapse to plain `cargo --workspace` and build the full workspace.

## Why

Branch protection on `main` requires matrix-expanded status check
contexts (`testing (ubuntu-latest)`, `static-analysis (windows-11-arm)`,
`coverage (ubuntu-24.04-arm)`, `extended-analysis (...)`, ...). When a
matrix job''s job-level `if:` evaluates to false, GitHub Actions does
**not** expand the matrix — it posts a single skipped check under the
bare job name (or the literal unsubstituted template, as we see for the
`extended-analysis (${{ matrix.os }})` check name). Result: every per-OS
context the ruleset waits on stays in
`Expected — Waiting for status to be reported` forever, and the PR
cannot be merged. `codecov/project` is also stuck because Codecov never
receives an upload from the skipped `coverage` job.

Example: PR #432 (a docs-only change) hit 16 stuck contexts.

A naive fix that only forces `skip=false` would still break: the
`exclude_not_*` outputs come from `cargo-excludes`, which emits the
workspace **complement** of the selected tier. On doc-only PRs
(`.delta.toml` excludes `*.md`) `--required` is empty, so the complement
is every crate; downstream `cargo --workspace --exclude crate1 ...
(every crate)` then selects zero packages and fails. So the workaround
also has to zero out the excludes.

## How

In the `delta` job''s `Compute Impact` step:

- Push-to-main path: unchanged (already emits empty excludes and
  `skip=false`).
- PR path:
  - Still run `cargo delta snapshot` against the base ref and the head,
    and still call `cargo delta impact` for each tier — but pipe the
    results to `/dev/null`. This keeps the tool exercised so we notice
    if it regresses while the workaround is in place.
  - Emit constants only: `exclude_not_modified=`, `exclude_not_affected=`,
    `exclude_not_required=`, `skip=false`.

An inline comment in the step documents both the matrix-expansion
trigger and the `cargo-excludes` complement pitfall, and points at
PR #435 (the long-term fan-in fix) as the path back to honoring
`cargo delta`''s output.

## Follow-up

This is a workaround. The long-term fix lives in PR #435: a single
`required-checks` fan-in job that `needs:` every other job, runs with
`if: always()`, and passes when its dependencies all succeed or skip,
plus making `coverage` always run so `codecov/project` is reliably
reported. Once that lands and the ruleset is migrated to require only
`required-checks` (plus `license/cla` and `codecov/project`), this PR
can be reverted so doc-only PRs once again skip the heavy matrix jobs.

## Risk

- Doc-only / no-impact PRs now build the full workspace on every gated
  job (testing, static-analysis, coverage, extended-analysis). Runner
  minutes go up temporarily; this disappears once PR #435 lands and
  this PR is reverted.
- `cargo delta` itself is still exercised, so we''ll still catch tool
  regressions during the workaround window.