### PR TITLE
chore: bump templated_uri version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fetch_hyper"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyspawn",
  "bytes",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "http_extensions"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloc_tracker",
  "bytes",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "seatbelt_http"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "futures",
  "http",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "templated_uri"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "data_privacy",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,19 +33,19 @@ cachet_tier = { path = "crates/cachet_tier", default-features = false, version =
 data_privacy = { path = "crates/data_privacy", default-features = false, version = "0.11.0" }
 data_privacy_macros = { path = "crates/data_privacy_macros", default-features = false, version = "0.9.0" }
 data_privacy_macros_impl = { path = "crates/data_privacy_macros_impl", default-features = false, version = "0.9.0" }
-fetch_hyper = { path = "crates/fetch_hyper", default-features = false, version = "0.1.0" }
+fetch_hyper = { path = "crates/fetch_hyper", default-features = false, version = "0.1.1" }
 fundle = { path = "crates/fundle", default-features = false, version = "0.3.0" }
 fundle_macros = { path = "crates/fundle_macros", default-features = false, version = "0.3.0" }
 fundle_macros_impl = { path = "crates/fundle_macros_impl", default-features = false, version = "0.3.0" }
-http_extensions = { path = "crates/http_extensions", default-features = false, version = "0.4.0" }
+http_extensions = { path = "crates/http_extensions", default-features = false, version = "0.4.1" }
 layered = { path = "crates/layered", default-features = false, version = "0.3.0" }
 multitude = { path = "crates/multitude", default-features = false, version = "0.1.0" }
 ohno = { path = "crates/ohno", default-features = false, version = "0.3.2" }
 ohno_macros = { path = "crates/ohno_macros", default-features = false, version = "0.3.0" }
 recoverable = { path = "crates/recoverable", default-features = false, version = "0.1.2" }
 seatbelt = { path = "crates/seatbelt", default-features = false, version = "0.5.0" }
-seatbelt_http = { path = "crates/seatbelt_http", default-features = false, version = "0.2.0" }
-templated_uri = { path = "crates/templated_uri", default-features = false, version = "0.2.0" }
+seatbelt_http = { path = "crates/seatbelt_http", default-features = false, version = "0.2.1" }
+templated_uri = { path = "crates/templated_uri", default-features = false, version = "0.2.1" }
 templated_uri_macros = { path = "crates/templated_uri_macros", default-features = false, version = "0.2.0" }
 templated_uri_macros_impl = { path = "crates/templated_uri_macros_impl", default-features = false, version = "0.2.0" }
 testing_aids = { path = "crates/testing_aids", default-features = false }

--- a/crates/fetch_hyper/CHANGELOG.md
+++ b/crates/fetch_hyper/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Changelog
+
+## [0.1.1] - 2026-05-25
+
+- 🔧 Maintenance
+
+  - bump `templated_uri` to 0.2.1

--- a/crates/fetch_hyper/Cargo.toml
+++ b/crates/fetch_hyper/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "fetch_hyper"
 description = "Hyper-based HTTP transport utilities for fetch."
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 keywords = ["oxidizer", "hyper", "fetch", "http", "tls"]
 categories = ["network-programming"]

--- a/crates/fetch_hyper/README.md
+++ b/crates/fetch_hyper/README.md
@@ -50,12 +50,12 @@ The runtime is supplied entirely by the caller via an
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/fetch_hyper">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG27JhwJzXkumG9Cgswtvbtk3G11RQ0eI0kW1G87aELyEYbR5YWSDgmhhbnlzcGF3bmUwLjUuMIJrZmV0Y2hfaHlwZXJlMC4xLjCCb2h0dHBfZXh0ZW5zaW9uc2UwLjQuMA
- [__link0]: https://docs.rs/fetch_hyper/0.1.0/fetch_hyper/?search=HyperTransportBuilder
- [__link1]: https://docs.rs/fetch_hyper/0.1.0/fetch_hyper/?search=Connect
- [__link2]: https://docs.rs/fetch_hyper/0.1.0/fetch_hyper/?search=HyperTransportBuilder::configure_hyper
- [__link3]: https://docs.rs/fetch_hyper/0.1.0/fetch_hyper/?search=HyperTransport
- [__link4]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=RequestHandler
- [__link5]: https://docs.rs/fetch_hyper/0.1.0/fetch_hyper/?search=HyperTransportBuilder::build
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG27JhwJzXkumG9Cgswtvbtk3G11RQ0eI0kW1G87aELyEYbR5YWSDgmhhbnlzcGF3bmUwLjUuMIJrZmV0Y2hfaHlwZXJlMC4xLjGCb2h0dHBfZXh0ZW5zaW9uc2UwLjQuMQ
+ [__link0]: https://docs.rs/fetch_hyper/0.1.1/fetch_hyper/?search=HyperTransportBuilder
+ [__link1]: https://docs.rs/fetch_hyper/0.1.1/fetch_hyper/?search=Connect
+ [__link2]: https://docs.rs/fetch_hyper/0.1.1/fetch_hyper/?search=HyperTransportBuilder::configure_hyper
+ [__link3]: https://docs.rs/fetch_hyper/0.1.1/fetch_hyper/?search=HyperTransport
+ [__link4]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=RequestHandler
+ [__link5]: https://docs.rs/fetch_hyper/0.1.1/fetch_hyper/?search=HyperTransportBuilder::build
  [__link6]: https://docs.rs/anyspawn/0.5.0/anyspawn/?search=Spawner
- [__link7]: https://docs.rs/fetch_hyper/0.1.0/fetch_hyper/?search=Connect
+ [__link7]: https://docs.rs/fetch_hyper/0.1.1/fetch_hyper/?search=Connect

--- a/crates/http_extensions/CHANGELOG.md
+++ b/crates/http_extensions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.1] - 2026-05-25
+
+- 🔧 Maintenance
+
+  - bump `templated_uri` to 0.2.1
+
 ## [0.4.0] - 2026-05-18
 
 - ✨ Features

--- a/crates/http_extensions/Cargo.toml
+++ b/crates/http_extensions/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "http_extensions"
 description = "Shared HTTP types and extension traits for clients and servers."
-version = "0.4.0"
+version = "0.4.1"
 readme = "README.md"
 keywords = ["oxidizer", "http", "extensions", "client", "server"]
 categories = ["network-programming"]

--- a/crates/http_extensions/README.md
+++ b/crates/http_extensions/README.md
@@ -170,23 +170,23 @@ for future requests. This makes the crate particularly efficient for high-throug
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/http_extensions">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG_MLOQQsiV6zG7SjqsDGgd-WG03lILZ1aMTjG5fuakLrAwKLYWSFgmVieXRlc2YxLjExLjGCaGJ5dGVzYnVmZTAuNS4wgmRodHRwZTEuNC4wgmlodHRwX2JvZHllMS4wLjGCb2h0dHBfZXh0ZW5zaW9uc2UwLjQuMA
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG_MLOQQsiV6zG7SjqsDGgd-WG03lILZ1aMTjG5fuakLrAwKLYWSFgmVieXRlc2YxLjExLjGCaGJ5dGVzYnVmZTAuNS4wgmRodHRwZTEuNC4wgmlodHRwX2JvZHllMS4wLjGCb2h0dHBfZXh0ZW5zaW9uc2UwLjQuMQ
  [__link0]: https://crates.io/crates/http/1.4.0
- [__link1]: https://docs.rs/http_extensions/0.4.0/http_extensions/type.HttpRequest.html
- [__link10]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=StatusExt
- [__link11]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=RequestExt
- [__link12]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=ResponseExt
- [__link13]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpRequestExt
- [__link14]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HeaderMapExt
- [__link15]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HeaderValueExt
+ [__link1]: https://docs.rs/http_extensions/0.4.1/http_extensions/type.HttpRequest.html
+ [__link10]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=StatusExt
+ [__link11]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=RequestExt
+ [__link12]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=ResponseExt
+ [__link13]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpRequestExt
+ [__link14]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HeaderMapExt
+ [__link15]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HeaderValueExt
  [__link16]: https://docs.rs/http/1.4.0/http/?search=HeaderValue
  [__link17]: https://docs.rs/bytes/1.11.1/bytes/?search=Bytes
- [__link18]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=ExtensionsExt
+ [__link18]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=ExtensionsExt
  [__link19]: https://docs.rs/http/1.4.0/http/?search=Extensions
- [__link2]: https://docs.rs/http_extensions/0.4.0/http_extensions/type.HttpResponse.html
- [__link20]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=RequestHandler
- [__link21]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpRequestBuilder
- [__link22]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=StatusExt::ensure_success
+ [__link2]: https://docs.rs/http_extensions/0.4.1/http_extensions/type.HttpResponse.html
+ [__link20]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=RequestHandler
+ [__link21]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpRequestBuilder
+ [__link22]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=StatusExt::ensure_success
  [__link23]: https://crates.io/crates/http/1.4.0
  [__link24]: https://docs.rs/http/1.4.0/http/?search=Request
  [__link25]: https://docs.rs/http/1.4.0/http/?search=Response
@@ -194,12 +194,12 @@ This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Br
  [__link27]: https://docs.rs/http/1.4.0/http/?search=StatusCode
  [__link28]: https://docs.rs/http/1.4.0/http/?search=HeaderMap
  [__link29]: https://docs.rs/http_body/1.0.1/http_body/?search=Body
- [__link3]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpBody
- [__link30]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpBodyBuilder
+ [__link3]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpBody
+ [__link30]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpBodyBuilder
  [__link31]: https://crates.io/crates/bytesbuf/0.5.0
- [__link4]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpRequestBuilder
- [__link5]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpResponseBuilder
- [__link6]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpBody
- [__link7]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpBodyBuilder
- [__link8]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpError
- [__link9]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=RequestHandler
+ [__link4]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpRequestBuilder
+ [__link5]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpResponseBuilder
+ [__link6]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpBody
+ [__link7]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpBodyBuilder
+ [__link8]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpError
+ [__link9]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=RequestHandler

--- a/crates/multitude/README.md
+++ b/crates/multitude/README.md
@@ -389,12 +389,12 @@ This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Br
  [__link10]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::String
  [__link11]: https://docs.rs/multitude/0.1.0/multitude/?search=vec::Vec
  [__link12]: https://crates.io/crates/dst-factory
- [__link13]: strings::format!
+ [__link13]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format
  [__link14]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::RcUtf16Str
  [__link15]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::ArcUtf16Str
  [__link16]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::BoxUtf16Str
  [__link17]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::Utf16String
- [__link18]: strings::format_utf16!
+ [__link18]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format_utf16
  [__link19]: https://docs.rs/multitude/0.1.0/multitude/?search=rc::Rc
  [__link2]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::RcStr
  [__link20]: https://docs.rs/multitude/0.1.0/multitude/?search=arc::Arc
@@ -426,8 +426,8 @@ This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Br
  [__link44]: https://docs.rs/multitude/0.1.0/multitude/?search=arena::Arena
  [__link45]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::String
  [__link46]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::Utf16String
- [__link47]: strings::format!
- [__link48]: strings::format_utf16!
+ [__link47]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format
+ [__link48]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format_utf16
  [__link49]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::String
  [__link5]: https://docs.rs/multitude/0.1.0/multitude/?search=r#box::Box
  [__link50]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::String::into_arena_str
@@ -456,7 +456,7 @@ This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Br
  [__link71]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::ArcUtf16Str
  [__link72]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::BoxUtf16Str
  [__link73]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::Utf16String
- [__link74]: strings::format_utf16!
+ [__link74]: https://docs.rs/multitude/0.1.0/multitude/?search=strings::format_utf16
  [__link75]: https://crates.io/crates/widestring
  [__link76]: https://docs.rs/multitude/0.1.0/multitude/?search=zerocopy::ZerocopyView
  [__link77]: https://docs.rs/zerocopy/0.8.48/zerocopy/?search=FromZeros

--- a/crates/seatbelt_http/CHANGELOG.md
+++ b/crates/seatbelt_http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1] - 2026-05-25
+
+- 🔧 Maintenance
+
+  - bump `templated_uri` to 0.2.1
+
 ## [0.2.0] - 2026-05-19
 
 - ✨ Features

--- a/crates/seatbelt_http/Cargo.toml
+++ b/crates/seatbelt_http/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "seatbelt_http"
 description = "HTTP-specific extensions for the seatbelt crate."
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 keywords = ["oxidizer", "resilience", "seatbelt", "http", "recovery"]
 categories = ["data-structures", "network-programming"]

--- a/crates/seatbelt_http/README.md
+++ b/crates/seatbelt_http/README.md
@@ -48,12 +48,12 @@ type aliases and an extension trait:
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/seatbelt_http">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG0zpOHumdJRlG7vvc1rvGGXMG8lb6BInDEwlGyUJKXppjYapYWSDgm9odHRwX2V4dGVuc2lvbnNlMC40LjCCaHNlYXRiZWx0ZTAuNS4wgm1zZWF0YmVsdF9odHRwZTAuMi4w
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG0zpOHumdJRlG7vvc1rvGGXMG8lb6BInDEwlGyUJKXppjYapYWSDgm9odHRwX2V4dGVuc2lvbnNlMC40LjGCaHNlYXRiZWx0ZTAuNS4wgm1zZWF0YmVsdF9odHRwZTAuMi4x
  [__link0]: https://crates.io/crates/seatbelt/0.5.0
  [__link1]: https://crates.io/crates/seatbelt/0.5.0
- [__link2]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=HttpRequest
- [__link3]: https://docs.rs/http_extensions/0.4.0/http_extensions/?search=Result
- [__link4]: https://docs.rs/seatbelt_http/0.2.0/seatbelt_http/?search=HttpRecovery
- [__link5]: https://docs.rs/seatbelt_http/0.2.0/seatbelt_http/?search=HttpClone
- [__link6]: https://docs.rs/seatbelt_http/0.2.0/seatbelt_http/type.HttpResilienceContext.html
+ [__link2]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=HttpRequest
+ [__link3]: https://docs.rs/http_extensions/0.4.1/http_extensions/?search=Result
+ [__link4]: https://docs.rs/seatbelt_http/0.2.1/seatbelt_http/?search=HttpRecovery
+ [__link5]: https://docs.rs/seatbelt_http/0.2.1/seatbelt_http/?search=HttpClone
+ [__link6]: https://docs.rs/seatbelt_http/0.2.1/seatbelt_http/type.HttpResilienceContext.html
  [__link7]: https://docs.rs/seatbelt/0.5.0/seatbelt/?search=ResilienceContext

--- a/crates/templated_uri/CHANGELOG.md
+++ b/crates/templated_uri/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1] - 2026-05-25
+
+- ✨ Features
+
+  - add effective_port and make port return explicit port ([#438](https://github.com/microsoft/oxidizer/pull/438))
+
 ## Unreleased
 
 - ✨ Features

--- a/crates/templated_uri/Cargo.toml
+++ b/crates/templated_uri/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "templated_uri"
 description = "Standards-compliant URI handling with templating, validation, and data classification"
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 keywords = ["oxidizer", "url", "parsing", "templates", "uri"]
 categories = ["encoding", "parser-implementations", "template-engine", "web-programming"]

--- a/crates/templated_uri/README.md
+++ b/crates/templated_uri/README.md
@@ -198,22 +198,22 @@ and servers based on [`hyper`][__link16] like [`reqwest`][__link17].
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG63iTBJYMadJG6nseEEoATCvG3YJS_EajemqG70n7pjeggIrYWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMi4w
- [__link0]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Uri
- [__link1]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=BaseUri
- [__link10]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Escape
- [__link11]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Raw
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEGy4k8ldDFPOhG2VNeXtD5nnKG6EPY6OfW5wBG8g18NOFNdxpYXKEG63iTBJYMadJG6nseEEoATCvG3YJS_EajemqG70n7pjeggIrYWSCgmRodHRwZTEuNC4wgm10ZW1wbGF0ZWRfdXJpZTAuMi4x
+ [__link0]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=Uri
+ [__link1]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=BaseUri
+ [__link10]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=Escape
+ [__link11]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=Raw
  [__link12]: https://datatracker.ietf.org/doc/html/rfc6570#section-2.3
  [__link13]: https://docs.rs/http/latest/http/
- [__link14]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Uri
+ [__link14]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=Uri
  [__link15]: https://docs.rs/http/1.4.0/http/?search=Uri
  [__link16]: https://docs.rs/hyper/latest/hyper/
  [__link17]: https://docs.rs/reqwest/latest/reqwest/
- [__link2]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=BaseUri
- [__link3]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=BasePath
- [__link4]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=PathAndQueryTemplate
- [__link5]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Escaped
- [__link6]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=EscapedString
- [__link7]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=Escaped
- [__link8]: https://docs.rs/templated_uri/0.2.0/templated_uri/?search=EscapedString
+ [__link2]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=BaseUri
+ [__link3]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=BasePath
+ [__link4]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=PathAndQueryTemplate
+ [__link5]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=Escaped
+ [__link6]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=EscapedString
+ [__link7]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=Escaped
+ [__link8]: https://docs.rs/templated_uri/0.2.1/templated_uri/?search=EscapedString
  [__link9]: https://datatracker.ietf.org/doc/html/rfc6570


### PR DESCRIPTION
To get access to a new `Origin::effective_port` and `BaseUri::effective_port` that infers the port based on HTTP/HTTPS scheme.

The behavior of existing `Origin::port` and `BaseUri::port` is unchanged, these return explicit port that was provided during construction of these types.


