### PR TITLE
chore: Tidy cargo dependencies to unbreak publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,9 +3651,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,21 +56,21 @@ tick = { path = "crates/tick", default-features = false, version = "0.3.1" }
 uniflight = { path = "crates/uniflight", default-features = false, version = "0.2.1" }
 
 # external dependencies
-ahash = { version = "0.8", default-features = false }
+ahash = { version = "0.8.4", default-features = false }
 alloc_tracker = { version = "0.5.9", default-features = false }
 allocator-api2 = { version = "0.4.0", default-features = false }
 anyhow = { version = "1.0.100", default-features = false }
-async-once-cell = { version = "0.5", default-features = false }
+async-once-cell = { version = "0.5.0", default-features = false }
 bolero = { version = "0.13.4", default-features = false }
 bumpalo = { version = "3.20.2", default-features = false }
-bytemuck = { version = "1.25", default-features = false }
+bytemuck = { version = "1.25.0", default-features = false }
 bytes = { version = "1.11.1", default-features = false }
 chrono = { version = "0.4.40", default-features = false }
 chrono-tz = { version = "0.10.4", default-features = false }
 chumsky = { version = "0.13.0", default-features = false }
 criterion = { version = "0.8.1", default-features = false }
 darling = { version = "0.23.0", default-features = false }
-dashmap = { version = "6.1", default-features = false }
+dashmap = { version = "6.1.0", default-features = false }
 derive_more = { version = "2.0.1", default-features = false }
 duct = { version = "1.1.1", default-features = false }
 dynosaur = { version = "0.3.0", default-features = false }
@@ -85,7 +85,7 @@ hashbrown = { version = "0.17.0", default-features = false }
 http = { version = "1.4.1", default-features = false, features = ["std"] }
 http-body = { version = "1.0.1", default-features = false }
 http-body-util = { version = "0.1.3", default-features = false }
-hyper = { version = "1.6.0", default-features = false }
+hyper = { version = "1.7.0", default-features = false }
 hyper-rustls = { version = "0.27.9", default-features = false }
 hyper-tls = { version = "0.6.0", default-features = false }
 hyper-util = { version = "0.1.16", default-features = false }
@@ -99,7 +99,7 @@ mockall = { version = "0.14.0", default-features = false }
 moka = { version = "0.12.14", default-features = false }
 mutants = { version = "0.0.3", default-features = false }
 native-tls = { version = "0.2.18", default-features = false }
-new_zealand = { version = "1.0.1", default-features = false }
+new_zealand = { version = "1.0.4", default-features = false }
 nm = { version = "0.1.21", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 once_cell = { version = "1.21.3", default-features = false }
@@ -119,13 +119,14 @@ ptr_meta = { version = "0.3.1", default-features = false }
 quote = { version = "1.0.42", default-features = false }
 rapidhash = { version = "4.1.1", default-features = false }
 regex = { version = "1.12.2", default-features = false }
-rstest = { version = "0.26", default-features = false }
+rstest = { version = "0.26.0", default-features = false }
 rustc-hash = { version = "2.1.0", default-features = false }
 rustls = { version = "0.23.40", default-features = false }
 serde = { version = "1.0.228", default-features = false }
 serde_core = { version = "1.0.228", default-features = false }
 serde_json = { version = "1.0.145", default-features = false }
 smallvec = { version = "1.15.1", default-features = false }
+smol = { version = "2.0.0", default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
 syn = { version = "2.0.111", default-features = false }
 thiserror = { version = "2.0.17", default-features = false }
@@ -146,7 +147,7 @@ widestring = { version = "1.2.1", default-features = false }
 windows-sys = { version = "0.61.2", default-features = false }
 wiremock = { version = "0.6.5", default-features = false }
 xxhash-rust = { version = "0.8.15", default-features = false }
-zerocopy = { version = "0.8", default-features = false }
+zerocopy = { version = "0.8.26", default-features = false }
 
 [workspace.lints.rust]
 ambiguous_negative_literals = "warn"

--- a/crates/anyspawn/Cargo.toml
+++ b/crates/anyspawn/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "async", "runtime", "futures"]
 categories = ["asynchronous"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/anyspawn"
 
 [package.metadata.cargo_check_external_types]
@@ -40,8 +40,8 @@ tokio = { workspace = true, features = ["rt"], optional = true }
 criterion = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 opentelemetry = { workspace = true, features = ["futures"] }
-smol = "2"
-static_assertions.workspace = true
+smol = { workspace = true }
+static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 
 [[test]]

--- a/crates/bytesbuf/Cargo.toml
+++ b/crates/bytesbuf/Cargo.toml
@@ -9,15 +9,12 @@ readme = "README.md"
 keywords = ["oxidizer", "buffers", "io", "zero-copy"]
 categories = ["data-structures", "network-programming"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf"
-
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-libc.workspace = true
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
@@ -43,21 +40,24 @@ test-util = []
 
 [dependencies]
 bytes = { workspace = true, features = ["std"], optional = true }
-infinity_pool.workspace = true
-new_zealand.workspace = true
-nm.workspace = true
-num-traits.workspace = true
+infinity_pool = { workspace = true }
+new_zealand = { workspace = true }
+nm = { workspace = true }
+num-traits = { workspace = true }
 smallvec = { workspace = true, features = ["const_new", "union"] }
-thread_aware.workspace = true
+thread_aware = { workspace = true }
 
 [dev-dependencies]
-alloc_tracker.workspace = true
+alloc_tracker = { workspace = true }
 bytes = { workspace = true, features = ["std"] }
-criterion.workspace = true
-mutants.workspace = true
-static_assertions.workspace = true
-testing_aids.workspace = true
-windows-sys.workspace = true
+criterion = { workspace = true }
+mutants = { workspace = true }
+static_assertions = { workspace = true }
+testing_aids = { path = "../testing_aids" }
+windows-sys = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+libc = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/bytesbuf_io/Cargo.toml
+++ b/crates/bytesbuf_io/Cargo.toml
@@ -39,11 +39,11 @@ ohno = { workspace = true }
 trait-variant = { workspace = true }
 
 [dev-dependencies]
-bytesbuf = { workspace = true, features = ["test-util"] }
+bytesbuf = { path = "../bytesbuf", features = ["test-util"] }
 futures = { workspace = true }
 mutants = { workspace = true }
 new_zealand = { workspace = true }
-testing_aids = { workspace = true }
+testing_aids = { path = "../testing_aids" }
 
 [lints]
 workspace = true

--- a/crates/cachet/Cargo.toml
+++ b/crates/cachet/Cargo.toml
@@ -63,9 +63,9 @@ uniflight = { workspace = true }
 
 [dev-dependencies]
 alloc_tracker = { workspace = true }
-bytesbuf = { workspace = true }
-cachet_memory = { workspace = true }
-cachet_tier = { workspace = true, features = ["test-util"] }
+bytesbuf = { path = "../bytesbuf" }
+cachet_memory = { path = "../cachet_memory" }
+cachet_tier = { path = "../cachet_tier", features = ["test-util"] }
 criterion = { workspace = true }
 dynosaur = { workspace = true }
 opentelemetry = { workspace = true, features = [
@@ -74,11 +74,11 @@ opentelemetry = { workspace = true, features = [
 ] }
 opentelemetry_sdk = { workspace = true, features = ["logs", "testing"] }
 postcard = { workspace = true }
-recoverable = { workspace = true }
+recoverable = { path = "../recoverable" }
 seatbelt = { path = "../seatbelt", features = ["retry", "tower-service"] }
 serde = { workspace = true, features = ["derive"] }
 testing_aids = { path = "../testing_aids" }
-tick = { workspace = true, features = ["test-util", "tokio"] }
+tick = { path = "../tick", features = ["test-util", "tokio"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true, features = ["std"] }
 tracing-subscriber = { workspace = true }

--- a/crates/cachet_memory/Cargo.toml
+++ b/crates/cachet_memory/Cargo.toml
@@ -37,8 +37,8 @@ thread_aware = { workspace = true, features = ["derive"] }
 criterion = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 mutants = { workspace = true }
-ohno = { workspace = true, features = ["test-util"] }
-tick = { workspace = true, features = ["test-util"] }
+ohno = { path = "../ohno", features = ["test-util"] }
+tick = { path = "../tick", features = ["test-util"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 
 [[bench]]

--- a/crates/cachet_tier/Cargo.toml
+++ b/crates/cachet_tier/Cargo.toml
@@ -38,7 +38,7 @@ recoverable = { workspace = true }
 
 [dev-dependencies]
 parking_lot = { workspace = true }
-tick = { workspace = true, features = ["test-util"] }
+tick = { path = "../tick", features = ["test-util"] }
 tokio = { workspace = true, features = [
     "macros",
     "rt",

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy"
 
 [package.metadata.docs.rs]
@@ -34,7 +34,7 @@ serde = ["dep:serde_core"]
 xxh3 = ["dep:xxhash-rust"]
 
 [dependencies]
-data_privacy_macros.workspace = true
+data_privacy_macros = { workspace = true }
 rapidhash = { workspace = true, optional = true }
 rustc-hash = { workspace = true, features = ["std"] }
 serde_core = { workspace = true, optional = true, default-features = false, features = ["std"] }
@@ -42,7 +42,7 @@ xxhash-rust = { workspace = true, optional = true, features = ["xxh3"] }
 
 [dev-dependencies]
 derive_more = { workspace = true, features = ["constructor", "from"] }
-mutants.workspace = true
+mutants = { workspace = true }
 once_cell = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/crates/data_privacy_macros/Cargo.toml
+++ b/crates/data_privacy_macros/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy_macros"
 
 [package.metadata.cargo_check_external_types]
@@ -26,10 +26,10 @@ all-features = true
 proc-macro = true
 
 [dependencies]
-data_privacy_macros_impl.workspace = true
+data_privacy_macros_impl = { workspace = true }
 
 [dev-dependencies]
-mutants.workspace = true
+mutants = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/data_privacy_macros_impl/Cargo.toml
+++ b/crates/data_privacy_macros_impl/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "compliance", "privacy", "redaction", "scrubbing"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy_macros_impl"
 
 [package.metadata.cargo_check_external_types]
@@ -27,14 +27,14 @@ allowed_external_types = [
 all-features = true
 
 [dependencies]
-proc-macro2.workspace = true
-quote.workspace = true
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["derive", "full", "parsing", "printing", "proc-macro"] }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml"] }
-mutants.workspace = true
-prettyplease.workspace = true
+mutants = { workspace = true }
+prettyplease = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/fetch_hyper/Cargo.toml
+++ b/crates/fetch_hyper/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "hyper", "fetch", "http", "tls"]
 categories = ["network-programming"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fetch_hyper"
 
 [package.metadata.cargo_check_external_types]
@@ -47,7 +47,7 @@ anyspawn = { workspace = true }
 bytesbuf = { workspace = true }
 http_extensions = { workspace = true }
 layered = { workspace = true, features = ["dynamic-service"] }
-ohno.workspace = true
+ohno = { workspace = true }
 seatbelt = { workspace = true }
 templated_uri = { workspace = true }
 tick = { workspace = true }
@@ -74,21 +74,21 @@ rustls = { workspace = true, features = ["tls12", "std"], default-features = fal
 tokio-native-tls = { workspace = true, optional = true }
 
 [dev-dependencies]
-anyspawn = { workspace = true, features = ["tokio"] }
+anyspawn = { path = "../anyspawn", features = ["tokio"] }
 bytes = { workspace = true }
 futures = { workspace = true, features = ["std", "executor"] }
-http_extensions = { workspace = true, features = ["test-util"] }
+http_extensions = { path = "../http_extensions", features = ["test-util"] }
 hyper-rustls = { workspace = true, features = ["http1", "http2"] }
 hyper-tls = { workspace = true, features = ["alpn"] }
 hyper-util = { workspace = true, features = ["client-legacy", "http1", "http2", "tokio"] }
 insta = { workspace = true }
-mutants.workspace = true
+mutants = { workspace = true }
 native-tls = { workspace = true }
-ohno = { workspace = true, features = ["test-util"] }
+ohno = { path = "../ohno", features = ["test-util"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "testing"], default-features = false }
 rustls = { workspace = true, features = ["tls12", "std", "aws-lc-rs"] }
-testing_aids = { workspace = true }
-tick = { workspace = true, features = ["tokio", "test-util"] }
+testing_aids = { path = "../testing_aids" }
+tick = { path = "../tick", features = ["tokio", "test-util"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "rt", "net"] }
 tokio-native-tls = { workspace = true }
 tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/crates/fundle/Cargo.toml
+++ b/crates/fundle/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "di"]
 categories = ["rust-patterns"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fundle"
 
 [package.metadata.cargo_check_external_types]
@@ -23,10 +23,10 @@ allowed_external_types = ["fundle_macros::*"]
 all-features = true
 
 [dependencies]
-fundle_macros.workspace = true
+fundle_macros = { workspace = true }
 
 [dev-dependencies]
-trybuild.workspace = true
+trybuild = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/fundle_macros/Cargo.toml
+++ b/crates/fundle_macros/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "di", "proc-macro"]
 categories = ["rust-patterns"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fundle_macros"
 
 [package.metadata.docs.rs]
@@ -23,10 +23,10 @@ all-features = true
 proc-macro = true
 
 [dependencies]
-fundle_macros_impl.workspace = true
+fundle_macros_impl = { workspace = true }
 
 [dev-dependencies]
-mutants.workspace = true
+mutants = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/fundle_macros_impl/Cargo.toml
+++ b/crates/fundle_macros_impl/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "di", "proc-macro"]
 categories = ["rust-patterns"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fundle_macros_impl"
 
 [package.metadata.cargo_check_external_types]
@@ -23,26 +23,15 @@ allowed_external_types = ["proc_macro2::*", "syn::error::*"]
 all-features = true
 
 [dependencies]
-proc-macro2.workspace = true
-quote.workspace = true
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["derive", "parsing", "proc-macro", "full", "extra-traits", "printing"] }
 
 [dev-dependencies]
-insta.workspace = true
-mutants.workspace = true
-prettyplease.workspace = true
-
-[dev-dependencies.syn]
-workspace = true
-features = [
-    "derive",
-    "parsing",
-    "proc-macro",
-    "full",
-    "extra-traits",
-    "printing",
-    "clone-impls",
-]
+insta = { workspace = true }
+mutants = { workspace = true }
+prettyplease = { workspace = true }
+syn = { workspace = true, features = ["derive", "parsing", "proc-macro", "full", "extra-traits", "printing", "clone-impls"] }
 
 [lints]
 workspace = true

--- a/crates/http_extensions/Cargo.toml
+++ b/crates/http_extensions/Cargo.toml
@@ -8,11 +8,11 @@ version = "0.4.2"
 readme = "README.md"
 keywords = ["oxidizer", "http", "extensions", "client", "server"]
 categories = ["network-programming"]
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/http_extensions"
 
 [package.metadata.cargo_check_external_types]
@@ -57,42 +57,42 @@ json = ["dep:serde_core", "dep:serde_json"]
 test-util = ["tick/test-util"]
 
 [dependencies]
-bytes.workspace = true
+bytes = { workspace = true }
 bytesbuf = { workspace = true, features = ["bytes-compat"] }
 futures = { workspace = true, features = ["std"] }
-http.workspace = true
-http-body.workspace = true
-http-body-util.workspace = true
-layered.workspace = true
-ohno.workspace = true
-pin-project.workspace = true
-recoverable.workspace = true
+http = { workspace = true }
+http-body = { workspace = true }
+http-body-util = { workspace = true }
+layered = { workspace = true }
+ohno = { workspace = true }
+pin-project = { workspace = true }
+recoverable = { workspace = true }
 serde_core = { workspace = true, optional = true }
 serde_json = { workspace = true, features = ["std"], optional = true }
-templated_uri.workspace = true
+templated_uri = { workspace = true }
 thread_aware = { workspace = true, features = ["derive"] }
 tick = { workspace = true, features = ["fmt"] }
 
 [dev-dependencies]
-alloc_tracker.workspace = true
-bytesbuf = { workspace = true, features = ["bytes-compat", "test-util"] }
-criterion.workspace = true
-data_privacy.workspace = true
+alloc_tracker = { workspace = true }
+bytesbuf = { path = "../bytesbuf", features = ["bytes-compat", "test-util"] }
+criterion = { workspace = true }
+data_privacy = { path = "../data_privacy" }
 futures = { workspace = true, features = ["std", "executor"] }
 hyper = { workspace = true, features = ["client", "http1"] }
 hyper-util = { workspace = true, features = ["server-auto", "tokio"] }
-layered = { workspace = true, features = ["intercept", "dynamic-service"] }
-mutants.workspace = true
-ohno = { workspace = true, features = ["test-util", "app-err"] }
+layered = { path = "../layered", features = ["intercept", "dynamic-service"] }
+mutants = { workspace = true }
+ohno = { path = "../ohno", features = ["test-util", "app-err"] }
 serde = { workspace = true, features = ["derive"] }
-serde_core.workspace = true
+serde_core = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
-static_assertions.workspace = true
-templated_uri = { workspace = true, features = ["uuid"] }
-testing_aids.workspace = true
-tick = { workspace = true, features = ["test-util", "tokio"] }
+static_assertions = { workspace = true }
+templated_uri = { path = "../templated_uri", features = ["uuid"] }
+testing_aids = { path = "../testing_aids" }
+tick = { path = "../tick", features = ["test-util", "tokio"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net"] }
-uuid.workspace = true
+uuid = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -9,15 +9,12 @@ readme = "README.md"
 keywords = ["arena", "memory", "allocator", "bump", "rc"]
 categories = ["memory-management", "data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/multitude"
-
-[target.'cfg(loom)'.dev-dependencies]
-loom.workspace = true
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
@@ -63,12 +60,6 @@ zerocopy = { workspace = true, optional = true }
 [target.'cfg(loom)'.dependencies]
 loom = { workspace = true }
 
-# Workspace dep declares `default-features = false`; we re-enable `default` here
-# (which pulls in the `benchmark` feature with `library_benchmark`,
-# `library_benchmark_group!`, and `gungraun::main!`) only on Linux.
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-gungraun = { workspace = true, features = ["default"] }
-
 [dev-dependencies]
 allocator-api2 = { workspace = true, features = ["alloc"] }
 bolero = { workspace = true, features = ["std"] }
@@ -76,9 +67,18 @@ bolero = { workspace = true, features = ["std"] }
 # because bolero-libfuzzer 0.13.0 references `bolero_engine::any::run`
 # but does not itself activate that feature on `bolero-engine`.
 bumpalo = { workspace = true, features = ["collections"] }
-criterion.workspace = true
-mutants.workspace = true
-serde_json.workspace = true
+criterion = { workspace = true }
+mutants = { workspace = true }
+serde_json = { workspace = true }
+
+[target.'cfg(loom)'.dev-dependencies]
+loom = { workspace = true }
+
+# Workspace dep declares `default-features = false`; we re-enable `default` here
+# (which pulls in the `benchmark` feature with `library_benchmark`,
+# `library_benchmark_group!`, and `gungraun::main!`) only on Linux.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+gungraun = { workspace = true, features = ["default"] }
 
 [lints]
 workspace = true

--- a/crates/ohno/Cargo.toml
+++ b/crates/ohno/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "error", "backtrace"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/ohno"
 
 [package.metadata.cargo_check_external_types]
@@ -27,16 +27,16 @@ app-err = []
 test-util = []
 
 [dependencies]
-ohno_macros.workspace = true
-typeid.workspace = true
+ohno_macros = { workspace = true }
+typeid = { workspace = true }
 
 [dev-dependencies]
-futures.workspace = true
-insta.workspace = true
-mutants.workspace = true
+futures = { workspace = true }
+insta = { workspace = true }
+mutants = { workspace = true }
 regex = { workspace = true, features = [ "unicode-perl"] }
-testing_aids.workspace = true
-thiserror.workspace = true
+testing_aids = { path = "../testing_aids" }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time", "rt-multi-thread"] }
 
 [lints]

--- a/crates/ohno_macros/Cargo.toml
+++ b/crates/ohno_macros/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "error", "backtrace"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/ohno_macros"
 
 [package.metadata.docs.rs]
@@ -23,14 +23,14 @@ all-features = true
 proc-macro = true
 
 [dependencies]
-proc-macro2.workspace = true
-quote.workspace = true
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["full", "derive", "printing", "parsing", "extra-traits", "proc-macro"] }
 
 [dev-dependencies]
-insta.workspace = true
-mutants.workspace = true
-prettyplease.workspace = true
+insta = { workspace = true }
+mutants = { workspace = true }
+prettyplease = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/recoverable/Cargo.toml
+++ b/crates/recoverable/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "resilience", "metadata", "classification", "oxidizer"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/recoverable"
 
 [package.metadata.docs.rs]
@@ -22,10 +22,10 @@ all-features = true
 [dependencies]
 
 [dev-dependencies]
-insta.workspace = true
-ohno.workspace = true
-static_assertions.workspace = true
-testing_aids.workspace = true
+insta = { workspace = true }
+ohno = { path = "../ohno" }
+static_assertions = { workspace = true }
+testing_aids = { path = "../testing_aids" }
 
 [lints]
 workspace = true

--- a/crates/seatbelt/Cargo.toml
+++ b/crates/seatbelt/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "resilience", "layered", "recovery", "retry"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/seatbelt"
 
 [package.metadata.cargo_check_external_types]
@@ -65,29 +65,29 @@ tower-service = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
-alloc_tracker.workspace = true
-criterion.workspace = true
-fastrand.workspace = true
+alloc_tracker = { workspace = true }
+criterion = { workspace = true }
+fastrand = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 futures-util = { workspace = true, features = ["alloc"] }
-http.workspace = true
+http = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 jiff = { workspace = true, default-features = true, features = ["serde"] }
-layered = { workspace = true, features = ["tower-service", "dynamic-service"] }
-mutants.workspace = true
-ohno = { workspace = true, features = ["app-err"] }
+layered = { path = "../layered", features = ["tower-service", "dynamic-service"] }
+mutants = { workspace = true }
+ohno = { path = "../ohno", features = ["app-err"] }
 opentelemetry = { workspace = true, default-features = false, features = ["metrics"] }
 opentelemetry-stdout = { workspace = true, default-features = false, features = ["metrics", "logs"] }
 opentelemetry_sdk = { workspace = true, default-features = false, features = ["metrics", "testing", "experimental_metrics_custom_reader"] }
-rstest.workspace = true
+rstest = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true }
-static_assertions.workspace = true
-tick = { workspace = true, features = ["test-util", "tokio"] }
+static_assertions = { workspace = true }
+tick = { path = "../tick", features = ["test-util", "tokio"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tower = { workspace = true, features = ["util"] }
-tower-service.workspace = true
-tracing.workspace = true
+tower-service = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "std"] }
 
 [[example]]

--- a/crates/seatbelt_http/Cargo.toml
+++ b/crates/seatbelt_http/Cargo.toml
@@ -45,11 +45,11 @@ tick = { workspace = true, optional = true }
 
 [dev-dependencies]
 futures = { workspace = true, features = ["executor"] }
-http_extensions = { workspace = true, features = ["test-util"] }
-layered = { workspace = true }
+http_extensions = { path = "../http_extensions", features = ["test-util"] }
+layered = { path = "../layered" }
 mutants = { workspace = true }
-ohno = { workspace = true }
-tick = { workspace = true, features = ["test-util"] }
+ohno = { path = "../ohno" }
+tick = { path = "../tick", features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/templated_uri/Cargo.toml
+++ b/crates/templated_uri/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "url", "parsing", "templates", "uri"]
 categories = ["encoding", "parser-implementations", "template-engine", "web-programming"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri"
 
 [package.metadata.cargo_check_external_types]
@@ -52,21 +52,21 @@ serde = ["dep:serde"]
 uuid = ["dep:uuid"]
 
 [dependencies]
-data_privacy.workspace = true
-http.workspace = true
-ohno.workspace = true
+data_privacy = { workspace = true }
+http = { workspace = true }
+ohno = { workspace = true }
 pct-str = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["std", "derive"], optional = true }
-templated_uri_macros.workspace = true
+templated_uri_macros = { workspace = true }
 uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
-mutants.workspace = true
+mutants = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
-static_assertions.workspace = true
+static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-trybuild.workspace = true
+trybuild = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [lints]

--- a/crates/templated_uri_macros/Cargo.toml
+++ b/crates/templated_uri_macros/Cargo.toml
@@ -9,21 +9,21 @@ readme = "README.md"
 keywords = ["oxidizer", "url", "parsing", "templates", "uri"]
 categories = ["encoding", "parser-implementations", "template-engine", "web-programming"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri_macros"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-templated_uri_macros_impl.workspace = true
+templated_uri_macros_impl = { workspace = true }
 
 [dev-dependencies]
-mutants.workspace = true
+mutants = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/templated_uri_macros_impl/Cargo.toml
+++ b/crates/templated_uri_macros_impl/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "url", "parsing", "templates", "uri"]
 categories = ["encoding", "parser-implementations", "template-engine", "web-programming"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri_macros_impl"
 
 [package.metadata.docs.rs]
@@ -21,16 +21,16 @@ all-features = true
 
 [dependencies]
 chumsky = { workspace = true, features = ["std"] }
-darling.workspace = true
-ohno.workspace = true
-proc-macro2.workspace = true
-quote.workspace = true
-syn.workspace = true
+darling = { workspace = true }
+ohno = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [dev-dependencies]
-insta.workspace = true
-mutants.workspace = true
-prettyplease.workspace = true
+insta = { workspace = true }
+mutants = { workspace = true }
+prettyplease = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/testing_aids/Cargo.toml
+++ b/crates/testing_aids/Cargo.toml
@@ -8,11 +8,11 @@ version = "0.0.0"
 readme = "README.md"
 publish = false
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 
 [dependencies]
 futures = { workspace = true, features = ["executor"] }
@@ -22,8 +22,8 @@ tracing = { workspace = true, features = ["std"] }
 tracing-subscriber = { workspace = true, features = ["fmt", "registry"] }
 
 [dev-dependencies]
-mockall.workspace = true
-mutants.workspace = true
+mockall = { workspace = true }
+mutants = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/thread_aware/Cargo.toml
+++ b/crates/thread_aware/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "thread", "aware"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware"
 
 [package.metadata.cargo_check_external_types]
@@ -35,9 +35,9 @@ thread_aware_macros = { workspace = true, optional = true }
 [dev-dependencies]
 futures = { workspace = true, features = ["executor"] }
 many_cpus = { workspace = true, features = ["test-util"] }
-mutants.workspace = true
-static_assertions.workspace = true
-thread_aware_macros = { workspace = true }
+mutants = { workspace = true }
+static_assertions = { workspace = true }
+thread_aware_macros = { path = "../thread_aware_macros" }
 
 [lints]
 workspace = true

--- a/crates/thread_aware_macros/Cargo.toml
+++ b/crates/thread_aware_macros/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "thread", "aware", "macro", "derive"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware_macros"
 
 [package.metadata.docs.rs]
@@ -24,10 +24,10 @@ proc-macro = true
 
 [dependencies]
 syn = { workspace = true, features = ["full", "derive", "printing", "parsing", "extra-traits", "proc-macro", "clone-impls"] }
-thread_aware_macros_impl.workspace = true
+thread_aware_macros_impl = { workspace = true }
 
 [dev-dependencies]
-mutants.workspace = true
+mutants = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/thread_aware_macros_impl/Cargo.toml
+++ b/crates/thread_aware_macros_impl/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "thread", "aware", "macro", "derive"]
 categories = ["data-structures"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware_macros_impl"
 
 [package.metadata.cargo_check_external_types]
@@ -29,13 +29,13 @@ allowed_external_types = [
 all-features = true
 
 [dependencies]
-proc-macro2.workspace = true
-quote.workspace = true
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["full", "derive", "printing", "parsing", "extra-traits", "proc-macro", "clone-impls"] }
 
 [dev-dependencies]
-insta.workspace = true
-prettyplease.workspace = true
+insta = { workspace = true }
+prettyplease = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/tick/Cargo.toml
+++ b/crates/tick/Cargo.toml
@@ -8,11 +8,11 @@ version = "0.3.1"
 readme = "README.md"
 keywords = ["time", "clock", "tick", "stopwatch"]
 categories = ["data-structures"]
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/tick"
 
 [package.metadata.cargo_check_external_types]
@@ -47,11 +47,11 @@ futures-core = { workspace = true }
 jiff = { workspace = true, features = ["std"], optional = true }
 pin-project-lite = { workspace = true }
 serde_core = { workspace = true, features = ["std"], optional = true }
-thread_aware.workspace = true
+thread_aware = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["time", "rt"] }
 
 [dev-dependencies]
-ohno = { workspace = true, features = ["app-err"] }
+ohno = { path = "../ohno", features = ["app-err"] }
 
 #external
 chrono = { workspace = true, features = ["clock"] }
@@ -64,7 +64,7 @@ mutants = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_core = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
-static_assertions.workspace = true
+static_assertions = { workspace = true }
 time = { workspace = true, features = ["formatting", "local-offset", "macros"] }
 tokio = { workspace = true, features = ["time", "rt", "macros", "rt-multi-thread"] }
 

--- a/crates/uniflight/Cargo.toml
+++ b/crates/uniflight/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 keywords = ["oxidizer", "coalescing", "stempede", "singleflight", "deduplication"]
 categories = ["concurrency"]
 
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/uniflight"
 
 [package.metadata.cargo_check_external_types]
@@ -25,16 +25,16 @@ allowed_external_types = [
 
 [dependencies]
 ahash = { workspace = true, default-features = false, features = ["std"] }
-async-once-cell.workspace = true
-dashmap.workspace = true
+async-once-cell = { workspace = true }
+dashmap = { workspace = true }
 futures-util = { workspace = true, default-features = false, features = ["std", "alloc"] }
-thread_aware.workspace = true
+thread_aware = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 futures-util = { workspace = true, features = ["alloc", "std"] }
-mutants.workspace = true
-tick = { workspace = true, features = ["tokio"] }
+mutants = { workspace = true }
+tick = { path = "../tick", features = ["tokio"] }
 tokio = { workspace = true, features = [
     "macros",
     "rt",


### PR DESCRIPTION
## Motivation

Untidy dev-dependency declarations caused breakage in release process due to resulting in a wrong order of dependency publishing.

## Summary

Applied [`/ss-cargo-deps-tidy`](https://github.com/sandersaares/ss-ai/blob/main/skills/ss-cargo-deps-tidy/SKILL.md) to tidy Cargo dependencies in the workspace.

The headliner is **Stage 3**: same-workspace dev-dependencies are now path-only references, which is required for the publishing-order resolver. The remaining stages are additional Cargo.toml tidying performed for consistency.

| Stage | What changed |
|---|---|
| 2 — Style | Converted 100+ `foo.workspace = true` and similar dotted-key declarations to inline-table style across 24 crate manifests; converted the one `[dev-dependencies.syn]` sub-table to inline-table; padded short version requirements (`"0.8"` → `"0.8.0"`) for ahash, async-once-cell, bytemuck, dashmap, rstest, zerocopy. |
| **3 — Same-workspace dev-deps** | **Converted 36 dev-dependencies referencing workspace members via `workspace = true` to `path = "../<crate>"` form (features preserved). This is the fix needed to unbreak publishing order resolution.** |
| 4 — Version centralization | Moved `smol` from `anyspawn`'s dev-dependencies into `[workspace.dependencies]`; `anyspawn` now uses `workspace = true`. |
| 5 — Default features off | No change — all workspace deps already had `default-features = false`. |
| 6 — Workspace-level features | No change. The only flagged item was `postcard = { features = ["use-std"] }` which is the hyphenated alt phrasing of the allow-listed `use_std`. Did not hoist `std` / `alloc` to workspace level because `multitude` is a `#![no_std]` crate that shares deps (serde, bytes) with std-using crates. |
| 7 — Minimum-version verification | Bumped the minimum versions discovered to be broken when pinned via `=x.y.z`: |

| Dep | Was | Now | Reason |
|---|---|---|---|
| `ahash` | `0.8` | `0.8.4` | 0.8.0 yanked |
| `hyper` | `1.6.0` | `1.7.0` | `wiremock` 0.6.5 requires `hyper >= 1.7` |
| `new_zealand` | `1.0.1` | `1.0.4` | `many_cpus` 2.1.0 requires `new_zealand >= 1.0.4` |
| `zerocopy` | `0.8` | `0.8.26` | `FromZeros` derive on `#[repr(C, align(N))]` structs needs >= 0.8.26 (bisected) |

## Verification

All passed on Windows with the temporarily-pinned `=x.y.z` minimum versions, then reverted to the bumped baselines above:

- `cargo check --workspace --all-targets`
- `cargo check --workspace --all-targets --release`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features`
