### PR TITLE
fix: resolve install-callgrind-tools.ps1 via justfile_directory()

### DIFF
--- a/justfiles/setup.just
+++ b/justfiles/setup.just
@@ -50,4 +50,8 @@ install-tools:
     }
 
     # Install platform-specific benchmark toolchain (Callgrind, Linux-only).
-    & (Join-Path $PSScriptRoot ".." "scripts" "install-callgrind-tools.ps1")
+    # `just` copies [script] recipes to a temp file before executing them, so
+    # $PSScriptRoot points at that temp directory rather than the repo. We use
+    # the `justfile_directory()` function to resolve the repo root at recipe
+    # expansion time so the call works no matter where the temp file lives.
+    & (Join-Path "{{ justfile_directory() }}" "scripts" "install-callgrind-tools.ps1")


### PR DESCRIPTION
`just install-tools` failed on Windows with:

```
The term 'C:\Users\<user>\AppData\Local\Temp\just-XXXXXX\..\scripts\install-callgrind-tools.ps1' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

## Cause

`just` copies `[script]` recipes to a temporary file before invoking the script interpreter, so `` resolved to `%TEMP%\just-XXXXXX\` and the `..\scripts\install-callgrind-tools.ps1` path did not exist.

## Fix

Use `just`'s `{{ justfile_directory() }}` interpolation to bake the repo root into the recipe at expansion time. The resulting path is absolute and independent of where the temp file lives.

Verified locally that `{{ justfile_directory() }}` expands to the repo root inside a `[script]` recipe and `Test-Path` confirms the resolved script exists.

Fixes [ADO 7477055](https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7477055).