### PR TITLE
test: draft-PR workflow trigger check (will close)

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -556,3 +556,4 @@ addressability
 bumpable
 dereferenceable
 NonNull
+# Diagnostic: draft-PR workflow trigger test


### PR DESCRIPTION
Diagnostic PR to test hypothesis: draft PRs are not running validation workflows.

This PR is intentionally a one-line .spelling change.

**For the human reviewer:**
1. Check whether any checks (beyond license/cla) appear while this PR is in draft state.
2. Mark this PR as **Ready for review** to verify whether un-drafting triggers workflows.
3. Close + delete branch when done — this is a throwaway diagnostic.