### PR TITLE
fix(multitude): restore coverage for transcode_utf16_into

### DIFF
--- a/crates/multitude/src/arena/alloc_utf16.rs
+++ b/crates/multitude/src/arena/alloc_utf16.rs
@@ -205,7 +205,13 @@ impl<A: Allocator + Clone> Arena<A> {
 /// via `encode_utf16` into the `u16` payload immediately after, and
 /// returns a thin pointer to the first payload element. `exact` must
 /// match `s.chars().map(char::len_utf16).sum()` from a pre-walk.
-#[inline(always)]
+//
+// Skip `inline(always)` under coverage instrumentation so a real
+// out-of-line function body exists for llvm-cov to attribute hits to.
+// With `inline(always)` the source-line mapping for the inlined copies
+// is fragile and shifts with the dep graph (observed: 11 lines went
+// from 100% to missed when PR #478 added optional deps elsewhere).
+#[cfg_attr(not(coverage_nightly), inline(always))]
 #[allow(
     clippy::cast_ptr_alignment,
     reason = "see callers: `base + PREFIX_BYTES` is u16-aligned by construction"


### PR DESCRIPTION
## Problem

PR #478 (`feat(thread_aware): add feature-gated ThreadAware impls for 3rd-party crate types`) dropped codecov coverage on `main` from 100% to 99.9% even though it didn't touch the `multitude` crate at all (its own patch coverage was 100%).

The 11 missed lines are all the body of the private `transcode_utf16_into` helper in `crates/multitude/src/arena/alloc_utf16.rs`: lines 213, 219–225, 227, 228, 230.

## Root cause

The helper is `#[inline(always)]`, so no out-of-line function body exists in the compiled test binary. `cargo llvm-cov` has to attribute hits to the inlined copies via debuginfo, and that mapping is fragile — it shifted when PR #478 added new optional deps (`bytes`, `http`, `jiff02`, `uuid`) to `thread_aware`, which is a transitive dep of `multitude` via `bytesbuf`. The function is still exercised by existing tests (`alloc_utf16_str_arc_from_str`, the oversized routes tests added in #487, etc.); coverage just stops getting attributed to the source lines.

## Fix

Gate the `inline(always)` on `not(coverage_nightly)`:

```rust
#[cfg_attr(not(coverage_nightly), inline(always))]
```

Under coverage instrumentation the function keeps a real callable body that llvm-cov attributes hits to deterministically. Release/dev/CI test builds keep `inline(always)` exactly as today — zero perf change for users.

The `coverage_nightly` cfg is already a known idiom in this crate (used widely with `#[coverage(off)]` and `feature(coverage_attribute)`).

## Verification

Ran `cargo +nightly-2026-05-30 llvm-cov --all-features -p multitude --lcov` locally:

- **Before:** `alloc_utf16.rs` reports 72 hit / 11 missed (exactly lines 213, 219–225, 227, 228, 230 — matches what codecov shows on `main`).
- **After:** `alloc_utf16.rs` reports 83 hit / 0 missed. 100% restored.
