### PR TITLE
chore: revert excesive mutation timeouts

### DIFF
--- a/scripts/mutants.rs
+++ b/scripts/mutants.rs
@@ -18,8 +18,8 @@ use ohno::AppError;
 use argh::FromArgs;
 
 const JOBS: u32 = 1;
-const BUILD_TIMEOUT_SEC: u32 = 6000;
-const TIMEOUT_SEC: u32 = 3000;
+const BUILD_TIMEOUT_SEC: u32 = 600;
+const TIMEOUT_SEC: u32 = 300;
 const MINIMUM_TEST_TIMEOUT_SEC: u32 = 60;
 
 /// Run mutation testing on the workspace


### PR DESCRIPTION
The new values are excessive and mutants won't timeout effectively anymore, reverts changes done by this PR:

https://github.com/microsoft/oxidizer/commit/c0b7572905ff99b714a237343347e60339b0947a#diff-b9d8f1106e1492b9a45476b57e61e1a54efaa4e8f464cf75f93fc40127678d59