### PR TITLE
fix(oxidizer): ensure that `cargo test` passes on a clean checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Doc Tests
         if: success() || failure()
         run: cargo test --doc --verbose --workspace ${{ needs.delta.outputs.exclude_not_affected }} --all-features
+      - name: Doc Tests (default features)
+        if: success() || failure()
+        run: cargo test --doc --verbose --workspace ${{ needs.delta.outputs.exclude_not_affected }}
       - name: Examples
         if: success() || failure()
         run: cargo +${{ env.RUST_NIGHTLY }} -Zscript ./scripts/run-examples.rs --cargo-profile dev ${{ needs.delta.outputs.exclude_not_affected }}

--- a/AGENTS-feature-gated-doctests.md
+++ b/AGENTS-feature-gated-doctests.md
@@ -1,13 +1,14 @@
 # Feature-gated doctests
 
-Doctests that reference items behind a Cargo feature (e.g. `test-util`,
-`retry`, `timeout`) fail to compile when the feature is off. The repository
-runs doctests both with and without features, so the same source must work
-in both configurations.
+Doctests that reference items behind a non-default Cargo feature (e.g.
+`test-util`, `retry`, `timeout`) fail to compile when only default features
+are enabled. The repository runs doctests both with default features and
+with `--all-features`, so the same source must work in both configurations.
 
 The fix wraps the body in hidden `#[cfg(...)]` lines that exclude the
-feature-dependent code when the feature is off. The `#` prefix hides the
-wrapper from rendered documentation but rustdoc still compiles those lines.
+feature-dependent code when the feature is not enabled. The `#` prefix hides
+the wrapper from rendered documentation but rustdoc still compiles those
+lines.
 
 ## Pattern A — implicit `main` with `?`
 

--- a/AGENTS-feature-gated-doctests.md
+++ b/AGENTS-feature-gated-doctests.md
@@ -1,0 +1,103 @@
+# Feature-gated doctests
+
+Doctests that reference items behind a Cargo feature (e.g. `test-util`,
+`retry`, `timeout`) fail to compile when the feature is off. The repository
+runs doctests both with and without features, so the same source must work
+in both configurations.
+
+The fix wraps the body in hidden `#[cfg(...)]` lines that exclude the
+feature-dependent code when the feature is off. The `#` prefix hides the
+wrapper from rendered documentation but rustdoc still compiles those lines.
+
+## Pattern A — implicit `main` with `?`
+
+When the body uses the `?` operator (and ends with a hidden
+`# Ok::<_, _>(())` for type inference), rustdoc auto-injects a
+`Result`-returning `fn main`. We can't simply cfg-gate a `{ ... }` block
+inside that auto-`main`: when the feature is off, the auto-`main` still has
+return type `Result<(), E>` but the cfg-gated `Ok(())` is gone, so the
+function falls through without a value and fails to compile.
+
+We replace rustdoc's auto-wrapping with our own non-`Result`-returning
+`fn main`, and absorb `?` via an IIFE inside a cfg-gated block:
+
+```text
+/// ```
+/// # fn main() {
+/// # #[cfg(feature = "test-util")] {
+/// # (|| {
+/// // ... visible body that uses `?` ...
+/// # Ok::<(), MyError>(())
+/// # })().unwrap();
+/// # }
+/// # }
+/// ```
+```
+
+When the feature is off the cfg-gated block compiles to nothing, and the
+empty `fn main` is a valid no-op test.
+
+## Pattern C — no `?`, no user `main`
+
+A single cfg-gated `{ ... }` block inside a hidden `fn main` is enough:
+
+```text
+/// ```
+/// # fn main() {
+/// # #[cfg(feature = "X")] {
+/// // ... body ...
+/// # }
+/// # }
+/// ```
+```
+
+## Pattern B — the doctest already declares `fn main`
+
+When the doctest defines `fn main` itself (often via `#[tokio::main]`), we
+can't introduce a second `fn main`, and we can't put a `#[tokio::main]`
+attribute inside a `{ ... }` block. Result-returning `async fn main` has the
+same return-type problem as Pattern A.
+
+We therefore use a **two-`main` shim**: a stub for the feature-off case and
+the user's real `main` for the feature-on case:
+
+```text
+/// ```
+/// // top-level items that don't reference the feature are left alone
+/// use my_crate::PublicType;
+///
+/// fn helper() -> PublicType { /* ... */ }
+///
+/// # #[cfg(not(feature = "test-util"))] fn main() {}
+/// # #[cfg(feature = "test-util")]
+/// # #[tokio::main]
+/// # async fn main() {
+/// #     // body that uses feature-only symbols (new_fake, FakeHandler, ...)
+/// # }
+/// ```
+```
+
+Top-level items that don't touch feature-gated symbols stay ungated.
+Only `use` statements that literally import a feature-only symbol
+(`FakeHandler`, `FakeRead`, `FakeWrite`, `FakeServer`, `Null`) need
+`#[cfg(feature = "test-util")]`:
+
+```text
+/// # #[cfg(feature = "test-util")]
+/// # use http_extensions::{HttpResponseBuilder, FakeHandler};
+```
+
+## Multiple required features
+
+When several features are needed, combine them with `all(...)`:
+
+```text
+/// # #[cfg(all(feature = "retry", feature = "timeout", feature = "tower-service"))] {
+```
+
+## Indented code blocks (Markdown lists)
+
+Inside a numbered or bulleted list, the code fence and its contents are
+indented relative to `///`. The injected `# #[cfg(...)]` and `# fn main`
+lines must match that inner indentation, otherwise they fall outside the
+code block and are parsed as prose.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@ to the changelogs, though you are permitted to do so if explicitly instructed.
 
 Pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/) naming, e.g. `feat(bytesbuf): add new metric` or `fix(cachet): correct eviction logic`.
 
+## Feature-gated Doctests
+
+Doctests that reference items behind a Cargo feature must compile both with and without that feature; wrap their bodies in hidden `#[cfg(...)]` shims. See [AGENTS-feature-gated-doctests.md](AGENTS-feature-gated-doctests.md).
+
 ## Required CI Checks
 
 The `required-checks` job in `.github/workflows/main.yml` is a "fan-in"

--- a/crates/bytesbuf_io/src/read.rs
+++ b/crates/bytesbuf_io/src/read.rs
@@ -68,6 +68,8 @@ pub trait Read: HasMemory + Memory + Debug {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # testing_aids::execute_or_terminate_process(|| futures::executor::block_on(async {
     /// # use bytesbuf_io::testing::Null;
     /// use bytesbuf::mem::Memory;
@@ -84,6 +86,8 @@ pub trait Read: HasMemory + Memory + Debug {
     ///
     /// let bytes = buf.consume_all();
     /// # }));
+    /// # }
+    /// # }
     /// ```
     async fn read_at_most_into(&mut self, len: usize, into: BytesBuf) -> Result<(usize, BytesBuf), Self::Error>;
 
@@ -108,6 +112,8 @@ pub trait Read: HasMemory + Memory + Debug {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # testing_aids::execute_or_terminate_process(|| futures::executor::block_on(async {
     /// # use bytesbuf_io::testing::Null;
     /// use bytesbuf_io::Read;
@@ -139,6 +145,8 @@ pub trait Read: HasMemory + Memory + Debug {
     ///     }
     /// }
     /// # }));
+    /// # }
+    /// # }
     /// ```
     async fn read_more_into(&mut self, into: BytesBuf) -> Result<(usize, BytesBuf), Self::Error>;
 
@@ -165,6 +173,8 @@ pub trait Read: HasMemory + Memory + Debug {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # testing_aids::execute_or_terminate_process(|| futures::executor::block_on(async {
     /// # use bytesbuf_io::testing::Null;
     /// use bytesbuf_io::Read;
@@ -176,6 +186,8 @@ pub trait Read: HasMemory + Memory + Debug {
     ///
     /// println!("first read produced {} bytes of data", buf.len());
     /// # }));
+    /// # }
+    /// # }
     /// ```
     async fn read_any(&mut self) -> Result<BytesBuf, Self::Error>;
 }

--- a/crates/bytesbuf_io/src/read_ext.rs
+++ b/crates/bytesbuf_io/src/read_ext.rs
@@ -31,6 +31,8 @@ pub trait ReadExt: Read {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # testing_aids::execute_or_terminate_process(|| futures::executor::block_on(async {
     /// # use bytesbuf_io::testing::Null;
     /// use bytesbuf_io::ReadExt;
@@ -42,6 +44,8 @@ pub trait ReadExt: Read {
     ///
     /// println!("read {} bytes of data", data.len());
     /// # }));
+    /// # }
+    /// # }
     /// ```
     async fn read_at_most(&mut self, len: usize) -> crate::Result<BytesView>;
 
@@ -52,6 +56,8 @@ pub trait ReadExt: Read {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # testing_aids::execute_or_terminate_process(|| futures::executor::block_on(async {
     /// # use bytesbuf_io::testing::FakeRead;
     /// # use bytesbuf::BytesView;
@@ -64,6 +70,8 @@ pub trait ReadExt: Read {
     /// let data = source.read_exactly(10).await.unwrap();
     /// assert_eq!(data.len(), 10);
     /// # }));
+    /// # }
+    /// # }
     /// ```
     async fn read_exactly(&mut self, len: usize) -> crate::Result<BytesView>;
 

--- a/crates/bytesbuf_io/src/write.rs
+++ b/crates/bytesbuf_io/src/write.rs
@@ -60,6 +60,8 @@ pub trait Write: HasMemory + Memory + Debug {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # testing_aids::execute_or_terminate_process(|| futures::executor::block_on(async {
     /// # use bytesbuf_io::testing::Null;
     /// use bytesbuf::mem::Memory;
@@ -74,6 +76,8 @@ pub trait Write: HasMemory + Memory + Debug {
     ///
     /// sink.write(bytes).await.unwrap();
     /// # }));
+    /// # }
+    /// # }
     /// ```
     async fn write(&mut self, data: BytesView) -> Result<(), Self::Error>;
 }

--- a/crates/bytesbuf_io/src/write_ext.rs
+++ b/crates/bytesbuf_io/src/write_ext.rs
@@ -20,6 +20,8 @@ pub trait WriteExt: Write {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # testing_aids::execute_or_terminate_process(|| futures::executor::block_on(async {
     /// # use bytesbuf_io::testing::Null;
     /// use std::convert::Infallible;
@@ -36,6 +38,8 @@ pub trait WriteExt: Write {
     /// .await
     /// .unwrap();
     /// # }));
+    /// # }
+    /// # }
     /// ```
     async fn prepare_and_write<F, E>(&mut self, min_capacity: usize, prepare_fn: F) -> Result<(), crate::Error>
     where

--- a/crates/http_extensions/README.md
+++ b/crates/http_extensions/README.md
@@ -170,7 +170,7 @@ for future requests. This makes the crate particularly efficient for high-throug
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/http_extensions">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG_yJjrPT_KlPGxYlOegplulrG7XEHHDTnouuGxKhZew-0ZljYWSFgmVieXRlc2YxLjExLjGCaGJ5dGVzYnVmZTAuNS4wgmRodHRwZTEuNC4wgmlodHRwX2JvZHllMS4wLjGCb2h0dHBfZXh0ZW5zaW9uc2UwLjQuMA
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG_MLOQQsiV6zG7SjqsDGgd-WG03lILZ1aMTjG5fuakLrAwKLYWSFgmVieXRlc2YxLjExLjGCaGJ5dGVzYnVmZTAuNS4wgmRodHRwZTEuNC4wgmlodHRwX2JvZHllMS4wLjGCb2h0dHBfZXh0ZW5zaW9uc2UwLjQuMA
  [__link0]: https://crates.io/crates/http/1.4.0
  [__link1]: https://docs.rs/http_extensions/0.4.0/http_extensions/type.HttpRequest.html
  [__link10]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=StatusExt

--- a/crates/http_extensions/src/_documentation/recipes.rs
+++ b/crates/http_extensions/src/_documentation/recipes.rs
@@ -123,6 +123,9 @@
 //! **Avoid** parsing the same string on every request:
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
+//! # (|| {
 //! use http_extensions::HttpRequestBuilder;
 //!
 //! for _ in 0..100 {
@@ -132,11 +135,17 @@
 //!         .build()?;
 //! }
 //! # Ok::<(), http_extensions::HttpError>(())
+//! # })().unwrap();
+//! # }
+//! # }
 //! ```
 //!
 //! **Prefer** to parse once, clone per request:
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
+//! # (|| {
 //! use http_extensions::HttpRequestBuilder;
 //! use templated_uri::Uri;
 //!
@@ -145,6 +154,9 @@
 //!     let request = HttpRequestBuilder::new_fake().get(uri.clone()).build()?;
 //! }
 //! # Ok::<(), http_extensions::HttpError>(())
+//! # })().unwrap();
+//! # }
+//! # }
 //! ```
 //!
 //! # Use Templated URIs
@@ -163,6 +175,9 @@
 //! **Avoid** raw string formatting, which loses the template and bypasses validation:
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
+//! # (|| {
 //! use http_extensions::HttpRequestBuilder;
 //!
 //! # let user_id = "test-user";
@@ -170,11 +185,17 @@
 //!     .get(format!("https://api.example.com/users/{user_id}/profile"))
 //!     .build()?;
 //! # Ok::<(), http_extensions::HttpError>(())
+//! # })().unwrap();
+//! # }
+//! # }
 //! ```
 //!
 //! **Prefer** a templated URI struct that is validated, low-allocation, and telemetry-ready:
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
+//! # (|| {
 //! use http_extensions::HttpRequestBuilder;
 //! use templated_uri::templated;
 //! use uuid::Uuid;
@@ -190,6 +211,9 @@
 //!     .get(UserProfilePath { user_id })
 //!     .build()?;
 //! # Ok::<(), http_extensions::HttpError>(())
+//! # })().unwrap();
+//! # }
+//! # }
 //! ```
 //!
 //! Templated paths are relative; set a base URI on the client so the final

--- a/crates/http_extensions/src/body/builder.rs
+++ b/crates/http_extensions/src/body/builder.rs
@@ -27,12 +27,16 @@ use crate::{HttpError, Result};
 /// # Examples
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "test-util")] {
 /// # use http_extensions::{HttpBody, HttpBodyBuilder};
 /// # let builder = HttpBodyBuilder::new_fake();
 /// // Create different body types
 /// let text_body: HttpBody = builder.text("Hello world");
 /// let empty_body: HttpBody = builder.empty();
 /// let binary_body: HttpBody = builder.slice(&[1, 2, 3, 4]);
+/// # }
+/// # }
 /// ```
 ///
 /// # Testing
@@ -56,9 +60,13 @@ impl HttpBodyBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::HttpBodyBuilder;
     /// let builder = HttpBodyBuilder::new_fake();
     /// let text_body = builder.text("Test content");
+    /// # }
+    /// # }
     /// ```
     #[cfg(any(feature = "test-util", test))]
     #[must_use]
@@ -113,6 +121,8 @@ impl HttpBodyBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::{HttpBodyOptions, HttpBodyBuilder, HttpError, HttpBody};
     /// # use http_body::Body;
     /// # use std::pin::Pin;
@@ -139,6 +149,8 @@ impl HttpBodyBuilder {
     /// // Create HttpBody from your custom body
     /// let custom_body = CustomBody(vec![1, 2, 3, 4]);
     /// let body = builder.body(custom_body, &HttpBodyOptions::default());
+    /// # }
+    /// # }
     /// ```
     pub fn body<B>(&self, body: B, options: &HttpBodyOptions) -> HttpBody
     where
@@ -167,6 +179,8 @@ impl HttpBodyBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::{HttpBodyOptions, HttpBodyBuilder, HttpError};
     /// # use bytesbuf::BytesView;
     /// # let builder = HttpBodyBuilder::new_fake();
@@ -177,6 +191,9 @@ impl HttpBodyBuilder {
     /// let body = builder.stream(futures::stream::iter(chunks), &HttpBodyOptions::default());
     ///
     /// assert_eq!(body.content_length(), None); // unknown length for streams
+    ///
+    /// # }
+    /// # }
     /// ```
     pub fn stream<S>(&self, stream: S, options: &HttpBodyOptions) -> HttpBody
     where
@@ -195,6 +212,8 @@ impl HttpBodyBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::{HttpBodyBuilder, HttpBody};
     /// #
     /// # let builder = HttpBodyBuilder::new_fake();
@@ -202,6 +221,8 @@ impl HttpBodyBuilder {
     /// let body2 = builder.text(String::from("Hello, world!")); // From String
     ///
     /// assert_eq!(body1.content_length(), body2.content_length());
+    /// # }
+    /// # }
     /// ```
     pub fn text(&self, str: impl AsRef<str>) -> HttpBody {
         self.slice(str.as_ref().as_bytes())
@@ -220,6 +241,8 @@ impl HttpBodyBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::HttpBodyBuilder;
     /// #
     /// # let builder = HttpBodyBuilder::new_fake();
@@ -228,6 +251,8 @@ impl HttpBodyBuilder {
     /// let body = builder.slice(&data);
     ///
     /// assert_eq!(body.content_length(), Some(5));
+    /// # }
+    /// # }
     /// ```
     pub fn slice(&self, data: impl AsRef<[u8]>) -> HttpBody {
         let mut builder = self.reserve(data.as_ref().len());
@@ -247,6 +272,8 @@ impl HttpBodyBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::HttpBodyBuilder;
     /// # use bytesbuf::BytesView;
     /// #
@@ -254,6 +281,8 @@ impl HttpBodyBuilder {
     /// // Create a body from existing bytes of data
     /// let body = builder.bytes(BytesView::new());
     /// assert_eq!(body.content_length(), Some(0));
+    /// # }
+    /// # }
     /// ```
     pub fn bytes(&self, b: impl Into<BytesView>) -> HttpBody {
         HttpBody::new(Kind::Bytes(Some(b.into())), self.clone())
@@ -280,6 +309,9 @@ impl HttpBodyBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError};
     /// # use serde::Serialize;
     /// #
@@ -298,6 +330,9 @@ impl HttpBodyBuilder {
     /// // Create a body containing the JSON representation of user
     /// let body = builder.json(&user)?;
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn json<T: serde_core::ser::Serialize>(&self, data: &T) -> std::result::Result<HttpBody, JsonError> {
         let builder = BytesBuf::new();

--- a/crates/http_extensions/src/body/mod.rs
+++ b/crates/http_extensions/src/body/mod.rs
@@ -49,12 +49,16 @@ pub(crate) mod timeout_body;
 /// # Examples
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "test-util")] {
 /// # use http_extensions::HttpBodyBuilder;
 /// # let builder = HttpBodyBuilder::new_fake();
 /// // Create different body types
 /// let text_body = builder.text("Hello world");
 /// let binary_body = builder.slice(&[1, 2, 3, 4]);
 /// let empty_body = builder.empty();
+/// # }
+/// # }
 /// ```
 ///
 /// # How does `HttpBody` work?
@@ -117,6 +121,8 @@ pub(crate) mod timeout_body;
 ///
 ///     Ok(())
 /// }
+/// # #[cfg(not(feature = "test-util"))] fn main() {}
+/// # #[cfg(feature = "test-util")]
 /// # #[tokio::main]
 /// # async fn main() {
 /// #     let path = std::env::temp_dir().join("http_extensions_doctest");
@@ -170,6 +176,8 @@ impl HttpBody {
     ///     println!("Received {} bytes", body_bytes.len());
     ///     Ok(())
     /// }
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     example(HttpBodyBuilder::new_fake().text("test")).await.unwrap();
@@ -208,6 +216,8 @@ impl HttpBody {
     ///     println!("Received: {}", text);
     ///     Ok(())
     /// }
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     example(HttpBodyBuilder::new_fake().text("test")).await.unwrap();
@@ -257,6 +267,8 @@ impl HttpBody {
     ///     // Now you can work with it multiple times...
     ///     Ok(())
     /// }
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     example(HttpBodyBuilder::new_fake().text("test")).await.unwrap();
@@ -310,6 +322,8 @@ impl HttpBody {
     ///     // Process the user data...
     ///     Ok(())
     /// }
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     let body = HttpBodyBuilder::new_fake()
@@ -367,6 +381,8 @@ impl HttpBody {
     ///     // avoiding unnecessary string allocations for better performance
     ///     Ok(())
     /// }
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     let body = HttpBodyBuilder::new_fake()
@@ -391,6 +407,8 @@ impl HttpBody {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::{HttpBodyBuilder, HttpBody};
     /// # let builder = HttpBodyBuilder::new_fake();
     /// let text_body = builder.text("Hello, world!");
@@ -398,6 +416,8 @@ impl HttpBody {
     ///
     /// let empty_body = builder.empty();
     /// assert_eq!(empty_body.content_length(), Some(0));
+    /// # }
+    /// # }
     /// ```
     #[must_use]
     pub fn content_length(&self) -> Option<u64> {
@@ -416,6 +436,8 @@ impl HttpBody {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::HttpBodyBuilder;
     /// # let builder = HttpBodyBuilder::new_fake();
     /// let empty_body = builder.empty();
@@ -423,6 +445,8 @@ impl HttpBody {
     ///
     /// let text_body = builder.text("Hello");
     /// assert!(!text_body.is_empty());
+    /// # }
+    /// # }
     /// ```
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -467,6 +491,8 @@ impl HttpBody {
     ///
     ///     Ok(())
     /// }
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     process_body(HttpBodyBuilder::new_fake().text("test")).await.unwrap();

--- a/crates/http_extensions/src/error.rs
+++ b/crates/http_extensions/src/error.rs
@@ -190,6 +190,8 @@ impl HttpError {
     /// this is an open circuit breaker that rejects executions without consuming the request.
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::{HttpError, HttpRequest, HttpRequestBuilder};
     /// # let http_request = HttpRequestBuilder::new_fake()
     /// #     .get("https://example.com")
@@ -203,6 +205,8 @@ impl HttpError {
     ///     execute_retry(request);
     /// }
     /// # fn execute_retry(http_request: HttpRequest) {}
+    /// # }
+    /// # }
     /// ```
     #[must_use]
     pub fn unavailable(msg: impl Into<Cow<'static, str>>) -> Self {

--- a/crates/http_extensions/src/fake_handler.rs
+++ b/crates/http_extensions/src/fake_handler.rs
@@ -26,16 +26,22 @@ type PinnedFuture = Pin<Box<dyn Future<Output = Result<HttpResponse>> + Send>>;
 /// Return a fixed status code:
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "test-util")] {
 /// use http::StatusCode;
 /// use http_extensions::FakeHandler;
 ///
 /// // All requests to this client will return 404 Not Found
 /// let handler = FakeHandler::from(StatusCode::NOT_FOUND);
+/// # }
+/// # }
 /// ```
 ///
 /// Return a sequence of responses:
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "test-util")] {
 /// use http::StatusCode;
 /// use http_extensions::FakeHandler;
 ///
@@ -49,11 +55,15 @@ type PinnedFuture = Pin<Box<dyn Future<Output = Result<HttpResponse>> + Send>>;
 /// // Second request → 400 Bad Request
 /// // Third request → 500 Internal Server Error
 /// // Fourth request → Error (all responses consumed)
+/// # }
+/// # }
 /// ```
 ///
 /// Create dynamic responses based on the request:
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "test-util")] {
 /// use http::StatusCode;
 /// use http_extensions::{FakeHandler, HttpResponseBuilder};
 ///
@@ -70,6 +80,8 @@ type PinnedFuture = Pin<Box<dyn Future<Output = Result<HttpResponse>> + Send>>;
 ///             .build()
 ///     }
 /// });
+/// # }
+/// # }
 /// ```
 ///
 /// # Working with [`HttpResponseBuilder`][crate::HttpResponseBuilder]
@@ -112,6 +124,8 @@ impl FakeHandler {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// use http::StatusCode;
     /// use http_extensions::{FakeHandler, HttpResponseBuilder};
     ///
@@ -121,6 +135,8 @@ impl FakeHandler {
     ///         .text("Hello World")
     ///         .build()
     /// });
+    /// # }
+    /// # }
     /// ```
     pub fn from_sync_handler<H>(handler: H) -> Self
     where
@@ -138,11 +154,15 @@ impl FakeHandler {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// use http_extensions::{FakeHandler, HttpError, HttpRequest};
     ///
     /// let handler = FakeHandler::from_http_error(|_request: HttpRequest| {
     ///     HttpError::validation("simulated error")
     /// });
+    /// # }
+    /// # }
     /// ```
     pub fn from_http_error(error: impl Fn(HttpRequest) -> HttpError + Send + Sync + 'static) -> Self {
         Self::from_sync_handler(move |req| Err(error(req)))
@@ -156,6 +176,8 @@ impl FakeHandler {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// use http::StatusCode;
     /// use http_extensions::{FakeHandler, HttpResponseBuilder};
     ///
@@ -168,6 +190,8 @@ impl FakeHandler {
     ///         .text("Response after delay")
     ///         .build()
     /// });
+    /// # }
+    /// # }
     /// ```
     pub fn from_async_handler<H, F>(handler: H) -> Self
     where
@@ -185,6 +209,8 @@ impl FakeHandler {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// use http::StatusCode;
     /// use http_extensions::FakeHandler;
     ///
@@ -193,6 +219,8 @@ impl FakeHandler {
     ///     StatusCode::BAD_REQUEST,
     ///     StatusCode::INTERNAL_SERVER_ERROR,
     /// ]);
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -223,6 +251,8 @@ impl FakeHandler {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// use http::StatusCode;
     /// use http_extensions::{FakeHandler, HttpResponseBuilder};
     ///
@@ -240,6 +270,8 @@ impl FakeHandler {
     /// ];
     ///
     /// let handler = FakeHandler::from_responses(responses);
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Errors

--- a/crates/http_extensions/src/http_request_builder.rs
+++ b/crates/http_extensions/src/http_request_builder.rs
@@ -31,6 +31,9 @@ use crate::{HttpBody, HttpBodyBuilder, HttpBodyOptions, HttpError, HttpRequest, 
 ///    build requests via [`build`](Self::build):
 ///
 ///    ```
+///    # fn main() {
+///    # #[cfg(feature = "test-util")] {
+///    # (|| {
 ///    # use http::Method;
 ///    # use http_extensions::{HttpBodyBuilder, HttpError, HttpRequest, HttpRequestBuilder};
 ///    # let builder = HttpBodyBuilder::new_fake();
@@ -41,6 +44,9 @@ use crate::{HttpBody, HttpBodyBuilder, HttpBodyOptions, HttpError, HttpRequest, 
 ///        .text("Hello world")
 ///        .build()?;
 ///    # Ok::<(), HttpError>(())
+///    # })().unwrap();
+///    # }
+///    # }
 ///    ```
 ///
 /// 2. **With a request handler** - Use [`with_request_handler`](Self::with_request_handler) to create
@@ -48,8 +54,11 @@ use crate::{HttpBody, HttpBodyBuilder, HttpBodyOptions, HttpError, HttpRequest, 
 ///    [`fetch_text`](Self::fetch_text):
 ///
 ///    ```
+///    # #[cfg(not(feature = "test-util"))] fn main() {}
+///    # #[cfg(feature = "test-util")]
 ///    # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponse, HttpResponseBuilder,
 ///    #     HttpRequestBuilderExt, FakeHandler, HttpRequestBuilder};
+///    # #[cfg(feature = "test-util")]
 ///    # #[tokio::main]
 ///    # async fn main() -> Result<(), HttpError> {
 ///    # let bb = HttpBodyBuilder::new_fake();
@@ -86,6 +95,9 @@ impl HttpRequestBuilder<'static> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http::Method;
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpRequest, HttpRequestBuilder};
     /// let request = HttpRequestBuilder::new_fake()
@@ -93,6 +105,9 @@ impl HttpRequestBuilder<'static> {
     ///     .uri("https://example.com")
     ///     .build()?;
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     #[cfg(any(feature = "test-util", test))]
     pub fn new_fake() -> Self {
@@ -220,6 +235,8 @@ impl<R> HttpRequestBuilder<'_, R> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::HttpRequestBuilder;
     /// #[derive(Clone)]
     /// struct RequestId(String);
@@ -229,6 +246,8 @@ impl<R> HttpRequestBuilder<'_, R> {
     ///     .extension(RequestId("req-456".to_string()))
     ///     .build()
     ///     .unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn extension<T>(mut self, extension: T) -> Self
     where
@@ -393,6 +412,9 @@ impl<R> HttpRequestBuilder<'_, R> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpRequestBuilder};
     /// # use bytesbuf::BytesView;
     /// # let body_builder = HttpBodyBuilder::new_fake();
@@ -405,6 +427,9 @@ impl<R> HttpRequestBuilder<'_, R> {
     ///     .stream(futures::stream::iter(chunks))
     ///     .build()?;
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn stream<S>(self, stream: S) -> Self
     where
@@ -426,8 +451,11 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// # Examples
     ///
     /// ```
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # use http_extensions::{HttpError, HttpRequestBuilder, HttpResponse, HttpResponseBuilder,
     /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), HttpError> {
     /// # let bb = HttpBodyBuilder::new_fake();
@@ -466,8 +494,11 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// # Examples
     ///
     /// ```
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # use http_extensions::{HttpError, HttpRequestBuilder, HttpResponse, HttpResponseBuilder,
     /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), HttpError> {
     /// # let bb = HttpBodyBuilder::new_fake();
@@ -513,8 +544,11 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     ///
     /// ```
     /// # use http::Response;
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # use http_extensions::{HttpError, HttpRequestBuilder, HttpResponse, HttpResponseBuilder,
     /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), HttpError> {
     /// # let bb = HttpBodyBuilder::new_fake();
@@ -556,10 +590,13 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     ///
     /// ```
     /// # use http::Response;
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # use http_extensions::{HttpError, HttpRequestBuilder, HttpResponse, HttpResponseBuilder,
     /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
     /// #
     /// # use bytesbuf::BytesView;
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), HttpError> {
     /// # let bb = HttpBodyBuilder::new_fake();
@@ -599,12 +636,15 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// ```
     /// # use http::Response;
     /// # use serde::Deserialize;
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # use http_extensions::{HttpError, HttpRequestBuilder, HttpResponseBuilder,
     /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
     /// #
     /// # #[derive(Deserialize)]
     /// # struct User { id: u32, name: String }
     /// #
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), HttpError> {
     /// # let bb = HttpBodyBuilder::new_fake();
@@ -656,12 +696,15 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// ```
     /// # use serde::Deserialize;
     /// # use std::borrow::Cow;
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # use http_extensions::{HttpError, HttpRequestBuilder, Json, HttpResponseBuilder,
     /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
     /// #
     /// # #[derive(Deserialize)]
     /// # struct User<'a> { id: u32, #[serde(borrow)] name: Cow<'a, str> }
     /// #
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), HttpError> {
     /// # let bb = HttpBodyBuilder::new_fake();

--- a/crates/http_extensions/src/http_response_builder.rs
+++ b/crates/http_extensions/src/http_response_builder.rs
@@ -24,6 +24,9 @@ use crate::{HttpBody, HttpBodyBuilder, HttpBodyOptions, HttpError, HttpResponse,
 /// # Examples
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "test-util")] {
+/// # (|| {
 /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponse, HttpResponseBuilder};
 /// # let builder = HttpBodyBuilder::new_fake();
 /// // Create a response builder
@@ -39,6 +42,9 @@ use crate::{HttpBody, HttpBodyBuilder, HttpBodyOptions, HttpError, HttpResponse,
 /// let response: HttpResponse = response_builder.build()?;
 ///
 /// # Ok::<(), HttpError>(())
+/// # })().unwrap();
+/// # }
+/// # }
 /// ```
 #[derive(Debug)]
 #[must_use]
@@ -61,12 +67,18 @@ impl HttpResponseBuilder<'static> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
     /// let response = HttpResponseBuilder::new_fake()
     ///     .status(200)
     ///     .text("Test response")
     ///     .build()?;
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     #[cfg(any(feature = "test-util", test))]
     pub fn new_fake() -> Self {
@@ -102,6 +114,9 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
     /// # let builder = HttpBodyBuilder::new_fake();
     /// let response_builder = HttpResponseBuilder::new(&builder)
@@ -109,6 +124,9 @@ impl HttpResponseBuilder<'_> {
     ///     .text("Hello world");
     ///
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn text(mut self, data: impl AsRef<str>) -> Self {
         let body = self.body_builder.text(data);
@@ -124,6 +142,9 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
     /// # use bytesbuf::BytesView;
     /// # let builder = HttpBodyBuilder::new_fake();
@@ -135,6 +156,9 @@ impl HttpResponseBuilder<'_> {
     ///     .bytes(payload);
     ///
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn bytes(self, b: impl Into<BytesView>) -> Self {
         let body = self.body_builder.bytes(b);
@@ -153,6 +177,9 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use serde_json::json;
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
     /// # let builder = HttpBodyBuilder::new_fake();
@@ -162,6 +189,9 @@ impl HttpResponseBuilder<'_> {
     ///     .json(&json_value);
     ///
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -179,6 +209,9 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
     /// # use http::StatusCode;
     /// # let builder = HttpBodyBuilder::new_fake();
@@ -187,6 +220,9 @@ impl HttpResponseBuilder<'_> {
     ///     .status(200); // You can also use integers
     ///
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn status(mut self, status: impl TryInto<http::StatusCode, Error: Into<http::Error>>) -> Self {
         self.builder = self.builder.status(status);
@@ -198,12 +234,18 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
     /// # use http::Version;
     /// # let builder = HttpBodyBuilder::new_fake();
     /// let response_builder = HttpResponseBuilder::new(&builder).version(Version::HTTP_2);
     ///
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn version(mut self, version: Version) -> Self {
         self.builder = self.builder.version(version);
@@ -218,6 +260,8 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use http_extensions::HttpResponseBuilder;
     /// #[derive(Clone)]
     /// struct RequestId(String);
@@ -227,6 +271,8 @@ impl HttpResponseBuilder<'_> {
     ///     .extension(RequestId("req-123".to_string()))
     ///     .build()
     ///     .unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn extension<T>(mut self, extension: T) -> Self
     where
@@ -249,6 +295,9 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http::header::CACHE_CONTROL;
     /// # use http::HeaderValue;
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
@@ -261,6 +310,9 @@ impl HttpResponseBuilder<'_> {
     ///     .header("X-Custom-Header", "value");
     ///
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn header(
         mut self,
@@ -281,6 +333,9 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
     /// # let builder = HttpBodyBuilder::new_fake();
     /// let mut response_builder = HttpResponseBuilder::new(&builder);
@@ -290,6 +345,9 @@ impl HttpResponseBuilder<'_> {
     /// }
     ///
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn headers_mut(&mut self) -> Option<&mut http::HeaderMap<HeaderValue>> {
         self.builder.headers_mut()
@@ -304,6 +362,9 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
     /// # use http_extensions::HttpBody;
     /// # let builder = HttpBodyBuilder::new_fake();
@@ -311,6 +372,9 @@ impl HttpResponseBuilder<'_> {
     /// let response_builder = HttpResponseBuilder::new(&builder).body(custom_body);
     ///
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn body(self, body: HttpBody) -> Self {
         self.body_result(Ok(body))
@@ -333,6 +397,9 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponse, HttpResponseBuilder};
     /// # let builder = HttpBodyBuilder::new_fake();
     /// let response: HttpResponse = HttpResponseBuilder::new(&builder)
@@ -340,6 +407,9 @@ impl HttpResponseBuilder<'_> {
     ///     .text("Success")
     ///     .build()?;
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -371,6 +441,8 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
     /// # use std::pin::Pin;
     /// # use std::task::{Context, Poll};
     /// # use http_body::Body;
@@ -398,6 +470,8 @@ impl HttpResponseBuilder<'_> {
     /// let response_builder = HttpResponseBuilder::new(&builder)
     ///     .status(200)
     ///     .custom_body(CustomBody::default());
+    /// # }
+    /// # }
     /// ```
     pub fn custom_body<B>(self, body: B) -> Self
     where
@@ -419,6 +493,9 @@ impl HttpResponseBuilder<'_> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "test-util")] {
+    /// # (|| {
     /// # use http_extensions::{HttpBodyBuilder, HttpError, HttpResponseBuilder};
     /// # use bytesbuf::BytesView;
     /// # let body_builder = HttpBodyBuilder::new_fake();
@@ -431,6 +508,9 @@ impl HttpResponseBuilder<'_> {
     ///     .stream(futures::stream::iter(chunks))
     ///     .build()?;
     /// # Ok::<(), HttpError>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
     pub fn stream<S>(self, stream: S) -> Self
     where

--- a/crates/http_extensions/src/json.rs
+++ b/crates/http_extensions/src/json.rs
@@ -132,6 +132,8 @@ impl<'a, T: Deserialize<'a>> Json<T> {
     ///     let person: Person = json.read()?;
     ///     Ok(())
     /// }
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     let body = HttpBodyBuilder::new_fake().text(r#"{"name":"Alice","age":30}"#);
@@ -181,6 +183,8 @@ impl<T: DeserializeOwned> Json<T> {
     ///     let person: Person = json.read_owned()?; // Consumes the parser
     ///     Ok(())
     /// }
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     let body = HttpBodyBuilder::new_fake().text(r#"{"name":"Alice","age":30}"#);

--- a/crates/http_extensions/src/lib.rs
+++ b/crates/http_extensions/src/lib.rs
@@ -42,10 +42,13 @@
 //! and validate the response:
 //!
 //! ```rust
+//! # #[cfg(not(feature = "test-util"))] fn main() {}
+//! # #[cfg(feature = "test-util")]
 //! # use http_extensions::{
 //! #     HttpRequestBuilder, HttpResponseBuilder, HttpBodyBuilder, HttpRequestBuilderExt,
 //! #     FakeHandler, StatusExt, Result,
 //! # };
+//! # #[cfg(feature = "test-util")]
 //! # #[tokio::main]
 //! # async fn main() -> Result<()> {
 //! // Create a body builder for constructing request/response bodies
@@ -96,25 +99,37 @@
 //!
 //! ## Validating Response Status
 //! ```rust
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
+//! # (|| {
 //! # use http_extensions::{StatusExt, HttpResponse, HttpResponseBuilder, HttpError};
 //! # let response: HttpResponse = HttpResponseBuilder::new_fake().status(200).build().unwrap();
 //! // Check if the response succeeded and return an error if not
 //! let validated_response = response.ensure_success()?;
 //! # Ok::<(), HttpError>(())
+//! # })().unwrap();
+//! # }
+//! # }
 //! ```
 //!
 //! ## Creating Request Bodies
 //! ```rust
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
 //! # use http_extensions::HttpBodyBuilder;
 //! # let builder = HttpBodyBuilder::new_fake();
 //! // Create different body types
 //! let text_body = builder.text("Hello, world!");
 //! let binary_body = builder.slice(&[1, 2, 3, 4]);
 //! let empty_body = builder.empty();
+//! # }
+//! # }
 //! ```
 //!
 //! ## Building HTTP Requests
 //! ```rust
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
 //! # use http_extensions::{HttpRequestBuilder, HttpBodyBuilder};
 //! # let body_builder = HttpBodyBuilder::new_fake();
 //! let request = HttpRequestBuilder::new(&body_builder)
@@ -122,10 +137,14 @@
 //!     .text("Hello World")
 //!     .build()
 //!     .unwrap();
+//! # }
+//! # }
 //! ```
 //!
 //! ## Building HTTP Responses
 //! ```rust
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
 //! # use http_extensions::{HttpResponseBuilder, HttpBodyBuilder};
 //! # let body_builder = HttpBodyBuilder::new_fake();
 //! let response = HttpResponseBuilder::new(&body_builder)
@@ -134,6 +153,8 @@
 //!     .body(body_builder.text("Success"))
 //!     .build()
 //!     .unwrap();
+//! # }
+//! # }
 //! ```
 //!
 //! ## Building Middleware with `RequestHandler`

--- a/crates/http_extensions/src/timeout/response_timeout.rs
+++ b/crates/http_extensions/src/timeout/response_timeout.rs
@@ -14,6 +14,8 @@ use std::time::Duration;
 /// # Example
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "test-util")] {
 /// use std::time::Duration;
 ///
 /// use http_extensions::HttpRequestBuilder;
@@ -23,6 +25,8 @@ use std::time::Duration;
 ///     .response_timeout(Duration::from_secs(30))
 ///     .build()
 ///     .unwrap();
+/// # }
+/// # }
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResponseTimeout(Duration);

--- a/crates/http_extensions/src/uri_template_label.rs
+++ b/crates/http_extensions/src/uri_template_label.rs
@@ -15,6 +15,8 @@ use std::borrow::Cow;
 /// # Example
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "test-util")] {
 /// use http_extensions::{HttpRequestBuilder, UriTemplateLabel};
 ///
 /// let request = HttpRequestBuilder::new_fake()
@@ -22,6 +24,8 @@ use std::borrow::Cow;
 ///     .extension(UriTemplateLabel::new("/api/users/{id}"))
 ///     .build()
 ///     .unwrap();
+/// # }
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct UriTemplateLabel(Cow<'static, str>);

--- a/crates/multitude/README.md
+++ b/crates/multitude/README.md
@@ -389,12 +389,12 @@ This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Br
  [__link10]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::String
  [__link11]: https://docs.rs/multitude/0.1.0/multitude/?search=vec::Vec
  [__link12]: https://crates.io/crates/dst-factory
- [__link13]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format
+ [__link13]: strings::format!
  [__link14]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::RcUtf16Str
  [__link15]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::ArcUtf16Str
  [__link16]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::BoxUtf16Str
  [__link17]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::Utf16String
- [__link18]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format_utf16
+ [__link18]: strings::format_utf16!
  [__link19]: https://docs.rs/multitude/0.1.0/multitude/?search=rc::Rc
  [__link2]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::RcStr
  [__link20]: https://docs.rs/multitude/0.1.0/multitude/?search=arc::Arc
@@ -426,8 +426,8 @@ This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Br
  [__link44]: https://docs.rs/multitude/0.1.0/multitude/?search=arena::Arena
  [__link45]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::String
  [__link46]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::Utf16String
- [__link47]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format
- [__link48]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format_utf16
+ [__link47]: strings::format!
+ [__link48]: strings::format_utf16!
  [__link49]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::String
  [__link5]: https://docs.rs/multitude/0.1.0/multitude/?search=r#box::Box
  [__link50]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::String::into_arena_str
@@ -456,7 +456,7 @@ This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Br
  [__link71]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::ArcUtf16Str
  [__link72]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::BoxUtf16Str
  [__link73]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::Utf16String
- [__link74]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format_utf16
+ [__link74]: strings::format_utf16!
  [__link75]: https://crates.io/crates/widestring
  [__link76]: https://docs.rs/multitude/0.1.0/multitude/?search=zerocopy::ZerocopyView
  [__link77]: https://docs.rs/zerocopy/0.8.48/zerocopy/?search=FromZeros

--- a/crates/seatbelt/README.md
+++ b/crates/seatbelt/README.md
@@ -199,7 +199,7 @@ This crate provides several optional features that can be enabled in your `Cargo
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/seatbelt">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG8pp1eYQdp8oG6dLFo3dCipdG8QD3fn6OuTtG82kq1QydD6NYWSFgmdsYXllcmVkZTAuMy4wgmtyZWNvdmVyYWJsZWUwLjEuMoJoc2VhdGJlbHRlMC41LjCCZHRpY2tlMC4zLjCCbXRvd2VyX3NlcnZpY2VlMC4zLjM
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG2LxVq77_N9dG1R--JdN59FkG5IrJw60OjsiGw6BM6tJVV5kYWSFgmdsYXllcmVkZTAuMy4wgmtyZWNvdmVyYWJsZWUwLjEuMoJoc2VhdGJlbHRlMC41LjCCZHRpY2tlMC4zLjCCbXRvd2VyX3NlcnZpY2VlMC4zLjM
  [__link0]: https://crates.io/crates/layered/0.3.0
  [__link1]: https://docs.rs/layered/0.3.0/layered/?search=Stack
  [__link10]: https://docs.rs/seatbelt/0.5.0/seatbelt/hedging/index.html

--- a/crates/seatbelt/src/lib.rs
+++ b/crates/seatbelt/src/lib.rs
@@ -148,6 +148,8 @@
 //! feature is enabled. This allows you to use `tower::ServiceBuilder` to compose middleware stacks:
 //!
 //! ```rust
+//! # fn main() {
+//! # #[cfg(all(feature = "retry", feature = "timeout", feature = "tower-service"))] {
 //! # use std::time::Duration;
 //! # use tick::Clock;
 //! use seatbelt::retry::Retry;
@@ -173,6 +175,8 @@
 //!             .timeout_error(|_| "operation timed out".to_string()),
 //!     )
 //!     .service_fn(|input: String| async move { Ok::<_, String>(format!("processed: {input}")) });
+//! # }
+//! # }
 //! # }
 //! ```
 //!

--- a/justfiles/basic.just
+++ b/justfiles/basic.just
@@ -16,6 +16,9 @@ check-changes:
     Write-Host "`n=== Running doc tests ===" -ForegroundColor Cyan
     just test-docs
 
+    Write-Host "`n=== Running doc tests (default features) ===" -ForegroundColor Cyan
+    just test-docs-default
+
     Write-Host "`n=== Running Clippy ===" -ForegroundColor Cyan
     just clippy
 
@@ -149,6 +152,26 @@ test-docs FILTER="":
             # Binary-only crate - skip doctests because Cargo expects library targets for doctests.
             # Binary crates (with only main.rs) cannot contain doctests, so running `cargo test --doc`
             # on them results in an error rather than gracefully running zero tests.
+            Write-Host "Skipping doctests for binary-only package: {{ package }}"
+        }
+    }
+
+# Runs doctests with only default features enabled. Doctests that reference
+# items behind a non-default feature must still compile in this configuration —
+# see AGENTS-feature-gated-doctests.md.
+[script]
+test-docs-default FILTER="":
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    if ("{{ package }}" -eq "") {
+        cargo +$env:RUST_MSRV test --doc --no-fail-fast --locked -- {{ FILTER }}
+    } else {
+        $lib_rs_path = "crates/{{ package }}/src/lib.rs"
+
+        if (Test-Path $lib_rs_path) {
+            cargo +$env:RUST_MSRV test {{ target_package }} --doc --no-fail-fast --locked -- {{ FILTER }}
+        } else {
             Write-Host "Skipping doctests for binary-only package: {{ package }}"
         }
     }


### PR DESCRIPTION
# Problem

`cargo test` fails. Even though this command is not a part of the standard development suite (`just test` instead), it creates a very bad first impression for newcomers to the repo.

# Solution

Doctests in `bytesbuf_io`, `http_extensions` and `seatbelt` reference items that live behind non-default Cargo features (`test-util`, `retry`, `timeout`, `tower-service`). With only default features enabled, `cargo test --doc` fails to compile those doctests. CI runs them with `--all-features` so the breakage only shows up when running per-crate or with the default feature set.

This PR wraps the affected doctest bodies in hidden `#[cfg(...)]` shims so they compile and pass in both feature configurations. Three patterns are documented in the new `AGENTS-feature-gated-doctests.md` and linked from the top-level `AGENTS.md`:

- **Pattern A** (rustdoc auto-injected `Result`-returning `main` because the body uses `?`): override the auto-`main` with our own hidden `fn main` containing one cfg-gated block + an IIFE to absorb `?`.
- **Pattern C** (no `?`, no user `main`): single hidden `fn main` + one cfg-gated block.
- **Pattern B** (doctest already declares its own `fn main` / `#[tokio::main]`): two-`main` shim — a stub for the feature-off case and the user's real `main` for the feature-on case. Top-level items that don't reference feature-gated symbols stay ungated; only `fn main` itself and `use` statements that literally import a feature-only symbol (`FakeHandler`, `FakeRead`, etc.) are gated.

The doc explains *why* Pattern B needs two `main`s while A/C don't (`#[tokio::main]` can't go inside a `{}` block, and a Result-returning `main` whose body is cfg-gated away fails to satisfy its return type).

Note: `cargo tests --no-default-features` continues to fail due to doctests but we can address that separately if we feel it is worthwhile.

## Regression guard

To prevent this from regressing, the `testing` CI job now also runs `cargo test --doc` with only the default features enabled (in addition to the existing `--all-features` step). A matching `just test-docs-default` recipe was added and wired into `just check-changes` so the pre-commit suite covers it too. The `testing` job is already part of `required-checks.needs`, so no fan-in changes are required.

We deliberately do not guard against `--no-default-features` — opting out of default features is opting in to trouble and not a configuration we prioritize.

## Verification

All six configurations pass:

|                     | default features | `--all-features` |
| ------------------- | ---------------: | -----------------: |
| `bytesbuf_io`     |     7 / 7 passed |       7 / 7 passed |
| `http_extensions` |   68 / 68 passed |     87 / 87 passed |
| `seatbelt`        |     7 / 7 passed |     44 / 44 passed |
