### PR TITLE
ci(main): add required-checks fan-in job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -462,6 +462,9 @@ jobs:
   #
   # Maintenance — when to add a job to `needs:` below:
   #
+  #   * Do NOT add jobs that are intentionally optional / advisory; this
+  #     fan-in is only for jobs that must pass before merge.
+  #
   #   * MUST add if the job has BOTH a `strategy.matrix` AND a job-level
   #     `if:` that can evaluate to false (e.g. gated on
   #     `needs.delta.outputs.skip`, `github.event_name`, etc.). Such jobs
@@ -472,8 +475,6 @@ jobs:
   #     every required job through this single context keeps branch
   #     protection simple: one workflow context to require here, plus
   #     externally-posted statuses (`license/cla`, `codecov/project`).
-  #
-  #   * Do NOT add jobs that are intentionally optional / advisory.
   #
   # When a new job is added below, also remove any direct entry for it
   # from the branch protection ruleset (only `required-checks` should be

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,14 +74,14 @@ jobs:
           exclude_not_affected=$(impact -f cargo-excludes --affected)
           exclude_not_required=$(impact -f cargo-excludes --required)
 
-          # `required` is the superset (required ⊇ affected ⊇ modified). If it
-          # has no impacted crates, nothing is impacted and downstream
-          # source-scoped jobs can be skipped entirely.
-          if [[ -z "$(impact -f names --required)" ]]; then
-            skip=true
-          else
-            skip=false
-          fi
+          # Workaround: branch protection requires matrix-expanded status check
+          # contexts (e.g. `testing (ubuntu-latest)`), but GitHub Actions does
+          # not expand the matrix for a job whose top-level `if:` evaluates to
+          # false — only a single skipped check is posted under the bare job
+          # name. Until the required-checks fan-in lands and the ruleset is
+          # migrated, force `skip=false` so every matrix job actually runs and
+          # posts the per-OS contexts the ruleset is waiting for.
+          skip=false
 
           {
             echo "exclude_not_modified=$exclude_not_modified"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,34 +40,6 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-
-          # Temporary workaround (see PR #434): the entire delta job is
-          # treated as a no-op. We still run `cargo delta snapshot/impact`
-          # below on PRs so we notice if the tool itself breaks, but we
-          # discard its opinion and emit constant `skip=false` plus empty
-          # excludes. This is needed because:
-          #
-          #   1. Branch protection on `main` requires matrix-expanded
-          #      contexts like `testing (ubuntu-latest)`. When a matrix
-          #      job's top-level `if:` evaluates to false, GitHub Actions
-          #      does not expand the matrix and only posts a single skipped
-          #      check under the bare job name, so those required contexts
-          #      stay in "Expected — Waiting for status to be reported"
-          #      forever.
-          #
-          #   2. `cargo-excludes` emits the workspace *complement* of the
-          #      selected tier. When `--required` is empty (e.g. doc-only
-          #      PRs that `.delta.toml` excludes), every tier's complement
-          #      excludes the entire workspace, which would make downstream
-          #      `cargo --workspace --exclude ...` invocations select zero
-          #      packages and fail. Forcing empty excludes makes downstream
-          #      jobs run the full workspace, which is correct (if not
-          #      minimal) for every PR.
-          #
-          # The proper fix is the `required-checks` fan-in (PR #435) and a
-          # ruleset migration; once that lands this whole block can return
-          # to honoring `cargo delta`'s computed outputs.
-
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             # push to main (or any non-PR trigger) -> full backstop: no excludes.
             {
@@ -98,18 +70,24 @@ jobs:
             cargo delta -c .delta.toml impact --baseline "$baseline" --current "$current" "$@"
           }
 
-          # Run impact for its side effect of exercising the tool; outputs are
-          # intentionally discarded while the workaround is in effect.
-          impact -f cargo-excludes --modified  >/dev/null
-          impact -f cargo-excludes --affected  >/dev/null
-          impact -f cargo-excludes --required  >/dev/null
-          impact -f names          --required  >/dev/null
+          exclude_not_modified=$(impact -f cargo-excludes --modified)
+          exclude_not_affected=$(impact -f cargo-excludes --affected)
+          exclude_not_required=$(impact -f cargo-excludes --required)
+
+          # `required` is the superset (required ⊇ affected ⊇ modified). If it
+          # has no impacted crates, nothing is impacted and downstream
+          # source-scoped jobs can be skipped entirely.
+          if [[ -z "$(impact -f names --required)" ]]; then
+            skip=true
+          else
+            skip=false
+          fi
 
           {
-            echo "exclude_not_modified="
-            echo "exclude_not_affected="
-            echo "exclude_not_required="
-            echo "skip=false"
+            echo "exclude_not_modified=$exclude_not_modified"
+            echo "exclude_not_affected=$exclude_not_affected"
+            echo "exclude_not_required=$exclude_not_required"
+            echo "skip=$skip"
           } | tee -a "$GITHUB_OUTPUT"
 
   testing:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -434,9 +434,7 @@ jobs:
 
   external-type-exposure:
     needs: [delta]
-    # TEMP(#435): force-skip this job so the `required-checks` fan-in is
-    # exercised against a real `skipped` dependency. Revert before merge.
-    if: false
+    if: needs.delta.outputs.skip != 'true'
     runs-on: ubuntu-slim
     steps:
       # prep

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -376,7 +376,14 @@ jobs:
 
   coverage:
     needs: [delta]
-    if: needs.delta.outputs.skip != 'true'
+    # Coverage always runs (no `delta.skip` gate) so the externally-posted
+    # `codecov/project` status check is always reported. Codecov posts that
+    # status in reaction to a coverage upload from this job; if `coverage`
+    # is skipped, `codecov/project` stays in
+    # `Expected — Waiting for status to be reported` and blocks merge. The
+    # `required-checks` fan-in only solves stuck contexts for jobs we own,
+    # so we eat the cost of running coverage on doc-only PRs here to keep
+    # the externally-posted check unblocked.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,34 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
+
+          # Temporary workaround (see PR #434): the entire delta job is
+          # treated as a no-op. We still run `cargo delta snapshot/impact`
+          # below on PRs so we notice if the tool itself breaks, but we
+          # discard its opinion and emit constant `skip=false` plus empty
+          # excludes. This is needed because:
+          #
+          #   1. Branch protection on `main` requires matrix-expanded
+          #      contexts like `testing (ubuntu-latest)`. When a matrix
+          #      job's top-level `if:` evaluates to false, GitHub Actions
+          #      does not expand the matrix and only posts a single skipped
+          #      check under the bare job name, so those required contexts
+          #      stay in "Expected — Waiting for status to be reported"
+          #      forever.
+          #
+          #   2. `cargo-excludes` emits the workspace *complement* of the
+          #      selected tier. When `--required` is empty (e.g. doc-only
+          #      PRs that `.delta.toml` excludes), every tier's complement
+          #      excludes the entire workspace, which would make downstream
+          #      `cargo --workspace --exclude ...` invocations select zero
+          #      packages and fail. Forcing empty excludes makes downstream
+          #      jobs run the full workspace, which is correct (if not
+          #      minimal) for every PR.
+          #
+          # The proper fix is the `required-checks` fan-in (PR #435) and a
+          # ruleset migration; once that lands this whole block can return
+          # to honoring `cargo delta`'s computed outputs.
+
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             # push to main (or any non-PR trigger) -> full backstop: no excludes.
             {
@@ -70,24 +98,18 @@ jobs:
             cargo delta -c .delta.toml impact --baseline "$baseline" --current "$current" "$@"
           }
 
-          exclude_not_modified=$(impact -f cargo-excludes --modified)
-          exclude_not_affected=$(impact -f cargo-excludes --affected)
-          exclude_not_required=$(impact -f cargo-excludes --required)
-
-          # Workaround: branch protection requires matrix-expanded status check
-          # contexts (e.g. `testing (ubuntu-latest)`), but GitHub Actions does
-          # not expand the matrix for a job whose top-level `if:` evaluates to
-          # false — only a single skipped check is posted under the bare job
-          # name. Until the required-checks fan-in lands and the ruleset is
-          # migrated, force `skip=false` so every matrix job actually runs and
-          # posts the per-OS contexts the ruleset is waiting for.
-          skip=false
+          # Run impact for its side effect of exercising the tool; outputs are
+          # intentionally discarded while the workaround is in effect.
+          impact -f cargo-excludes --modified  >/dev/null
+          impact -f cargo-excludes --affected  >/dev/null
+          impact -f cargo-excludes --required  >/dev/null
+          impact -f names          --required  >/dev/null
 
           {
-            echo "exclude_not_modified=$exclude_not_modified"
-            echo "exclude_not_affected=$exclude_not_affected"
-            echo "exclude_not_required=$exclude_not_required"
-            echo "skip=$skip"
+            echo "exclude_not_modified="
+            echo "exclude_not_affected="
+            echo "exclude_not_required="
+            echo "skip=false"
           } | tee -a "$GITHUB_OUTPUT"
 
   testing:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -465,3 +465,50 @@ jobs:
       # execute
       - name: Check External Type Exposure
         run: cargo +${{ env.RUST_NIGHTLY_EXTERNAL_TYPES }} -Zscript scripts/check-external-types.rs ${{ env.RUST_NIGHTLY_EXTERNAL_TYPES }}
+
+  # Single aggregating ("fan-in") status check. Branch protection should
+  # require ONLY this context for the workflow jobs below: it succeeds when
+  # every dependency either succeeded or was skipped, and fails if any
+  # dependency failed or was cancelled. This avoids the GitHub Actions
+  # quirk where a matrix job gated by a job-level `if:` posts only a single
+  # skipped check under the bare job name, leaving matrix-expanded required
+  # contexts (`testing (ubuntu-latest)` etc.) stuck on
+  # `Expected — Waiting for status to be reported`.
+  required-checks:
+    name: required-checks
+    if: always()
+    needs:
+      - delta
+      - testing
+      - static-analysis
+      - spell-check
+      - semver
+      - extended-analysis
+      - model-checking
+      - fuzz-testing
+      - mutation-testing
+      - coverage
+      - pr-title
+      - license-headers
+      - external-type-exposure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Dependency Results
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
+          # Pass when every dependency is success or skipped; fail otherwise
+          # (failure, cancelled, or any unexpected state).
+          bad=$(echo "$NEEDS_JSON" | jq -r '
+            to_entries
+            | map(select(.value.result != "success" and .value.result != "skipped"))
+            | .[] | "\(.key): \(.value.result)"
+          ')
+          if [[ -n "$bad" ]]; then
+            printf '::error::One or more required jobs did not succeed or skip:\n%s\n' "$bad"
+            exit 1
+          fi
+          echo "All required jobs succeeded or were skipped."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -459,6 +459,25 @@ jobs:
   # skipped check under the bare job name, leaving matrix-expanded required
   # contexts (`testing (ubuntu-latest)` etc.) stuck on
   # `Expected — Waiting for status to be reported`.
+  #
+  # Maintenance — when to add a job to `needs:` below:
+  #
+  #   * MUST add if the job has BOTH a `strategy.matrix` AND a job-level
+  #     `if:` that can evaluate to false (e.g. gated on
+  #     `needs.delta.outputs.skip`, `github.event_name`, etc.). Such jobs
+  #     trigger the stuck-context bug above and can only be made required
+  #     safely via this fan-in.
+  #
+  #   * SHOULD add any other job that must pass before merge. Funnelling
+  #     every required job through this single context keeps branch
+  #     protection simple: one workflow context to require here, plus
+  #     externally-posted statuses (`license/cla`, `codecov/project`).
+  #
+  #   * Do NOT add jobs that are intentionally optional / advisory.
+  #
+  # When a new job is added below, also remove any direct entry for it
+  # from the branch protection ruleset (only `required-checks` should be
+  # listed for jobs defined in this workflow).
   required-checks:
     name: required-checks
     if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -456,7 +456,9 @@ jobs:
 
   external-type-exposure:
     needs: [delta]
-    if: needs.delta.outputs.skip != 'true'
+    # TEMP(#435): force-skip this job so the `required-checks` fan-in is
+    # exercised against a real `skipped` dependency. Revert before merge.
+    if: false
     runs-on: ubuntu-slim
     steps:
       # prep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,25 @@ to the changelogs, though you are permitted to do so if explicitly instructed.
 
 Pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/) naming, e.g. `feat(bytesbuf): add new metric` or `fix(cachet): correct eviction logic`.
 
+## Required CI Checks
+
+The `required-checks` job in `.github/workflows/main.yml` is a "fan-in"
+aggregator: branch protection requires only this single context for jobs
+defined in that workflow, and it succeeds when every dependency either
+succeeded or was skipped.
+
+When you add a new job to `main.yml`, you MUST also add it to the `needs:`
+list of `required-checks` if it has BOTH a `strategy.matrix` AND a
+job-level `if:` that can evaluate to false (typically gated on
+`needs.delta.outputs.skip` or `github.event_name`). GitHub Actions does
+not expand the matrix when such a gate skips the job, so per-OS contexts
+like `testing (ubuntu-latest)` are never posted and would stay stuck on
+`Expected — Waiting for status to be reported` if required directly.
+
+Other required jobs should also be funnelled through `required-checks`
+so branch protection only references one workflow context. See the
+inline comment on the `required-checks` job for the full policy.
+
 ## Maintainability
 
 While it is fine to use `.expect()`, the precondition is that it is either a programming error (the caller did something wrong)


### PR DESCRIPTION
## What

Three changes that together let the branch protection ruleset for `main`
require a single status check from this workflow:

1. **Add a `required-checks` fan-in job** that depends on every other job
   in `main.yml` (delta, testing, static-analysis, spell-check, semver,
   extended-analysis, model-checking, fuzz-testing, mutation-testing,
   coverage, pr-title, license-headers, external-type-exposure). It runs
   with `if: always()` and passes when each dependency is either
   `success` or `skipped`; it fails on `failure` or `cancelled` (or any
   other unexpected result state).

2. **Always run the `coverage` job** (drop its `delta.skip` gate). Codecov
   posts the `codecov/project` status check in reaction to a coverage
   upload, so if `coverage` is skipped that externally-posted required
   context stays in `Expected — Waiting for status to be reported` and
   blocks merge. The fan-in only solves stuck contexts for jobs *we*
   own, so coverage has to actually run on every PR for `codecov/project`
   to be reported.

3. **Revert PR #434**: restore the `delta` job''s `Compute Impact` step
   to its pre-#434 behavior (honor `cargo delta`''s output, including
   `skip=true` when no crates are impacted, with the proper
   `exclude_not_*` lists). Once the fan-in is in place there is no
   reason to keep treating the delta job as a no-op.

## Why

Branch protection on `main` requires the matrix-expanded contexts
(`testing (ubuntu-latest)`, `static-analysis (windows-11-arm)`,
`coverage (ubuntu-24.04-arm)`, `extended-analysis (...)`, ...). When a
matrix job''s top-level `if:` evaluates to false, GitHub Actions does
**not** expand the matrix — it posts a single skipped check under the
bare job name (or the literal unsubstituted template, as we see for
`extended-analysis (${{ matrix.os }})`). The per-OS contexts the ruleset
is waiting on are therefore never posted, and the PR sits forever at
`Expected — Waiting for status to be reported` (see PR #432, which hit
16 stuck contexts including `codecov/project`).

A single fan-in context sidesteps the matrix-expansion quirk entirely:
the ruleset only has to wait for one check that we control end-to-end,
and skipped matrix jobs are tolerated by design. Combined with always
running coverage, this handles all 16 of the previously-stuck contexts
**without** forcing every other job to also run (the heavier hammer used
by the short-term workaround in #434).

## How

The fan-in job:

```yaml
required-checks:
  name: required-checks
  if: always()
  needs: [delta, testing, static-analysis, spell-check, semver,
          extended-analysis, model-checking, fuzz-testing,
          mutation-testing, coverage, pr-title, license-headers,
          external-type-exposure]
  runs-on: ubuntu-latest
  steps:
    - name: Validate Dependency Results
      shell: bash
      env:
        NEEDS_JSON: ${{ toJSON(needs) }}
      run: |
        ...  # prints each dep, exits non-zero on any failure/cancelled
```

The coverage change removes the `if: needs.delta.outputs.skip != ''true''`
line on the `coverage` job (keeps `needs: [delta]` for ordering/outputs)
and documents the rationale inline.

The revert restores the original `Compute Impact` script: snapshot base
and head, run `cargo delta impact` for each tier, and emit `skip=true`
iff no required crates are impacted (with the corresponding
`exclude_not_*` lists from `cargo-excludes`).

## Dependency

This PR is stacked on top of #434 — the rebase contains #434''s two
commits, plus the three new commits described above. After #434
squash-merges into main, this PR''s rebase onto the updated main will
drop the duplicate workaround commits (via patch-id) and leave just the
three new commits as the effective diff.

## Follow-up (cannot land in this PR alone)

After this PR merges, the branch protection ruleset for `main` (ruleset
`7612218`) must be updated:

- **Remove** the 15 matrix-expanded required contexts and the bare
  `model-checking` / `fuzz-testing` / `mutation-testing` / `spell-check`
  / `pr-title` / `license-headers` / `external-type-exposure` entries.
- **Add** `required-checks` as the only required context for this
  workflow.
- `license/cla` (externally posted by the Policy Service app) stays.
- `codecov/project` stays and will now reliably report, because the
  `coverage` job always runs.

## Risk

- The fan-in check only resolves after every dependency reports — same
  total wall-clock as today, just collapsed into one context.
- Always running coverage costs runner minutes on doc-only PRs; trade-off
  is keeping `codecov/project` unblocked permanently.
- A misconfigured ruleset migration could let a failing job slip through;
  mitigated by leaving the existing required contexts in place during
  this PR and only switching them out once `required-checks` is observed
  green on a few PRs.