### PR TITLE
verify: ARM Miri reproducer for chacha20 NEON failure (do not merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "_miri_chacha20_repro"
+version = "0.0.0"
+dependencies = [
+ "rand 0.10.1",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,7 +325,7 @@ dependencies = [
  "bolero-kani",
  "bolero-libfuzzer",
  "cfg-if",
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -341,7 +348,7 @@ dependencies = [
  "bolero-generator",
  "lazy_static",
  "pretty-hex",
- "rand",
+ "rand 0.9.4",
  "rand_xoshiro",
 ]
 
@@ -354,7 +361,7 @@ dependencies = [
  "bolero-generator-derive",
  "either",
  "getrandom 0.3.4",
- "rand_core",
+ "rand_core 0.9.5",
  "rand_xoshiro",
 ]
 
@@ -565,6 +572,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +719,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpulist"
@@ -1318,6 +1345,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1950,7 +1978,7 @@ dependencies = [
  "libc",
  "new_zealand",
  "nonempty",
- "rand",
+ "rand 0.9.4",
  "smallvec",
  "windows",
 ]
@@ -2292,7 +2320,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand",
+ "rand 0.9.4",
  "thiserror",
  "tokio",
 ]
@@ -2624,7 +2652,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2634,7 +2673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2647,12 +2686,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3142,7 +3187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/_miri_chacha20_repro/Cargo.toml
+++ b/crates/_miri_chacha20_repro/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "_miri_chacha20_repro"
+description = "Throwaway crate that reproduces a Miri unsupported-operation failure caused by rand 0.10 + chacha20 NEON on aarch64. Not for publishing."
+version = "0.0.0"
+publish = false
+
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/_miri_chacha20_repro"
+
+[dev-dependencies]
+rand = { version = "0.10", default-features = false, features = ["std", "thread_rng", "std_rng", "sys_rng"] }

--- a/crates/_miri_chacha20_repro/src/lib.rs
+++ b/crates/_miri_chacha20_repro/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Throwaway reproducer crate to verify the precise failure mode of
+//! `rand` 0.10's default `ThreadRng` (backed by `chacha20`'s NEON
+//! backend) under Miri on `aarch64-unknown-linux-gnu`.
+//!
+//! This crate intentionally has no production code; the single test
+//! below is the minimum surface area required to trigger the
+//! `llvm.aarch64.neon.tbl1.v16i8` unsupported-operation abort in
+//! Miri so the reproducer can be cited in upstream bug reports.
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn rand_random_u32_triggers_chacha20_generate() {
+        // A single draw is enough: ThreadRng's BlockRng will call
+        // chacha20::ChaChaCore::generate, which dispatches to the
+        // NEON backend on aarch64 and ends up invoking vqtbl1q_u8.
+        let _: u32 = rand::random();
+    }
+}


### PR DESCRIPTION
Throwaway PR to let CI's extended-analysis (aarch64 Miri) confirm the exact failure mode of `rand` 0.10 + `chacha20` 0.10's NEON backend on `aarch64-unknown-linux-gnu`.

Not for merging — once the ARM Miri job has failed with the expected `llvm.aarch64.neon.tbl1.v16i8` unsupported-operation error, this branch will be deleted and the verified evidence cited in upstream bug reports against:
- `rust-lang/miri`
- `RustCrypto/stream-ciphers` (`chacha20` crate)

See parent PR #457 (`chore/msrv-1.91`) where the same failure originally surfaced.