### PR TITLE
fix: resolve install-callgrind-tools.ps1 path via justfile_directory()

### DIFF
--- a/justfiles/setup.just
+++ b/justfiles/setup.just
@@ -50,4 +50,4 @@ install-tools:
     }
 
     # Install platform-specific benchmark toolchain (Callgrind, Linux-only).
-    & (Join-Path $PSScriptRoot ".." "scripts" "install-callgrind-tools.ps1")
+    & (Join-Path '{{justfile_directory()}}' "scripts" "install-callgrind-tools.ps1")


### PR DESCRIPTION
Fixes the `just install-tools` failure on Windows reported in [AB#7477055](https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7477055/).

## Problem

The `install-tools` recipe is declared as `[script]`. Just writes script recipes to a temporary file (`%TEMP%\just-XXXXXX\install-tools.ps1`) before executing them with the configured interpreter. As a result, `` inside the recipe resolves to that temp directory rather than the repo, and the relative lookup `\..\scripts\install-callgrind-tools.ps1` does not exist:

```
The term 'C:\Users\sasaares\AppData\Local\Temp\just-s8ukYf\..\scripts\install-callgrind-tools.ps1'
is not recognized as a name of a cmdlet, function, script file, or executable program.
error: recipe install-tools failed with exit code 1
```

## Fix

Use Just's built-in `{{justfile_directory()}}` interpolation, which is expanded at recipe-build time and always points at the repository root — independent of where Just chooses to stage the script file.

## Validation

- Manually invoked the resolved path: `Callgrind toolchain is Linux-only; skipping.` (script's intended Windows behavior).
- No changelog entry — repository convention is no changelog for build-infra fixes.