### PR TITLE
feat(fetch)!: improve working with response bodies

### DIFF
--- a/crates/fetch/Cargo.toml
+++ b/crates/fetch/Cargo.toml
@@ -40,6 +40,9 @@ allowed_external_types = [
     "tower_layer::Layer",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = []
 tls = ["rustls"]

--- a/crates/fetch/Cargo.toml
+++ b/crates/fetch/Cargo.toml
@@ -57,7 +57,7 @@ native-tls = [
     "fetch_hyper?/native-tls",
     "fetch_tls/native-tls",
 ]
-json = ["dep:serde", "http_extensions/json"]
+json = ["http_extensions/json"]
 test-util = ["tick/test-util", "http_extensions/test-util"]
 tokio = [
     "dep:tokio",
@@ -104,7 +104,6 @@ opentelemetry = { workspace = true, features = ["futures", "metrics"] }
 opentelemetry-semantic-conventions = { workspace = true, features = [
     "semconv_experimental",
 ] }
-serde = { workspace = true, optional = true }
 smallvec = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/fetch/README.md
+++ b/crates/fetch/README.md
@@ -89,21 +89,18 @@ This client runs on the Tokio runtime by default. (Other runtimes can be plugged
 custom transport — see the [`custom`][__link7] module.)
 
 ```rust
-use fetch::{HttpClient, HttpError, Response, StatusExt};
+use fetch::{HttpClient, HttpError};
 
 #[tokio::main]
 async fn main() -> Result<(), HttpError> {
     // Create a client using the builder
     let client: HttpClient = HttpClient::new_tokio();
 
-    // Retrieve the response as text
-    let response: Response<String> = client
-        .get("https://example.com")
-        .fetch_text()
-        .await?
-        .ensure_success()?; // Verifies that the response was successful
+    // Retrieve the response body as text. This validates the status (returning an
+    // error for `4xx`/`5xx` responses) and hands back the body in a single step.
+    let body: String = client.get("https://example.com").fetch_text_body().await?;
 
-    println!("response: {}", response.body());
+    println!("response: {body}");
 
     Ok(())
 }
@@ -229,8 +226,8 @@ convenient shortcut methods:
 
 * [`fetch_text`][__link28]: Gets the response body as a string in one step.
 * [`fetch_bytes`][__link29]: Gets the body as a memory-efficient `BytesView`.
-* [`fetch_json`][__link30]: Gets the response body as zero-copy JSON (requires `json` feature).
-* [`fetch_json_owned`][__link31]: Gets the response body as owned JSON (requires `json` feature).
+* [`fetch_json`][__link30]: Gets the response body as owned JSON (requires `json` feature).
+* [`fetch_json_ref`][__link31]: Gets the response body as zero-copy JSON (requires `json` feature).
 
 These methods automatically convert the response body to the format you want (string, JSON, etc.),
 saving you from handling the raw [`HttpBody`][__link32] type directly. They return a [`Response<T>`][__link33] where `T`
@@ -255,23 +252,42 @@ let text: String = response
 
 ```
 
+### Body-Only Shortcuts
+
+When you only need the body of a *successful* response, the `_body` variants go one step further:
+they call [`ensure_success`][__link34] for you, discard the response
+metadata, and return just the materialized body.
+
+* [`fetch_text_body`][__link35]: Validates the status and returns the body as a `String`.
+* [`fetch_bytes_body`][__link36]: Validates the status and returns the body as a `BytesView`.
+* [`fetch_json_body`][__link37]: Validates the status and deserializes the body into an owned value (requires `json` feature).
+
+```rust
+// Fetch, validate the status, and extract the body in a single call
+let text: String = client
+    .get("https://api.example.com/users")
+    .fetch_text_body()
+    .await?;
+println!("body: {text}");
+```
+
 ## URL Handling
 
-The HTTP client uses the [`templated_uri`][__link34] crate for
+The HTTP client uses the [`templated_uri`][__link38] crate for
 URL handling, which provides a powerful and flexible way to work with URIs.
 
-You can use the [`Uri`][__link35] type to build URIs with templated paths and queries, allowing you to
+You can use the [`Uri`][__link39] type to build URIs with templated paths and queries, allowing you to
 create URLs with dynamic segments and query parameters.
-The template format follows [RFC 6570][__link36] level 3,
+The template format follows [RFC 6570][__link40] level 3,
 which means you can use it to easily template more complex paths and queries as well.
 
-You can also use the [`Uri`][__link37] type or string types to represent URIs for backwards compatibility, or
+You can also use the [`Uri`][__link41] type or string types to represent URIs for backwards compatibility, or
 if you don’t need templated paths. In that case, the whole `PathAndQuery` string is treated as a template.
 
-[`handlers::Logging`][__link38] will log the used URL template as
+[`handlers::Logging`][__link42] will log the used URL template as
 `url.path.template`
 
-For example, you can create a [`Uri`][__link39] with a templated path like this:
+For example, you can create a [`Uri`][__link43] with a templated path like this:
 
 ```rust
 use templated_uri::{BaseUri, EscapedString, PathAndQueryTemplate, Uri, templated};
@@ -301,7 +317,7 @@ client
 
 `templated_uri` supports classification of URL paths and queries using the `data_privacy` crate.
 
-You can also use the `classified` attribute to mark [`PathAndQueryTemplate`][__link40]
+You can also use the `classified` attribute to mark [`PathAndQueryTemplate`][__link44]
 structs as classified, allowing you to use classified types from `data_privacy` in your URL templates.
 
 ```rust
@@ -320,18 +336,56 @@ struct UserPath {
 
 Working with JSON APIs is straightforward with the `json` feature, which offers:
 
-* **Send JSON data**: [`HttpRequestBuilder::json`][__link41] serializes any Rust type to JSON.
-* **Receive zero-copy JSON**: [`HttpRequestBuilder::fetch_json`][__link42] returns a
-  [`Json<T>`][__link43] wrapper that borrows strings and byte arrays directly from the response buffer for maximum
-  performance. Use it when you can work with borrowed data.
-* **Receive owned JSON**: [`HttpRequestBuilder::fetch_json_owned`][__link44]
-  deserializes directly into owned Rust types. Use it when the data must outlive the response or cross thread boundaries.
-* **Convert bodies to JSON**: [`HttpBody::into_json`][__link45] transforms response bodies into JSON values.
+* **Send JSON data**: [`HttpRequestBuilder::json`][__link45] serializes any Rust type to JSON.
+* **Receive owned JSON**: [`HttpRequestBuilder::fetch_json`][__link46] deserializes
+  directly into owned Rust types. This is the common case: the data can outlive the response and cross thread boundaries.
+* **Receive zero-copy JSON**: [`HttpRequestBuilder::fetch_json_ref`][__link47] returns a
+  [`Json<T>`][__link48] wrapper that borrows strings and byte arrays directly from the response buffer for maximum
+  performance. Reach for it in hot paths where you can work with borrowed data.
+* **Convert bodies to JSON**: [`HttpBody::into_json`][__link49] transforms response bodies into JSON values.
 
-### Zero-Copy JSON with `fetch_json`
+### Owned JSON with `fetch_json`
 
-Pair `fetch_json` with borrowed string fields (`Cow<'a, str>`) to avoid allocations; the
-[`Json<T>`][__link46] wrapper borrows directly from the response buffer. Prefer `Cow<'a, str>` over
+Use `fetch_json` when you need owned data; it deserializes the JSON directly into your
+target type with owned `String` fields. This is the most common choice:
+
+```rust
+// Define a Person type with owned data
+#[derive(Serialize, Deserialize)]
+struct Person {
+    id: u32,
+    name: String,
+}
+
+let person = Person {
+    id: 1,
+    name: "Alice Johnson".to_owned(),
+};
+
+// Send and receive owned JSON
+let response: Response<Person> = client
+    .put("https://api.company.com/people")
+    .json(&person) // Add JSON payload
+    .fetch_json::<Person>() // Returns Response<Person> directly
+    .await?;
+
+// You can inspect the response metadata if needed
+let response = response.ensure_success()?;
+
+// Extract the deserialized Person directly - no wrapper needed
+let person: Person = response.into_body();
+
+println!("Person retrieved, name: {}", person.name);
+
+```
+
+If you only need the body of a successful response, [`fetch_json_body`][__link50]
+goes one step further and folds the fetch, status check, and owned deserialization into a single call.
+
+### Zero-Copy JSON with `fetch_json_ref`
+
+Pair `fetch_json_ref` with borrowed string fields (`Cow<'a, str>`) to avoid allocations; the
+[`Json<T>`][__link51] wrapper borrows directly from the response buffer. Prefer `Cow<'a, str>` over
 `&'a str`, as it transparently falls back to an owned value when a JSON string was escaped in the buffer
 and cannot be borrowed:
 
@@ -353,7 +407,7 @@ let person = Person {
 let response: Response<Json<Person>> = client
     .put("https://api.company.com/people")
     .json(&person) // Add JSON payload
-    .fetch_json::<Person>() // Returns Response<Json<Person>>
+    .fetch_json_ref::<Person>() // Returns Response<Json<Person>>
     .await?;
 
 // You can inspect the response metadata if needed
@@ -371,50 +425,13 @@ println!("Person retrieved, name: {}", person.name);
 ```
 
 This minimizes heap allocations and copying because string fields borrow directly from the
-response buffer instead of allocating new memory for each string.
-
-### Owned JSON with `fetch_json_owned`
-
-Use `fetch_json_owned` when you need owned data; it deserializes the JSON directly into your
-target type with owned `String` fields:
-
-```rust
-// Define a Person type with owned data
-#[derive(Serialize, Deserialize)]
-struct Person {
-    id: u32,
-    name: String,
-}
-
-let person = Person {
-    id: 1,
-    name: "Alice Johnson".to_owned(),
-};
-
-// Send and receive owned JSON
-let response: Response<Person> = client
-    .put("https://api.company.com/people")
-    .json(&person) // Add JSON payload
-    .fetch_json_owned::<Person>() // Returns Response<Person> directly
-    .await?;
-
-// You can inspect the response metadata if needed
-let response = response.ensure_success()?;
-
-// Extract the deserialized Person directly - no wrapper needed
-let person: Person = response.into_body();
-
-println!("Person retrieved, name: {}", person.name);
-
-```
-
-This performs more allocations than `fetch_json`, but is more convenient when the data must
-outlive the response, cross thread boundaries, or satisfy APIs that require owned types.
+response buffer instead of allocating new memory for each string, at the cost of tying the parsed
+value to the response buffer’s lifetime.
 
 ## Request Pipeline
 
 The HTTP client uses a pipeline architecture to process requests. Think of it like an assembly
-line - every request passes through a sequence of [`RequestHandler`][__link47]s, each handling
+line - every request passes through a sequence of [`RequestHandler`][__link52]s, each handling
 a specific aspect of HTTP communication.
 
 Each handler in the pipeline can:
@@ -424,13 +441,13 @@ Each handler in the pipeline can:
 * Process the response after it’s received
 * Add cross-cutting functionality like logging or metrics
 
-At the very end of the pipeline sits the **transport handler** — the leaf [`RequestHandler`][__link48]
+At the very end of the pipeline sits the **transport handler** — the leaf [`RequestHandler`][__link53]
 that actually performs the I/O and turns a request into a response. This is the seam that makes
 `fetch` transport- and runtime-agnostic: everything above the transport (resilience, telemetry,
 routing, logging, …) is supplied by `fetch`, while the transport itself can be the bundled
 hyper-based implementation, your own runtime/I/O, or a wrapper around an existing HTTP client
-such as [`reqwest`][__link49]. To supply your own transport, see the
-[`custom`][__link50] module and [`custom::create_builder`][__link51].
+such as [`reqwest`][__link54]. To supply your own transport, see the
+[`custom`][__link55] module and [`custom::create_builder`][__link56].
 
 ### Built-in Pipeline Types
 
@@ -443,19 +460,19 @@ The standard pipeline is what you get by default - it includes all the essential
 you’ll want for production use. Handlers are applied in a nested structure, with the outermost
 handler processing the request first and the response last.
 
-See the [`StandardRequestPipeline`][__link52] and [`HttpClientBuilder::standard_pipeline`][__link53]
+See the [`StandardRequestPipeline`][__link57] and [`HttpClientBuilder::standard_pipeline`][__link58]
 for more details and examples.
 
 #### Custom Pipeline
 
 When you need precise control over request processing, you can build a custom pipeline with
-exactly the handlers you want. See the [`HttpClientBuilder::custom_pipeline`][__link54] method for
+exactly the handlers you want. See the [`HttpClientBuilder::custom_pipeline`][__link59] method for
 more details and examples.
 
 #### Minimal Pipeline
 
 For maximum flexibility, you can use the minimal pipeline that includes only the
-essential [`Dispatch`][__link55] handler that actually sends requests to the network.
+essential [`Dispatch`][__link60] handler that actually sends requests to the network.
 This gives you a clean slate to build on:
 
 ```rust
@@ -471,7 +488,7 @@ or integrate with external middleware systems.
 
 ### Creating Custom Handlers
 
-To add your own processing logic, see the [`RequestHandler`][__link56] trait documentation, which covers
+To add your own processing logic, see the [`RequestHandler`][__link61] trait documentation, which covers
 patterns for modifying requests, processing responses, and integrating with the pipeline.
 
 ## Testing with the HTTP Client
@@ -525,21 +542,20 @@ let client = HttpClient::new_fake(fake_handler);
 ## Smart Memory Management with `BytesView`
 
 When handling large HTTP responses or sending big requests, memory usage matters, so `fetch` uses
-[`BytesView`][__link57] for request and response bodies. Its key features:
+[`BytesView`][__link62] for request and response bodies. Its key features:
 
 * **Memory Pooling**: Reuses memory instead of constantly allocating and freeing it.
 * **Less Copying**: Smart buffer management reduces unnecessary data copying.
 * **Multiple Chunks**: Can handle data as multiple pieces that look like a single buffer.
 * **Zero-Copy When Possible**: Avoids copying data when it can for better performance.
-* **Works with Ecosystem**: Fully compatible with the popular [`bytes`][__link58] crate.
+* **Works with Ecosystem**: Fully compatible with the popular [`bytes`][__link63] crate.
 
-You can use [`BytesView`][__link59] just like other byte buffer types because it implements the same
-interfaces ([`Buf`][__link60] and [`BufMut`][__link61]) as the [`bytes`][__link62] crate:
+You can use [`BytesView`][__link64] just like other byte buffer types because it implements the same
+interfaces ([`Buf`][__link65] and [`BufMut`][__link66]) as the [`bytes`][__link67] crate:
 
 ```rust
-// Get a response body as a BytesView
-let response = client.get("https://example.com").fetch().await?;
-let mut body_bytes = response.into_body().into_bytes().await?;
+// Fetch the response body directly as a BytesView (validating the status along the way)
+let mut body_bytes = client.get("https://example.com").fetch_bytes_body().await?;
 
 // Work with the BytesView using standard bytes methods
 let length = body_bytes.remaining();
@@ -567,35 +583,34 @@ let users_uri: Uri = "https://api.example.com/users".parse()?;
 let items_uri: Uri = "https://api.example.com/items".parse()?;
 
 // 3. Work with raw BytesView to avoid allocations when possible
-let response = client.get(users_uri.clone()).fetch().await?;
-let bytes = response.into_body().into_bytes().await?;
+let bytes = client.get(users_uri.clone()).fetch_bytes_body().await?;
 process_binary_data(bytes);
 ```
 
 In detail:
 
-* **Reuse your client**: Creating an [`HttpClient`][__link63] is expensive (connection pooling, security setup).
+* **Reuse your client**: Creating an [`HttpClient`][__link68] is expensive (connection pooling, security setup).
   Create it once and keep using it throughout your application. Share a single instance across
   multiple tasks.
-* **Pre-parse URIs**: If you’re repeatedly calling the same endpoints, parse the [`Uri`][__link64]s once and
+* **Pre-parse URIs**: If you’re repeatedly calling the same endpoints, parse the [`Uri`][__link69]s once and
   reuse them to skip the parsing overhead.
-* **Work with raw [`BytesView`][__link65]**: Converting between formats (like [`BytesView`][__link66] to `String`) creates
-  allocations and copies data. When handling binary data or large responses, work with [`BytesView`][__link67] directly.
+* **Work with raw [`BytesView`][__link70]**: Converting between formats (like [`BytesView`][__link71] to `String`) creates
+  allocations and copies data. When handling binary data or large responses, work with [`BytesView`][__link72] directly.
 
 ## Integration with the HTTP Ecosystem
 
 Instead of creating our own HTTP types from scratch, we use extensions and wrappers around
-the widely adopted [`http`][__link68] crate. These extensions are defined in the [`http_extensions`][__link69] crate
+the widely adopted [`http`][__link73] crate. These extensions are defined in the [`http_extensions`][__link74] crate
 and re-exported here for convenience.
 
 ## Resilience
 
-The HTTP client has built-in resilience features powered by the [`seatbelt`][__link70] crate. These
+The HTTP client has built-in resilience features powered by the [`seatbelt`][__link75] crate. These
 resilience patterns help your application handle failures gracefully and maintain availability
 even when network issues or server problems occur.
 
 The resilience middleware integrates directly into the request pipeline via the
-[`Service`][__link71] trait. Because both the client’s handlers and the seatbelt
+[`Service`][__link76] trait. Because both the client’s handlers and the seatbelt
 middleware implement this trait, they compose seamlessly - no adapter code is needed to mix
 resilience patterns with other request processing logic.
 
@@ -605,21 +620,21 @@ Common resilience patterns available include:
 * **Timeouts**: Prevent requests from hanging indefinitely
 * **Circuit Breakers**: Fail fast when a service is down to avoid cascading failures
 
-These patterns are already configured in the [standard pipeline][__link72] with sensible defaults.
+These patterns are already configured in the [standard pipeline][__link77] with sensible defaults.
 
 ## TLS Support
 
 The HTTP client supports two TLS backends for making HTTPS requests:
 
-* **`rustls`** (default): Uses [`rustls`][__link73] with the
-  [`aws-lc-rs`][__link74] crypto provider. This is the recommended
+* **`rustls`** (default): Uses [`rustls`][__link78] with the
+  [`aws-lc-rs`][__link79] crypto provider. This is the recommended
   backend and is selected by default when the `tls` feature is enabled.
 * **`native-tls`**: Uses the platform’s native TLS implementation (`SChannel` on Windows,
   Security Framework on `macOS`, `OpenSSL` on Linux). This can be explicitly selected, or is
   chosen automatically when the `native-tls` feature is enabled and `rustls` is not.
 
 When using the `rustls` backend, the HTTP client validates server certificates against the
-platform trust store via [`rustls-platform-verifier`][__link75],
+platform trust store via [`rustls-platform-verifier`][__link80],
 which takes care of essential TLS operations:
 
 * Verifies certificates against the operating system’s trusted root `CAs`.
@@ -654,7 +669,7 @@ To use native TLS instead, enable the `native-tls` feature explicitly:
 fetch = { version = "*", features = ["native-tls", "tokio"] }
 ```
 
-You can also select the TLS backend at runtime via [`TlsOptions::builder_rustls()`][__link76] or
+You can also select the TLS backend at runtime via [`TlsOptions::builder_rustls()`][__link81] or
 `TlsOptions::builder_native_tls()` when both features are enabled, allowing different client
 instances to use different backends.
 
@@ -697,7 +712,7 @@ fetch = { version = "*", features = ["json", "tokio"] }
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/fetch">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbg9gUGftKOZYbOcUidqRvtlIb4jNz0TaSSBQbzELqodjgpHxhZIeCZWJ5dGVzZjEuMTEuMYJoYnl0ZXNidWZlMC41LjOCZWZldGNoZjAuMTAuMoJvaHR0cF9leHRlbnNpb25zZTAuNS4xgmdsYXllcmVkZTAuMy4ygmhzZWF0YmVsdGUwLjUuNYJtdGVtcGxhdGVkX3VyaWUwLjMuMA
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbxkEgVi3K7esbSiqQCVICXPsb03rVGNzis1cboVawTWvPmr1hZIeCZWJ5dGVzZjEuMTEuMYJoYnl0ZXNidWZlMC41LjOCZWZldGNoZjAuMTAuMoJvaHR0cF9leHRlbnNpb25zZTAuNS4xgmdsYXllcmVkZTAuMy4ygmhzZWF0YmVsdGUwLjUuNYJtdGVtcGxhdGVkX3VyaWUwLjMuMA
  [__link0]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClient
  [__link1]: https://docs.rs/http_extensions/0.5.1/http_extensions/?search=RequestHandler
  [__link10]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClient::post
@@ -723,55 +738,60 @@ This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Br
  [__link29]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_bytes
  [__link3]: https://docs.rs/fetch/0.10.2/fetch/custom/index.html
  [__link30]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_json
- [__link31]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_json_owned
+ [__link31]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_json_ref
  [__link32]: https://docs.rs/http_extensions/0.5.1/http_extensions/?search=HttpBody
  [__link33]: https://docs.rs/fetch/0.10.2/fetch/?search=http::Response
- [__link34]: https://crates.io/crates/templated_uri/0.3.0
- [__link35]: https://docs.rs/templated_uri/0.3.0/templated_uri/?search=Uri
- [__link36]: https://datatracker.ietf.org/doc/html/rfc6570
- [__link37]: https://docs.rs/templated_uri/0.3.0/templated_uri/?search=Uri
- [__link38]: https://docs.rs/fetch/0.10.2/fetch/?search=handlers::Logging
+ [__link34]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpResponse::ensure_success
+ [__link35]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_text_body
+ [__link36]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_bytes_body
+ [__link37]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_json_body
+ [__link38]: https://crates.io/crates/templated_uri/0.3.0
  [__link39]: https://docs.rs/templated_uri/0.3.0/templated_uri/?search=Uri
  [__link4]: https://docs.rs/fetch/0.10.2/fetch/?search=custom::create_builder
- [__link40]: https://docs.rs/templated_uri/0.3.0/templated_uri/?search=PathAndQueryTemplate
- [__link41]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::json
- [__link42]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_json
- [__link43]: https://docs.rs/fetch/0.10.2/fetch/?search=Json
- [__link44]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_json_owned
- [__link45]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpBody::into_json
- [__link46]: https://docs.rs/fetch/0.10.2/fetch/?search=Json
- [__link47]: https://docs.rs/http_extensions/0.5.1/http_extensions/?search=RequestHandler
- [__link48]: https://docs.rs/http_extensions/0.5.1/http_extensions/?search=RequestHandler
- [__link49]: https://docs.rs/reqwest/
+ [__link40]: https://datatracker.ietf.org/doc/html/rfc6570
+ [__link41]: https://docs.rs/templated_uri/0.3.0/templated_uri/?search=Uri
+ [__link42]: https://docs.rs/fetch/0.10.2/fetch/?search=handlers::Logging
+ [__link43]: https://docs.rs/templated_uri/0.3.0/templated_uri/?search=Uri
+ [__link44]: https://docs.rs/templated_uri/0.3.0/templated_uri/?search=PathAndQueryTemplate
+ [__link45]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::json
+ [__link46]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_json
+ [__link47]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_json_ref
+ [__link48]: https://docs.rs/fetch/0.10.2/fetch/?search=Json
+ [__link49]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpBody::into_json
  [__link5]: https://docs.rs/reqwest/
- [__link50]: https://docs.rs/fetch/0.10.2/fetch/custom/index.html
- [__link51]: https://docs.rs/fetch/0.10.2/fetch/?search=custom::create_builder
- [__link52]: https://docs.rs/fetch/0.10.2/fetch/?search=pipeline::StandardRequestPipeline
- [__link53]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClientBuilder::standard_pipeline
- [__link54]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClientBuilder::custom_pipeline
- [__link55]: https://docs.rs/fetch/0.10.2/fetch/?search=handlers::Dispatch
- [__link56]: https://docs.rs/http_extensions/0.5.1/http_extensions/?search=RequestHandler
- [__link57]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
- [__link58]: https://docs.rs/bytes
- [__link59]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
+ [__link50]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpRequestBuilder::fetch_json_body
+ [__link51]: https://docs.rs/fetch/0.10.2/fetch/?search=Json
+ [__link52]: https://docs.rs/http_extensions/0.5.1/http_extensions/?search=RequestHandler
+ [__link53]: https://docs.rs/http_extensions/0.5.1/http_extensions/?search=RequestHandler
+ [__link54]: https://docs.rs/reqwest/
+ [__link55]: https://docs.rs/fetch/0.10.2/fetch/custom/index.html
+ [__link56]: https://docs.rs/fetch/0.10.2/fetch/?search=custom::create_builder
+ [__link57]: https://docs.rs/fetch/0.10.2/fetch/?search=pipeline::StandardRequestPipeline
+ [__link58]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClientBuilder::standard_pipeline
+ [__link59]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClientBuilder::custom_pipeline
  [__link6]: https://docs.rs/hyper/
- [__link60]: https://docs.rs/bytes/1.11.1/bytes/?search=Buf
- [__link61]: https://docs.rs/bytes/1.11.1/bytes/?search=BufMut
- [__link62]: https://docs.rs/bytes
- [__link63]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClient
- [__link64]: https://docs.rs/templated_uri/0.3.0/templated_uri/?search=Uri
- [__link65]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
- [__link66]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
- [__link67]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
- [__link68]: https://docs.rs/fetch/0.10.2/fetch/http/index.html
- [__link69]: https://crates.io/crates/http_extensions/0.5.1
+ [__link60]: https://docs.rs/fetch/0.10.2/fetch/?search=handlers::Dispatch
+ [__link61]: https://docs.rs/http_extensions/0.5.1/http_extensions/?search=RequestHandler
+ [__link62]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
+ [__link63]: https://docs.rs/bytes
+ [__link64]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
+ [__link65]: https://docs.rs/bytes/1.11.1/bytes/?search=Buf
+ [__link66]: https://docs.rs/bytes/1.11.1/bytes/?search=BufMut
+ [__link67]: https://docs.rs/bytes
+ [__link68]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClient
+ [__link69]: https://docs.rs/templated_uri/0.3.0/templated_uri/?search=Uri
  [__link7]: https://docs.rs/fetch/0.10.2/fetch/custom/index.html
- [__link70]: https://crates.io/crates/seatbelt/0.5.5
- [__link71]: https://docs.rs/layered/0.3.2/layered/?search=Service
- [__link72]: https://docs.rs/fetch/0.10.2/fetch/?search=pipeline::StandardRequestPipeline
- [__link73]: https://docs.rs/rustls
- [__link74]: https://docs.rs/aws-lc-rs
- [__link75]: https://docs.rs/rustls-platform-verifier
- [__link76]: https://docs.rs/fetch/0.10.2/fetch/?search=tls::TlsOptions::builder_rustls
+ [__link70]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
+ [__link71]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
+ [__link72]: https://docs.rs/bytesbuf/0.5.3/bytesbuf/?search=BytesView
+ [__link73]: https://docs.rs/fetch/0.10.2/fetch/http/index.html
+ [__link74]: https://crates.io/crates/http_extensions/0.5.1
+ [__link75]: https://crates.io/crates/seatbelt/0.5.5
+ [__link76]: https://docs.rs/layered/0.3.2/layered/?search=Service
+ [__link77]: https://docs.rs/fetch/0.10.2/fetch/?search=pipeline::StandardRequestPipeline
+ [__link78]: https://docs.rs/rustls
+ [__link79]: https://docs.rs/aws-lc-rs
  [__link8]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClient::builder_tokio
+ [__link80]: https://docs.rs/rustls-platform-verifier
+ [__link81]: https://docs.rs/fetch/0.10.2/fetch/?search=tls::TlsOptions::builder_rustls
  [__link9]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClient::get

--- a/crates/fetch/README.md
+++ b/crates/fetch/README.md
@@ -526,7 +526,7 @@ let client = HttpClient::new_fake(response);
 
 // Create a fake HTTP client that uses a custom handler. The handler can be
 // synchronous or asynchronous. Usually for testing, the synchronous handler is sufficient.
-let fake_handler = FakeHandler::from_sync_handler(|req| {
+let fake_handler = FakeHandler::from_fn(|req| {
     println!("Fake handler called for request, url: {}", req.uri());
 
     HttpResponseBuilder::new_fake()
@@ -712,7 +712,7 @@ fetch = { version = "*", features = ["json", "tokio"] }
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/fetch">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbxkEgVi3K7esbSiqQCVICXPsb03rVGNzis1cboVawTWvPmr1hZIeCZWJ5dGVzZjEuMTEuMYJoYnl0ZXNidWZlMC41LjOCZWZldGNoZjAuMTAuMoJvaHR0cF9leHRlbnNpb25zZTAuNS4xgmdsYXllcmVkZTAuMy4ygmhzZWF0YmVsdGUwLjUuNYJtdGVtcGxhdGVkX3VyaWUwLjMuMA
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbRcdYrc3P77cbVjz14MYzPFkbTKiKwHYuBbcbSr09Rcd_lPZhZIeCZWJ5dGVzZjEuMTEuMYJoYnl0ZXNidWZlMC41LjOCZWZldGNoZjAuMTAuMoJvaHR0cF9leHRlbnNpb25zZTAuNS4xgmdsYXllcmVkZTAuMy4ygmhzZWF0YmVsdGUwLjUuNYJtdGVtcGxhdGVkX3VyaWUwLjMuMA
  [__link0]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClient
  [__link1]: https://docs.rs/http_extensions/0.5.1/http_extensions/?search=RequestHandler
  [__link10]: https://docs.rs/fetch/0.10.2/fetch/?search=HttpClient::post

--- a/crates/fetch/examples/http_client_api_with_templated_uri.rs
+++ b/crates/fetch/examples/http_client_api_with_templated_uri.rs
@@ -33,14 +33,14 @@ mod api {
         where
             T: serde::de::DeserializeOwned,
         {
-            let mut result = self
+            let result = self
                 .client
                 .get(templated_uri::Uri::from(api_endpoint))
                 .header("User-Agent", "http-client")
                 .fetch_json::<T>()
                 .await?
                 .into_body();
-            Ok(result.read()?)
+            Ok(result)
         }
 
         pub async fn get_crate(&self, crate_name: EscapedString) -> Result<CrateResponse> {

--- a/crates/fetch/examples/http_client_breaker.rs
+++ b/crates/fetch/examples/http_client_breaker.rs
@@ -26,7 +26,7 @@ const HEALTHY_HOST: &str = "https://healthy.example.com";
 #[tokio::main]
 async fn main() -> Result<(), ohno::AppError> {
     // Fake handler: 500 for the failing host, 200 for everything else.
-    let fake_handler = FakeHandler::from_sync_handler(|req| {
+    let fake_handler = FakeHandler::from_fn(|req| {
         let status = if req.uri().host() == Some("failing.example.com") {
             StatusCode::INTERNAL_SERVER_ERROR
         } else {

--- a/crates/fetch/examples/http_client_customization.rs
+++ b/crates/fetch/examples/http_client_customization.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), ohno::AppError> {
     utils::init_tracing();
 
     // Simulate issues with the request by using a fake handler.
-    let fake_handler = FakeHandler::from_sync_handler(|req| {
+    let fake_handler = FakeHandler::from_fn(|req| {
         let status_code = match fastrand::u32(0..10) {
             0..5 => StatusCode::INTERNAL_SERVER_ERROR,
             _ => StatusCode::OK,

--- a/crates/fetch/examples/http_client_customization.rs
+++ b/crates/fetch/examples/http_client_customization.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), ohno::AppError> {
         })
         .build();
 
-    let text = client.get("https://example.com").fetch_text().await?.into_body();
+    let text = client.get("https://example.com").fetch_text_body().await?;
 
     println!("response: {text}");
 

--- a/crates/fetch/examples/http_client_fake.rs
+++ b/crates/fetch/examples/http_client_fake.rs
@@ -9,7 +9,7 @@ use http::StatusCode;
 
 #[tokio::main]
 async fn main() -> Result<(), ohno::AppError> {
-    let fake_handler = FakeHandler::from_sync_handler(|req| {
+    let fake_handler = FakeHandler::from_fn(|req| {
         println!("fake handler called for request, url: {}", req.uri());
 
         HttpResponseBuilder::new_fake()

--- a/crates/fetch/examples/http_client_json.rs
+++ b/crates/fetch/examples/http_client_json.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), ohno::AppError> {
             crate_name: crate_name.clone(),
         })
         .header("User-Agent", "http-client")
-        .fetch_json::<CrateResponse>()
+        .fetch_json_ref::<CrateResponse>()
         .await?
         .into_body();
 

--- a/crates/fetch/examples/util/crates_io_mock.rs
+++ b/crates/fetch/examples/util/crates_io_mock.rs
@@ -11,7 +11,7 @@ fn json_response(value: &Value) -> Result<HttpResponse, HttpError> {
 }
 
 pub(super) fn crates_io_fake_handler(crate_name: String) -> FakeHandler {
-    FakeHandler::from_sync_handler(move |request| {
+    FakeHandler::from_fn(move |request| {
         let path = request.uri().path();
         let query = request.uri().query();
         if path == format!("/api/v1/crates/{crate_name}") {

--- a/crates/fetch/favicon.ico
+++ b/crates/fetch/favicon.ico
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e48225cb42c8ac02df5dd4a9bdba29c1e8d10436cc27055d6a021bcb951d4145
-size 480683
+oid sha256:140215583c71ac6fd9cf69ab5b44e11cbb053916426104e9dd40eeba6b0ae865
+size 23418

--- a/crates/fetch/logo.png
+++ b/crates/fetch/logo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63ad64ebb0185d7cd153acc291989d72e3a0094603d8bfe781a220861de247f2
-size 17876
+oid sha256:8ac6d1cfa25763c51eb14541fa4defa965e8f16462e9d61e7de7fee6387a2553
+size 67062

--- a/crates/fetch/src/_documentation/examples.rs
+++ b/crates/fetch/src/_documentation/examples.rs
@@ -19,7 +19,7 @@
 //! | Example | Description |
 //! |---------|-------------|
 //! | [`http_client_tokio`](https://github.com/microsoft/oxidizer/blob/main/crates/fetch/examples/http_client_tokio.rs) | Minimal Tokio-runtime client that issues a couple of GET requests, including one from a spawned task. |
-//! | [`http_client_json`](https://github.com/microsoft/oxidizer/blob/main/crates/fetch/examples/http_client_json.rs) | Deserializes a JSON response into a borrowed struct with [`fetch_json`](crate::HttpRequestBuilder::fetch_json) against a fake handler. |
+//! | [`http_client_json`](https://github.com/microsoft/oxidizer/blob/main/crates/fetch/examples/http_client_json.rs) | Deserializes a JSON response into a borrowed struct with [`fetch_json_ref`](crate::HttpRequestBuilder::fetch_json_ref) against a fake handler. |
 //! | [`http_client_streaming`](https://github.com/microsoft/oxidizer/blob/main/crates/fetch/examples/http_client_streaming.rs) | Downloads a response incrementally as a [`Stream`](futures::Stream) and writes each chunk to a file. |
 //!
 //! # Configuration & pipelines

--- a/crates/fetch/src/client.rs
+++ b/crates/fetch/src/client.rs
@@ -457,7 +457,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_request_method_with_string_params() {
-        let fake = FakeHandler::from_sync_handler(|request| {
+        let fake = FakeHandler::from_fn(|request| {
             assert_eq!(request.method(), http::Method::DELETE);
             assert_eq!(request.uri().to_string(), "https://example.com/path");
             HttpResponseBuilder::new_fake().status(StatusCode::IM_A_TEAPOT).build()
@@ -569,7 +569,7 @@ mod tests {
         let uri = Uri::from_static("https://example.com/test");
         let uri_cloned = uri.clone();
 
-        let client = HttpClient::new_fake(FakeHandler::from_sync_handler(move |request| {
+        let client = HttpClient::new_fake(FakeHandler::from_fn(move |request| {
             assert_eq!(request.method(), method);
             assert_eq!(request.uri().path(), "/test");
             HttpResponseBuilder::new_fake().build()

--- a/crates/fetch/src/custom.rs
+++ b/crates/fetch/src/custom.rs
@@ -268,7 +268,7 @@ mod tests {
 
     #[mutants::skip]
     fn ok_factory(_ctx: CustomContext) -> FakeHandler {
-        FakeHandler::from_sync_handler(|_req| HttpResponseBuilder::new_fake().status(StatusCode::OK).build())
+        FakeHandler::from_fn(|_req| HttpResponseBuilder::new_fake().status(StatusCode::OK).build())
     }
 
     #[cfg_attr(miri, ignore)]
@@ -317,7 +317,7 @@ mod tests {
                 // Touching `extras` during factory invocation proves the value travels
                 // all the way through the transport plumbing.
                 ctx.extras.fetch_add(1, Ordering::Relaxed);
-                FakeHandler::from_sync_handler(|_req| HttpResponseBuilder::new_fake().status(StatusCode::OK).build())
+                FakeHandler::from_fn(|_req| HttpResponseBuilder::new_fake().status(StatusCode::OK).build())
             },
             Isolation::Shared,
             deps,

--- a/crates/fetch/src/handlers/metrics.rs
+++ b/crates/fetch/src/handlers/metrics.rs
@@ -556,7 +556,7 @@ mod tests {
             .on_record(move |_duration, _result, attrs| {
                 attrs_clone.lock().unwrap().extend(attrs.iter().cloned());
             })
-            .layer(FakeHandler::from_async_handler(|_req| async {
+            .layer(FakeHandler::from_async_fn(|_req| async {
                 // This future will never complete because it pends forever.
                 std::future::pending::<Result<HttpResponse>>().await
             }));

--- a/crates/fetch/src/lib.rs
+++ b/crates/fetch/src/lib.rs
@@ -257,8 +257,8 @@
 //!
 //! - [`fetch_text`][crate::HttpRequestBuilder::fetch_text]: Gets the response body as a string in one step.
 //! - [`fetch_bytes`][crate::HttpRequestBuilder::fetch_bytes]: Gets the body as a memory-efficient `BytesView`.
-//! - [`fetch_json`][crate::HttpRequestBuilder::fetch_json]: Gets the response body as zero-copy JSON (requires `json` feature).
-//! - [`fetch_json_owned`][crate::HttpRequestBuilder::fetch_json_owned]: Gets the response body as owned JSON (requires `json` feature).
+//! - [`fetch_json`][crate::HttpRequestBuilder::fetch_json]: Gets the response body as owned JSON (requires `json` feature).
+//! - [`fetch_json_ref`][crate::HttpRequestBuilder::fetch_json_ref]: Gets the response body as zero-copy JSON (requires `json` feature).
 //!
 //! These methods automatically convert the response body to the format you want (string, JSON, etc.),
 //! saving you from handling the raw [`HttpBody`] type directly. They return a [`Response<T>`] where `T`
@@ -380,16 +380,60 @@
 //! Working with JSON APIs is straightforward with the `json` feature, which offers:
 //!
 //! - **Send JSON data**: [`HttpRequestBuilder::json`][crate::HttpRequestBuilder::json] serializes any Rust type to JSON.
-//! - **Receive zero-copy JSON**: [`HttpRequestBuilder::fetch_json`][crate::HttpRequestBuilder::fetch_json] returns a
+//! - **Receive owned JSON**: [`HttpRequestBuilder::fetch_json`][crate::HttpRequestBuilder::fetch_json] deserializes
+//!   directly into owned Rust types. This is the common case: the data can outlive the response and cross thread boundaries.
+//! - **Receive zero-copy JSON**: [`HttpRequestBuilder::fetch_json_ref`][crate::HttpRequestBuilder::fetch_json_ref] returns a
 //!   [`Json<T>`][crate::Json] wrapper that borrows strings and byte arrays directly from the response buffer for maximum
-//!   performance. Use it when you can work with borrowed data.
-//! - **Receive owned JSON**: [`HttpRequestBuilder::fetch_json_owned`][crate::HttpRequestBuilder::fetch_json_owned]
-//!   deserializes directly into owned Rust types. Use it when the data must outlive the response or cross thread boundaries.
+//!   performance. Reach for it in hot paths where you can work with borrowed data.
 //! - **Convert bodies to JSON**: [`HttpBody::into_json`][crate::HttpBody::into_json] transforms response bodies into JSON values.
 //!
-//! ## Zero-Copy JSON with `fetch_json`
+//! ## Owned JSON with `fetch_json`
 //!
-//! Pair `fetch_json` with borrowed string fields (`Cow<'a, str>`) to avoid allocations; the
+//! Use `fetch_json` when you need owned data; it deserializes the JSON directly into your
+//! target type with owned `String` fields. This is the most common choice:
+//!
+//! ```rust
+//! # use fetch::{HttpClient, Response, StatusExt};
+//! # use serde::{Deserialize, Serialize};
+//! # #[cfg(feature = "json")]
+//! # async fn example(client: &HttpClient) -> Result<(), Box<dyn std::error::Error>> {
+//! // Define a Person type with owned data
+//! #[derive(Serialize, Deserialize)]
+//! struct Person {
+//!     id: u32,
+//!     name: String,
+//! }
+//!
+//! let person = Person {
+//!     id: 1,
+//!     name: "Alice Johnson".to_owned(),
+//! };
+//!
+//! // Send and receive owned JSON
+//! let response: Response<Person> = client
+//!     .put("https://api.company.com/people")
+//!     .json(&person) // Add JSON payload
+//!     .fetch_json::<Person>() // Returns Response<Person> directly
+//!     .await?;
+//!
+//! // You can inspect the response metadata if needed
+//! let response = response.ensure_success()?;
+//!
+//! // Extract the deserialized Person directly - no wrapper needed
+//! let person: Person = response.into_body();
+//!
+//! println!("Person retrieved, name: {}", person.name);
+//!
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! If you only need the body of a successful response, [`fetch_json_body`][crate::HttpRequestBuilder::fetch_json_body]
+//! goes one step further and folds the fetch, status check, and owned deserialization into a single call.
+//!
+//! ## Zero-Copy JSON with `fetch_json_ref`
+//!
+//! Pair `fetch_json_ref` with borrowed string fields (`Cow<'a, str>`) to avoid allocations; the
 //! [`Json<T>`][crate::Json] wrapper borrows directly from the response buffer. Prefer `Cow<'a, str>` over
 //! `&'a str`, as it transparently falls back to an owned value when a JSON string was escaped in the buffer
 //! and cannot be borrowed:
@@ -419,7 +463,7 @@
 //! let response: Response<Json<Person>> = client
 //!     .put("https://api.company.com/people")
 //!     .json(&person) // Add JSON payload
-//!     .fetch_json::<Person>() // Returns Response<Json<Person>>
+//!     .fetch_json_ref::<Person>() // Returns Response<Json<Person>>
 //!     .await?;
 //!
 //! // You can inspect the response metadata if needed
@@ -439,51 +483,8 @@
 //! ```
 //!
 //! This minimizes heap allocations and copying because string fields borrow directly from the
-//! response buffer instead of allocating new memory for each string.
-//!
-//! ## Owned JSON with `fetch_json_owned`
-//!
-//! Use `fetch_json_owned` when you need owned data; it deserializes the JSON directly into your
-//! target type with owned `String` fields:
-//!
-//! ```rust
-//! # use fetch::{HttpClient, Response, StatusExt};
-//! # use serde::{Deserialize, Serialize};
-//! # #[cfg(feature = "json")]
-//! # async fn example(client: &HttpClient) -> Result<(), Box<dyn std::error::Error>> {
-//! // Define a Person type with owned data
-//! #[derive(Serialize, Deserialize)]
-//! struct Person {
-//!     id: u32,
-//!     name: String,
-//! }
-//!
-//! let person = Person {
-//!     id: 1,
-//!     name: "Alice Johnson".to_owned(),
-//! };
-//!
-//! // Send and receive owned JSON
-//! let response: Response<Person> = client
-//!     .put("https://api.company.com/people")
-//!     .json(&person) // Add JSON payload
-//!     .fetch_json_owned::<Person>() // Returns Response<Person> directly
-//!     .await?;
-//!
-//! // You can inspect the response metadata if needed
-//! let response = response.ensure_success()?;
-//!
-//! // Extract the deserialized Person directly - no wrapper needed
-//! let person: Person = response.into_body();
-//!
-//! println!("Person retrieved, name: {}", person.name);
-//!
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! This performs more allocations than `fetch_json`, but is more convenient when the data must
-//! outlive the response, cross thread boundaries, or satisfy APIs that require owned types.
+//! response buffer instead of allocating new memory for each string, at the cost of tying the parsed
+//! value to the response buffer's lifetime.
 //!
 //! # Request Pipeline
 //!

--- a/crates/fetch/src/lib.rs
+++ b/crates/fetch/src/lib.rs
@@ -595,7 +595,7 @@
 //!
 //! // Create a fake HTTP client that uses a custom handler. The handler can be
 //! // synchronous or asynchronous. Usually for testing, the synchronous handler is sufficient.
-//! let fake_handler = FakeHandler::from_sync_handler(|req| {
+//! let fake_handler = FakeHandler::from_fn(|req| {
 //!     println!("Fake handler called for request, url: {}", req.uri());
 //!
 //!     HttpResponseBuilder::new_fake()

--- a/crates/fetch/src/lib.rs
+++ b/crates/fetch/src/lib.rs
@@ -86,21 +86,18 @@
 //! ```rust,no_run
 //! # #[cfg(all(feature = "tokio", any(feature = "rustls", feature = "native-tls")))]
 //! # {
-//! use fetch::{HttpClient, HttpError, Response, StatusExt};
+//! use fetch::{HttpClient, HttpError};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), HttpError> {
 //!     // Create a client using the builder
 //!     let client: HttpClient = HttpClient::new_tokio();
 //!
-//!     // Retrieve the response as text
-//!     let response: Response<String> = client
-//!         .get("https://example.com")
-//!         .fetch_text()
-//!         .await?
-//!         .ensure_success()?; // Verifies that the response was successful
+//!     // Retrieve the response body as text. This validates the status (returning an
+//!     // error for `4xx`/`5xx` responses) and hands back the body in a single step.
+//!     let body: String = client.get("https://example.com").fetch_text_body().await?;
 //!
-//!     println!("response: {}", response.body());
+//!     println!("response: {body}");
 //!
 //!     Ok(())
 //! }
@@ -288,6 +285,29 @@
 //!     .ensure_success()? // Ensure the response was successful
 //!     .into_body(); // Discard the response metadata and get the body as a string
 //!
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Body-Only Shortcuts
+//!
+//! When you only need the body of a *successful* response, the `_body` variants go one step further:
+//! they call [`ensure_success`][crate::HttpResponse::ensure_success] for you, discard the response
+//! metadata, and return just the materialized body.
+//!
+//! - [`fetch_text_body`][crate::HttpRequestBuilder::fetch_text_body]: Validates the status and returns the body as a `String`.
+//! - [`fetch_bytes_body`][crate::HttpRequestBuilder::fetch_bytes_body]: Validates the status and returns the body as a `BytesView`.
+//! - [`fetch_json_body`][crate::HttpRequestBuilder::fetch_json_body]: Validates the status and deserializes the body into an owned value (requires `json` feature).
+//!
+//! ```rust
+//! # use fetch::HttpClient;
+//! # async fn example(client: &HttpClient) -> Result<(), Box<dyn std::error::Error>> {
+//! // Fetch, validate the status, and extract the body in a single call
+//! let text: String = client
+//!     .get("https://api.example.com/users")
+//!     .fetch_text_body()
+//!     .await?;
+//! println!("body: {text}");
 //! # Ok(())
 //! # }
 //! ```
@@ -608,9 +628,8 @@
 //! # use bytes::Buf;
 //! #
 //! # async fn example(client: &HttpClient) -> Result<(), Box<dyn std::error::Error>> {
-//! // Get a response body as a BytesView
-//! let response = client.get("https://example.com").fetch().await?;
-//! let mut body_bytes = response.into_body().into_bytes().await?;
+//! // Fetch the response body directly as a BytesView (validating the status along the way)
+//! let mut body_bytes = client.get("https://example.com").fetch_bytes_body().await?;
 //!
 //! // Work with the BytesView using standard bytes methods
 //! let length = body_bytes.remaining();
@@ -650,8 +669,7 @@
 //! let items_uri: Uri = "https://api.example.com/items".parse()?;
 //!
 //! // 3. Work with raw BytesView to avoid allocations when possible
-//! let response = client.get(users_uri.clone()).fetch().await?;
-//! let bytes = response.into_body().into_bytes().await?;
+//! let bytes = client.get(users_uri.clone()).fetch_bytes_body().await?;
 //! process_binary_data(bytes);
 //! # Ok(())
 //! # }
@@ -785,7 +803,7 @@ pub use http_extensions::routing;
 #[doc(inline)]
 pub use seatbelt::{Recovery, RecoveryInfo};
 #[doc(inline)]
-pub use templated_uri::{BasePath, BaseUri, Origin, Uri};
+pub use templated_uri::{BasePath, BaseUri, Origin, PathAndQuery, Uri};
 
 /// Re-exports of the [`http`](https://docs.rs/http) crate's submodules.
 ///

--- a/crates/fetch/src/tokio.rs
+++ b/crates/fetch/src/tokio.rs
@@ -215,7 +215,7 @@ mod tests {
 
         let mut client = HttpClient::builder_tokio(TokioDeps::with_clock(&clock))
             .custom_pipeline(|_root, _ctx| {
-                FakeHandler::from_sync_handler(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).build())
+                FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).build())
             })
             .build();
 

--- a/crates/fetch/src/tokio.rs
+++ b/crates/fetch/src/tokio.rs
@@ -214,9 +214,7 @@ mod tests {
         let clock = Clock::new_tokio();
 
         let mut client = HttpClient::builder_tokio(TokioDeps::with_clock(&clock))
-            .custom_pipeline(|_root, _ctx| {
-                FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).build())
-            })
+            .custom_pipeline(|_root, _ctx| FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).build()))
             .build();
 
         // Verify the client works before relocation.

--- a/crates/fetch/tests/requests.rs
+++ b/crates/fetch/tests/requests.rs
@@ -113,7 +113,7 @@ async fn json_owned() {
 
     let person = client
         .get(server.uri() + "/hello-world")
-        .fetch_json_owned::<Person>()
+        .fetch_json::<Person>()
         .await
         .unwrap()
         .into_body();
@@ -139,7 +139,7 @@ async fn json_borrowed() {
 
     let mut json = client
         .get(server.uri() + "/hello-world")
-        .fetch_json::<Person>()
+        .fetch_json_ref::<Person>()
         .await
         .unwrap()
         .into_body();

--- a/crates/fetch/tests/resilience.rs
+++ b/crates/fetch/tests/resilience.rs
@@ -61,7 +61,7 @@ async fn retry_defaults_non_transient_codes() {
 #[cfg_attr(miri, ignore)]
 #[tokio::test]
 async fn retry_defaults_restore_requests() {
-    let handler = FakeHandler::from_http_error(|req| {
+    let handler = FakeHandler::from_error_fn(|req| {
         let index = req.extensions().get::<Attempt>().copied().unwrap().index();
         HttpError::unavailable(format!("unavailable-{index}")).with_request(req)
     });

--- a/crates/fetch/tests/standard_pipeline.rs
+++ b/crates/fetch/tests/standard_pipeline.rs
@@ -60,7 +60,7 @@ async fn send_requests(client: &HttpClient, uri: &str, count: usize) {
 /// `failing.example.com` → 500 Internal Server Error
 /// everything else       → 200 OK
 fn create_per_host_client(calls: Calls) -> HttpClient {
-    let handler = FakeHandler::from_sync_handler(move |req| {
+    let handler = FakeHandler::from_fn(move |req| {
         calls.increment();
 
         let status = if req.uri().host() == Some("failing.example.com") {
@@ -93,7 +93,7 @@ fn create_per_host_client(calls: Calls) -> HttpClient {
 
 /// Creates a client where every request returns the given status code.
 fn create_uniform_client(status: StatusCode, calls: Calls) -> HttpClient {
-    let handler = FakeHandler::from_sync_handler(move |_req| {
+    let handler = FakeHandler::from_fn(move |_req| {
         calls.increment();
         HttpResponseBuilder::new_fake().status(status).build()
     });
@@ -287,7 +287,7 @@ fn create_hedging_client(calls: Calls, responses: Vec<StatusCode>) -> HttpClient
     let clock = ClockControl::default().auto_advance_timers(true).to_clock();
     let responses = Arc::new(std::sync::Mutex::new(responses.into_iter()));
 
-    let handler = FakeHandler::from_sync_handler(move |_req| {
+    let handler = FakeHandler::from_fn(move |_req| {
         calls.increment();
         let status = responses.lock().unwrap().next().unwrap_or(StatusCode::SERVICE_UNAVAILABLE);
         HttpResponseBuilder::new_fake().status(status).build()
@@ -356,7 +356,7 @@ async fn fallback_router_recovers_when_primary_is_unavailable() {
     // Primary always fails with an `unavailable` error so the retry layer in
     // the standard pipeline (which enables `handle_unavailable` whenever the
     // router exposes alternatives) routes the next attempt to the fallback.
-    let handler = FakeHandler::from_sync_handler(move |req| match req.uri().host() {
+    let handler = FakeHandler::from_fn(move |req| match req.uri().host() {
         Some(PRIMARY_HOST) => {
             handler_calls.primary.fetch_add(1, Ordering::Relaxed);
             Err(HttpError::unavailable("primary is down").with_request(req))

--- a/crates/fetch/tests/uri_handling.rs
+++ b/crates/fetch/tests/uri_handling.rs
@@ -13,7 +13,7 @@ use templated_uri::{BaseUri, PathAndQuery, Uri};
 
 fn prepare_client_with_base_uri(base_uri: BaseUri) -> HttpClient {
     HttpClient::builder_fake(
-        FakeHandler::from_async_handler(|request| async move {
+        FakeHandler::from_async_fn(|request| async move {
             let response = format!("requested URI: {}", request.uri());
             HttpResponseBuilder::new_fake().status(StatusCode::OK).text(response).build()
         }),

--- a/crates/http_extensions/src/body/mod.rs
+++ b/crates/http_extensions/src/body/mod.rs
@@ -330,7 +330,7 @@ impl HttpBody {
     ///
     /// async fn example(body: HttpBody) -> Result<(), HttpError> {
     ///     // Parse the JSON body into a structured type
-    ///     let user: User = body.into_json_owned().await?;
+    ///     let user: User = body.into_json().await?;
     ///
     ///     println!("Received user: {} (ID: {})", user.name, user.id);
     ///
@@ -347,14 +347,14 @@ impl HttpBody {
     /// # }
     /// ```
     #[cfg(any(feature = "json", test))]
-    pub fn into_json_owned<T: serde_core::de::DeserializeOwned>(self) -> impl Future<Output = Result<T>> + Send {
-        self.into_json::<T>().map(|json| Ok(json?.read_owned()?))
+    pub fn into_json<T: serde_core::de::DeserializeOwned>(self) -> impl Future<Output = Result<T>> + Send {
+        self.into_json_ref::<T>().map(|json| Ok(json?.read_owned()?))
     }
 
     /// Consumes the body and converts it to a zero-copy JSON parser.
     ///
     /// This method provides zero-copy JSON parsing by working directly with the underlying
-    /// memory buffer. Unlike [`into_json_owned`][HttpBody::into_json_owned], this method can work with borrowed data
+    /// memory buffer. Unlike [`into_json`][HttpBody::into_json], this method can work with borrowed data
     /// and types that use `Cow<str>` for efficient string handling.
     ///
     /// The returned [`Json<T>`][crate::Json] allows you to deserialize into types that can borrow from
@@ -386,7 +386,7 @@ impl HttpBody {
     ///
     /// async fn example(body: HttpBody) -> Result<(), HttpError> {
     ///     // Parse JSON while potentially borrowing string data
-    ///     let mut json = body.into_json::<User>().await?;
+    ///     let mut json = body.into_json_ref::<User>().await?;
     ///     let user = json.read()?;
     ///
     ///     println!("User: {} <{}> (ID: {})", user.name, user.email, user.id);
@@ -405,9 +405,9 @@ impl HttpBody {
     /// # }
     /// ```
     ///
-    /// For types that don't need borrowing, prefer [`into_json_owned`][HttpBody::into_json_owned] for simpler usage.
+    /// For types that don't need borrowing, prefer [`into_json`][HttpBody::into_json] for simpler usage.
     #[cfg(any(feature = "json", test))]
-    pub fn into_json<'a, T: serde_core::de::Deserialize<'a>>(self) -> impl Future<Output = Result<crate::json::Json<T>>> + Send {
+    pub fn into_json_ref<'a, T: serde_core::de::Deserialize<'a>>(self) -> impl Future<Output = Result<crate::json::Json<T>>> + Send {
         self.into_bytes().map_ok(crate::json::Json::<T>::new)
     }
 
@@ -660,7 +660,7 @@ mod tests {
 
         assert_eq!(Some(22), body.content_length());
 
-        let result: Model = block_on(body.into_json_owned()).unwrap();
+        let result: Model = block_on(body.into_json()).unwrap();
 
         assert_eq!(data, result);
     }
@@ -672,12 +672,12 @@ mod tests {
         let body = builder.text("{invalid json}");
 
         // Attempt to deserialize to our model, which should fail
-        let result: Result<Model> = block_on(body.into_json_owned());
+        let result: Result<Model> = block_on(body.into_json());
         result.unwrap_err();
     }
 
     #[test]
-    fn into_json_with_cow_strings() {
+    fn into_json_ref_with_cow_strings() {
         use std::borrow::Cow;
 
         #[derive(Debug, Deserialize, PartialEq)]
@@ -694,7 +694,7 @@ mod tests {
         let builder = HttpBodyBuilder::new_fake();
         let body = builder.text(json_data);
 
-        let mut json_result = block_on(body.into_json::<User>()).unwrap();
+        let mut json_result = block_on(body.into_json_ref::<User>()).unwrap();
         let user = json_result.read().unwrap();
 
         assert_eq!(user.id, 42);
@@ -1049,11 +1049,11 @@ mod tests {
     }
 
     #[test]
-    fn external_body_into_json_owned() {
+    fn external_body_into_json() {
         let builder = HttpBodyBuilder::new_fake();
         let json_bytes = br#"{"id":42,"name":"alice"}"#;
         let body = create_stream_body(&builder, json_bytes, &HttpBodyOptions::default());
-        let model: Model = block_on(body.into_json_owned()).unwrap();
+        let model: Model = block_on(body.into_json()).unwrap();
         assert_eq!(
             model,
             Model {

--- a/crates/http_extensions/src/error.rs
+++ b/crates/http_extensions/src/error.rs
@@ -514,7 +514,7 @@ mod tests {
         #[derive(Debug, Deserialize)]
         struct Person;
 
-        let handler = FakeHandler::from_sync_handler(|_| HttpResponseBuilder::new_fake().text("invalid json").build());
+        let handler = FakeHandler::from_fn(|_| HttpResponseBuilder::new_fake().text("invalid json").build());
 
         let err = block_on(handler.request_builder().uri("https://dummy.com").fetch_json::<Person>()).unwrap_err();
 

--- a/crates/http_extensions/src/error.rs
+++ b/crates/http_extensions/src/error.rs
@@ -516,7 +516,7 @@ mod tests {
 
         let handler = FakeHandler::from_sync_handler(|_| HttpResponseBuilder::new_fake().text("invalid json").build());
 
-        let err = block_on(handler.request_builder().uri("https://dummy.com").fetch_json_owned::<Person>()).unwrap_err();
+        let err = block_on(handler.request_builder().uri("https://dummy.com").fetch_json::<Person>()).unwrap_err();
 
         let label = ErrorLabel::from_error_chain(&err, HttpError::resolve_error_label);
         assert_eq!(label, "json.json_deserialization");

--- a/crates/http_extensions/src/fake_handler.rs
+++ b/crates/http_extensions/src/fake_handler.rs
@@ -158,13 +158,13 @@ impl FakeHandler {
     /// # #[cfg(feature = "test-util")] {
     /// use http_extensions::{FakeHandler, HttpError, HttpRequest};
     ///
-    /// let handler = FakeHandler::from_http_error(|_request: HttpRequest| {
+    /// let handler = FakeHandler::from_error_fn(|_request: HttpRequest| {
     ///     HttpError::validation("simulated error")
     /// });
     /// # }
     /// # }
     /// ```
-    pub fn from_http_error(error: impl Fn(HttpRequest) -> HttpError + Send + Sync + 'static) -> Self {
+    pub fn from_error_fn(error: impl Fn(HttpRequest) -> HttpError + Send + Sync + 'static) -> Self {
         Self::from_fn(move |req| Err(error(req)))
     }
 
@@ -575,8 +575,8 @@ mod tests {
     }
 
     #[test]
-    fn from_http_error() {
-        let handler = FakeHandler::from_http_error(|_request| HttpError::validation("simulated error"));
+    fn from_error_fn() {
+        let handler = FakeHandler::from_error_fn(|_request| HttpError::validation("simulated error"));
 
         let error = get_response(&handler).unwrap_err();
         assert_eq!(error.message(), "simulated error");

--- a/crates/http_extensions/src/fake_handler.rs
+++ b/crates/http_extensions/src/fake_handler.rs
@@ -67,7 +67,7 @@ type PinnedFuture = Pin<Box<dyn Future<Output = Result<HttpResponse>> + Send>>;
 /// use http::StatusCode;
 /// use http_extensions::{FakeHandler, HttpResponseBuilder};
 ///
-/// let handler = FakeHandler::from_sync_handler(|request| {
+/// let handler = FakeHandler::from_fn(|request| {
 ///     if request.uri().path() == "/api/users" {
 ///         HttpResponseBuilder::new_fake()
 ///             .status(StatusCode::OK)
@@ -87,7 +87,7 @@ type PinnedFuture = Pin<Box<dyn Future<Output = Result<HttpResponse>> + Send>>;
 /// # Working with [`HttpResponseBuilder`][crate::HttpResponseBuilder]
 ///
 /// Use [`HttpResponseBuilder::new_fake`][crate::HttpResponseBuilder::new_fake] to generate tailored test responses
-/// with a fluent API. This is especially useful with [`FakeHandler::from_sync_handler`]
+/// with a fluent API. This is especially useful with [`FakeHandler::from_fn`]
 /// to create responses that react to request data:
 #[derive(Clone, Debug)]
 pub struct FakeHandler {
@@ -129,7 +129,7 @@ impl FakeHandler {
     /// use http::StatusCode;
     /// use http_extensions::{FakeHandler, HttpResponseBuilder};
     ///
-    /// let handler = FakeHandler::from_sync_handler(|request| {
+    /// let handler = FakeHandler::from_fn(|request| {
     ///     HttpResponseBuilder::new_fake()
     ///         .status(StatusCode::OK)
     ///         .text("Hello World")
@@ -138,12 +138,12 @@ impl FakeHandler {
     /// # }
     /// # }
     /// ```
-    pub fn from_sync_handler<H>(handler: H) -> Self
+    pub fn from_fn<H>(handler: H) -> Self
     where
         H: Fn(HttpRequest) -> Result<HttpResponse> + 'static + Send + Sync,
     {
         let handler = Arc::new(handler);
-        Self::from_async_handler(move |req| {
+        Self::from_async_fn(move |req| {
             let cloned = Arc::clone(&handler);
             async move { cloned(req) }
         })
@@ -165,7 +165,7 @@ impl FakeHandler {
     /// # }
     /// ```
     pub fn from_http_error(error: impl Fn(HttpRequest) -> HttpError + Send + Sync + 'static) -> Self {
-        Self::from_sync_handler(move |req| Err(error(req)))
+        Self::from_fn(move |req| Err(error(req)))
     }
 
     /// Creates a handler from an asynchronous function.
@@ -181,7 +181,7 @@ impl FakeHandler {
     /// use http::StatusCode;
     /// use http_extensions::{FakeHandler, HttpResponseBuilder};
     ///
-    /// let handler = FakeHandler::from_async_handler(|request| async move {
+    /// let handler = FakeHandler::from_async_fn(|request| async move {
     ///     // Simulate network delay
     ///     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     ///
@@ -193,7 +193,7 @@ impl FakeHandler {
     /// # }
     /// # }
     /// ```
-    pub fn from_async_handler<H, F>(handler: H) -> Self
+    pub fn from_async_fn<H, F>(handler: H) -> Self
     where
         H: Fn(HttpRequest) -> F + 'static + Send + Sync,
         F: Future<Output = Result<HttpResponse>> + Send + 'static,
@@ -323,7 +323,7 @@ impl From<HttpResponse> for FakeHandler {
         let (parts, body) = value.into_parts();
         let body = MaybeUnbufferedBody(Mutex::new(body));
 
-        Self::from_sync_handler(move |_| {
+        Self::from_fn(move |_| {
             let data = body.get_data()?;
             Ok(Response::from_parts(parts.clone(), data))
         })
@@ -456,9 +456,9 @@ mod tests {
     }
 
     #[test]
-    fn from_sync_handler_ok() -> std::result::Result<(), ohno::AppError> {
+    fn from_fn_ok() -> std::result::Result<(), ohno::AppError> {
         let handler =
-            FakeHandler::from_sync_handler(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("Sync response").build());
+            FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("Sync response").build());
 
         assert_eq!(get_response_text(&handler)?, "Sync response");
 
@@ -466,8 +466,8 @@ mod tests {
     }
 
     #[test]
-    fn from_async_handler_ok() -> std::result::Result<(), ohno::AppError> {
-        let handler = FakeHandler::from_async_handler(|_request| async move {
+    fn from_async_fn_ok() -> std::result::Result<(), ohno::AppError> {
+        let handler = FakeHandler::from_async_fn(|_request| async move {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .text("Async response")
@@ -530,7 +530,7 @@ mod tests {
     #[test]
     fn async_handler_returns_error() {
         let handler =
-            FakeHandler::from_async_handler(|_request| async { Err(HttpError::validation("this is a test error from async handler")) });
+            FakeHandler::from_async_fn(|_request| async { Err(HttpError::validation("this is a test error from async handler")) });
 
         // Next call should produce a specific error message
         let error = get_response(&handler).unwrap_err();
@@ -601,7 +601,7 @@ mod tests {
         assert!(
             format!(
                 "{:?}",
-                FakeHandler::from_sync_handler(|_| Ok(Response::new(HttpBodyBuilder::new_fake().empty())))
+                FakeHandler::from_fn(|_| Ok(Response::new(HttpBodyBuilder::new_fake().empty())))
             )
             .contains("Custom")
         );

--- a/crates/http_extensions/src/fake_handler.rs
+++ b/crates/http_extensions/src/fake_handler.rs
@@ -457,8 +457,7 @@ mod tests {
 
     #[test]
     fn from_fn_ok() -> std::result::Result<(), ohno::AppError> {
-        let handler =
-            FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("Sync response").build());
+        let handler = FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("Sync response").build());
 
         assert_eq!(get_response_text(&handler)?, "Sync response");
 

--- a/crates/http_extensions/src/http_request_builder.rs
+++ b/crates/http_extensions/src/http_request_builder.rs
@@ -1375,8 +1375,7 @@ mod tests {
 
     #[test]
     fn fetch_ok() {
-        let client =
-            FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("response body").build());
+        let client = FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("response body").build());
 
         let response = block_on(client.request_builder().uri("https://example.com").method(Method::GET).fetch()).unwrap();
 
@@ -1408,8 +1407,7 @@ mod tests {
 
     #[test]
     fn fetch_text_ok() {
-        let client =
-            FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("text response").build());
+        let client = FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("text response").build());
 
         let response = block_on(client.request_builder().uri("https://example.com").method(Method::GET).fetch_text()).unwrap();
 
@@ -1464,8 +1462,7 @@ mod tests {
 
     #[test]
     fn fetch_text_body_ok() {
-        let client =
-            FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("text body").build());
+        let client = FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("text body").build());
 
         let body = block_on(client.request_builder().get("https://example.com").fetch_text_body()).unwrap();
 

--- a/crates/http_extensions/src/http_request_builder.rs
+++ b/crates/http_extensions/src/http_request_builder.rs
@@ -888,6 +888,75 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
             .and_then(|response| ready(response.ensure_success()))
             .and_then(|response| response.into_body().into_json_owned::<J>())
     }
+
+    /// Sends the request, validates the response status, and returns the JSON body with optional borrowing.
+    ///
+    /// This is a convenience method equivalent to calling [`fetch`](Self::fetch), then
+    /// [`ensure_success`](crate::StatusExt::ensure_success) on the response, and finally preparing the
+    /// body for borrowed JSON deserialization. The response metadata is discarded, yielding only the
+    /// [`Json<J>`][crate::Json] wrapper.
+    ///
+    /// Like [`fetch_json_ref`](Self::fetch_json_ref), the returned [`Json<J>`][crate::Json] can borrow
+    /// strings and byte arrays directly from the underlying response data, avoiding allocations in
+    /// performance-sensitive code. When you want an owned value instead, prefer
+    /// [`fetch_json_body`](Self::fetch_json_body).
+    ///
+    /// This method requires the `json` feature to be enabled.
+    ///
+    /// # Note
+    ///
+    /// This method only prepares the data for deserialization by downloading all content
+    /// to memory. The actual JSON deserialization happens lazily when you access the data
+    /// through the [`Json<J>`][crate::Json] wrapper.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use serde::Deserialize;
+    /// # use std::borrow::Cow;
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
+    /// # use http_extensions::{HttpError, HttpRequestBuilder, Json, HttpResponseBuilder,
+    /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
+    /// #
+    /// # #[derive(Deserialize)]
+    /// # struct User<'a> { id: u32, #[serde(borrow)] name: Cow<'a, str> }
+    /// #
+    /// # #[cfg(feature = "test-util")]
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), HttpError> {
+    /// # let bb = HttpBodyBuilder::new_fake();
+    /// # let handler = FakeHandler::from(
+    /// #     HttpResponseBuilder::new(&bb).status(200).text(r#"{"id":42,"name":"Alice"}"#).build()?
+    /// # );
+    /// # let request_builder = handler.request_builder();
+    /// let mut body: Json<User> = request_builder
+    ///     .get("https://example.com/users/42")
+    ///     .fetch_json_ref_body::<User>()
+    ///     .await?;
+    ///
+    /// let user: User = body.read()?;
+    /// println!("User: {}", user.name);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The request couldn't be built
+    /// - The network request failed
+    /// - The response status is not in the `2xx` success range
+    /// - The response body isn't valid UTF-8
+    // Chained `and_then` (rather than `Either` + `ready(Err(..))`) keeps the returned future
+    // `Send` without requiring `J: Send`: the only stage that mentions `J` is `into_json`, which
+    // yields the `Json<J>` wrapper as its final output and never holds it across an await point.
+    #[cfg(any(feature = "json", test))]
+    pub fn fetch_json_ref_body<'de, J: serde_core::de::Deserialize<'de>>(self) -> impl Future<Output = Result<crate::Json<J>>> + Send {
+        self.fetch()
+            .and_then(|response| ready(response.ensure_success()))
+            .and_then(|response| response.into_body().into_json::<J>())
+    }
 }
 
 #[cfg(test)]
@@ -1469,6 +1538,47 @@ mod tests {
         });
 
         let err = block_on(client.request_builder().get("https://example.com").fetch_json_body::<JsonData>()).unwrap_err();
+
+        assert_eq!(err.label(), "response_unsuccessful");
+    }
+
+    #[test]
+    fn fetch_json_ref_body_ok() {
+        let client = FakeHandler::from_sync_handler(|_request| {
+            HttpResponseBuilder::new_fake()
+                .status(StatusCode::OK)
+                .json(&JsonData { id: 7 })
+                .build()
+        });
+
+        let mut json = block_on(
+            client
+                .request_builder()
+                .get("https://example.com")
+                .fetch_json_ref_body::<JsonData>(),
+        )
+        .unwrap();
+
+        let json_data = json.read().unwrap();
+        assert_eq!(json_data.id, 7);
+    }
+
+    #[test]
+    fn fetch_json_ref_body_ensures_success() {
+        let client = FakeHandler::from_sync_handler(|_request| {
+            HttpResponseBuilder::new_fake()
+                .status(StatusCode::BAD_REQUEST)
+                .json(&JsonData { id: 1 })
+                .build()
+        });
+
+        let err = block_on(
+            client
+                .request_builder()
+                .get("https://example.com")
+                .fetch_json_ref_body::<JsonData>(),
+        )
+        .unwrap_err();
 
         assert_eq!(err.label(), "response_unsuccessful");
     }

--- a/crates/http_extensions/src/http_request_builder.rs
+++ b/crates/http_extensions/src/http_request_builder.rs
@@ -621,11 +621,15 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
         })
     }
 
-    /// Sends the request and deserializes the response body as JSON.
+    /// Sends the request and deserializes the response body as owned JSON.
     ///
     /// Handles the complete request-response cycle and JSON deserialization. Consumes the
     /// [`HttpRequestBuilder`] and automatically sets headers like `Content-Length` and `Content-Type`.
-    /// Use this when you need owned data that can outlive the response.
+    /// This is the most common way to read a JSON response: it deserializes directly into an owned
+    /// value that can outlive the response and cross thread boundaries.
+    ///
+    /// For performance-sensitive scenarios where you want to borrow string and byte data directly from
+    /// the response buffer, use [`fetch_json_ref`](Self::fetch_json_ref) instead.
     ///
     /// This method requires the `json` feature to be enabled.
     ///
@@ -652,7 +656,7 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// # let request_builder = handler.request_builder();
     /// let response: Response<User> = request_builder
     ///     .get("https://example.com/users/42")
-    ///     .fetch_json_owned::<User>()
+    ///     .fetch_json::<User>()
     ///     .await?;
     ///
     /// println!("User: {}", response.body().name);
@@ -668,7 +672,7 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// - The response body isn't valid UTF-8
     /// - JSON deserialization failed
     #[cfg(any(feature = "json", test))]
-    pub fn fetch_json_owned<J: serde_core::de::DeserializeOwned>(self) -> impl Future<Output = Result<Response<J>>> + Send {
+    pub fn fetch_json<J: serde_core::de::DeserializeOwned>(self) -> impl Future<Output = Result<Response<J>>> + Send {
         self.fetch().and_then(|response| {
             let (parts, body) = response.into_parts();
             body.into_json_owned::<J>().map_ok(move |body| Response::from_parts(parts, body))
@@ -679,7 +683,10 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     ///
     /// Handles the complete request-response cycle and JSON deserialization. Consumes the
     /// [`HttpRequestBuilder`] and automatically sets headers like `Content-Length` and `Content-Type`.
-    /// Returns a [`Json<T>`][crate::Json] wrapper that can borrow from the underlying response data.
+    /// Returns a [`Json<T>`][crate::Json] wrapper that can borrow strings and byte arrays directly from
+    /// the underlying response data, avoiding allocations in performance-sensitive code.
+    ///
+    /// For the common case where you want owned data, prefer [`fetch_json`](Self::fetch_json).
     ///
     /// This method requires the `json` feature to be enabled.
     ///
@@ -712,7 +719,7 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// # let request_builder = handler.request_builder();
     /// let mut response: Json<User> = request_builder
     ///     .get("https://example.com/users/42")
-    ///     .fetch_json::<User>()
+    ///     .fetch_json_ref::<User>()
     ///     .await?
     ///     .into_body();
     ///
@@ -729,7 +736,7 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// - The network request failed
     /// - The response body isn't valid UTF-8
     #[cfg(any(feature = "json", test))]
-    pub fn fetch_json<'de, J: serde_core::de::Deserialize<'de>>(self) -> impl Future<Output = Result<Response<crate::Json<J>>>> + Send {
+    pub fn fetch_json_ref<'de, J: serde_core::de::Deserialize<'de>>(self) -> impl Future<Output = Result<Response<crate::Json<J>>>> + Send {
         self.fetch().and_then(|response| {
             let (parts, body) = response.into_parts();
             body.into_json::<J>().map_ok(move |body| Response::from_parts(parts, body))
@@ -828,9 +835,9 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// the body into an owned value of type `J`. The response metadata is discarded, yielding only the
     /// materialized body.
     ///
-    /// Like [`fetch_json_owned`](Self::fetch_json_owned), this deserializes into an owned type that can
+    /// Like [`fetch_json`](Self::fetch_json), this deserializes into an owned type that can
     /// outlive the response. When you want to borrow from the response buffer for zero-copy parsing, use
-    /// [`fetch_json`](Self::fetch_json) and read from the returned [`Json<J>`][crate::Json] instead.
+    /// [`fetch_json_ref`](Self::fetch_json_ref) and read from the returned [`Json<J>`][crate::Json] instead.
     ///
     /// This method requires the `json` feature to be enabled.
     ///
@@ -1256,7 +1263,7 @@ mod tests {
                 .request_builder()
                 .uri("https://example.com/user")
                 .method(Method::GET)
-                .fetch_json::<BorrowedJsonData>(),
+                .fetch_json_ref::<BorrowedJsonData>(),
         )
         .unwrap()
         .into_body();
@@ -1289,7 +1296,7 @@ mod tests {
                 .request_builder()
                 .uri("https://example.com")
                 .method(Method::GET)
-                .fetch_json_owned::<JsonData>(),
+                .fetch_json::<JsonData>(),
         );
 
         assert!(result.is_err());
@@ -1364,7 +1371,7 @@ mod tests {
     }
 
     #[test]
-    fn fetch_json_ok() {
+    fn fetch_json_ref_ok() {
         let client = FakeHandler::from_sync_handler(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
@@ -1377,7 +1384,7 @@ mod tests {
                 .request_builder()
                 .uri("https://example.com")
                 .method(Method::GET)
-                .fetch_json::<JsonData>(),
+                .fetch_json_ref::<JsonData>(),
         )
         .unwrap();
 
@@ -1475,7 +1482,7 @@ mod tests {
         let text = client.request_builder().get("https://example.com").fetch_text();
         let bytes = client.request_builder().get("https://example.com").fetch_bytes();
         let json = client.request_builder().get("https://example.com").fetch_json::<JsonData>();
-        let json_owned = client.request_builder().get("https://example.com").fetch_json_owned::<JsonData>();
+        let json_ref = client.request_builder().get("https://example.com").fetch_json_ref::<JsonData>();
         let text_body = client.request_builder().get("https://example.com").fetch_text_body();
         let bytes_body = client.request_builder().get("https://example.com").fetch_bytes_body();
         let json_body = client.request_builder().get("https://example.com").fetch_json_body::<JsonData>();
@@ -1486,7 +1493,7 @@ mod tests {
             ("fetch_text", size_of_val(&text)),
             ("fetch_bytes", size_of_val(&bytes)),
             ("fetch_json", size_of_val(&json)),
-            ("fetch_json_owned", size_of_val(&json_owned)),
+            ("fetch_json_ref", size_of_val(&json_ref)),
             ("fetch_text_body", size_of_val(&text_body)),
             ("fetch_bytes_body", size_of_val(&bytes_body)),
             ("fetch_json_body", size_of_val(&json_body)),
@@ -1503,7 +1510,7 @@ mod tests {
     }
 
     #[test]
-    fn fetch_json_owned_ok() {
+    fn fetch_json_ok() {
         let client = FakeHandler::from_sync_handler(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
@@ -1516,7 +1523,7 @@ mod tests {
                 .request_builder()
                 .uri("https://example.com")
                 .method(Method::GET)
-                .fetch_json_owned::<JsonData>(),
+                .fetch_json::<JsonData>(),
         )
         .unwrap();
 

--- a/crates/http_extensions/src/http_request_builder.rs
+++ b/crates/http_extensions/src/http_request_builder.rs
@@ -1317,7 +1317,7 @@ mod tests {
         // JSON with escaped characters that should be properly deserialized into Cow
         let json_response = r#"{"id":123,"name":"John Doe","description":"A person with \"special\" characters: \n\t\\"}"#;
 
-        let client = FakeHandler::from_sync_handler(move |_request| {
+        let client = FakeHandler::from_fn(move |_request| {
             let json_response = json_response.to_string();
 
             HttpResponseBuilder::new_fake()
@@ -1353,7 +1353,7 @@ mod tests {
 
     #[test]
     fn json_deserialization_error() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .text("corrupted json")
@@ -1376,7 +1376,7 @@ mod tests {
     #[test]
     fn fetch_ok() {
         let client =
-            FakeHandler::from_sync_handler(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("response body").build());
+            FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("response body").build());
 
         let response = block_on(client.request_builder().uri("https://example.com").method(Method::GET).fetch()).unwrap();
 
@@ -1386,7 +1386,7 @@ mod tests {
 
     #[test]
     fn fetch_buffered_ok() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .text("buffered response")
@@ -1409,7 +1409,7 @@ mod tests {
     #[test]
     fn fetch_text_ok() {
         let client =
-            FakeHandler::from_sync_handler(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("text response").build());
+            FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("text response").build());
 
         let response = block_on(client.request_builder().uri("https://example.com").method(Method::GET).fetch_text()).unwrap();
 
@@ -1419,7 +1419,7 @@ mod tests {
 
     #[test]
     fn fetch_bytes_ok() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .bytes(BytesView::copied_from_slice(b"BytesView response", &HttpBodyBuilder::new_fake()))
@@ -1441,7 +1441,7 @@ mod tests {
 
     #[test]
     fn fetch_json_ref_ok() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .json(&JsonData { id: 42 })
@@ -1465,7 +1465,7 @@ mod tests {
     #[test]
     fn fetch_text_body_ok() {
         let client =
-            FakeHandler::from_sync_handler(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("text body").build());
+            FakeHandler::from_fn(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("text body").build());
 
         let body = block_on(client.request_builder().get("https://example.com").fetch_text_body()).unwrap();
 
@@ -1474,7 +1474,7 @@ mod tests {
 
     #[test]
     fn fetch_bytes_body_ok() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .bytes(BytesView::copied_from_slice(b"bytes body", &HttpBodyBuilder::new_fake()))
@@ -1488,7 +1488,7 @@ mod tests {
 
     #[test]
     fn fetch_json_body_ok() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .json(&JsonData { id: 7 })
@@ -1502,7 +1502,7 @@ mod tests {
 
     #[test]
     fn fetch_text_body_ensures_success() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .text("boom")
@@ -1516,7 +1516,7 @@ mod tests {
 
     #[test]
     fn fetch_bytes_body_ensures_success() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::NOT_FOUND)
                 .text("missing")
@@ -1530,7 +1530,7 @@ mod tests {
 
     #[test]
     fn fetch_json_body_ensures_success() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::BAD_REQUEST)
                 .json(&JsonData { id: 1 })
@@ -1544,7 +1544,7 @@ mod tests {
 
     #[test]
     fn fetch_json_ref_body_ok() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .json(&JsonData { id: 7 })
@@ -1565,7 +1565,7 @@ mod tests {
 
     #[test]
     fn fetch_json_ref_body_ensures_success() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::BAD_REQUEST)
                 .json(&JsonData { id: 1 })
@@ -1621,7 +1621,7 @@ mod tests {
 
     #[test]
     fn fetch_json_ok() {
-        let client = FakeHandler::from_sync_handler(|_request| {
+        let client = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .json(&JsonData { id: 123 })
@@ -1643,7 +1643,7 @@ mod tests {
 
     #[test]
     fn fetch_with_request_validation() {
-        let client = FakeHandler::from_async_handler(|request| {
+        let client = FakeHandler::from_async_fn(|request| {
             async move {
                 // Validate the request that was sent
                 assert_eq!(request.method(), Method::POST);
@@ -1672,7 +1672,7 @@ mod tests {
 
     #[test]
     fn fetch_with_empty_body() {
-        let client = FakeHandler::from_async_handler(|request| async move {
+        let client = FakeHandler::from_async_fn(|request| async move {
             assert_eq!(request.headers().get_value_or(CONTENT_LENGTH, -1), 0);
             assert!(request.headers().get(CONTENT_TYPE).is_none());
             let body_len = request.into_body().into_bytes().await.unwrap().len();
@@ -1686,7 +1686,7 @@ mod tests {
 
     #[test]
     fn fetch_with_json_body_validation() {
-        let client = FakeHandler::from_sync_handler(|request| {
+        let client = FakeHandler::from_fn(|request| {
             // Both Content-Length and Content-Type should be set
             assert_eq!(request.headers().get_value_or(CONTENT_LENGTH, 0), 9);
             assert_eq!(request.headers().get_str_value_or(CONTENT_TYPE, ""), "application/json");
@@ -1707,7 +1707,7 @@ mod tests {
 
     #[test]
     fn fetch_with_multiple_headers() {
-        let client = FakeHandler::from_sync_handler(|request| {
+        let client = FakeHandler::from_fn(|request| {
             assert_eq!(request.headers().get_str_value_or("x-first", ""), "first");
             assert_eq!(request.headers().get_str_value_or("x-second", ""), "second");
             assert_eq!(request.version(), http::Version::HTTP_11);
@@ -1809,7 +1809,7 @@ mod tests {
 
     #[test]
     fn method_convenience_with_fetch() {
-        let client = FakeHandler::from_sync_handler(|request| {
+        let client = FakeHandler::from_fn(|request| {
             assert_eq!(request.method(), Method::POST);
             assert_eq!(request.uri(), "https://example.com/api");
 
@@ -1934,7 +1934,7 @@ mod tests {
 
     #[test]
     fn fetch_returns_error_when_build_fails() {
-        let handler = FakeHandler::from_sync_handler(|_request| {
+        let handler = FakeHandler::from_fn(|_request| {
             HttpResponseBuilder::new_fake()
                 .status(StatusCode::OK)
                 .text("should not reach")

--- a/crates/http_extensions/src/http_request_builder.rs
+++ b/crates/http_extensions/src/http_request_builder.rs
@@ -15,7 +15,7 @@ use templated_uri::Uri;
 use crate::error_labels::LABEL_URI_MISSING;
 use crate::http_utils::{CONTENT_TYPE_TEXT, try_content_length_header, try_header};
 use crate::timeout::{BodyTimeout, ResponseTimeout};
-use crate::{HttpBody, HttpBodyBuilder, HttpBodyOptions, HttpError, HttpRequest, HttpResponse, RequestHandler, Result};
+use crate::{HttpBody, HttpBodyBuilder, HttpBodyOptions, HttpError, HttpRequest, HttpResponse, RequestHandler, Result, StatusExt};
 
 /// A fluent builder for creating HTTP requests.
 ///
@@ -735,6 +735,152 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
             body.into_json::<J>().map_ok(move |body| Response::from_parts(parts, body))
         })
     }
+
+    /// Sends the request, validates the response status, and returns just the response body as text.
+    ///
+    /// This is a convenience method equivalent to calling [`fetch`](Self::fetch), then
+    /// [`ensure_success`](crate::StatusExt::ensure_success) on the response, and finally reading the
+    /// body as UTF-8 text. The response metadata is discarded, yielding only the materialized text body.
+    ///
+    /// Calling this method consumes the [`HttpRequestBuilder`] instance. It automatically sets
+    /// appropriate headers based on the request body, such as `Content-Length` and `Content-Type`,
+    /// if they haven't been set already.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
+    /// # use http_extensions::{HttpError, HttpRequestBuilder, HttpResponseBuilder,
+    /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
+    /// # #[cfg(feature = "test-util")]
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), HttpError> {
+    /// # let bb = HttpBodyBuilder::new_fake();
+    /// # let handler = FakeHandler::from(HttpResponseBuilder::new(&bb).status(200).text("hello").build()?);
+    /// # let request_builder = handler.request_builder();
+    /// let body: String = request_builder.get("https://example.com").fetch_text_body().await?;
+    /// assert_eq!(body, "hello");
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The request couldn't be built because of errors
+    /// - The network request failed
+    /// - The response status is not in the `2xx` success range
+    /// - Body processing failed
+    pub fn fetch_text_body(self) -> impl Future<Output = Result<String>> + Send {
+        self.fetch()
+            .and_then(|response| ready(response.ensure_success()))
+            .and_then(|response| response.into_body().into_text())
+    }
+
+    /// Sends the request, validates the response status, and returns just the response body as bytes.
+    ///
+    /// This is a convenience method equivalent to calling [`fetch`](Self::fetch), then
+    /// [`ensure_success`](crate::StatusExt::ensure_success) on the response, and finally reading the
+    /// body as raw bytes. The response metadata is discarded, yielding only the materialized byte body.
+    ///
+    /// Calling this method consumes the [`HttpRequestBuilder`] instance. It automatically sets
+    /// appropriate headers based on the request body, such as `Content-Length` and `Content-Type`,
+    /// if they haven't been set already.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bytesbuf::BytesView;
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
+    /// # use http_extensions::{HttpError, HttpRequestBuilder, HttpResponseBuilder,
+    /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
+    /// # #[cfg(feature = "test-util")]
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), HttpError> {
+    /// # let bb = HttpBodyBuilder::new_fake();
+    /// # let handler = FakeHandler::from(HttpResponseBuilder::new(&bb).status(200).text("hello").build()?);
+    /// # let request_builder = handler.request_builder();
+    /// let body: BytesView = request_builder.get("https://example.com").fetch_bytes_body().await?;
+    /// assert_eq!(body, b"hello");
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The request couldn't be built because of errors
+    /// - The network request failed
+    /// - The response status is not in the `2xx` success range
+    /// - Body processing failed
+    pub fn fetch_bytes_body(self) -> impl Future<Output = Result<BytesView>> + Send {
+        self.fetch()
+            .and_then(|response| ready(response.ensure_success()))
+            .and_then(|response| response.into_body().into_bytes())
+    }
+
+    /// Sends the request, validates the response status, and returns just the deserialized JSON body.
+    ///
+    /// This is a convenience method equivalent to calling [`fetch`](Self::fetch), then
+    /// [`ensure_success`](crate::StatusExt::ensure_success) on the response, and finally deserializing
+    /// the body into an owned value of type `J`. The response metadata is discarded, yielding only the
+    /// materialized body.
+    ///
+    /// Like [`fetch_json_owned`](Self::fetch_json_owned), this deserializes into an owned type that can
+    /// outlive the response. When you want to borrow from the response buffer for zero-copy parsing, use
+    /// [`fetch_json`](Self::fetch_json) and read from the returned [`Json<J>`][crate::Json] instead.
+    ///
+    /// This method requires the `json` feature to be enabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use serde::Deserialize;
+    /// # #[cfg(not(feature = "test-util"))] fn main() {}
+    /// # #[cfg(feature = "test-util")]
+    /// # use http_extensions::{HttpError, HttpRequestBuilder, HttpResponseBuilder,
+    /// #     HttpBodyBuilder, FakeHandler, HttpRequestBuilderExt};
+    /// #
+    /// # #[derive(Deserialize)]
+    /// # struct User { id: u32, name: String }
+    /// #
+    /// # #[cfg(feature = "test-util")]
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), HttpError> {
+    /// # let bb = HttpBodyBuilder::new_fake();
+    /// # let handler = FakeHandler::from(
+    /// #     HttpResponseBuilder::new(&bb).status(200).text(r#"{"id":42,"name":"Alice"}"#).build()?
+    /// # );
+    /// # let request_builder = handler.request_builder();
+    /// let user: User = request_builder
+    ///     .get("https://example.com/users/42")
+    ///     .fetch_json_body::<User>()
+    ///     .await?;
+    ///
+    /// println!("User: {}", user.name);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The request couldn't be built
+    /// - The network request failed
+    /// - The response status is not in the `2xx` success range
+    /// - The response body isn't valid UTF-8
+    /// - JSON deserialization failed
+    // Chained `and_then` (rather than `Either` + `ready(Err(..))`) keeps the returned future
+    // `Send` without requiring `J: Send`: the only stage that mentions `J` is `into_json_owned`,
+    // which never stores the value in its future state, so no `J` is held across the chain.
+    #[cfg(any(feature = "json", test))]
+    pub fn fetch_json_body<J: serde_core::de::DeserializeOwned>(self) -> impl Future<Output = Result<J>> + Send {
+        self.fetch()
+            .and_then(|response| ready(response.ensure_success()))
+            .and_then(|response| response.into_body().into_json_owned::<J>())
+    }
 }
 
 #[cfg(test)]
@@ -1241,6 +1387,86 @@ mod tests {
     }
 
     #[test]
+    fn fetch_text_body_ok() {
+        let client =
+            FakeHandler::from_sync_handler(|_request| HttpResponseBuilder::new_fake().status(StatusCode::OK).text("text body").build());
+
+        let body = block_on(client.request_builder().get("https://example.com").fetch_text_body()).unwrap();
+
+        assert_eq!(body, "text body");
+    }
+
+    #[test]
+    fn fetch_bytes_body_ok() {
+        let client = FakeHandler::from_sync_handler(|_request| {
+            HttpResponseBuilder::new_fake()
+                .status(StatusCode::OK)
+                .bytes(BytesView::copied_from_slice(b"bytes body", &HttpBodyBuilder::new_fake()))
+                .build()
+        });
+
+        let body = block_on(client.request_builder().get("https://example.com").fetch_bytes_body()).unwrap();
+
+        assert_eq!(body, b"bytes body");
+    }
+
+    #[test]
+    fn fetch_json_body_ok() {
+        let client = FakeHandler::from_sync_handler(|_request| {
+            HttpResponseBuilder::new_fake()
+                .status(StatusCode::OK)
+                .json(&JsonData { id: 7 })
+                .build()
+        });
+
+        let json_data = block_on(client.request_builder().get("https://example.com").fetch_json_body::<JsonData>()).unwrap();
+
+        assert_eq!(json_data.id, 7);
+    }
+
+    #[test]
+    fn fetch_text_body_ensures_success() {
+        let client = FakeHandler::from_sync_handler(|_request| {
+            HttpResponseBuilder::new_fake()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .text("boom")
+                .build()
+        });
+
+        let err = block_on(client.request_builder().get("https://example.com").fetch_text_body()).unwrap_err();
+
+        assert_eq!(err.label(), "response_unsuccessful");
+    }
+
+    #[test]
+    fn fetch_bytes_body_ensures_success() {
+        let client = FakeHandler::from_sync_handler(|_request| {
+            HttpResponseBuilder::new_fake()
+                .status(StatusCode::NOT_FOUND)
+                .text("missing")
+                .build()
+        });
+
+        let err = block_on(client.request_builder().get("https://example.com").fetch_bytes_body()).unwrap_err();
+
+        assert_eq!(err.label(), "response_unsuccessful");
+    }
+
+    #[test]
+    fn fetch_json_body_ensures_success() {
+        let client = FakeHandler::from_sync_handler(|_request| {
+            HttpResponseBuilder::new_fake()
+                .status(StatusCode::BAD_REQUEST)
+                .json(&JsonData { id: 1 })
+                .build()
+        });
+
+        let err = block_on(client.request_builder().get("https://example.com").fetch_json_body::<JsonData>()).unwrap_err();
+
+        assert_eq!(err.label(), "response_unsuccessful");
+    }
+
+    #[test]
     fn fetch_future_sizes() {
         let client = FakeHandler::default();
 
@@ -1250,6 +1476,9 @@ mod tests {
         let bytes = client.request_builder().get("https://example.com").fetch_bytes();
         let json = client.request_builder().get("https://example.com").fetch_json::<JsonData>();
         let json_owned = client.request_builder().get("https://example.com").fetch_json_owned::<JsonData>();
+        let text_body = client.request_builder().get("https://example.com").fetch_text_body();
+        let bytes_body = client.request_builder().get("https://example.com").fetch_bytes_body();
+        let json_body = client.request_builder().get("https://example.com").fetch_json_body::<JsonData>();
 
         let sizes = [
             ("fetch", size_of_val(&fetch)),
@@ -1258,6 +1487,9 @@ mod tests {
             ("fetch_bytes", size_of_val(&bytes)),
             ("fetch_json", size_of_val(&json)),
             ("fetch_json_owned", size_of_val(&json_owned)),
+            ("fetch_text_body", size_of_val(&text_body)),
+            ("fetch_bytes_body", size_of_val(&bytes_body)),
+            ("fetch_json_body", size_of_val(&json_body)),
         ];
 
         for (name, size) in sizes {

--- a/crates/http_extensions/src/http_request_builder.rs
+++ b/crates/http_extensions/src/http_request_builder.rs
@@ -675,7 +675,7 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     pub fn fetch_json<J: serde_core::de::DeserializeOwned>(self) -> impl Future<Output = Result<Response<J>>> + Send {
         self.fetch().and_then(|response| {
             let (parts, body) = response.into_parts();
-            body.into_json_owned::<J>().map_ok(move |body| Response::from_parts(parts, body))
+            body.into_json::<J>().map_ok(move |body| Response::from_parts(parts, body))
         })
     }
 
@@ -739,7 +739,7 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     pub fn fetch_json_ref<'de, J: serde_core::de::Deserialize<'de>>(self) -> impl Future<Output = Result<Response<crate::Json<J>>>> + Send {
         self.fetch().and_then(|response| {
             let (parts, body) = response.into_parts();
-            body.into_json::<J>().map_ok(move |body| Response::from_parts(parts, body))
+            body.into_json_ref::<J>().map_ok(move |body| Response::from_parts(parts, body))
         })
     }
 
@@ -880,13 +880,13 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// - The response body isn't valid UTF-8
     /// - JSON deserialization failed
     // Chained `and_then` (rather than `Either` + `ready(Err(..))`) keeps the returned future
-    // `Send` without requiring `J: Send`: the only stage that mentions `J` is `into_json_owned`,
+    // `Send` without requiring `J: Send`: the only stage that mentions `J` is `into_json`,
     // which never stores the value in its future state, so no `J` is held across the chain.
     #[cfg(any(feature = "json", test))]
     pub fn fetch_json_body<J: serde_core::de::DeserializeOwned>(self) -> impl Future<Output = Result<J>> + Send {
         self.fetch()
             .and_then(|response| ready(response.ensure_success()))
-            .and_then(|response| response.into_body().into_json_owned::<J>())
+            .and_then(|response| response.into_body().into_json::<J>())
     }
 
     /// Sends the request, validates the response status, and returns the JSON body with optional borrowing.
@@ -949,13 +949,13 @@ impl<R: RequestHandler> HttpRequestBuilder<'_, R> {
     /// - The response status is not in the `2xx` success range
     /// - The response body isn't valid UTF-8
     // Chained `and_then` (rather than `Either` + `ready(Err(..))`) keeps the returned future
-    // `Send` without requiring `J: Send`: the only stage that mentions `J` is `into_json`, which
+    // `Send` without requiring `J: Send`: the only stage that mentions `J` is `into_json_ref`, which
     // yields the `Json<J>` wrapper as its final output and never holds it across an await point.
     #[cfg(any(feature = "json", test))]
     pub fn fetch_json_ref_body<'de, J: serde_core::de::Deserialize<'de>>(self) -> impl Future<Output = Result<crate::Json<J>>> + Send {
         self.fetch()
             .and_then(|response| ready(response.ensure_success()))
-            .and_then(|response| response.into_body().into_json::<J>())
+            .and_then(|response| response.into_body().into_json_ref::<J>())
     }
 }
 

--- a/crates/http_extensions/src/json.rs
+++ b/crates/http_extensions/src/json.rs
@@ -84,8 +84,8 @@ impl Recovery for JsonError {
 /// - **Owned parsing** via [`read_owned`](Self::read_owned): For types that own their data, the parser consumes itself
 ///   and returns an owned deserialized value.
 ///
-/// See the [`HttpBody::into_json`](crate::HttpBody::into_json) and
-/// [`HttpBody::into_json_owned`](crate::HttpBody::into_json_owned) methods for more details and
+/// See the [`HttpBody::into_json_ref`](crate::HttpBody::into_json_ref) and
+/// [`HttpBody::into_json`](crate::HttpBody::into_json) methods for more details and
 /// examples on how to use this type.
 #[derive(Debug)]
 pub struct Json<T> {
@@ -137,7 +137,7 @@ impl<'a, T: Deserialize<'a>> Json<T> {
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     let body = HttpBodyBuilder::new_fake().text(r#"{"name":"Alice","age":30}"#);
-    /// #     let mut json = body.into_json::<Person>().await.unwrap();
+    /// #     let mut json = body.into_json_ref::<Person>().await.unwrap();
     /// #     handle_json(&mut json).unwrap();
     /// # }
     /// ```
@@ -188,7 +188,7 @@ impl<T: DeserializeOwned> Json<T> {
     /// # #[tokio::main]
     /// # async fn main() {
     /// #     let body = HttpBodyBuilder::new_fake().text(r#"{"name":"Alice","age":30}"#);
-    /// #     handle_json(body.into_json().await.unwrap()).unwrap();
+    /// #     handle_json(body.into_json_ref().await.unwrap()).unwrap();
     /// # }
     /// ```
     ///

--- a/crates/seatbelt_http/src/breaker.rs
+++ b/crates/seatbelt_http/src/breaker.rs
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn server_errors_trip_breaker() {
         let handler =
-            FakeHandler::from_sync_handler(|_req| HttpResponseBuilder::new_fake().status(StatusCode::INTERNAL_SERVER_ERROR).build());
+            FakeHandler::from_fn(|_req| HttpResponseBuilder::new_fake().status(StatusCode::INTERNAL_SERVER_ERROR).build());
         let clock = ClockControl::default().auto_advance_timers(true).to_clock();
         let context = crate::HttpResilienceContext::new(&clock);
 
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn success_does_not_trip_breaker() {
-        let handler = FakeHandler::from_sync_handler(|_req| HttpResponseBuilder::new_fake().status(StatusCode::OK).build());
+        let handler = FakeHandler::from_fn(|_req| HttpResponseBuilder::new_fake().status(StatusCode::OK).build());
         let clock = ClockControl::default().auto_advance_timers(true).to_clock();
         let context = crate::HttpResilienceContext::new(&clock);
 
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn client_errors_do_not_trip_breaker() {
-        let handler = FakeHandler::from_sync_handler(|_req| HttpResponseBuilder::new_fake().status(StatusCode::BAD_REQUEST).build());
+        let handler = FakeHandler::from_fn(|_req| HttpResponseBuilder::new_fake().status(StatusCode::BAD_REQUEST).build());
         let clock = ClockControl::default().auto_advance_timers(true).to_clock();
         let context = crate::HttpResilienceContext::new(&clock);
 

--- a/crates/seatbelt_http/src/breaker.rs
+++ b/crates/seatbelt_http/src/breaker.rs
@@ -204,8 +204,7 @@ mod tests {
 
     #[test]
     fn server_errors_trip_breaker() {
-        let handler =
-            FakeHandler::from_fn(|_req| HttpResponseBuilder::new_fake().status(StatusCode::INTERNAL_SERVER_ERROR).build());
+        let handler = FakeHandler::from_fn(|_req| HttpResponseBuilder::new_fake().status(StatusCode::INTERNAL_SERVER_ERROR).build());
         let clock = ClockControl::default().auto_advance_timers(true).to_clock();
         let context = crate::HttpResilienceContext::new(&clock);
 

--- a/crates/seatbelt_http/src/hedging.rs
+++ b/crates/seatbelt_http/src/hedging.rs
@@ -188,7 +188,7 @@ mod tests {
         let captured_uris: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_uris_for_handler = Arc::clone(&captured_uris);
 
-        let handler = FakeHandler::from_sync_handler(move |request: HttpRequest| {
+        let handler = FakeHandler::from_fn(move |request: HttpRequest| {
             captured_uris_for_handler
                 .lock()
                 .expect("mutex is only accessed in single-threaded test")

--- a/crates/seatbelt_http/src/retry.rs
+++ b/crates/seatbelt_http/src/retry.rs
@@ -208,7 +208,7 @@ mod tests {
     fn restore_request_from_unavailable_error() {
         let call_count = Arc::new(AtomicU32::new(0));
         let counter = Arc::clone(&call_count);
-        let handler = FakeHandler::from_sync_handler(move |req| {
+        let handler = FakeHandler::from_fn(move |req| {
             let n = counter.fetch_add(1, Ordering::Relaxed);
             if n < 2 {
                 Err(HttpError::unavailable("service down").with_request(req))
@@ -262,7 +262,7 @@ mod tests {
         let captured_uris: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_uris_for_handler = Arc::clone(&captured_uris);
 
-        let handler = FakeHandler::from_sync_handler(move |request: HttpRequest| {
+        let handler = FakeHandler::from_fn(move |request: HttpRequest| {
             captured_uris_for_handler
                 .lock()
                 .expect("mutex is only accessed in single-threaded test")


### PR DESCRIPTION
## Summary

Refines the `HttpRequestBuilder` response-fetching API in two ways:

1. **Renames the JSON convenience methods** so the common (owned) case gets the
   shortest, most discoverable name.
2. **Adds three "body-only" shortcuts** that fetch, validate the status, and hand
   back just the materialized body in a single call.

## Motivation

Previously, the zero-copy variant owned the short name `fetch_json` while the more
commonly needed owned variant was the longer `fetch_json_owned`. That pushed most
users toward the more advanced, lifetime-bound API by default. Owned deserialization
is the common case (data can outlive the response and cross threads), so it should be
the path of least resistance.

Separately, reading a successful response body almost always means: fetch →
`ensure_success()` → materialize body. The new `_body` shortcuts collapse that
boilerplate into one call.

## Breaking changes — JSON method renames

| Before              | After             | Returns                | Semantics            |
|---------------------|-------------------|------------------------|----------------------|
| `fetch_json_owned`  | `fetch_json`      | `Response<T>`          | Owned (common case)  |
| `fetch_json`        | `fetch_json_ref`  | `Response<Json<T>>`    | Zero-copy / borrowed |

### Migration

- Replace `fetch_json_owned::<T>()` with `fetch_json::<T>()`.
- Replace `fetch_json::<T>()` (zero-copy borrow) with `fetch_json_ref::<T>()`.

Note that callers who keep using `fetch_json` without changes will silently switch
from borrowed to owned semantics (the return type changes from `Response<Json<T>>`
to `Response<T>`), so the compiler will flag the affected call sites.

## New body-only shortcuts

Each fetches the response, calls `ensure_success()` (erroring on `4xx`/`5xx`),
discards the response metadata, and returns just the body:

- `fetch_text_body()` → `Result<String>`
- `fetch_bytes_body()` → `Result<BytesView>`
- `fetch_json_body::<J>()` → `Result<J>` (owned, requires the `json` feature)

```rust
// Before
let text = client.get(url).fetch_text().await?.ensure_success()?.into_body();

// After
let text: String = client.get(url).fetch_text_body().await?;