### PR TITLE
feat(templated_uri): add effective_port and make port return explicit port

### DIFF
--- a/crates/templated_uri/src/base_uri.rs
+++ b/crates/templated_uri/src/base_uri.rs
@@ -300,12 +300,11 @@ impl BaseUri {
         Self { origin, path: self.path }
     }
 
-    /// Returns the port of this [`BaseUri`].
+    /// Returns the explicit port of this [`BaseUri`].
     ///
-    /// Returns the explicit port from the authority when present. For HTTP and
-    /// HTTPS, the well-known default port is inferred from the scheme when no
-    /// port is specified. For other schemes without an explicit port this
-    /// method returns `None`.
+    /// Returns the explicit port from the authority when present, or `None`
+    /// when no port is specified. Default ports are not inferred from the
+    /// scheme; use [`BaseUri::effective_port`] for that.
     ///
     /// # Examples
     ///
@@ -315,17 +314,50 @@ impl BaseUri {
     /// let base_uri = BaseUri::from_static("https://example.com:8443");
     /// assert_eq!(base_uri.port(), Some(8443));
     ///
-    /// // Default HTTPS port
+    /// // No explicit port: even for HTTPS, this returns None.
     /// let base_uri = BaseUri::from_static("https://example.com");
     /// assert_eq!(base_uri.port(), None);
     ///
-    /// // Default HTTP port
+    /// // No explicit port: even for HTTP, this returns None.
     /// let base_uri = BaseUri::from_static("http://example.com");
     /// assert_eq!(base_uri.port(), None);
     /// ```
     #[must_use]
     pub fn port(&self) -> Option<u16> {
         self.origin.port()
+    }
+
+    /// Returns the effective port of this [`BaseUri`], falling back to
+    /// well-known scheme defaults when no explicit port is present.
+    ///
+    /// Returns the explicit port from the authority when present. Otherwise,
+    /// returns the IANA-registered default port for the scheme:
+    ///
+    /// - `80` for `http`
+    /// - `443` for `https`
+    ///
+    /// Returns `None` when no explicit port is present and the scheme has no
+    /// well-known default known to this crate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use templated_uri::{BaseUri, Scheme};
+    /// // Explicit port
+    /// let base_uri = BaseUri::from_static("https://example.com:8443");
+    /// assert_eq!(base_uri.effective_port(), Some(8443));
+    ///
+    /// // Default HTTPS port
+    /// let base_uri = BaseUri::from_static("https://example.com");
+    /// assert_eq!(base_uri.effective_port(), Some(443));
+    ///
+    /// // Default HTTP port
+    /// let base_uri = BaseUri::from_static("http://example.com");
+    /// assert_eq!(base_uri.effective_port(), Some(80));
+    /// ```
+    #[must_use]
+    pub fn effective_port(&self) -> Option<u16> {
+        self.origin.effective_port()
     }
 
     /// Returns a new [`BaseUri`] with the given port.
@@ -817,6 +849,33 @@ mod tests {
         fn port_explicit() {
             let base_uri = BaseUri::from_static("https://example.com:8443");
             assert_eq!(base_uri.port(), Some(8443));
+        }
+
+        #[test]
+        fn port_implicit_returns_none() {
+            let base_uri = BaseUri::from_static("https://example.com");
+            assert_eq!(base_uri.port(), None);
+
+            let base_uri = BaseUri::from_static("http://example.com");
+            assert_eq!(base_uri.port(), None);
+        }
+
+        #[test]
+        fn effective_port_explicit() {
+            let base_uri = BaseUri::from_static("https://example.com:8443");
+            assert_eq!(base_uri.effective_port(), Some(8443));
+        }
+
+        #[test]
+        fn effective_port_infers_https_default() {
+            let base_uri = BaseUri::from_static("https://example.com");
+            assert_eq!(base_uri.effective_port(), Some(443));
+        }
+
+        #[test]
+        fn effective_port_infers_http_default() {
+            let base_uri = BaseUri::from_static("http://example.com");
+            assert_eq!(base_uri.effective_port(), Some(80));
         }
     }
 

--- a/crates/templated_uri/src/origin.rs
+++ b/crates/templated_uri/src/origin.rs
@@ -99,10 +99,52 @@ impl Origin {
     /// Returns the explicit port of this origin, if any.
     ///
     /// Returns the explicit port from the authority when present, or `None` when
-    /// the authority does not specify a port.
+    /// the authority does not specify a port. Default ports are not inferred from
+    /// the scheme; use [`Origin::effective_port`] for that.
     #[must_use]
     pub fn port(&self) -> Option<u16> {
         self.authority.port_u16()
+    }
+
+    /// Returns the effective port of this origin, falling back to well-known
+    /// scheme defaults when no explicit port is present.
+    ///
+    /// Returns the explicit port from the authority when present. Otherwise,
+    /// returns the IANA-registered default port for the scheme:
+    ///
+    /// - `80` for `http`
+    /// - `443` for `https`
+    ///
+    /// Returns `None` when no explicit port is present and the scheme has no
+    /// well-known default known to this crate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use templated_uri::Origin;
+    /// // Explicit port is returned as-is.
+    /// let origin = Origin::from_static("https://example.com:8443");
+    /// assert_eq!(origin.effective_port(), Some(8443));
+    ///
+    /// // HTTPS default is used when no port is specified.
+    /// let origin = Origin::from_static("https://example.com");
+    /// assert_eq!(origin.effective_port(), Some(443));
+    ///
+    /// // HTTP default is used when no port is specified.
+    /// let origin = Origin::from_static("http://example.com");
+    /// assert_eq!(origin.effective_port(), Some(80));
+    /// ```
+    #[must_use]
+    pub fn effective_port(&self) -> Option<u16> {
+        if let Some(port) = self.authority.port_u16() {
+            return Some(port);
+        }
+
+        match self.scheme.as_str() {
+            s if s == Scheme::HTTP.as_str() => Some(HTTP_DEFAULT_PORT),
+            s if s == Scheme::HTTPS.as_str() => Some(HTTPS_DEFAULT_PORT),
+            _ => None,
+        }
     }
 
     /// Set port for this `Origin` instance.
@@ -228,6 +270,31 @@ mod tests {
         // An explicit port is always reported regardless of the scheme.
         let origin_with_port = Origin::from_parts(Scheme::from_str("ftp").unwrap(), Authority::from_static("example.com:21"));
         assert_eq!(origin_with_port.port(), Some(21));
+    }
+
+    #[test]
+    fn test_effective_port() {
+        // Explicit ports are returned verbatim.
+        let origin = Origin::from_parts(Scheme::HTTP, Authority::from_static("example.com:8080"));
+        assert_eq!(origin.effective_port(), Some(8080));
+
+        let origin = Origin::from_parts(Scheme::HTTPS, Authority::from_static("example.com:8443"));
+        assert_eq!(origin.effective_port(), Some(8443));
+
+        // Well-known defaults are inferred from the scheme when no port is set.
+        let origin = Origin::from_parts(Scheme::HTTP, Authority::from_static("example.com"));
+        assert_eq!(origin.effective_port(), Some(HTTP_DEFAULT_PORT));
+
+        let origin = Origin::from_parts(Scheme::HTTPS, Authority::from_static("example.com"));
+        assert_eq!(origin.effective_port(), Some(HTTPS_DEFAULT_PORT));
+
+        // Unknown schemes without an explicit port have no inferred default.
+        let origin = Origin::from_parts(Scheme::from_str("ftp").unwrap(), Authority::from_static("example.com"));
+        assert_eq!(origin.effective_port(), None);
+
+        // Unknown schemes still surface an explicit port.
+        let origin = Origin::from_parts(Scheme::from_str("ftp").unwrap(), Authority::from_static("example.com:21"));
+        assert_eq!(origin.effective_port(), Some(21));
     }
 
     #[test]


### PR DESCRIPTION
BaseUri::port() and Origin::port() now return only the explicit port from the authority, without inferring scheme defaults. The new effective_port() method returns the explicit port or falls back to the IANA-registered default (80 for http, 443 for https).