### PR TITLE
refactor(multitude): consolidate unsafe idioms behind shared helpers

### DIFF
--- a/crates/multitude/src/arc.rs
+++ b/crates/multitude/src/arc.rs
@@ -176,8 +176,7 @@ impl<T, A: Allocator + Clone> Arc<MaybeUninit<T>, A> {
         let ptr = self.ptr.as_non_null().cast::<T>();
         if needs_drop::<T>() {
             let chunk = self.chunk();
-            // SAFETY: caller-held refcount keeps the chunk live.
-            let data_addr = unsafe { SharedChunk::<A>::data_ptr(NonNull::from(chunk)) }.as_ptr() as usize;
+            let data_addr = chunk.data().as_ptr() as usize;
             let value_offset = self.ptr.as_ptr() as *const u8 as usize - data_addr;
             // Acquire pairs with the owner-thread Release publish so
             // all of `entries[0..count]` is visible. Retargeting the
@@ -243,8 +242,7 @@ impl<T, A: Allocator + Clone> Arc<[MaybeUninit<T>], A> {
         let len = old_ptr.len();
         if needs_drop::<T>() {
             let chunk = self.chunk();
-            // SAFETY: caller-held refcount keeps the chunk live.
-            let data_addr = unsafe { SharedChunk::<A>::data_ptr(NonNull::from(chunk)) }.as_ptr() as usize;
+            let data_addr = chunk.data().as_ptr() as usize;
             let value_offset = old_ptr.as_ptr() as *const u8 as usize - data_addr;
             // Synchronization matches the scalar `assume_init` case
             // above (Acquire load + Release retarget).

--- a/crates/multitude/src/arena/alloc_str.rs
+++ b/crates/multitude/src/arena/alloc_str.rs
@@ -257,7 +257,9 @@ impl<A: Allocator + Clone> Arena<A> {
         // SAFETY: refcount-positive — chunk held at LARGE inflation
         // immediately after `acquire_local`.
         let chunk_ref = unsafe { chunk.as_ref() };
-        // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on
+        // `data_ptr`, which would later collide with `free_backing`.
         let data_ptr = unsafe { LocalChunk::<A>::data_ptr(chunk) };
         // Byte data has `align_of::<u8>() == 1`, so the chunk's
         // `CHUNK_ALIGN`-aligned payload base is trivially aligned for

--- a/crates/multitude/src/arena/alloc_unsized.rs
+++ b/crates/multitude/src/arena/alloc_unsized.rs
@@ -20,7 +20,7 @@ use allocator_api2::alloc::{AllocError, Allocator};
 
 use super::{
     AllocFlavor, Arena, OversizedLocalGuard, OversizedSharedGuard, ProtectiveHold, SharedArcsIssuedHold, align_up, bump_local_drop_count,
-    bump_shared_drop_count, expect_alloc,
+    bump_shared_drop_count, expect_alloc, u16_truncate_unchecked, value_offset_in_chunk,
 };
 use crate::arc::Arc;
 use crate::arena::check_isize_overflow;
@@ -105,14 +105,13 @@ impl<A: Allocator + Clone> Arena<A> {
                 // SAFETY: gated above; lies in chunk payload.
                 let new_drop_back_ptr = unsafe { drop_back_ptr.byte_sub(entry_size) };
                 // SAFETY: bump-fit gate above implies non-stub slot ⇒ `current_local.chunk` is `Some`.
-                let chunk = unsafe { self.current_local.chunk.get().unwrap_unchecked() };
-                // SAFETY: refcount-positive — chunk held at LARGE inflation.
-                let payload_base_addr = unsafe { LocalChunk::<A>::data_ptr(chunk) }.as_ptr() as usize;
+                let chunk = unsafe { self.current_local.chunk_assume_present() };
                 // Bump-fit success means the allocation lands inside the
                 // current chunk, whose payload is capped at
                 // `max_bump_extent <= MAX_CHUNK_BYTES < u16::MAX`.
-                // SAFETY: bounded by current-chunk payload extent.
-                let value_offset = unsafe { u16::try_from((aligned_ptr.as_ptr() as usize) - payload_base_addr).unwrap_unchecked() };
+                // SAFETY: refcount-positive — chunk held at LARGE inflation;
+                // offset bounded by current-chunk payload extent.
+                let value_offset = unsafe { value_offset_in_chunk(chunk, aligned_ptr) };
                 let value_ptr: *mut u8 = aligned_ptr.as_ptr();
 
                 // Account for the +1 we will hand to the caller
@@ -217,14 +216,13 @@ impl<A: Allocator + Clone> Arena<A> {
                 // SAFETY: gated above; lies in chunk payload.
                 let new_drop_back_ptr = unsafe { drop_back_ptr.byte_sub(entry_size) };
                 // SAFETY: bump-fit gate above implies non-stub slot ⇒ `current_shared.chunk` is `Some`.
-                let chunk = unsafe { self.current_shared.chunk.get().unwrap_unchecked() };
-                // SAFETY: refcount-positive — chunk held at LARGE inflation.
-                let payload_base_addr = unsafe { SharedChunk::<A>::data_ptr(chunk) }.as_ptr() as usize;
+                let chunk = unsafe { self.current_shared.chunk_assume_present() };
                 // Bump-fit success means the allocation lands inside the
                 // current chunk, whose payload is capped at
                 // `max_bump_extent <= MAX_CHUNK_BYTES < u16::MAX`.
-                // SAFETY: bounded by current-chunk payload extent.
-                let value_offset = unsafe { u16::try_from((aligned_ptr.as_ptr() as usize) - payload_base_addr).unwrap_unchecked() };
+                // SAFETY: refcount-positive — chunk held at LARGE inflation;
+                // offset bounded by current-chunk payload extent.
+                let value_offset = unsafe { value_offset_in_chunk(chunk, aligned_ptr) };
                 let value_ptr: *mut u8 = aligned_ptr.as_ptr();
 
                 // Account for the +1 we will hand to the caller
@@ -312,7 +310,9 @@ impl<A: Allocator + Clone> Arena<A> {
         let chunk = self.provider.acquire_local(needed)?;
         // SAFETY: chunk live — held at LARGE inflation.
         let chunk_ref = unsafe { chunk.as_ref() };
-        // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on
+        // `data_ptr`, which would later collide with `free_backing`.
         let data_ptr = unsafe { LocalChunk::<A>::data_ptr(chunk) };
         let cap = chunk_ref.capacity;
         let data_addr = data_ptr.as_ptr() as usize;
@@ -326,21 +326,12 @@ impl<A: Allocator + Clone> Arena<A> {
         core::mem::forget(guard);
 
         let new_drop_back = cap - entry_size;
-        #[expect(
-            clippy::cast_ptr_alignment,
-            reason = "chunk payloads are 64 KiB aligned (CHUNK_ALIGN), so any `InnerDropEntry` slot computed as `data + new_drop_back` is naturally aligned"
-        )]
-        // SAFETY: payload-extent invariant.
-        let entry_ptr = unsafe { data_ptr.as_ptr().add(new_drop_back).cast::<InnerDropEntry>() };
         // Bound: `aligned < layout.align() ≤ MAX_SMART_PTR_ALIGN = 32768 < u16::MAX`.
-        debug_assert!(u16::try_from(aligned).is_ok());
         // SAFETY: bounded by `MAX_SMART_PTR_ALIGN` cap enforced by the caller.
-        unsafe { core::hint::assert_unchecked(u16::try_from(aligned).is_ok()) };
-        // SAFETY: precondition asserted above.
-        let value_offset_u16 = unsafe { u16::try_from(aligned).unwrap_unchecked() };
+        let value_offset_u16 = unsafe { u16_truncate_unchecked(aligned) };
         let entry = InnerDropEntry::new(final_shim, value_offset_u16, metadata_u16);
-        // SAFETY: payload-extent invariant; first write to a fresh entry.
-        unsafe { core::ptr::write(entry_ptr, entry) };
+        // SAFETY: back-stack slot lies within the chunk payload and is naturally aligned for `InnerDropEntry`.
+        unsafe { entry.write_at_offset(data_ptr, new_drop_back) };
         chunk_ref.drop_count.set(1);
 
         self.charge_alloc_stats(layout.size());
@@ -376,7 +367,9 @@ impl<A: Allocator + Clone> Arena<A> {
         let chunk = self.provider.acquire_shared(needed)?;
         // SAFETY: chunk live — held at LARGE inflation.
         let chunk_ref = unsafe { chunk.as_ref() };
-        // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on
+        // `data_ptr`, which would later collide with `free_backing`.
         let data_ptr = unsafe { SharedChunk::<A>::data_ptr(chunk) };
         let cap = chunk_ref.capacity;
         let data_addr = data_ptr.as_ptr() as usize;
@@ -390,21 +383,12 @@ impl<A: Allocator + Clone> Arena<A> {
         core::mem::forget(guard);
 
         let new_drop_back = cap - entry_size;
-        #[expect(
-            clippy::cast_ptr_alignment,
-            reason = "chunk payloads are 64 KiB aligned (CHUNK_ALIGN), so any `InnerDropEntry` slot computed as `data + new_drop_back` is naturally aligned"
-        )]
-        // SAFETY: payload-extent invariant.
-        let entry_ptr = unsafe { data_ptr.as_ptr().add(new_drop_back).cast::<InnerDropEntry>() };
         // Bound: `aligned < layout.align() ≤ MAX_SMART_PTR_ALIGN = 32768 < u16::MAX`.
-        debug_assert!(u16::try_from(aligned).is_ok());
         // SAFETY: bounded by `MAX_SMART_PTR_ALIGN` cap enforced by the caller.
-        unsafe { core::hint::assert_unchecked(u16::try_from(aligned).is_ok()) };
-        // SAFETY: precondition asserted above.
-        let value_offset_u16 = unsafe { u16::try_from(aligned).unwrap_unchecked() };
+        let value_offset_u16 = unsafe { u16_truncate_unchecked(aligned) };
         let entry = InnerDropEntry::new(final_shim, value_offset_u16, metadata_u16);
-        // SAFETY: payload-extent invariant; first write to a fresh entry.
-        unsafe { core::ptr::write(entry_ptr, entry) };
+        // SAFETY: back-stack slot lies within the chunk payload and is naturally aligned for `InnerDropEntry`.
+        unsafe { entry.write_at_offset(data_ptr, new_drop_back) };
         // Chunk live — LARGE inflation; no other strand observes it yet.
         chunk_ref.drop_count.store(1, Ordering::Relaxed);
 

--- a/crates/multitude/src/arena/chunks.rs
+++ b/crates/multitude/src/arena/chunks.rs
@@ -110,6 +110,21 @@ impl<C: ChunkKind + ?Sized> Default for CurrentChunk<C> {
 }
 
 impl<C: ChunkKind + ?Sized> CurrentChunk<C> {
+    /// Returns the installed chunk pointer for a non-stub slot.
+    ///
+    /// Centralizes the ubiquitous `unsafe { chunk.get().unwrap_unchecked() }`
+    /// idiom used by every bump-fit fast path; the caller's bump-fit gate
+    /// already proves non-stub state.
+    ///
+    /// # Safety
+    ///
+    /// The slot must be in non-stub state (`chunk.get().is_some()`).
+    #[inline(always)]
+    pub(super) unsafe fn chunk_assume_present(&self) -> NonNull<C> {
+        // SAFETY: caller asserts non-stub state.
+        unsafe { self.chunk.get().unwrap_unchecked() }
+    }
+
     /// Number of drop entries currently recorded in the back-stack of
     /// the chunk that this slot mirrors. Derived from the chunk's own
     /// payload extent and the slot's `drop_back` limit pointer, so the

--- a/crates/multitude/src/arena/inner_slice.rs
+++ b/crates/multitude/src/arena/inner_slice.rs
@@ -13,9 +13,10 @@ use core::ptr::NonNull;
 use allocator_api2::alloc::{AllocError, Allocator};
 
 use super::{
-    AllocFlavor, Arena, OversizedLocalGuard, OversizedSharedGuard, ProtectiveHold, SharedArcsIssuedHold, SliceInitGuard, align_offset,
-    bump_local_drop_count, bump_shared_drop_count, compute_worst_case_size, expect_alloc, has_drop_entry, panic_alloc,
-    size_exceeds_normal_alloc, slow_refill_needed, try_bump_fit, worst_case_refill_for,
+    AllocFlavor, Arena, OversizedLocalGuard, OversizedSharedGuard, ProtectiveHold, SharedArcsIssuedHold, SliceInitGuard,
+    aligned_payload_offset, bump_local_drop_count, bump_shared_drop_count, compute_worst_case_size, expect_alloc, has_drop_entry,
+    panic_alloc, size_exceeds_normal_alloc, slow_refill_needed, try_bump_fit, u16_truncate_unchecked, value_offset_in_chunk,
+    worst_case_refill_for,
 };
 use crate::internal::constants::MAX_SMART_PTR_ALIGN;
 use crate::internal::drop_list::{DropEntry as InnerDropEntry, noop_drop_shim};
@@ -67,20 +68,16 @@ impl<A: Allocator + Clone> Arena<A> {
         let chunk = self.provider.acquire_local(needed)?;
         // SAFETY: refcount-positive — LARGE inflation keeps the chunk live.
         let chunk_ref = unsafe { chunk.as_ref() };
-        // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on
+        // `data_ptr`, which would later collide with `free_backing`.
         let data_ptr = unsafe { LocalChunk::<A>::data_ptr(chunk) };
         let cap = chunk_ref.capacity;
         let data_addr = data_ptr.as_ptr() as usize;
-        // SAFETY: provider post-condition guarantees the chunk fits the request after
-        // alignment and drop-entry slack, so neither computation below can fail.
-        let aligned = unsafe { align_offset(data_addr, layout.align().max(1)).unwrap_unchecked() };
-        // SAFETY: same post-condition; computation fits well below `usize::MAX`.
-        let end = unsafe { aligned.checked_add(layout.size()).unwrap_unchecked() };
-        // SAFETY: same post-condition.
-        unsafe { core::hint::assert_unchecked(end <= cap.saturating_sub(entry_size)) };
+        // SAFETY: provider post-condition guarantees the request fits the chunk.
+        let aligned = unsafe { aligned_payload_offset(data_addr, layout.align().max(1), layout.size(), cap, entry_size) };
         // SAFETY: payload-extent invariant — `aligned` is `T`-aligned and within `[0, cap)`.
         let value_ptr: *mut T = unsafe { data_ptr.as_ptr().add(aligned).cast::<T>() };
-        let _ = end;
 
         let chunk_guard = OversizedLocalGuard { chunk };
         let mut init_guard = SliceInitGuard { ptr: value_ptr, len: 0 };
@@ -95,12 +92,6 @@ impl<A: Allocator + Clone> Arena<A> {
 
         if entry_size > 0 {
             let new_drop_back = cap - entry_size;
-            #[expect(
-                clippy::cast_ptr_alignment,
-                reason = "chunk payloads are 64 KiB aligned (CHUNK_ALIGN), so any `InnerDropEntry` slot computed as `data + new_drop_back` is naturally aligned for `InnerDropEntry`"
-            )]
-            // SAFETY: payload-extent invariant — back-stack slot lies within payload.
-            let entry_ptr = unsafe { data_ptr.as_ptr().add(new_drop_back).cast::<InnerDropEntry>() };
             let installed_drop_fn = if matches!(flavor, AllocFlavor::Box) {
                 noop_drop_shim
             } else {
@@ -113,18 +104,13 @@ impl<A: Allocator + Clone> Arena<A> {
             // We must NOT panic here: `core::mem::forget(init_guard)` above committed
             // the initialized slice; a panic past that point would skip element drops
             // while `chunk_guard` still frees the backing on unwind.
-            debug_assert!(u16::try_from(aligned).is_ok() && u16::try_from(len).is_ok());
             // SAFETY: precondition asserted via the bound chain above.
-            unsafe { core::hint::assert_unchecked(u16::try_from(aligned).is_ok()) };
-            // SAFETY: same.
-            unsafe { core::hint::assert_unchecked(u16::try_from(len).is_ok()) };
-            // SAFETY: preconditions asserted above; conversions have no panic surface.
-            let value_offset_u16 = unsafe { u16::try_from(aligned).unwrap_unchecked() };
+            let value_offset_u16 = unsafe { u16_truncate_unchecked(aligned) };
             // SAFETY: see comment above.
-            let len_u16 = unsafe { u16::try_from(len).unwrap_unchecked() };
+            let len_u16 = unsafe { u16_truncate_unchecked(len) };
             let entry = InnerDropEntry::new(installed_drop_fn, value_offset_u16, len_u16);
-            // SAFETY: payload-extent invariant.
-            unsafe { core::ptr::write(entry_ptr, entry) };
+            // SAFETY: back-stack slot lies within the chunk payload and is naturally aligned for `InnerDropEntry`.
+            unsafe { entry.write_at_offset(data_ptr, new_drop_back) };
             chunk_ref.drop_count.set(1);
         }
 
@@ -186,19 +172,16 @@ impl<A: Allocator + Clone> Arena<A> {
         let chunk = self.provider.acquire_shared(needed)?;
         // SAFETY: refcount-positive — LARGE inflation keeps the chunk live.
         let chunk_ref = unsafe { chunk.as_ref() };
-        // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on
+        // `data_ptr`, which would later collide with `free_backing`.
         let data_ptr = unsafe { SharedChunk::<A>::data_ptr(chunk) };
         let cap = chunk_ref.capacity;
         let data_addr = data_ptr.as_ptr() as usize;
-        // SAFETY: provider post-condition.
-        let aligned = unsafe { align_offset(data_addr, layout.align().max(1)).unwrap_unchecked() };
-        // SAFETY: same post-condition.
-        let end = unsafe { aligned.checked_add(layout.size()).unwrap_unchecked() };
-        // SAFETY: same post-condition.
-        unsafe { core::hint::assert_unchecked(end <= cap.saturating_sub(entry_size)) };
+        // SAFETY: provider post-condition guarantees the request fits the chunk.
+        let aligned = unsafe { aligned_payload_offset(data_addr, layout.align().max(1), layout.size(), cap, entry_size) };
         // SAFETY: payload-extent invariant.
         let value_ptr: *mut T = unsafe { data_ptr.as_ptr().add(aligned).cast::<T>() };
-        let _ = end;
 
         let chunk_guard = OversizedSharedGuard { chunk };
         let mut init_guard = SliceInitGuard { ptr: value_ptr, len: 0 };
@@ -212,30 +195,19 @@ impl<A: Allocator + Clone> Arena<A> {
 
         if entry_size > 0 {
             let new_drop_back = cap - entry_size;
-            #[expect(
-                clippy::cast_ptr_alignment,
-                reason = "chunk payloads are 64 KiB aligned (CHUNK_ALIGN), so any `InnerDropEntry` slot computed as `data + new_drop_back` is naturally aligned for `InnerDropEntry`"
-            )]
-            // SAFETY: payload-extent invariant.
-            let entry_ptr = unsafe { data_ptr.as_ptr().add(new_drop_back).cast::<InnerDropEntry>() };
             // SAFETY: `entry_size > 0` implies `drop_fn.is_some()`.
             let installed_drop_fn = unsafe { drop_fn.unwrap_unchecked() };
             // See the local sibling for why these must not be a panic
             // surface: `core::mem::forget(init_guard)` above already
             // committed the initialized slice.
-            debug_assert!(u16::try_from(aligned).is_ok() && u16::try_from(len).is_ok());
             // SAFETY: `aligned < layout.align() ≤ MAX_SMART_PTR_ALIGN < u16::MAX`.
-            unsafe { core::hint::assert_unchecked(u16::try_from(aligned).is_ok()) };
+            let value_offset_u16 = unsafe { u16_truncate_unchecked(aligned) };
             // SAFETY: the `entry_size != 0 && len > u16::MAX` guard at the top of
             // this function already excluded `len > u16::MAX`.
-            unsafe { core::hint::assert_unchecked(u16::try_from(len).is_ok()) };
-            // SAFETY: preconditions asserted above; conversions have no panic surface.
-            let value_offset_u16 = unsafe { u16::try_from(aligned).unwrap_unchecked() };
-            // SAFETY: see comment above.
-            let len_u16 = unsafe { u16::try_from(len).unwrap_unchecked() };
+            let len_u16 = unsafe { u16_truncate_unchecked(len) };
             let entry = InnerDropEntry::new(installed_drop_fn, value_offset_u16, len_u16);
-            // SAFETY: payload-extent invariant.
-            unsafe { core::ptr::write(entry_ptr, entry) };
+            // SAFETY: back-stack slot lies within the chunk payload and is naturally aligned for `InnerDropEntry`.
+            unsafe { entry.write_at_offset(data_ptr, new_drop_back) };
             // No other thread can yet observe this chunk: the
             // inflation has not been published via any cross-thread handoff.
             chunk_ref.drop_count.store(1, Ordering::Relaxed);
@@ -365,7 +337,7 @@ impl<A: Allocator + Clone> Arena<A> {
                 let new_drop_back_ptr = __fit.new_drop_back_ptr;
                 {
                     // SAFETY: bump-fit gate above implies non-stub slot ⇒ `current_local.chunk` is `Some`.
-                    let chunk = unsafe { self.current_local.chunk.get().unwrap_unchecked() };
+                    let chunk = unsafe { self.current_local.chunk_assume_present() };
                     let ptr: *mut T = aligned_ptr.cast::<T>().as_ptr();
 
                     // Take the protective hold before running the
@@ -402,8 +374,6 @@ impl<A: Allocator + Clone> Arena<A> {
                     // inside that branch so non-drop slices skip the panic
                     // surface of the `u16` cast and an extra chunk-pointer load.
                     let (value_offset, len_u16) = if entry_size > 0 {
-                        // SAFETY: refcount-positive — chunk held at LARGE inflation.
-                        let payload_base_addr = unsafe { LocalChunk::<A>::data_ptr(chunk) }.as_ptr() as usize;
                         // Bump-fit success means the allocation lands
                         // inside the current chunk, whose bump extent
                         // is capped at `max_bump_extent <= MAX_CHUNK_BYTES`
@@ -411,10 +381,11 @@ impl<A: Allocator + Clone> Arena<A> {
                         // it fits in `u16`. `len_u16` is bounded by
                         // the `entry_size != 0 && len > u16::MAX`
                         // guard at the top of the function.
-                        // SAFETY: bounded by current-chunk extent.
-                        let value_offset = unsafe { u16::try_from((aligned_ptr.as_ptr() as usize) - payload_base_addr).unwrap_unchecked() };
+                        // SAFETY: refcount-positive — chunk held at LARGE
+                        // inflation; offset bounded by current-chunk extent.
+                        let value_offset = unsafe { value_offset_in_chunk(chunk, aligned_ptr) };
                         // SAFETY: gated by `len > u16::MAX` check earlier in this function.
-                        let len_u16 = unsafe { u16::try_from(len).unwrap_unchecked() };
+                        let len_u16 = unsafe { u16_truncate_unchecked(len) };
                         self.current_local.drop_back.set(new_drop_back_ptr);
                         let entry_ptr: *mut InnerDropEntry = new_drop_back_ptr.cast::<InnerDropEntry>().as_ptr();
                         let noop_entry = InnerDropEntry::new(noop_drop_shim, value_offset, len_u16);
@@ -586,7 +557,7 @@ impl<A: Allocator + Clone> Arena<A> {
 
         // SAFETY: chunk-present invariant — fast-path gate above
         // implies a real chunk is loaded.
-        let chunk = unsafe { self.current_local.chunk.get().unwrap_unchecked() };
+        let chunk = unsafe { self.current_local.chunk_assume_present() };
         let ptr: *mut T = aligned_ptr.cast::<T>().as_ptr();
 
         match flavor {
@@ -1029,7 +1000,7 @@ impl<A: Allocator + Clone> Arena<A> {
                 let new_drop_back_ptr = __fit.new_drop_back_ptr;
                 {
                     // SAFETY: bump-fit gate above implies non-stub slot ⇒ `current_shared.chunk` is `Some`.
-                    let chunk = unsafe { self.current_shared.chunk.get().unwrap_unchecked() };
+                    let chunk = unsafe { self.current_shared.chunk_assume_present() };
                     let ptr: *mut T = aligned_ptr.cast::<T>().as_ptr();
 
                     // Account before `init` so reentrant refill preserves this +1.
@@ -1051,15 +1022,14 @@ impl<A: Allocator + Clone> Arena<A> {
                     // inside that branch so non-drop slices skip the panic
                     // surface of the `u16` casts and an extra chunk-pointer load.
                     let (value_offset, len_u16) = if has_drop_entry(entry_size) {
-                        // SAFETY: refcount-positive — chunk held at LARGE inflation.
-                        let payload_base_addr = unsafe { SharedChunk::<A>::data_ptr(chunk) }.as_ptr() as usize;
                         // Bounded by fast-path invariants: chunk payload < 64 KiB, so the offset
                         // fits in `u16`; the `entry_size != 0 && len > u16::MAX` guard above
                         // already excluded large `len`.
-                        // SAFETY: see comment above.
-                        let value_offset = unsafe { u16::try_from((aligned_ptr.as_ptr() as usize) - payload_base_addr).unwrap_unchecked() };
+                        // SAFETY: refcount-positive — chunk held at LARGE
+                        // inflation; offset bounded by current-chunk extent.
+                        let value_offset = unsafe { value_offset_in_chunk(chunk, aligned_ptr) };
                         // SAFETY: gated by `len > u16::MAX` check earlier in this function.
-                        let len_u16 = unsafe { u16::try_from(len).unwrap_unchecked() };
+                        let len_u16 = unsafe { u16_truncate_unchecked(len) };
                         self.current_shared.drop_back.set(new_drop_back_ptr);
                         let entry_ptr: *mut InnerDropEntry = new_drop_back_ptr.cast::<InnerDropEntry>().as_ptr();
                         let noop_entry = InnerDropEntry::new(noop_drop_shim, value_offset, len_u16);
@@ -1205,7 +1175,7 @@ impl<A: Allocator + Clone> Arena<A> {
                 let end_ptr = __fit.end_ptr;
                 {
                     // SAFETY: bump-fit gate above implies non-stub slot ⇒ `current_shared.chunk` is `Some`.
-                    let chunk = unsafe { self.current_shared.chunk.get().unwrap_unchecked() };
+                    let chunk = unsafe { self.current_shared.chunk_assume_present() };
                     let ptr: *mut T = aligned_ptr.cast::<T>().as_ptr();
 
                     // Account before `init` so reentrant refill preserves this +1.

--- a/crates/multitude/src/arena/inner_value.rs
+++ b/crates/multitude/src/arena/inner_value.rs
@@ -12,9 +12,9 @@ use core::ptr::NonNull;
 use allocator_api2::alloc::{AllocError, Allocator};
 
 use super::{
-    AllocFlavor, Arena, OversizedLocalGuard, OversizedSharedGuard, ProtectiveHold, SharedArcsIssuedHold, align_offset,
+    AllocFlavor, Arena, OversizedLocalGuard, OversizedSharedGuard, ProtectiveHold, SharedArcsIssuedHold, aligned_payload_offset,
     bump_local_drop_count, bump_shared_drop_count, bumped_exceeds_chunk, current_chunk_evicted, expect_alloc, panic_alloc,
-    size_exceeds_normal_alloc, slow_refill_needed, try_bump_fit, write_through_ptr,
+    size_exceeds_normal_alloc, slow_refill_needed, try_bump_fit, value_offset_in_chunk, write_through_ptr,
 };
 use crate::internal::constants::{MAX_CHUNK_BYTES, MAX_SMART_PTR_ALIGN};
 use crate::internal::drop_list::{DropEntry as InnerDropEntry, drop_shim_one, noop_drop_shim};
@@ -79,7 +79,7 @@ impl<A: Allocator + Clone> Arena<A> {
                     let value_ptr: *mut T = aligned_ptr.cast::<T>().as_ptr();
                     // SAFETY: passing the bump-fit gate above implies a non-stub slot,
                     // which implies `current_shared.chunk` is `Some`.
-                    let chunk = unsafe { self.current_shared.chunk.get().unwrap_unchecked() };
+                    let chunk = unsafe { self.current_shared.chunk_assume_present() };
 
                     // Account before `f` so reentrant refill preserves this +1.
                     self.current_shared.bump_smart_pointers_issued();
@@ -90,22 +90,16 @@ impl<A: Allocator + Clone> Arena<A> {
                         // Compute is hoisted inside the drop-entry branch so
                         // `T: !Drop` allocations skip the panic surface of the
                         // u16 cast — mirrors `try_alloc_inner_with`.
-                        // SAFETY: refcount-positive — chunk held at LARGE
-                        // inflation while installed as `current_shared`.
-                        let payload_base_addr = unsafe { SharedChunk::<A>::data_ptr(chunk) }.as_ptr() as usize;
-                        let raw_value_offset = (aligned_ptr.as_ptr() as usize) - payload_base_addr;
+                        //
                         // Same bound chain as `impl_alloc_inner_value` (see
                         // there for the full derivation): bump-fit success
                         // implies `raw_value_offset < shared_max_bump_extent::<A>()
                         // = CHUNK_ALIGN − shared_header_size::<A>() ≤ u16::MAX`.
-                        debug_assert!(
-                            u16::try_from(raw_value_offset).is_ok(),
-                            "value_offset must fit in u16; reachable only if oversized chunk leaks into `current_shared`"
-                        );
-                        // SAFETY: bounded by current-chunk bump extent.
-                        unsafe { core::hint::assert_unchecked(u16::try_from(raw_value_offset).is_ok()) };
-                        // SAFETY: precondition asserted above.
-                        let value_offset = unsafe { u16::try_from(raw_value_offset).unwrap_unchecked() };
+                        // SAFETY: refcount-positive — chunk held at LARGE
+                        // inflation while installed as `current_shared`;
+                        // offset bounded by current-chunk bump extent
+                        // (reachable only if an oversized chunk leaks in).
+                        let value_offset = unsafe { value_offset_in_chunk(chunk, aligned_ptr) };
                         self.current_shared.drop_back.set(new_drop_back_ptr);
                         let entry_ptr: *mut InnerDropEntry = new_drop_back_ptr.cast::<InnerDropEntry>().as_ptr();
                         let noop_entry = InnerDropEntry::new(noop_drop_shim, value_offset, 1);
@@ -224,17 +218,14 @@ impl<A: Allocator + Clone> Arena<A> {
         // Chunk arrives with refcount inflated to LARGE.
         // SAFETY: refcount-positive — LARGE inflation keeps the chunk live.
         let chunk_ref = unsafe { chunk.as_ref() };
-        // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on
+        // `data_ptr`, which would later collide with `free_backing`.
         let data_ptr = unsafe { LocalChunk::<A>::data_ptr(chunk) };
         let cap = chunk_ref.capacity;
         let data_addr = data_ptr.as_ptr() as usize;
-        // SAFETY: provider post-condition guarantees the chunk fits the request after
-        // alignment and drop-entry slack, so neither computation below can fail.
-        let aligned = unsafe { align_offset(data_addr, layout.align()).unwrap_unchecked() };
-        // SAFETY: same post-condition as above; computation fits well below `usize::MAX`.
-        let end = unsafe { aligned.checked_add(layout.size()).unwrap_unchecked() };
-        // SAFETY: same post-condition as above.
-        unsafe { core::hint::assert_unchecked(end <= cap.saturating_sub(entry_size)) };
+        // SAFETY: provider post-condition guarantees the request fits the chunk.
+        let aligned = unsafe { aligned_payload_offset(data_addr, layout.align().max(1), layout.size(), cap, entry_size) };
         // SAFETY: payload-extent invariant — `aligned` is `T`-aligned and within `[0, cap)`.
         let value_ptr = unsafe { data_ptr.as_ptr().add(aligned).cast::<T>() };
 
@@ -246,12 +237,6 @@ impl<A: Allocator + Clone> Arena<A> {
 
         if entry_size > 0 {
             let new_drop_back = cap - entry_size;
-            #[expect(
-                clippy::cast_ptr_alignment,
-                reason = "chunk payloads are 64 KiB aligned (CHUNK_ALIGN), so any `InnerDropEntry` slot computed as `data + new_drop_back` is naturally aligned for `InnerDropEntry`"
-            )]
-            // SAFETY: payload-extent invariant — back-stack slot lies within the chunk's payload.
-            let entry_ptr = unsafe { data_ptr.as_ptr().add(new_drop_back).cast::<InnerDropEntry>() };
             // Box flavor installs a noop here; `Box::drop` runs `drop_in_place` directly and
             // `Box::into_rc` retargets this slot to `drop_shim_one::<T>` on conversion.
             let installed_drop_fn = if matches!(flavor, AllocFlavor::Box) {
@@ -265,8 +250,8 @@ impl<A: Allocator + Clone> Arena<A> {
                     .expect("oversized chunk payload starts at offset 0; aligned < align < MAX_SMART_PTR_ALIGN ≤ u16::MAX"),
                 1,
             );
-            // SAFETY: payload-extent invariant.
-            unsafe { core::ptr::write(entry_ptr, entry) };
+            // SAFETY: back-stack slot lies within the chunk payload and is naturally aligned for `InnerDropEntry`.
+            unsafe { entry.write_at_offset(data_ptr, new_drop_back) };
             chunk_ref.drop_count.set(1);
         }
 
@@ -390,7 +375,7 @@ impl<A: Allocator + Clone> Arena<A> {
         // `T: !Drop` non-Box flavors `entry_size == 0` and the chunk
         // pointer is never needed in this function — the load is
         // deferred and elided by LLVM.
-        let chunk_lazy = || unsafe { self.current_local.chunk.get().unwrap_unchecked() };
+        let chunk_lazy = || unsafe { self.current_local.chunk_assume_present() };
 
         match flavor {
             AllocFlavor::SimpleRef => {
@@ -417,9 +402,6 @@ impl<A: Allocator + Clone> Arena<A> {
 
         if entry_size > 0 {
             let chunk = chunk_lazy();
-            // SAFETY: refcount-positive — chunk held at LARGE inflation.
-            let payload_base_addr = unsafe { LocalChunk::<A>::data_ptr(chunk) }.as_ptr() as usize;
-            let raw_value_offset = (aligned_ptr.as_ptr() as usize) - payload_base_addr;
             // Bound chain:
             //   raw_value_offset < bump_extent
             //                    = capacity.min(local_max_bump_extent::<A>())
@@ -431,14 +413,10 @@ impl<A: Allocator + Clone> Arena<A> {
             // the offset fits in `u16`. (Note: `MAX_CHUNK_BYTES = 65536`
             // is *not* itself ≤ `u16::MAX` — the real bound is
             // `local_max_bump_extent::<A>()`, which is strictly less.)
-            debug_assert!(
-                u16::try_from(raw_value_offset).is_ok(),
-                "value_offset must fit in u16; reachable only if oversized chunk leaks into `current_local`"
-            );
-            // SAFETY: bounded by the chain above.
-            unsafe { core::hint::assert_unchecked(u16::try_from(raw_value_offset).is_ok()) };
-            // SAFETY: precondition asserted above; this conversion has no panic surface.
-            let value_offset = unsafe { u16::try_from(raw_value_offset).unwrap_unchecked() };
+            // SAFETY: refcount-positive — chunk held at LARGE inflation;
+            // offset bounded by the chain above (reachable only if an
+            // oversized chunk leaks into `current_local`).
+            let value_offset = unsafe { value_offset_in_chunk(chunk, aligned_ptr) };
             self.current_local.drop_back.set(new_drop_back_ptr);
             let entry_ptr: *mut InnerDropEntry = new_drop_back_ptr.cast::<InnerDropEntry>().as_ptr();
             // `Box` installs a noop shim (retargeted at `Box::into_rc` time);
@@ -529,16 +507,14 @@ impl<A: Allocator + Clone> Arena<A> {
         // chunk arrives with refcount inflated to LARGE.
         // SAFETY: refcount-positive — LARGE inflation keeps the chunk live.
         let chunk_ref = unsafe { chunk.as_ref() };
-        // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on
+        // `data_ptr`, which would later collide with `free_backing`.
         let data_ptr = unsafe { LocalChunk::<A>::data_ptr(chunk) };
         let cap = chunk_ref.capacity;
         let data_addr = data_ptr.as_ptr() as usize;
-        // SAFETY: provider post-condition guarantees the chunk fits the request.
-        let aligned = unsafe { align_offset(data_addr, layout.align()).unwrap_unchecked() };
-        // SAFETY: same post-condition as above; computation fits well below `usize::MAX`.
-        let end = unsafe { aligned.checked_add(layout.size()).unwrap_unchecked() };
-        // SAFETY: provider post-condition.
-        unsafe { core::hint::assert_unchecked(end <= cap.saturating_sub(entry_size)) };
+        // SAFETY: provider post-condition guarantees the request fits the chunk.
+        let aligned = unsafe { aligned_payload_offset(data_addr, layout.align().max(1), layout.size(), cap, entry_size) };
         // SAFETY: payload-extent invariant — `aligned` is `T`-aligned and within `[0, cap)`.
         let value_ptr = unsafe { data_ptr.as_ptr().add(aligned).cast::<T>() };
 
@@ -548,12 +524,6 @@ impl<A: Allocator + Clone> Arena<A> {
 
         if entry_size > 0 {
             let new_drop_back = cap - entry_size;
-            #[expect(
-                clippy::cast_ptr_alignment,
-                reason = "chunk payloads are 64 KiB aligned (CHUNK_ALIGN), so any `InnerDropEntry` slot computed as `data + new_drop_back` is naturally aligned for `InnerDropEntry`"
-            )]
-            // SAFETY: payload-extent invariant — back-stack slot lies within the chunk's payload.
-            let entry_ptr = unsafe { data_ptr.as_ptr().add(new_drop_back).cast::<InnerDropEntry>() };
             // See [`Self::try_alloc_inner_oversized_with`] for the Box-flavor rationale.
             let installed_drop_fn = if matches!(flavor, AllocFlavor::Box) {
                 noop_drop_shim
@@ -566,8 +536,8 @@ impl<A: Allocator + Clone> Arena<A> {
                     .expect("oversized chunk payload starts at offset 0; aligned < align < MAX_SMART_PTR_ALIGN ≤ u16::MAX"),
                 1,
             );
-            // SAFETY: payload-extent invariant.
-            unsafe { core::ptr::write(entry_ptr, entry) };
+            // SAFETY: back-stack slot lies within the chunk payload and is naturally aligned for `InnerDropEntry`.
+            unsafe { entry.write_at_offset(data_ptr, new_drop_back) };
             chunk_ref.drop_count.set(1);
         }
 
@@ -612,16 +582,14 @@ impl<A: Allocator + Clone> Arena<A> {
         let chunk = self.provider.acquire_shared(needed)?;
         // SAFETY: refcount-positive — LARGE inflation keeps the chunk live.
         let chunk_ref = unsafe { chunk.as_ref() };
-        // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on
+        // `data_ptr`, which would later collide with `free_backing`.
         let data_ptr = unsafe { SharedChunk::<A>::data_ptr(chunk) };
         let cap = chunk_ref.capacity;
         let data_addr = data_ptr.as_ptr() as usize;
-        // SAFETY: provider post-condition guarantees the chunk fits the request.
-        let aligned = unsafe { align_offset(data_addr, layout.align()).unwrap_unchecked() };
-        // SAFETY: same post-condition as above; computation fits well below `usize::MAX`.
-        let end = unsafe { aligned.checked_add(layout.size()).unwrap_unchecked() };
-        // SAFETY: provider post-condition.
-        unsafe { core::hint::assert_unchecked(end <= cap.saturating_sub(entry_size)) };
+        // SAFETY: provider post-condition guarantees the request fits the chunk.
+        let aligned = unsafe { aligned_payload_offset(data_addr, layout.align().max(1), layout.size(), cap, entry_size) };
         // SAFETY: payload-extent invariant — `aligned` is `T`-aligned and within `[0, cap)`.
         let value_ptr = unsafe { data_ptr.as_ptr().add(aligned).cast::<T>() };
 
@@ -633,20 +601,14 @@ impl<A: Allocator + Clone> Arena<A> {
 
         if entry_size > 0 {
             let new_drop_back = cap - entry_size;
-            #[expect(
-                clippy::cast_ptr_alignment,
-                reason = "chunk payloads are 64 KiB aligned (CHUNK_ALIGN), so any `InnerDropEntry` slot computed as `data + new_drop_back` is naturally aligned for `InnerDropEntry`"
-            )]
-            // SAFETY: payload-extent invariant.
-            let entry_ptr = unsafe { data_ptr.as_ptr().add(new_drop_back).cast::<InnerDropEntry>() };
             let entry = InnerDropEntry::new(
                 drop_shim_one::<T>,
                 u16::try_from(aligned)
                     .expect("oversized chunk payload starts at offset 0; aligned < align < MAX_SMART_PTR_ALIGN ≤ u16::MAX"),
                 1,
             );
-            // SAFETY: payload-extent invariant.
-            unsafe { core::ptr::write(entry_ptr, entry) };
+            // SAFETY: back-stack slot lies within the chunk payload and is naturally aligned for `InnerDropEntry`.
+            unsafe { entry.write_at_offset(data_ptr, new_drop_back) };
             // No other thread can yet observe this chunk: the
             // inflation has not been published via any cross-thread handoff.
             chunk_ref.drop_count.store(1, Ordering::Relaxed);
@@ -657,7 +619,6 @@ impl<A: Allocator + Clone> Arena<A> {
         // SAFETY: chunk held LARGE while we acted as its sole tenant.
         unsafe { SharedChunk::reconcile_swap_out(chunk, 1) };
 
-        let _ = end;
         // SAFETY: `value_ptr` is non-null and now points at an initialized `T`.
         Ok(unsafe { NonNull::new_unchecked(value_ptr) })
     }
@@ -739,7 +700,7 @@ impl<A: Allocator + Clone> Arena<A> {
         // implies `aligned + bumped <= drop_back`, with `drop_back !=
         // dangling(1)` (stub state has data_ptr == drop_back == 1, so
         // `bumped > 0` would have failed the gate).
-        let chunk = unsafe { self.current_local.chunk.get().unwrap_unchecked() };
+        let chunk = unsafe { self.current_local.chunk_assume_present() };
 
         // Protect the reserved chunk across reentrant calls from `f`.
         match flavor {
@@ -768,21 +729,14 @@ impl<A: Allocator + Clone> Arena<A> {
         // they vanish for `T: !Drop` non-Box flavors — LLVM otherwise
         // hoists the panic check unconditionally and bloats the loop.
         let value_offset = if entry_size > 0 {
-            // SAFETY: refcount-positive — chunk held at LARGE inflation
-            // while installed as `current_local`.
-            let payload_base_addr = unsafe { LocalChunk::<A>::data_ptr(chunk) }.as_ptr() as usize;
-            let raw_value_offset = (aligned_ptr.as_ptr() as usize) - payload_base_addr;
             // Same bound chain as `impl_alloc_inner_value` — successful
             // bump-fit places the offset within `local_max_bump_extent::<A>()
             // = CHUNK_ALIGN − local_header_size::<A>() ≤ u16::MAX`.
-            debug_assert!(
-                u16::try_from(raw_value_offset).is_ok(),
-                "value_offset must fit in u16; reachable only if oversized chunk leaks into `current_local`"
-            );
-            // SAFETY: bounded by current-chunk bump extent.
-            unsafe { core::hint::assert_unchecked(u16::try_from(raw_value_offset).is_ok()) };
-            // SAFETY: precondition asserted above.
-            let value_offset = unsafe { u16::try_from(raw_value_offset).unwrap_unchecked() };
+            // SAFETY: refcount-positive — chunk held at LARGE inflation
+            // while installed as `current_local`; offset bounded by
+            // current-chunk bump extent (reachable only if an oversized
+            // chunk leaks into `current_local`).
+            let value_offset = unsafe { value_offset_in_chunk(chunk, aligned_ptr) };
             self.current_local.drop_back.set(new_drop_back_ptr);
             let entry_ptr: *mut InnerDropEntry = new_drop_back_ptr.cast::<InnerDropEntry>().as_ptr();
             let noop_entry = InnerDropEntry::new(noop_drop_shim, value_offset, 1);

--- a/crates/multitude/src/arena/internals.rs
+++ b/crates/multitude/src/arena/internals.rs
@@ -13,6 +13,7 @@ use core::ptr::NonNull;
 use allocator_api2::alloc::{AllocError, Allocator, Global};
 
 use super::Arena;
+use super::chunks::ChunkKind;
 use crate::internal::drop_list::{DropEntry as InnerDropEntry, drop_shim_slice};
 use crate::internal::local_chunk::LocalChunk;
 use crate::internal::shared_chunk::SharedChunk;
@@ -31,6 +32,46 @@ pub(super) const fn compute_worst_case_size(layout: Layout, has_drop: bool) -> u
 #[cfg_attr(test, mutants::skip)]
 pub(super) const fn worst_case_refill_for(layout: Layout, entry_size: usize) -> usize {
     compute_worst_case_size(layout, entry_size != 0)
+}
+
+/// Truncate `value` to `u16` under a caller-asserted bound.
+///
+/// In debug builds the bound is checked with `debug_assert!`; in release
+/// the optimizer is told via `assert_unchecked` so the conversion has no
+/// panic surface. Centralizes the three-call `debug_assert! + assert_unchecked +
+/// unwrap_unchecked` idiom used at every drop-entry install site.
+///
+/// # Safety
+///
+/// `value <= u16::MAX`. Violating this is UB in release builds.
+#[inline(always)]
+pub(super) unsafe fn u16_truncate_unchecked(value: usize) -> u16 {
+    let res = u16::try_from(value);
+    debug_assert!(res.is_ok(), "u16_truncate_unchecked: value {value} exceeds u16::MAX");
+    // SAFETY: caller-asserted bound; debug builds panic above instead.
+    unsafe { core::hint::assert_unchecked(res.is_ok()) };
+    // SAFETY: caller-asserted bound; debug builds panic above instead.
+    unsafe { res.unwrap_unchecked() }
+}
+
+/// In-payload `u16` offset of `value_ptr` within `chunk`.
+///
+/// Folds the three-step `data_ptr + subtract + u16_truncate_unchecked`
+/// dance used at every drop-entry install site into one helper, so the
+/// chunk-liveness and offset-bound proofs live in a single place.
+///
+/// # Safety
+///
+/// - `chunk` must be live (refcount-positive) for the duration of the call.
+/// - `value_ptr` must lie within `chunk`'s payload AND within the
+///   max-bump-extent, so the offset fits in `u16`.
+#[inline(always)]
+pub(super) unsafe fn value_offset_in_chunk<C: ChunkKind + ?Sized>(chunk: NonNull<C>, value_ptr: NonNull<u8>) -> u16 {
+    // SAFETY: caller asserts `chunk` is live.
+    let payload_base_addr = unsafe { C::data_ptr_of(chunk) }.as_ptr() as usize;
+    let raw_value_offset = (value_ptr.as_ptr() as usize) - payload_base_addr;
+    // SAFETY: caller asserts the offset fits in `u16`.
+    unsafe { u16_truncate_unchecked(raw_value_offset) }
 }
 
 /// `bumped > MAX_CHUNK_BYTES` boundary predicate.
@@ -475,6 +516,29 @@ pub(super) fn align_offset(value: usize, align: usize) -> Option<usize> {
     debug_assert!(align.is_power_of_two());
     let aligned = value.checked_add(align - 1)? & !(align - 1);
     Some(aligned - value)
+}
+
+/// Computes the aligned offset of a payload of `size` bytes inside a
+/// chunk of `cap` bytes that reserves `reserved_tail` bytes at the
+/// end (e.g. for drop-back entries), feeding optimizer hints that
+/// align with the chunk provider's post-condition.
+///
+/// # Safety
+///
+/// Caller guarantees, via the chunk provider's post-condition, that
+/// the request fits the chunk: `align_offset(data_addr, align)` does
+/// not overflow, `aligned + size` does not overflow, and
+/// `aligned + size <= cap - reserved_tail`.
+#[inline]
+pub(super) unsafe fn aligned_payload_offset(data_addr: usize, align: usize, size: usize, cap: usize, reserved_tail: usize) -> usize {
+    // SAFETY: the chunk-provider post-condition cited by the caller
+    // proves each of these unchecked operations succeeds.
+    unsafe {
+        let aligned = align_offset(data_addr, align).unwrap_unchecked();
+        let end = aligned.checked_add(size).unwrap_unchecked();
+        core::hint::assert_unchecked(end <= cap.saturating_sub(reserved_tail));
+        aligned
+    }
 }
 
 impl<A: Allocator + Clone> Arena<A> {

--- a/crates/multitude/src/arena/mod.rs
+++ b/crates/multitude/src/arena/mod.rs
@@ -136,13 +136,16 @@ mod refill;
 mod tests;
 
 use chunks::{CurrentLocalChunk, CurrentSharedChunk, OversizedLocalGuard, OversizedSharedGuard};
+#[cfg(test)]
+use internals::align_offset;
 #[cfg(feature = "dst")]
 use internals::align_up;
 pub(crate) use internals::check_isize_overflow;
 use internals::{
-    AllocFlavor, ProtectiveHold, SharedArcsIssuedHold, SliceInitGuard, align_offset, bump_local_drop_count, bump_shared_drop_count,
-    bumped_exceeds_chunk, compute_worst_case_size, current_chunk_evicted, drop_fn_for_slice, has_drop_entry, size_exceeds_normal_alloc,
-    slow_refill_needed, try_bump_fit, worst_case_refill_for, write_through_ptr,
+    AllocFlavor, ProtectiveHold, SharedArcsIssuedHold, SliceInitGuard, aligned_payload_offset, bump_local_drop_count,
+    bump_shared_drop_count, bumped_exceeds_chunk, compute_worst_case_size, current_chunk_evicted, drop_fn_for_slice, has_drop_entry,
+    size_exceeds_normal_alloc, slow_refill_needed, try_bump_fit, u16_truncate_unchecked, value_offset_in_chunk, worst_case_refill_for,
+    write_through_ptr,
 };
 pub use internals::{expect_alloc, panic_alloc};
 

--- a/crates/multitude/src/arena/primitives.rs
+++ b/crates/multitude/src/arena/primitives.rs
@@ -11,7 +11,7 @@ use core::ptr::NonNull;
 
 use allocator_api2::alloc::{AllocError, Allocator};
 
-use super::{Arena, bump_local_drop_count, check_isize_overflow, try_bump_fit};
+use super::{Arena, bump_local_drop_count, check_isize_overflow, try_bump_fit, u16_truncate_unchecked};
 use crate::internal::constants::MAX_SMART_PTR_ALIGN;
 use crate::internal::drop_list::DropEntry as InnerDropEntry;
 use crate::internal::in_chunk::InLocalChunk;
@@ -413,7 +413,7 @@ impl<A: Allocator + Clone> Arena<A> {
         unsafe { core::hint::assert_unchecked(value_offset_isize >= 0) };
         let value_offset = value_offset_isize.cast_unsigned();
         // SAFETY: payload-extent invariant — offset bounded by chunk capacity (< u16::MAX).
-        let value_offset_u16 = unsafe { u16::try_from(value_offset).unwrap_unchecked() };
+        let value_offset_u16 = unsafe { u16_truncate_unchecked(value_offset) };
 
         let entry_size = core::mem::size_of::<InnerDropEntry>();
         let drop_back_ptr = self.current_local.drop_back.get();

--- a/crates/multitude/src/arena/refill.rs
+++ b/crates/multitude/src/arena/refill.rs
@@ -68,9 +68,12 @@ impl<A: Allocator + Clone> Arena<A> {
         let want = min_payload.max(DEFAULT_MIN_PAYLOAD);
         let chunk = self.provider.acquire_shared(want)?;
         // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        let chunk_ref = unsafe { chunk.as_ref() };
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on `data`,
+        // which would later collide with `free_backing`.
         let data = unsafe { SharedChunk::<A>::data_ptr(chunk) };
-        // SAFETY: chunk live — acquired with inflated refcount.
-        let capacity = unsafe { chunk.as_ref() }.capacity;
+        let capacity = chunk_ref.capacity;
 
         // Cap the bump cursor at the mask-recoverable region.
         let bump_extent = capacity.min(shared_max_bump_extent::<A>());
@@ -158,9 +161,12 @@ impl<A: Allocator + Clone> Arena<A> {
         let want = min_payload.max(DEFAULT_MIN_PAYLOAD);
         let chunk = self.provider.acquire_local(want)?;
         // SAFETY: refcount-positive — chunk held at LARGE inflation.
+        let chunk_ref = unsafe { chunk.as_ref() };
+        // SAFETY: same liveness as `chunk.as_ref()` above; we use the
+        // raw `chunk` to avoid putting a SharedReadOnly tag on `data`,
+        // which would later collide with `free_backing`.
         let data = unsafe { LocalChunk::<A>::data_ptr(chunk) };
-        // SAFETY: refcount-positive — acquired with refcount inflated to LARGE.
-        let capacity = unsafe { chunk.as_ref() }.capacity;
+        let capacity = chunk_ref.capacity;
 
         // Cap the bump cursor at the mask-recoverable region.
         let bump_extent = capacity.min(local_max_bump_extent::<A>());

--- a/crates/multitude/src/box.rs
+++ b/crates/multitude/src/box.rs
@@ -604,8 +604,7 @@ impl<T: ?Sized, A: Allocator + Clone> Unpin for Box<T, A> {}
 /// This panics if the allocation never reserved a drop entry,
 /// because silently skipping `T::drop` would leak.
 fn retarget_box_drop_entry<A: Allocator + Clone>(chunk: &LocalChunk<A>, value_ptr: NonNull<u8>, drop_fn: unsafe fn(*mut u8, usize)) {
-    // SAFETY: `chunk` is a live reference, so `NonNull::from(chunk)` names a live chunk.
-    let data = unsafe { LocalChunk::<A>::data_ptr(NonNull::from(chunk)) };
+    let data = chunk.data();
     // SAFETY: `value_ptr` points into `chunk`'s payload, so `offset_from`
     // stays within one allocation and yields a non-negative offset.
     let value_offset = unsafe { value_ptr.as_ptr().offset_from(data.as_ptr()) } as usize;

--- a/crates/multitude/src/internal/drop_list.rs
+++ b/crates/multitude/src/internal/drop_list.rs
@@ -152,6 +152,31 @@ impl DropEntry {
         // cast at construction or via `store_drop_fn`.
         unsafe { mem::transmute::<*mut (), unsafe fn(*mut u8, usize)>(p) }
     }
+
+    /// Write `self` as a fresh entry at `data_ptr + byte_offset`. Used
+    /// by allocation paths that already proved the back-stack slot is
+    /// inside the live chunk payload and naturally aligned for
+    /// [`DropEntry`].
+    ///
+    /// # Safety
+    ///
+    /// `data_ptr + byte_offset` must point at writable, owned,
+    /// `DropEntry`-aligned bytes inside a live chunk (the back-stack
+    /// slot the caller just reserved), and the slot must not currently
+    /// hold an initialized entry (the write is non-drop / overwriting
+    /// memory).
+    #[inline]
+    pub(crate) unsafe fn write_at_offset(self, data_ptr: core::ptr::NonNull<u8>, byte_offset: usize) {
+        #[expect(
+            clippy::cast_ptr_alignment,
+            reason = "back-stack slots are placed at naturally-aligned addresses by the bump allocator (CHUNK_ALIGN >= align_of::<DropEntry>())"
+        )]
+        // SAFETY: caller proves the slot is in-payload, aligned, and writable.
+        unsafe {
+            let entry_ptr = data_ptr.as_ptr().add(byte_offset).cast::<Self>();
+            core::ptr::write(entry_ptr, self);
+        }
+    }
 }
 
 /// No-op shim for allocations whose storage is intentionally uninitialized.
@@ -221,9 +246,78 @@ impl Drop for AbortOnUnwind {
     }
 }
 
+/// Iterate the trailing drop list at `(data, capacity)` and invoke each
+/// recorded drop-shim. Shared between [`LocalChunk::replay_drops`] and
+/// [`SharedChunk::replay_drops`] (their per-flavor parts cover the
+/// `drop_count` read / reset and the chunk-liveness contract).
+///
+/// Each call is wrapped panic-safely: under `std` with `catch_unwind`
+/// (so one panicking `T::Drop` leaks only its own value, not the
+/// chunk), under `no_std` with an [`AbortOnUnwind`] guard (no
+/// `catch_unwind`; the only way to keep chunk reclamation correct is
+/// to escalate the panic to a process abort via double-panic).
+///
+/// # Safety
+///
+/// * `data` must be the chunk's payload base and remain valid for
+///   reads for `capacity` bytes (caller-owned chunk).
+/// * The last `count * size_of::<DropEntry>()` bytes of the payload
+///   must hold `count` initialized `DropEntry`s installed by
+///   [`crate::arena::primitives`] (densely packed, naturally aligned).
+/// * Each entry's `(value_offset, len, drop_fn)` must satisfy the
+///   drop-shim invariant: `data + value_offset` points at `len`
+///   initialized values of the type `drop_fn` was synthesized for.
+/// * The caller must have reset the on-chunk `drop_count` to zero
+///   before invoking, so a panicking `Drop` cannot leave stale entries
+///   to be replayed twice.
+pub(crate) unsafe fn replay_drop_entries(data: *mut u8, capacity: usize, count: usize) {
+    if count == 0 {
+        return;
+    }
+    let base = capacity - count * mem::size_of::<DropEntry>();
+    #[expect(
+        clippy::cast_ptr_alignment,
+        reason = "chunk payloads are CHUNK_ALIGN aligned; `data + base` is naturally `DropEntry`-aligned by construction"
+    )]
+    // SAFETY: `base = capacity - count * size_of::<DropEntry>()` is
+    // the byte offset of the first entry; together with `data` it
+    // addresses `count` initialized `DropEntry`s.
+    let entries_ptr = unsafe { data.add(base).cast::<DropEntry>() };
+    for i in 0..count {
+        // SAFETY: `i < count`; all `count` entries are initialized at allocation time.
+        let entry = unsafe { &*entries_ptr.add(i) };
+        // SAFETY: payload-extent + drop-shim invariants.
+        let value_ptr = unsafe { data.add(entry.value_offset as usize) };
+        let f = entry.load_drop_fn(Ordering::Relaxed);
+        #[cfg(feature = "std")]
+        {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                // SAFETY: drop-shim invariant.
+                unsafe { f(value_ptr, entry.len as usize) };
+            }));
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            let abort_guard = AbortOnUnwind;
+            // SAFETY: drop-shim invariant.
+            unsafe { f(value_ptr, entry.len as usize) };
+            core::mem::forget(abort_guard);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn replay_drop_entries_zero_count_is_noop() {
+        // `count == 0` returns immediately before touching `data` or
+        // `capacity`, so passing dangling/zero values is fine.
+        // SAFETY: see above — the early-return branch never reads
+        // through `data` nor uses `capacity`.
+        unsafe { replay_drop_entries(core::ptr::null_mut(), 0, 0) };
+    }
 
     #[test]
     fn round_payload_overflow_returns_none() {

--- a/crates/multitude/src/internal/local_chunk.rs
+++ b/crates/multitude/src/internal/local_chunk.rs
@@ -28,7 +28,6 @@ use core::alloc::Layout;
 use core::cell::Cell;
 use core::mem;
 use core::ptr::NonNull;
-use core::sync::atomic::Ordering;
 
 use allocator_api2::alloc::Allocator;
 
@@ -242,6 +241,17 @@ impl<A: Allocator + Clone> LocalChunk<A> {
         unsafe { NonNull::new_unchecked(p) }
     }
 
+    /// Safe `&self`-based payload-base accessor. The borrow proves the
+    /// chunk is live, so [`Self::data_ptr`]'s safety condition is met.
+    /// The returned pointer carries chunk-wide provenance and does
+    /// *not* pin a borrow tag onto the chunk's payload region.
+    #[inline]
+    pub(crate) fn data(&self) -> NonNull<u8> {
+        // SAFETY: `&self` proves the chunk is live for at least the
+        // duration of this borrow.
+        unsafe { Self::data_ptr(NonNull::from(self)) }
+    }
+
     /// Increment the refcount. Safe because `&self` proves the chunk
     /// is live (some other party already holds a +1).
     #[inline]
@@ -331,50 +341,11 @@ impl<A: Allocator + Clone> LocalChunk<A> {
         // observer must not see the already-replayed entries.
         // SAFETY: caller-owned refcount.
         unsafe { (*chunk.as_ptr()).drop_count.set(0) };
-        let top = capacity;
-        let base = top - count * mem::size_of::<DropEntry>();
         // SAFETY: chunk-layout invariant — `count` densely packed,
-        // naturally aligned `DropEntry`s live at `data + base`.
-        #[expect(
-            clippy::cast_ptr_alignment,
-            reason = "chunk payloads are CHUNK_ALIGN aligned; `data + base` is naturally `DropEntry`-aligned by construction"
-        )]
-        // SAFETY: `base = capacity - count * size_of::<DropEntry>()`
-        // is the byte offset of the first entry; `data` is the chunk's
-        // payload base. Together they address `count` initialized
-        // `DropEntry`s.
-        let entries_ptr = unsafe { data.add(base).cast::<DropEntry>() };
-        for i in 0..count {
-            // SAFETY: `i < count`, all `count` entries are initialized
-            // at allocation time.
-            let entry = unsafe { &*entries_ptr.add(i) };
-            // SAFETY: payload-extent + drop-shim invariants.
-            let value_ptr = unsafe { data.add(entry.value_offset as usize) };
-            let f = entry.load_drop_fn(Ordering::Relaxed);
-            // Isolate each call (when `std` is available) so a panicking
-            // `T::Drop` doesn't abort the chunk reclamation path — at
-            // worst we leak that value's resources; the chunk itself
-            // still gets freed. Under `no_std` an unwinding `T::Drop`
-            // forces a process abort via the `AbortOnUnwind` guard
-            // below (consistent with `core` semantics under
-            // `panic = abort`; for `panic = unwind` builds, this
-            // prevents the panic from leaking the chunk by
-            // propagating out past `route_release`).
-            #[cfg(feature = "std")]
-            {
-                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    // SAFETY: drop-shim invariant.
-                    unsafe { f(value_ptr, entry.len as usize) };
-                }));
-            }
-            #[cfg(not(feature = "std"))]
-            {
-                let abort_guard = crate::internal::drop_list::AbortOnUnwind;
-                // SAFETY: drop-shim invariant.
-                unsafe { f(value_ptr, entry.len as usize) };
-                core::mem::forget(abort_guard);
-            }
-        }
+        // naturally aligned `DropEntry`s live at the tail of the
+        // payload; each one's `(value_offset, len, drop_fn)` satisfies
+        // the drop-shim invariant.
+        unsafe { crate::internal::drop_list::replay_drop_entries(data, capacity, count) };
     }
 
     /// Tear the chunk down: drop the header fields and free the
@@ -389,25 +360,25 @@ impl<A: Allocator + Clone> LocalChunk<A> {
     /// must already have been replayed (or the chunk's `drop_count`
     /// must be `0`).
     pub(crate) unsafe fn free_backing(chunk: NonNull<Self>) {
-        // SAFETY: caller owns the last +1.
-        let capacity = unsafe { (*chunk.as_ptr()).capacity };
-
-        let total_bytes = alloc_size::<A>(header_size::<A>() + capacity);
-        let layout =
-            Layout::from_size_align(total_bytes, chunk_align::<A>()).expect("layout was valid at allocation time, must remain valid here");
-
         // Move `allocator` out so we can free with it *after* the
         // header runs its destructors.
-        // SAFETY: we own the last reference; `allocator` is live.
-        let allocator: A = unsafe { core::ptr::read(core::ptr::addr_of!((*chunk.as_ptr()).allocator)) };
-        // SAFETY: each `addr_of!` field is a live value and we drop
-        // it exactly once.
-        unsafe {
+        // SAFETY: caller owns the last +1; `capacity`, `allocator`, and
+        // each `addr_of!`d header field are live values dropped exactly
+        // once here. The chunk's pointer + layout match what `A::allocate`
+        // originally returned (chunk-header invariant).
+        let (capacity, allocator) = unsafe {
+            let capacity = (*chunk.as_ptr()).capacity;
+            let allocator: A = core::ptr::read(core::ptr::addr_of!((*chunk.as_ptr()).allocator));
             core::ptr::drop_in_place(core::ptr::addr_of_mut!((*chunk.as_ptr()).provider));
             core::ptr::drop_in_place(core::ptr::addr_of_mut!((*chunk.as_ptr()).refcount));
             core::ptr::drop_in_place(core::ptr::addr_of_mut!((*chunk.as_ptr()).drop_count));
             core::ptr::drop_in_place(core::ptr::addr_of_mut!((*chunk.as_ptr()).next));
-        }
+            (capacity, allocator)
+        };
+
+        let total_bytes = alloc_size::<A>(header_size::<A>() + capacity);
+        let layout =
+            Layout::from_size_align(total_bytes, chunk_align::<A>()).expect("layout was valid at allocation time, must remain valid here");
 
         let raw_ptr = chunk.as_ptr().cast::<u8>();
         // SAFETY: the chunk's pointer + layout is exactly what

--- a/crates/multitude/src/internal/mask.rs
+++ b/crates/multitude/src/internal/mask.rs
@@ -16,6 +16,80 @@ use super::constants::CHUNK_ALIGN;
 use super::local_chunk::LocalChunk;
 use super::shared_chunk::SharedChunk;
 
+/// Chunk-header types that share the masking-based recovery layout:
+/// they carry a `capacity: usize` field at the sized prefix and are
+/// reconstituted as a `*mut Self` DST whose slice-style metadata
+/// records the `capacity` byte length of the trailing payload.
+///
+/// # Safety
+///
+/// Implementations must:
+/// * begin with a sized prefix whose `capacity` field gives the byte
+///   length of the trailing payload (the fat-pointer metadata);
+/// * be reachable via the chunk-header invariant (start of every
+///   `CHUNK_ALIGN`-tile owned by the allocator).
+pub(crate) unsafe trait ChunkHeader {
+    /// Reconstruct a fat-pointer `NonNull<Self>` from a header-byte
+    /// pointer by reading the `capacity` field as the metadata.
+    ///
+    /// # Safety
+    ///
+    /// `header_byte_ptr` must point at a live header's sized prefix
+    /// (start of a `CHUNK_ALIGN` tile owned by the allocator).
+    unsafe fn fat_from_header_bytes(header_byte_ptr: *mut u8) -> NonNull<Self>;
+}
+
+// SAFETY: `LocalChunk<A>` begins with a `capacity: usize` field and
+// the chunk-header invariant places it at a `CHUNK_ALIGN`-tile start.
+unsafe impl<A: Allocator + Clone> ChunkHeader for LocalChunk<A> {
+    #[inline]
+    unsafe fn fat_from_header_bytes(header_byte_ptr: *mut u8) -> NonNull<Self> {
+        // SAFETY: chunk-header invariant — header prefix is live and
+        // initialized, so reading `capacity` and reconstituting the
+        // fat pointer is sound.
+        unsafe {
+            let header_only: *const Self = core::ptr::slice_from_raw_parts(header_byte_ptr, 0) as *const Self;
+            let capacity = (*header_only).capacity;
+            let fat: *mut Self = core::ptr::slice_from_raw_parts_mut(header_byte_ptr, capacity) as *mut Self;
+            NonNull::new_unchecked(fat)
+        }
+    }
+}
+
+// SAFETY: same as `LocalChunk` — `capacity: usize` is the sized prefix.
+unsafe impl<A: Allocator + Clone> ChunkHeader for SharedChunk<A> {
+    #[inline]
+    unsafe fn fat_from_header_bytes(header_byte_ptr: *mut u8) -> NonNull<Self> {
+        // SAFETY: see `LocalChunk` impl.
+        unsafe {
+            let header_only: *const Self = core::ptr::slice_from_raw_parts(header_byte_ptr, 0) as *const Self;
+            let capacity = (*header_only).capacity;
+            let fat: *mut Self = core::ptr::slice_from_raw_parts_mut(header_byte_ptr, capacity) as *mut Self;
+            NonNull::new_unchecked(fat)
+        }
+    }
+}
+
+/// Recover the chunk header for `value` by masking within its
+/// `CHUNK_ALIGN` tile.
+///
+/// # Safety
+///
+/// `value` must come from an arena allocation whose chunk flavor is
+/// `C` and still satisfy the chunk-header invariant.
+#[inline]
+pub(crate) unsafe fn chunk_of<C: ChunkHeader + ?Sized, T: ?Sized>(value: NonNull<T>) -> NonNull<C> {
+    let raw = value.as_ptr().cast::<u8>();
+    let offset_within_chunk = (raw as usize) & (CHUNK_ALIGN - 1);
+    // SAFETY: the chunk-header invariant says this lands on the
+    // header, and `byte_sub` preserves provenance; rebuilding the fat
+    // pointer is delegated to the per-flavor impl.
+    unsafe {
+        let header_byte_ptr = raw.byte_sub(offset_within_chunk);
+        C::fat_from_header_bytes(header_byte_ptr)
+    }
+}
+
 /// Recover the [`LocalChunk`] header for `value`.
 ///
 /// # Safety
@@ -24,20 +98,8 @@ use super::shared_chunk::SharedChunk;
 /// still satisfy the chunk-header invariant.
 #[inline]
 pub(crate) unsafe fn local_chunk_of<T: ?Sized, A: Allocator + Clone>(value: NonNull<T>) -> NonNull<LocalChunk<A>> {
-    let raw = value.as_ptr().cast::<u8>();
-    let offset_within_chunk = (raw as usize) & (CHUNK_ALIGN - 1);
-    // SAFETY: the chunk-header invariant says this lands on the
-    // header, and `byte_sub` preserves provenance.
-    let header_byte_ptr = unsafe { raw.byte_sub(offset_within_chunk) };
-
-    // Read the sized prefix so we can rebuild the fat chunk pointer.
-    let header_only: *const LocalChunk<A> = core::ptr::slice_from_raw_parts(header_byte_ptr, 0) as *const LocalChunk<A>;
-    // SAFETY: chunk-header invariant — header prefix is live and initialized.
-    let capacity = unsafe { (*header_only).capacity };
-
-    let fat: *mut LocalChunk<A> = core::ptr::slice_from_raw_parts_mut(header_byte_ptr, capacity) as *mut LocalChunk<A>;
-    // SAFETY: `value` is non-null, and `byte_sub` stays in the same allocation.
-    unsafe { NonNull::new_unchecked(fat) }
+    // SAFETY: forwarded to caller's contract on `value`.
+    unsafe { chunk_of::<LocalChunk<A>, T>(value) }
 }
 
 /// Recover the [`SharedChunk`] header for `value`.
@@ -48,16 +110,6 @@ pub(crate) unsafe fn local_chunk_of<T: ?Sized, A: Allocator + Clone>(value: NonN
 /// allocation and still satisfy the chunk-header invariant.
 #[inline]
 pub(crate) unsafe fn shared_chunk_of<T: ?Sized, A: Allocator + Clone>(value: NonNull<T>) -> NonNull<SharedChunk<A>> {
-    let raw = value.as_ptr().cast::<u8>();
-    let offset_within_chunk = (raw as usize) & (CHUNK_ALIGN - 1);
-    // SAFETY: same rationale as `local_chunk_of`.
-    let header_byte_ptr = unsafe { raw.byte_sub(offset_within_chunk) };
-
-    let header_only: *const SharedChunk<A> = core::ptr::slice_from_raw_parts(header_byte_ptr, 0) as *const SharedChunk<A>;
-    // SAFETY: chunk-header invariant — header prefix is live and initialized.
-    let capacity = unsafe { (*header_only).capacity };
-
-    let fat: *mut SharedChunk<A> = core::ptr::slice_from_raw_parts_mut(header_byte_ptr, capacity) as *mut SharedChunk<A>;
-    // SAFETY: `header_byte_ptr` is non-null (see `local_chunk_of`).
-    unsafe { NonNull::new_unchecked(fat) }
+    // SAFETY: forwarded to caller's contract on `value`.
+    unsafe { chunk_of::<SharedChunk<A>, T>(value) }
 }

--- a/crates/multitude/src/internal/shared_chunk.rs
+++ b/crates/multitude/src/internal/shared_chunk.rs
@@ -283,6 +283,15 @@ impl<A: Allocator + Clone> SharedChunk<A> {
         unsafe { NonNull::new_unchecked(p) }
     }
 
+    /// Safe `&self`-based payload-base accessor. The borrow proves the
+    /// chunk is live, so [`Self::data_ptr`]'s safety condition is met.
+    #[inline]
+    pub(crate) fn data(&self) -> NonNull<u8> {
+        // SAFETY: `&self` proves the chunk is live for at least the
+        // duration of this borrow.
+        unsafe { Self::data_ptr(NonNull::from(self)) }
+    }
+
     /// Atomically bump the refcount. Safe because `&self` proves the
     /// chunk is live (some other party already holds a refcount).
     #[inline]
@@ -401,50 +410,11 @@ impl<A: Allocator + Clone> SharedChunk<A> {
         // from outside the refcount-zero state, this store must be
         // upgraded to Release to pair with the consumer's Acquire load.
         unsafe { (*chunk.as_ptr()).drop_count.store(0, Ordering::Relaxed) };
-        let top = capacity;
-        let base = top - count * mem::size_of::<DropEntry>();
         // SAFETY: chunk-layout invariant — `count` densely packed,
-        // naturally aligned `DropEntry`s live at `data + base`.
-        #[expect(
-            clippy::cast_ptr_alignment,
-            reason = "chunk payloads are CHUNK_ALIGN aligned; `data + base` is naturally `DropEntry`-aligned by construction"
-        )]
-        // SAFETY: `base = capacity - count * size_of::<DropEntry>()`
-        // is the byte offset of the first entry; `data` is the chunk's
-        // payload base. Together they address `count` initialized
-        // `DropEntry`s.
-        let entries_ptr = unsafe { data.add(base).cast::<DropEntry>() };
-        for i in 0..count {
-            // SAFETY: `i < count`; all `count` entries are initialized
-            // at allocation time.
-            let entry = unsafe { &*entries_ptr.add(i) };
-            // SAFETY: payload-extent + drop-shim invariants.
-            let value_ptr = unsafe { data.add(entry.value_offset as usize) };
-            let f = entry.load_drop_fn(Ordering::Relaxed);
-            // Isolate each call (when `std` is available) so a panicking
-            // `T::Drop` doesn't abort the chunk reclamation path — at
-            // worst we leak that value's resources; the chunk itself
-            // still gets freed. Under `no_std` an unwinding `T::Drop`
-            // forces a process abort via the `AbortOnUnwind` guard
-            // below: this is consistent with `core` semantics under
-            // `panic = abort`, and prevents the panic from leaking
-            // the chunk by propagating past `route_release` under
-            // `panic = unwind`.
-            #[cfg(feature = "std")]
-            {
-                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    // SAFETY: drop-shim invariant.
-                    unsafe { f(value_ptr, entry.len as usize) };
-                }));
-            }
-            #[cfg(not(feature = "std"))]
-            {
-                let abort_guard = crate::internal::drop_list::AbortOnUnwind;
-                // SAFETY: drop-shim invariant.
-                unsafe { f(value_ptr, entry.len as usize) };
-                core::mem::forget(abort_guard);
-            }
-        }
+        // naturally aligned `DropEntry`s live at the tail of the
+        // payload; each one's `(value_offset, len, drop_fn)` satisfies
+        // the drop-shim invariant.
+        unsafe { crate::internal::drop_list::replay_drop_entries(data, capacity, count) };
     }
 
     /// Tear the chunk down: drop the header fields and free the
@@ -455,25 +425,24 @@ impl<A: Allocator + Clone> SharedChunk<A> {
     /// Caller must own the chunk exclusively (refcount zero) and the
     /// drop list must have already been replayed.
     pub(crate) unsafe fn free_backing(chunk: NonNull<Self>) {
-        // SAFETY: caller owns the chunk exclusively.
-        let capacity = unsafe { (*chunk.as_ptr()).capacity };
-
-        let total_bytes = alloc_size::<A>(header_size::<A>() + capacity);
-        let layout =
-            Layout::from_size_align(total_bytes, chunk_align::<A>()).expect("layout was valid at allocation time, must remain valid here");
-
         // Move `allocator` out so we can free *after* dropping the
         // other header fields.
-        // SAFETY: caller owns the chunk; `allocator` is live.
-        let allocator: A = unsafe { core::ptr::read(core::ptr::addr_of!((*chunk.as_ptr()).allocator)) };
-        // SAFETY: each `addr_of!` field is a live value and we drop
-        // it exactly once.
-        unsafe {
+        // SAFETY: caller owns the chunk exclusively; `capacity`,
+        // `allocator`, and each `addr_of!`d header field are live values
+        // dropped exactly once here.
+        let (capacity, allocator) = unsafe {
+            let capacity = (*chunk.as_ptr()).capacity;
+            let allocator: A = core::ptr::read(core::ptr::addr_of!((*chunk.as_ptr()).allocator));
             core::ptr::drop_in_place(core::ptr::addr_of_mut!((*chunk.as_ptr()).provider));
             core::ptr::drop_in_place(core::ptr::addr_of_mut!((*chunk.as_ptr()).refcount));
             core::ptr::drop_in_place(core::ptr::addr_of_mut!((*chunk.as_ptr()).drop_count));
             core::ptr::drop_in_place(core::ptr::addr_of_mut!((*chunk.as_ptr()).next));
-        }
+            (capacity, allocator)
+        };
+
+        let total_bytes = alloc_size::<A>(header_size::<A>() + capacity);
+        let layout =
+            Layout::from_size_align(total_bytes, chunk_align::<A>()).expect("layout was valid at allocation time, must remain valid here");
 
         let raw_ptr = chunk.as_ptr().cast::<u8>();
         // SAFETY: chunk-header invariant — pointer + layout matches

--- a/crates/multitude/src/rc.rs
+++ b/crates/multitude/src/rc.rs
@@ -176,8 +176,7 @@ impl<T, A: Allocator + Clone> Rc<MaybeUninit<T>, A> {
         let ptr = self.ptr.as_non_null().cast::<T>();
         if needs_drop::<T>() {
             let chunk = self.chunk();
-            // SAFETY: caller-held refcount keeps the chunk live.
-            let data_addr = unsafe { LocalChunk::<A>::data_ptr(NonNull::from(chunk)) }.as_ptr() as usize;
+            let data_addr = chunk.data().as_ptr() as usize;
             let value_offset = self.ptr.as_ptr() as *const u8 as usize - data_addr;
             let entry = chunk
                 .drop_entries()
@@ -238,8 +237,7 @@ impl<T, A: Allocator + Clone> Rc<[MaybeUninit<T>], A> {
         let len = old_ptr.len();
         if needs_drop::<T>() {
             let chunk = self.chunk();
-            // SAFETY: caller-held refcount keeps the chunk live.
-            let data_addr = unsafe { LocalChunk::<A>::data_ptr(NonNull::from(chunk)) }.as_ptr() as usize;
+            let data_addr = chunk.data().as_ptr() as usize;
             let value_offset = old_ptr.as_ptr() as *const u8 as usize - data_addr;
             let entry = chunk
                 .drop_entries()


### PR DESCRIPTION
Reduce production unsafe-block count from 693 to 646 (-47, -6.8%) by introducing small abstractions that isolate repeated unsafety:

- Safe `data(&self)` accessor on `LocalChunk` and `SharedChunk`, used wherever a chunk reference is already in hand.
- `ChunkHeader` trait + generic `chunk_of` for header-to-chunk recovery, unifying local and shared variants.
- `replay_drop_entries` helper shared by drop-list teardown paths.
- `DropEntry::write_at_offset` consolidates drop-entry installation.
- `aligned_payload_offset` folds align + extent hints into one site.
- `free_backing` field teardown collapsed into a single unsafe block.
- `u16_truncate_unchecked` replaces the debug_assert + assert_unchecked + unwrap_unchecked triplet at 14 sites.
- `CurrentChunk::chunk_assume_present` unifies post-bump-fit chunk presence assumptions across 9 sites.
- `value_offset_in_chunk<C: ChunkKind>` collapses the data_ptr + offset-subtract + u16-truncate dance at 7 sites.

Net surface: +10 unsafe fns (helpers), -47 unsafe blocks at call sites. No behavior change; all multitude tests and clippy pass.