### PR TITLE
test(multitude): cover oversized utf16 from_str alloc path

### DIFF
--- a/crates/multitude/tests/utf16.rs
+++ b/crates/multitude/tests/utf16.rs
@@ -3139,6 +3139,24 @@ mod from_coverage_extras_utf16 {
         let arc = arena.alloc_utf16_str_arc(src);
         assert_eq!(arc.len(), len_u16);
     }
+
+    #[test]
+    fn alloc_utf16_str_arc_from_str_oversized_routes_via_oversized_shared() {
+        let arena = Arena::new();
+        let len = 16 * 1024;
+        let src: String = "a".repeat(len);
+        let arc = arena.alloc_utf16_str_arc_from_str(&src);
+        assert_eq!(arc.len(), len);
+    }
+
+    #[test]
+    fn alloc_utf16_str_box_from_str_oversized_routes_via_oversized_shared() {
+        let arena = Arena::new();
+        let len = 16 * 1024;
+        let src: String = "a".repeat(len);
+        let b = arena.alloc_utf16_str_box_from_str(&src);
+        assert_eq!(b.len(), len);
+    }
 }
 
 // === relocated from mutants_extras.rs (utf16-gated tests) ===

--- a/crates/multitude/tests/utf16.rs
+++ b/crates/multitude/tests/utf16.rs
@@ -3142,14 +3142,21 @@ mod from_coverage_extras_utf16 {
 
     #[test]
     fn alloc_utf16_str_arc_from_str_oversized_routes_via_oversized_shared() {
-        // Force a small `max_normal_alloc` (in bytes) so the ~32 KiB UTF-16
-        // payload transcoded from a 16 KiB ASCII string (2 bytes per code
-        // unit, plus the length prefix) deterministically takes the
+        let len = 16 * 1024;
+        let src = "a".repeat(len);
+
+        // First exercise the default arena so any default-config code paths
+        // remain covered.
+        let arena = Arena::new();
+        let arc = arena.alloc_utf16_str_arc_from_str(&src);
+        assert_eq!(arc.len(), len);
+
+        // Then force a small `max_normal_alloc` (in bytes) so the ~32 KiB
+        // UTF-16 payload transcoded from a 16 KiB ASCII string (2 bytes per
+        // code unit, plus the length prefix) deterministically takes the
         // oversized-shared branch regardless of any future change to the
         // default threshold.
         let arena = ArenaBuilder::new().max_normal_alloc(4096).build();
-        let len = 16 * 1024;
-        let src = "a".repeat(len);
         let arc = arena.alloc_utf16_str_arc_from_str(&src);
         assert_eq!(arc.len(), len);
         #[cfg(feature = "stats")]
@@ -3158,14 +3165,21 @@ mod from_coverage_extras_utf16 {
 
     #[test]
     fn alloc_utf16_str_box_from_str_oversized_routes_via_oversized_shared() {
-        // Force a small `max_normal_alloc` (in bytes) so the ~32 KiB UTF-16
-        // payload transcoded from a 16 KiB ASCII string (2 bytes per code
-        // unit, plus the length prefix) deterministically takes the
+        let len = 16 * 1024;
+        let src = "a".repeat(len);
+
+        // First exercise the default arena so any default-config code paths
+        // remain covered.
+        let arena = Arena::new();
+        let b = arena.alloc_utf16_str_box_from_str(&src);
+        assert_eq!(b.len(), len);
+
+        // Then force a small `max_normal_alloc` (in bytes) so the ~32 KiB
+        // UTF-16 payload transcoded from a 16 KiB ASCII string (2 bytes per
+        // code unit, plus the length prefix) deterministically takes the
         // oversized-shared branch regardless of any future change to the
         // default threshold.
         let arena = ArenaBuilder::new().max_normal_alloc(4096).build();
-        let len = 16 * 1024;
-        let src = "a".repeat(len);
         let b = arena.alloc_utf16_str_box_from_str(&src);
         assert_eq!(b.len(), len);
         #[cfg(feature = "stats")]

--- a/crates/multitude/tests/utf16.rs
+++ b/crates/multitude/tests/utf16.rs
@@ -3142,9 +3142,11 @@ mod from_coverage_extras_utf16 {
 
     #[test]
     fn alloc_utf16_str_arc_from_str_oversized_routes_via_oversized_shared() {
-        // Force a small `max_normal_alloc` so the 16 KiB transcoded
-        // payload is guaranteed to take the oversized-shared branch
-        // regardless of any future change to the default threshold.
+        // Force a small `max_normal_alloc` (in bytes) so the ~32 KiB UTF-16
+        // payload transcoded from a 16 KiB ASCII string (2 bytes per code
+        // unit, plus the length prefix) deterministically takes the
+        // oversized-shared branch regardless of any future change to the
+        // default threshold.
         let arena = ArenaBuilder::new().max_normal_alloc(4096).build();
         let len = 16 * 1024;
         let src = "a".repeat(len);
@@ -3156,9 +3158,11 @@ mod from_coverage_extras_utf16 {
 
     #[test]
     fn alloc_utf16_str_box_from_str_oversized_routes_via_oversized_shared() {
-        // Force a small `max_normal_alloc` so the 16 KiB transcoded
-        // payload is guaranteed to take the oversized-shared branch
-        // regardless of any future change to the default threshold.
+        // Force a small `max_normal_alloc` (in bytes) so the ~32 KiB UTF-16
+        // payload transcoded from a 16 KiB ASCII string (2 bytes per code
+        // unit, plus the length prefix) deterministically takes the
+        // oversized-shared branch regardless of any future change to the
+        // default threshold.
         let arena = ArenaBuilder::new().max_normal_alloc(4096).build();
         let len = 16 * 1024;
         let src = "a".repeat(len);

--- a/crates/multitude/tests/utf16.rs
+++ b/crates/multitude/tests/utf16.rs
@@ -3142,20 +3142,30 @@ mod from_coverage_extras_utf16 {
 
     #[test]
     fn alloc_utf16_str_arc_from_str_oversized_routes_via_oversized_shared() {
-        let arena = Arena::new();
+        // Force a small `max_normal_alloc` so the 16 KiB transcoded
+        // payload is guaranteed to take the oversized-shared branch
+        // regardless of any future change to the default threshold.
+        let arena = ArenaBuilder::new().max_normal_alloc(4096).build();
         let len = 16 * 1024;
         let src: String = "a".repeat(len);
         let arc = arena.alloc_utf16_str_arc_from_str(&src);
         assert_eq!(arc.len(), len);
+        #[cfg(feature = "stats")]
+        assert!(arena.stats().oversized_shared_chunks_allocated >= 1);
     }
 
     #[test]
     fn alloc_utf16_str_box_from_str_oversized_routes_via_oversized_shared() {
-        let arena = Arena::new();
+        // Force a small `max_normal_alloc` so the 16 KiB transcoded
+        // payload is guaranteed to take the oversized-shared branch
+        // regardless of any future change to the default threshold.
+        let arena = ArenaBuilder::new().max_normal_alloc(4096).build();
         let len = 16 * 1024;
         let src: String = "a".repeat(len);
         let b = arena.alloc_utf16_str_box_from_str(&src);
         assert_eq!(b.len(), len);
+        #[cfg(feature = "stats")]
+        assert!(arena.stats().oversized_shared_chunks_allocated >= 1);
     }
 }
 

--- a/crates/multitude/tests/utf16.rs
+++ b/crates/multitude/tests/utf16.rs
@@ -3147,7 +3147,7 @@ mod from_coverage_extras_utf16 {
         // regardless of any future change to the default threshold.
         let arena = ArenaBuilder::new().max_normal_alloc(4096).build();
         let len = 16 * 1024;
-        let src: String = "a".repeat(len);
+        let src = "a".repeat(len);
         let arc = arena.alloc_utf16_str_arc_from_str(&src);
         assert_eq!(arc.len(), len);
         #[cfg(feature = "stats")]
@@ -3161,7 +3161,7 @@ mod from_coverage_extras_utf16 {
         // regardless of any future change to the default threshold.
         let arena = ArenaBuilder::new().max_normal_alloc(4096).build();
         let len = 16 * 1024;
-        let src: String = "a".repeat(len);
+        let src = "a".repeat(len);
         let b = arena.alloc_utf16_str_box_from_str(&src);
         assert_eq!(b.len(), len);
         #[cfg(feature = "stats")]

--- a/crates/multitude/tests/utf16.rs
+++ b/crates/multitude/tests/utf16.rs
@@ -3160,7 +3160,7 @@ mod from_coverage_extras_utf16 {
         let arc = arena.alloc_utf16_str_arc_from_str(&src);
         assert_eq!(arc.len(), len);
         #[cfg(feature = "stats")]
-        assert!(arena.stats().oversized_shared_chunks_allocated >= 1);
+        assert_eq!(arena.stats().oversized_shared_chunks_allocated, 1);
     }
 
     #[test]
@@ -3183,7 +3183,7 @@ mod from_coverage_extras_utf16 {
         let b = arena.alloc_utf16_str_box_from_str(&src);
         assert_eq!(b.len(), len);
         #[cfg(feature = "stats")]
-        assert!(arena.stats().oversized_shared_chunks_allocated >= 1);
+        assert_eq!(arena.stats().oversized_shared_chunks_allocated, 1);
     }
 }
 


### PR DESCRIPTION
The `oversized` branch of `impl_alloc_utf16_prefixed_from_str` (used by `alloc_utf16_str_arc_from_str` / `alloc_utf16_str_box_from_str` when the transcoded payload exceeds the per-chunk size threshold) was previously uncovered: the existing oversized tests only exercised the slice-based `alloc_utf16_str_{arc,box}` entry points, which route through `impl_alloc_prefixed_shared`.

Add two tests that push a 16 KiB ASCII string through the `*_from_str` variants so the transcoding oversized path is exercised.

Noticed while addressing the codecov drop on #478.