### PR TITLE
feat(templated_uri): implement RedactedDisplay/RedactedDebug for BasePath and BaseUri

### DIFF
--- a/crates/templated_uri/src/base_path.rs
+++ b/crates/templated_uri/src/base_path.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::Display;
+use std::fmt::{self, Debug, Display, Formatter};
 use std::str::FromStr;
 
+use data_privacy::{RedactedDebug, RedactedDisplay, Redactor};
 use http::uri::PathAndQuery;
 
 use crate::UriError;
@@ -150,6 +151,20 @@ impl Display for BasePath {
     }
 }
 
+impl RedactedDisplay for BasePath {
+    fn fmt(&self, _redactor: &dyn Redactor, f: &mut Formatter<'_>) -> fmt::Result {
+        // A base path is static configuration rather than request data, so it is
+        // rendered unredacted, consistently with how `Uri` formats its base components.
+        Display::fmt(self, f)
+    }
+}
+
+impl RedactedDebug for BasePath {
+    fn fmt(&self, _redactor: &dyn Redactor, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
 impl From<BasePath> for PathAndQuery {
     fn from(base_path: BasePath) -> Self {
         base_path.inner
@@ -243,6 +258,31 @@ mod tests {
     fn from_static_valid() {
         let path = BasePath::from_static("/api/v1/");
         assert_eq!(path.as_str(), "/api/v1/");
+    }
+
+    #[test]
+    fn redacted_display_matches_display() {
+        use data_privacy::{RedactedToString, RedactionEngine};
+
+        let engine = RedactionEngine::builder().build();
+        let path = BasePath::from_static("/api/v1/");
+
+        // A base path carries no request data, so redaction is a no-op and renders
+        // identically to `Display`, consistently with the `Uri` redaction impl.
+        assert_eq!(path.to_redacted_string(&engine), path.to_string());
+        assert_eq!(path.to_redacted_string(&engine), "/api/v1/");
+    }
+
+    #[test]
+    fn redacted_debug_matches_debug() {
+        use data_privacy::RedactionEngine;
+
+        let engine = RedactionEngine::builder().build();
+        let path = BasePath::from_static("/api/v1/");
+
+        let mut redacted = String::new();
+        engine.redacted_debug(&path, &mut redacted).unwrap();
+        assert_eq!(redacted, format!("{path:?}"));
     }
 
     #[test]

--- a/crates/templated_uri/src/base_uri.rs
+++ b/crates/templated_uri/src/base_uri.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::{Debug, Display};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::str::FromStr;
 
+use data_privacy::{RedactedDebug, RedactedDisplay, Redactor};
 use http::uri::{Authority, Parts, PathAndQuery, Scheme};
 
 use crate::origin::{HTTP_DEFAULT_PORT, HTTPS_DEFAULT_PORT};
@@ -650,6 +651,20 @@ impl Display for BaseUri {
     }
 }
 
+impl RedactedDisplay for BaseUri {
+    fn fmt(&self, _redactor: &dyn Redactor, f: &mut Formatter<'_>) -> fmt::Result {
+        // A base URI is static configuration rather than request data, so it is
+        // rendered unredacted, consistently with how `Uri` formats its base components.
+        Display::fmt(self, f)
+    }
+}
+
+impl RedactedDebug for BaseUri {
+    fn fmt(&self, _redactor: &dyn Redactor, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
 #[cfg(feature = "serde")]
 impl serde::Serialize for BaseUri {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -668,6 +683,40 @@ impl<'de> serde::Deserialize<'de> for BaseUri {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    mod redaction {
+        use data_privacy::{RedactedToString, RedactionEngine};
+
+        use super::*;
+
+        #[test]
+        fn redacted_display_matches_display() {
+            let engine = RedactionEngine::builder().build();
+            let base_uri = BaseUri::from_static("https://example.com/api/v1/");
+
+            // A base URI carries no request data, so redaction is a no-op and renders
+            // identically to `Display`, consistently with the `Uri` redaction impl.
+            assert_eq!(base_uri.to_redacted_string(&engine), base_uri.to_string());
+            assert_eq!(base_uri.to_redacted_string(&engine), "https://example.com/api/v1/");
+        }
+
+        #[test]
+        fn redacted_display_with_custom_port() {
+            let engine = RedactionEngine::builder().build();
+            let base_uri = BaseUri::from_static("https://example.com:8443/path/");
+            assert_eq!(base_uri.to_redacted_string(&engine), "https://example.com:8443/path/");
+        }
+
+        #[test]
+        fn redacted_debug_matches_debug() {
+            let engine = RedactionEngine::builder().build();
+            let base_uri = BaseUri::from_static("https://example.com/api/v1/");
+
+            let mut redacted = String::new();
+            engine.redacted_debug(&base_uri, &mut redacted).unwrap();
+            assert_eq!(redacted, format!("{base_uri:?}"));
+        }
+    }
 
     mod from_parts {
         use super::*;

--- a/crates/templated_uri/src/origin.rs
+++ b/crates/templated_uri/src/origin.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::Display;
+use std::fmt::{self, Debug, Display, Formatter};
 
+use data_privacy::{RedactedDebug, RedactedDisplay, Redactor};
 use http::uri::{Authority, Scheme};
 
 use crate::UriError;
@@ -275,11 +276,59 @@ impl Display for Origin {
     }
 }
 
+impl RedactedDisplay for Origin {
+    fn fmt(&self, _redactor: &dyn Redactor, f: &mut Formatter<'_>) -> fmt::Result {
+        // An origin is static configuration rather than request data, so it is
+        // rendered unredacted, consistently with how `Uri` formats its base components.
+        Display::fmt(self, f)
+    }
+}
+
+impl RedactedDebug for Origin {
+    fn fmt(&self, _redactor: &dyn Redactor, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
     use super::*;
+
+    mod redaction {
+        use data_privacy::{RedactedToString, RedactionEngine};
+
+        use super::*;
+
+        #[test]
+        fn redacted_display_matches_display() {
+            let engine = RedactionEngine::builder().build();
+            let origin = Origin::from_static("https://example.com");
+
+            // An origin carries no request data, so redaction is a no-op and renders
+            // identically to `Display`, consistently with the `Uri` redaction impl.
+            assert_eq!(origin.to_redacted_string(&engine), origin.to_string());
+            assert_eq!(origin.to_redacted_string(&engine), "https://example.com");
+        }
+
+        #[test]
+        fn redacted_display_with_custom_port() {
+            let engine = RedactionEngine::builder().build();
+            let origin = Origin::from_static("https://example.com:8443");
+            assert_eq!(origin.to_redacted_string(&engine), "https://example.com:8443");
+        }
+
+        #[test]
+        fn redacted_debug_matches_debug() {
+            let engine = RedactionEngine::builder().build();
+            let origin = Origin::from_static("https://example.com");
+
+            let mut redacted = String::new();
+            engine.redacted_debug(&origin, &mut redacted).unwrap();
+            assert_eq!(redacted, format!("{origin:?}"));
+        }
+    }
 
     #[test]
     fn test_port() {


### PR DESCRIPTION
Implement `RedactedDisplay` and `RedactedDebug` for both types. Consistent with the existing Uri impl (which renders its base components via Display, unredacted, and only routes the appended path-and-query through the Redactor), base URIs and base paths are treated as static configuration rather than request data: their redacted output matches their plain Display/Debug output.
