### PR TITLE
feat(multitude): add uninit, fallible try_*, and string Arc-freeze APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "multitude"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "allocator-api2 0.4.0",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ fundle_macros = { path = "crates/fundle_macros", default-features = false, versi
 fundle_macros_impl = { path = "crates/fundle_macros_impl", default-features = false, version = "0.3.3" }
 http_extensions = { path = "crates/http_extensions", default-features = false, version = "0.6.1" }
 layered = { path = "crates/layered", default-features = false, version = "0.3.4" }
-multitude = { path = "crates/multitude", default-features = false, version = "0.2.0" }
+multitude = { path = "crates/multitude", default-features = false, version = "0.3.0" }
 ohno = { path = "crates/ohno", default-features = false, version = "0.3.6" }
 ohno_macros = { path = "crates/ohno_macros", default-features = false, version = "0.3.4" }
 recoverable = { path = "crates/recoverable", default-features = false, version = "0.1.6" }

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "multitude"
-version = "0.2.0"
+version = "0.3.0"
 description = "Fast and flexible arena allocator."
 readme = "README.md"
 keywords = ["arena", "memory", "allocator", "bump"]

--- a/crates/multitude/README.md
+++ b/crates/multitude/README.md
@@ -397,94 +397,94 @@ existing `_arc` slice methods).
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/multitude">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbBzV3ofWgqIgbt8brW1MeN_Mb9N6Ac8XJFEIbIYjmnKUrOjRhZIWCaGJ5dGVtdWNrZjEuMjUuMIJlYnl0ZXNmMS4xMS4xgmhieXRlc2J1ZmUwLjUuNIJpbXVsdGl0dWRlZTAuMi4wgmh6ZXJvY29weWYwLjguNTA
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbBzV3ofWgqIgbt8brW1MeN_Mb9N6Ac8XJFEIbIYjmnKUrOjRhZIWCaGJ5dGVtdWNrZjEuMjUuMIJlYnl0ZXNmMS4xMS4xgmhieXRlc2J1ZmUwLjUuNIJpbXVsdGl0dWRlZTAuMy4wgmh6ZXJvY29weWYwLjguNTA
  [__link0]: https://crates.io/crates/bumpalo
- [__link1]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link10]: https://docs.rs/multitude/0.2.0/multitude/?search=vec::Vec
+ [__link1]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link10]: https://docs.rs/multitude/0.3.0/multitude/?search=vec::Vec
  [__link11]: https://crates.io/crates/dst-factory
- [__link12]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::format
- [__link13]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::ArcUtf16Str
- [__link14]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::BoxUtf16Str
- [__link15]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::Utf16String
- [__link16]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::format_utf16
- [__link17]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link18]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link19]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena
- [__link2]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
+ [__link12]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::format
+ [__link13]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::ArcUtf16Str
+ [__link14]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::BoxUtf16Str
+ [__link15]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::Utf16String
+ [__link16]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::format_utf16
+ [__link17]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link18]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link19]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena
+ [__link2]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
  [__link20]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html
- [__link21]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link22]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link23]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link24]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
+ [__link21]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link22]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link23]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link24]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
  [__link25]: https://doc.rust-lang.org/stable/alloc/?search=boxed::Box
- [__link26]: https://docs.rs/multitude/0.2.0/multitude/?search=vec::Vec
- [__link27]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::String
+ [__link26]: https://docs.rs/multitude/0.3.0/multitude/?search=vec::Vec
+ [__link27]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::String
  [__link28]: https://crates.io/crates/allocator-api2
- [__link29]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::String
- [__link3]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link30]: https://docs.rs/multitude/0.2.0/multitude/?search=vec::Vec
- [__link31]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::String::into_boxed_str
- [__link32]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link33]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link34]: https://docs.rs/multitude/0.2.0/multitude/?search=vec::Vec::into_boxed_slice
- [__link35]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link36]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link37]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link38]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link39]: https://docs.rs/multitude/0.2.0/multitude/?search=vec::Vec::leak
- [__link4]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
+ [__link29]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::String
+ [__link3]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link30]: https://docs.rs/multitude/0.3.0/multitude/?search=vec::Vec
+ [__link31]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::String::into_boxed_str
+ [__link32]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link33]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link34]: https://docs.rs/multitude/0.3.0/multitude/?search=vec::Vec::into_boxed_slice
+ [__link35]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link36]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link37]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link38]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link39]: https://docs.rs/multitude/0.3.0/multitude/?search=vec::Vec::leak
+ [__link4]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
  [__link40]: https://github.com/microsoft/oxidizer/blob/main/crates/multitude/BUMPALO.md
  [__link41]: https://crates.io/crates/bumpalo
- [__link42]: https://docs.rs/multitude/0.2.0/multitude/strings/index.html
- [__link43]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link44]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::ArcUtf16Str
- [__link45]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link46]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::BoxUtf16Str
- [__link47]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena
- [__link48]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::String
- [__link49]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::Utf16String
- [__link5]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link50]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::format
- [__link51]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::format_utf16
- [__link52]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::String
- [__link53]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::String::into_boxed_str
- [__link54]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link55]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::Utf16String
- [__link56]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::Utf16String::into_boxed_utf16_str
- [__link57]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::BoxUtf16Str
- [__link58]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link59]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena
- [__link6]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link60]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena::alloc_dst_arc
- [__link61]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena::alloc_dst_box
+ [__link42]: https://docs.rs/multitude/0.3.0/multitude/strings/index.html
+ [__link43]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link44]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::ArcUtf16Str
+ [__link45]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link46]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::BoxUtf16Str
+ [__link47]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena
+ [__link48]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::String
+ [__link49]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::Utf16String
+ [__link5]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link50]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::format
+ [__link51]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::format_utf16
+ [__link52]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::String
+ [__link53]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::String::into_boxed_str
+ [__link54]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link55]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::Utf16String
+ [__link56]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::Utf16String::into_boxed_utf16_str
+ [__link57]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::BoxUtf16Str
+ [__link58]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link59]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena
+ [__link6]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link60]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena::alloc_dst_arc
+ [__link61]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena::alloc_dst_box
  [__link62]: https://doc.rust-lang.org/stable/core/?search=alloc::Layout
  [__link63]: https://crates.io/crates/dst-factory
  [__link64]: https://doc.rust-lang.org/stable/std/?search=io::Write
- [__link65]: https://docs.rs/multitude/0.2.0/multitude/?search=vec::Vec
- [__link66]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link67]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link68]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::String
- [__link69]: https://docs.rs/multitude/0.2.0/multitude/?search=vec::Vec
- [__link7]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link70]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena::alloc_dst_arc
- [__link71]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena::alloc_dst_box
- [__link72]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::ArcUtf16Str
- [__link73]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::BoxUtf16Str
- [__link74]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::Utf16String
- [__link75]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::format_utf16
+ [__link65]: https://docs.rs/multitude/0.3.0/multitude/?search=vec::Vec
+ [__link66]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link67]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link68]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::String
+ [__link69]: https://docs.rs/multitude/0.3.0/multitude/?search=vec::Vec
+ [__link7]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link70]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena::alloc_dst_arc
+ [__link71]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena::alloc_dst_box
+ [__link72]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::ArcUtf16Str
+ [__link73]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::BoxUtf16Str
+ [__link74]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::Utf16String
+ [__link75]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::format_utf16
  [__link76]: https://crates.io/crates/widestring
- [__link77]: https://docs.rs/multitude/0.2.0/multitude/?search=zerocopy::ZerocopyView
+ [__link77]: https://docs.rs/multitude/0.3.0/multitude/?search=zerocopy::ZerocopyView
  [__link78]: https://docs.rs/zerocopy/0.8.50/zerocopy/?search=FromZeros
- [__link79]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena::zerocopy
- [__link8]: https://docs.rs/multitude/0.2.0/multitude/?search=Box
- [__link80]: https://docs.rs/multitude/0.2.0/multitude/?search=bytemuck::BytemuckView
+ [__link79]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena::zerocopy
+ [__link8]: https://docs.rs/multitude/0.3.0/multitude/?search=Box
+ [__link80]: https://docs.rs/multitude/0.3.0/multitude/?search=bytemuck::BytemuckView
  [__link81]: https://docs.rs/bytemuck/1.25.0/bytemuck/?search=Zeroable
- [__link82]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena::bytemuck
+ [__link82]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena::bytemuck
  [__link83]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
- [__link84]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
- [__link85]: https://docs.rs/multitude/0.2.0/multitude/?search=Arc
+ [__link84]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
+ [__link85]: https://docs.rs/multitude/0.3.0/multitude/?search=Arc
  [__link86]: https://docs.rs/bytes/1.11.1/bytes/?search=Bytes
  [__link87]: https://docs.rs/bytesbuf/0.5.4/bytesbuf/?search=mem::Memory
- [__link88]: https://docs.rs/multitude/0.2.0/multitude/?search=Arena
+ [__link88]: https://docs.rs/multitude/0.3.0/multitude/?search=Arena
  [__link89]: https://docs.rs/bytesbuf/0.5.4/bytesbuf/?search=BytesBuf
- [__link9]: https://docs.rs/multitude/0.2.0/multitude/?search=strings::String
+ [__link9]: https://docs.rs/multitude/0.3.0/multitude/?search=strings::String

--- a/crates/multitude/docs/TODO.md
+++ b/crates/multitude/docs/TODO.md
@@ -11,8 +11,6 @@ arena is Send, that teardown can run on a migrated thread, which would be unsoun
 bound is now documented on `Arena::alloc`. Still open: a !Send-friendly path for thread-local-only use (give up
 `Arena: Send` to drop the `T: Send` requirement), and/or relaxing the bound to the `T: Drop` case only (needs specialization).
 
-- Add missing try_xxx for any allocating functions.
- 
 - No owning IntoIterator for Box<[T]> (std has it). Minor, but an easy ergonomic win.
 
 ## Zero-copy `Vec`/`String` → `Arc<[T]>` / `Arc<str>`

--- a/crates/multitude/src/arena/alloc_growable.rs
+++ b/crates/multitude/src/arena/alloc_growable.rs
@@ -90,7 +90,25 @@ impl<A: Allocator + Clone> Arena<A> {
     /// Panics if the backing allocator fails.
     #[must_use]
     pub fn alloc_string_from_utf8_lossy(&self, bytes: &[u8]) -> String<'_, A> {
-        String::from_str_in(&alloc::string::String::from_utf8_lossy(bytes), self)
+        crate::arena::ExpectAlloc::expect_alloc(self.try_alloc_string_from_utf8_lossy(bytes))
+    }
+
+    /// Fallible variant of [`Self::alloc_string_from_utf8_lossy`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails.
+    pub fn try_alloc_string_from_utf8_lossy(&self, bytes: &[u8]) -> Result<String<'_, A>, AllocError> {
+        // Decode directly into the arena string; no intermediate global
+        // allocation (unlike `str::from_utf8_lossy`'s owned `Cow`).
+        let mut out = self.try_alloc_string_with_capacity(bytes.len())?;
+        for chunk in bytes.utf8_chunks() {
+            out.try_push_str(chunk.valid())?;
+            if !chunk.invalid().is_empty() {
+                out.try_push(char::REPLACEMENT_CHARACTER)?;
+            }
+        }
+        Ok(out)
     }
 
     /// Copy `bytes` into a fresh arena [`String`] without validating that
@@ -107,7 +125,21 @@ impl<A: Allocator + Clone> Arena<A> {
     #[must_use]
     pub unsafe fn alloc_string_from_utf8_unchecked(&self, bytes: &[u8]) -> String<'_, A> {
         // SAFETY: the caller guarantees `bytes` is valid UTF-8.
-        String::from_str_in(unsafe { core::str::from_utf8_unchecked(bytes) }, self)
+        crate::arena::ExpectAlloc::expect_alloc(unsafe { self.try_alloc_string_from_utf8_unchecked(bytes) })
+    }
+
+    /// Fallible variant of [`Self::alloc_string_from_utf8_unchecked`].
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must be valid UTF-8.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails.
+    pub unsafe fn try_alloc_string_from_utf8_unchecked(&self, bytes: &[u8]) -> Result<String<'_, A>, AllocError> {
+        // SAFETY: the caller guarantees `bytes` is valid UTF-8.
+        String::try_from_str_in(unsafe { core::str::from_utf8_unchecked(bytes) }, self)
     }
 
     /// Decode native-endian UTF-16 `units` into a fresh arena [`String`].
@@ -139,11 +171,20 @@ impl<A: Allocator + Clone> Arena<A> {
     /// Panics if the backing allocator fails.
     #[must_use]
     pub fn alloc_string_from_utf16_lossy(&self, units: &[u16]) -> String<'_, A> {
-        let mut out = self.alloc_string_with_capacity(units.len());
+        crate::arena::ExpectAlloc::expect_alloc(self.try_alloc_string_from_utf16_lossy(units))
+    }
+
+    /// Fallible variant of [`Self::alloc_string_from_utf16_lossy`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails.
+    pub fn try_alloc_string_from_utf16_lossy(&self, units: &[u16]) -> Result<String<'_, A>, AllocError> {
+        let mut out = self.try_alloc_string_with_capacity(units.len())?;
         for unit in char::decode_utf16(units.iter().copied()) {
-            out.push(unit.unwrap_or(char::REPLACEMENT_CHARACTER));
+            out.try_push(unit.unwrap_or(char::REPLACEMENT_CHARACTER))?;
         }
-        out
+        Ok(out)
     }
 
     /// Decode little-endian UTF-16 `bytes` into a fresh arena [`String`]. The
@@ -191,6 +232,15 @@ impl<A: Allocator + Clone> Arena<A> {
         self.alloc_string_from_utf16_bytes_lossy(bytes, false)
     }
 
+    /// Fallible variant of [`Self::alloc_string_from_utf16le_lossy`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails.
+    pub fn try_alloc_string_from_utf16le_lossy(&self, bytes: &[u8]) -> Result<String<'_, A>, AllocError> {
+        self.try_alloc_string_from_utf16_bytes_lossy(bytes, false)
+    }
+
     /// Decode big-endian UTF-16 `bytes` into a fresh arena [`String`] (lossy).
     ///
     /// Odd trailing bytes and unpaired surrogates are replaced with `U+FFFD`. The
@@ -202,6 +252,15 @@ impl<A: Allocator + Clone> Arena<A> {
     #[must_use]
     pub fn alloc_string_from_utf16be_lossy(&self, bytes: &[u8]) -> String<'_, A> {
         self.alloc_string_from_utf16_bytes_lossy(bytes, true)
+    }
+
+    /// Fallible variant of [`Self::alloc_string_from_utf16be_lossy`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails.
+    pub fn try_alloc_string_from_utf16be_lossy(&self, bytes: &[u8]) -> Result<String<'_, A>, AllocError> {
+        self.try_alloc_string_from_utf16_bytes_lossy(bytes, true)
     }
 
     /// Shared body for the byte-oriented UTF-16 constructors. `big_endian`
@@ -231,7 +290,12 @@ impl<A: Allocator + Clone> Arena<A> {
 
     /// Shared body for the lossy byte-oriented UTF-16 constructors.
     fn alloc_string_from_utf16_bytes_lossy(&self, bytes: &[u8], big_endian: bool) -> String<'_, A> {
-        let mut out = self.alloc_string_with_capacity(bytes.len() / 2 + 1);
+        crate::arena::ExpectAlloc::expect_alloc(self.try_alloc_string_from_utf16_bytes_lossy(bytes, big_endian))
+    }
+
+    /// Fallible variant of [`Self::alloc_string_from_utf16_bytes_lossy`].
+    fn try_alloc_string_from_utf16_bytes_lossy(&self, bytes: &[u8], big_endian: bool) -> Result<String<'_, A>, AllocError> {
+        let mut out = self.try_alloc_string_with_capacity(bytes.len() / 2 + 1)?;
         let units = bytes.chunks_exact(2).map(|pair| {
             let raw = [pair[0], pair[1]];
             if big_endian {
@@ -241,14 +305,12 @@ impl<A: Allocator + Clone> Arena<A> {
             }
         });
         for unit in char::decode_utf16(units) {
-            out.push(unit.unwrap_or(char::REPLACEMENT_CHARACTER));
+            out.try_push(unit.unwrap_or(char::REPLACEMENT_CHARACTER))?;
         }
         if !bytes.len().is_multiple_of(2) {
-            // An odd trailing byte is invalid; mirror std by appending one
-            // replacement character.
-            out.push(char::REPLACEMENT_CHARACTER);
+            out.try_push(char::REPLACEMENT_CHARACTER)?;
         }
-        out
+        Ok(out)
     }
 
     /// Create a new, empty growable [`Vec`](crate::vec::Vec) backed by this arena.

--- a/crates/multitude/src/arena/alloc_uninit.rs
+++ b/crates/multitude/src/arena/alloc_uninit.rs
@@ -18,6 +18,117 @@ use crate::arc::Arc;
 use crate::r#box::Box;
 
 impl<A: Allocator + Clone> Arena<A> {
+    /// Allocate uninitialized space for a `T`, returning `&mut MaybeUninit<T>`.
+    ///
+    /// The arena-lifetime analog of [`Self::alloc_uninit_box`]: write the value
+    /// (e.g. via [`MaybeUninit::write`]) then read it back with
+    /// [`MaybeUninit::assume_init_mut`].
+    ///
+    /// Unlike [`Self::alloc`], the value's destructor is **never** run — the
+    /// slot holds `MaybeUninit<T>`, which has no drop glue, and there is no way
+    /// to register one after the fact for a bare reference. If you need
+    /// drop-at-teardown semantics use [`Self::alloc`] / [`Self::alloc_with`],
+    /// or freeze into a [`Box`](crate::Box) / [`Arc`](crate::Arc).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the backing allocator fails or if `align_of::<T>()` is at least 32 KiB.
+    /// Use [`Self::try_alloc_uninit`] for a fallible variant.
+    #[allow(clippy::mut_from_ref, reason = "Simple references: see Self::try_alloc_with")]
+    #[inline]
+    pub fn alloc_uninit<T: Send>(&self) -> &mut MaybeUninit<T> {
+        self.alloc_with::<MaybeUninit<T>, _>(MaybeUninit::uninit)
+    }
+
+    /// Fallible variant of [`Self::alloc_uninit`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails or if the data alignment
+    /// is at least 32 KiB.
+    #[allow(clippy::mut_from_ref, reason = "Simple references: see Self::try_alloc_with")]
+    #[inline]
+    pub fn try_alloc_uninit<T: Send>(&self) -> Result<&mut MaybeUninit<T>, AllocError> {
+        self.try_alloc_with::<MaybeUninit<T>, _>(MaybeUninit::uninit)
+    }
+
+    /// Like [`Self::alloc_uninit`] but the value bytes are zeroed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the backing allocator fails or if `align_of::<T>()` is at least 32 KiB.
+    /// Use [`Self::try_alloc_zeroed`] for a fallible variant.
+    #[allow(clippy::mut_from_ref, reason = "Simple references: see Self::try_alloc_with")]
+    #[inline]
+    pub fn alloc_zeroed<T: Send>(&self) -> &mut MaybeUninit<T> {
+        self.alloc_with::<MaybeUninit<T>, _>(MaybeUninit::zeroed)
+    }
+
+    /// Fallible variant of [`Self::alloc_zeroed`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails or if the data alignment
+    /// is at least 32 KiB.
+    #[allow(clippy::mut_from_ref, reason = "Simple references: see Self::try_alloc_with")]
+    #[inline]
+    pub fn try_alloc_zeroed<T: Send>(&self) -> Result<&mut MaybeUninit<T>, AllocError> {
+        self.try_alloc_with::<MaybeUninit<T>, _>(MaybeUninit::zeroed)
+    }
+
+    /// Allocate an uninitialized `[MaybeUninit<T>]` of length `len`.
+    ///
+    /// The arena-lifetime analog of [`Self::alloc_uninit_slice_box`]. Each
+    /// element's destructor is never run (see [`Self::alloc_uninit`]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the backing allocator fails or if `align_of::<T>()` is at least 32 KiB.
+    /// Use [`Self::try_alloc_uninit_slice`] for a fallible variant.
+    #[allow(clippy::mut_from_ref, reason = "Simple references: see Self::try_alloc_with")]
+    #[inline]
+    pub fn alloc_uninit_slice<T: Send>(&self, len: usize) -> &mut [MaybeUninit<T>] {
+        self.alloc_slice_fill_with::<MaybeUninit<T>, _>(len, |_| MaybeUninit::uninit())
+    }
+
+    /// Fallible variant of [`Self::alloc_uninit_slice`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails or if the data alignment
+    /// is at least 32 KiB.
+    #[allow(clippy::mut_from_ref, reason = "Simple references: see Self::try_alloc_with")]
+    #[inline]
+    pub fn try_alloc_uninit_slice<T: Send>(&self, len: usize) -> Result<&mut [MaybeUninit<T>], AllocError> {
+        self.try_alloc_slice_fill_with::<MaybeUninit<T>, _>(len, |_| MaybeUninit::uninit())
+    }
+
+    /// Like [`Self::alloc_uninit_slice`] but the slice bytes are zeroed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the backing allocator fails or if `align_of::<T>()` is at least 32 KiB.
+    /// Use [`Self::try_alloc_zeroed_slice`] for a fallible variant.
+    #[allow(clippy::mut_from_ref, reason = "Simple references: see Self::try_alloc_with")]
+    #[inline]
+    pub fn alloc_zeroed_slice<T: Send>(&self, len: usize) -> &mut [MaybeUninit<T>] {
+        self.alloc_slice_fill_with::<MaybeUninit<T>, _>(len, |_| MaybeUninit::zeroed())
+    }
+
+    /// Fallible variant of [`Self::alloc_zeroed_slice`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails or if the data alignment
+    /// is at least 32 KiB.
+    #[allow(clippy::mut_from_ref, reason = "Simple references: see Self::try_alloc_with")]
+    #[inline]
+    pub fn try_alloc_zeroed_slice<T: Send>(&self, len: usize) -> Result<&mut [MaybeUninit<T>], AllocError> {
+        self.try_alloc_slice_fill_with::<MaybeUninit<T>, _>(len, |_| MaybeUninit::zeroed())
+    }
+}
+
+impl<A: Allocator + Clone> Arena<A> {
     /// Allocate uninitialized space for a `T` and return an
     /// [`Box<MaybeUninit<T>, A>`](crate::Box). The caller must
     /// initialize the value (e.g., via [`MaybeUninit::write`]) before

--- a/crates/multitude/src/internal/arena_buf.rs
+++ b/crates/multitude/src/internal/arena_buf.rs
@@ -554,4 +554,36 @@ mod tests {
         // Drop both halves cleanly.
         drop(tail);
     }
+
+    #[test]
+    fn drop_runs_live_element_destructors() {
+        use core::cell::Cell;
+        use core::mem::ManuallyDrop;
+
+        struct Dropper<'c>(&'c Cell<usize>);
+        impl Drop for Dropper<'_> {
+            fn drop(&mut self) {
+                self.0.set(self.0.get() + 1);
+            }
+        }
+
+        let count = Cell::new(0);
+        // Stack-backed storage that outlives `buf`. `ManuallyDrop` keeps the
+        // array from dropping the elements itself, so `ArenaBuf::drop` is the
+        // sole owner that runs their destructors.
+        let mut storage = [
+            ManuallyDrop::new(Dropper(&count)),
+            ManuallyDrop::new(Dropper(&count)),
+            ManuallyDrop::new(Dropper(&count)),
+        ];
+        let ptr = NonNull::new(storage.as_mut_ptr().cast::<Dropper<'_>>()).expect("array pointer is non-null");
+
+        // SAFETY: `storage` holds three initialized, well-aligned `Dropper`s
+        // and outlives `buf`; `ArenaBuf::drop` only drops them in place and
+        // never frees the (stack-owned) backing memory.
+        let buf = unsafe { ArenaBuf::from_raw_parts(ptr, 3, 3) };
+        assert_eq!(count.get(), 0);
+        drop(buf);
+        assert_eq!(count.get(), 3, "ArenaBuf::drop must run the live elements' destructors");
+    }
 }

--- a/crates/multitude/src/internal/drop_entry.rs
+++ b/crates/multitude/src/internal/drop_entry.rs
@@ -363,13 +363,11 @@ mod tests {
         assert!(installed.is_some());
     }
 
-    /// Regression test for the unaligned-payload formula: when
-    /// `payload_ptr` is **not** `align_of::<DropEntry>()`-aligned (as
-    /// happens for the post-padding-removal chunk layouts), both
-    /// `commit_placeholder_drop_fn` and `replay_drops` must still place
-    /// drop entries at absolutely-aligned addresses near the payload
-    /// tail. The buffer below intentionally offsets the payload start
-    /// by `entry_align - 1` bytes from an aligned base, so the
+    /// When `payload_ptr` is **not** `align_of::<DropEntry>()`-aligned,
+    /// both `commit_placeholder_drop_fn` and `replay_drops` must still
+    /// place drop entries at absolutely-aligned addresses near the
+    /// payload tail. The buffer below intentionally offsets the payload
+    /// start by `entry_align - 1` bytes from an aligned base, so the
     /// payload start address is 1-aligned but the *end* of the
     /// reserved payload still lands on an `entry_align` multiple.
     #[test]

--- a/crates/multitude/src/internal/shared_chunk.rs
+++ b/crates/multitude/src/internal/shared_chunk.rs
@@ -460,8 +460,7 @@ mod tests {
         assert_eq!(got, super::super::constants::CHUNK_ALIGN);
     }
 
-    /// Regression guard for the "every shared chunk is allocated at 64 KiB"
-    /// bug: `chunk_layout` must round the allocation *size* up to
+    /// `chunk_layout` must round the allocation *size* up to
     /// `value_align` (8) and set the *base* alignment to `struct_align`
     /// (`CHUNK_ALIGN`), but must NOT round the size up to `CHUNK_ALIGN`.
     /// Each cacheable size class must therefore produce an allocation

--- a/crates/multitude/src/strings/string.rs
+++ b/crates/multitude/src/strings/string.rs
@@ -81,6 +81,13 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
         out
     }
 
+    /// Fallible variant of [`Self::from_str_in`].
+    pub(crate) fn try_from_str_in(s: &str, arena: &'a Arena<A>) -> Result<Self, allocator_api2::alloc::AllocError> {
+        let mut out = Self::try_with_capacity_in(s.len(), arena)?;
+        out.try_push_str(s)?;
+        Ok(out)
+    }
+
     /// Remove the last character from the string and return it.
     ///
     /// Returns `None` if the string is empty.
@@ -116,10 +123,25 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
     ///
     /// Panics if `idx` is greater than `self.len()` or not on a UTF-8
     /// character boundary, or if the backing allocator fails on growth.
+    /// Use [`Self::try_insert`] for a fallible variant.
     pub fn insert(&mut self, idx: usize, ch: char) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_insert(idx, ch));
+    }
+
+    /// Fallible variant of [`Self::insert`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx` is greater than `self.len()` or not on a UTF-8
+    /// character boundary.
+    pub fn try_insert(&mut self, idx: usize, ch: char) -> Result<(), AllocError> {
         let mut buf = [0u8; 4];
         let s = ch.encode_utf8(&mut buf);
-        self.insert_str(idx, s);
+        self.try_insert_str(idx, s)
     }
 
     /// Insert a string slice at byte index `idx`.
@@ -129,16 +151,32 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
     /// Panics if `idx` is greater than `self.len()`, if `idx` is not
     /// on a UTF-8 character boundary, if the resulting length would
     /// overflow `usize`, or if the backing allocator fails on growth.
+    /// Use [`Self::try_insert_str`] for a fallible variant.
     pub fn insert_str(&mut self, idx: usize, s: &str) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_insert_str(idx, s));
+    }
+
+    /// Fallible variant of [`Self::insert_str`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth, or
+    /// if the resulting length would overflow `usize`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx` is greater than `self.len()` or if `idx` is not on a
+    /// UTF-8 character boundary.
+    pub fn try_insert_str(&mut self, idx: usize, s: &str) -> Result<(), AllocError> {
         let len = self.inner.len();
         assert!(idx <= len, "insertion index out of bounds (was {idx}, len = {len})");
         assert!(self.as_str().is_char_boundary(idx), "insert_str: idx is not on a char boundary");
         let bytes = s.as_bytes();
         let added = bytes.len();
         if added == 0 {
-            return;
+            return Ok(());
         }
-        self.inner.reserve(added);
+        self.inner.try_reserve(added)?;
         // Append the new bytes at the end (the buffer grew by `added`),
         // then rotate the region [idx..len+added] right by `added` so
         // the layout becomes [prefix ++ bytes ++ old_suffix].
@@ -147,6 +185,7 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
         }
         let region = &mut self.inner.as_mut_slice()[idx..len + added];
         region.rotate_right(added);
+        Ok(())
     }
 
     /// Remove the character at byte index `idx` and return it.
@@ -224,8 +263,25 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
     ///
     /// Panics if either bound is out of range, the bounds are not on
     /// UTF-8 character boundaries, the resulting length would overflow
-    /// `usize`, or the backing allocator fails on growth.
+    /// `usize`, or the backing allocator fails on growth. Use
+    /// [`Self::try_replace_range`] for a fallible variant.
     pub fn replace_range<R: RangeBounds<usize>>(&mut self, range: R, replace_with: &str) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_replace_range(range, replace_with));
+    }
+
+    /// Fallible variant of [`Self::replace_range`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth, or
+    /// if the resulting length would overflow `usize`. On error `self` is
+    /// left unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either bound is out of range or the bounds are not on UTF-8
+    /// character boundaries.
+    pub fn try_replace_range<R: RangeBounds<usize>>(&mut self, range: R, replace_with: &str) -> Result<(), AllocError> {
         let len = self.len();
         let start = match range.start_bound() {
             Bound::Included(&i) => i,
@@ -243,13 +299,7 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
         assert!(s_ref.is_char_boundary(start), "replace_range: start is not on a char boundary");
         assert!(s_ref.is_char_boundary(end), "replace_range: end is not on a char boundary");
 
-        // Rebuild via a staging vec to keep this fully safe.
-        let mut staging: allocator_api2::vec::Vec<u8> = allocator_api2::vec::Vec::with_capacity(start + replace_with.len() + (len - end));
-        staging.extend_from_slice(&self.as_bytes()[..start]);
-        staging.extend_from_slice(replace_with.as_bytes());
-        staging.extend_from_slice(&self.as_bytes()[end..]);
-        self.inner.clear();
-        self.inner.extend_from_slice(staging.as_slice());
+        self.inner.try_replace_range_with_slice(start, end, replace_with.as_bytes())
     }
 
     /// Append a single character.
@@ -330,13 +380,28 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
     ///
     /// # Panics
     ///
-    /// Panics if `at` is not on a `char` boundary, or is past the end.
+    /// Panics if `at` is not on a `char` boundary, or is past the end. Use
+    /// [`Self::try_split_off`] for a fallible variant.
     #[must_use]
     pub fn split_off(&mut self, at: usize) -> Self {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_split_off(at))
+    }
+
+    /// Fallible variant of [`Self::split_off`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails. On error `self`
+    /// is left unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at` is not on a `char` boundary, or is past the end.
+    pub fn try_split_off(&mut self, at: usize) -> Result<Self, AllocError> {
         assert!(self.as_str().is_char_boundary(at), "String::split_off: `at` is not a char boundary");
-        Self {
-            inner: self.inner.split_off(at),
-        }
+        Ok(Self {
+            inner: self.inner.try_split_off(at)?,
+        })
     }
 
     /// Clone the bytes in `src` and append them to the end.
@@ -347,8 +412,22 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
     /// # Panics
     ///
     /// Panics if the range is out of bounds or its bounds are not on `char`
-    /// boundaries.
+    /// boundaries. Use [`Self::try_extend_from_within`] for a fallible variant.
     pub fn extend_from_within<R: RangeBounds<usize>>(&mut self, src: R) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_extend_from_within(src));
+    }
+
+    /// Fallible variant of [`Self::extend_from_within`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails while reserving.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the range is out of bounds or its bounds are not on `char`
+    /// boundaries.
+    pub fn try_extend_from_within<R: RangeBounds<usize>>(&mut self, src: R) -> Result<(), AllocError> {
         let len = self.len();
         let start = match src.start_bound() {
             Bound::Included(&i) => i,
@@ -365,7 +444,7 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
         let s_ref = self.as_str();
         assert!(s_ref.is_char_boundary(start), "extend_from_within: start is not on a char boundary");
         assert!(s_ref.is_char_boundary(end), "extend_from_within: end is not on a char boundary");
-        self.inner.extend_from_within(start..end);
+        self.inner.try_extend_from_within(start..end)
     }
 
     /// Remove the `char`s in byte range `range`, returning a draining iterator.
@@ -409,10 +488,49 @@ impl<'a, A: Allocator + Clone> String<'a, A> {
     ///
     /// # Panics
     ///
-    /// Panics if the underlying allocator fails.
+    /// Panics if the underlying allocator fails. Use
+    /// [`Self::try_into_boxed_str`] for a fallible variant.
     #[must_use]
     pub fn into_boxed_str(self) -> Box<str, A> {
-        self.inner.arena().alloc_str_box(self.as_str())
+        crate::arena::ExpectAlloc::expect_alloc(self.try_into_boxed_str())
+    }
+
+    /// Fallible variant of [`Self::into_boxed_str`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the underlying allocator fails.
+    pub fn try_into_boxed_str(self) -> Result<Box<str, A>, AllocError> {
+        self.inner.arena().try_alloc_str_box(self.as_str())
+    }
+
+    /// Freeze into a shared [`Arc<str, A>`](crate::Arc). [`Arc::from`] is the
+    /// trait form.
+    ///
+    /// **O(n)** — copies the contents.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying allocator fails. Use [`Self::try_into_arc_str`]
+    /// for a fallible variant.
+    #[must_use]
+    pub fn into_arc_str(self) -> Arc<str, A>
+    where
+        A: Send + Sync,
+    {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_into_arc_str())
+    }
+
+    /// Fallible variant of [`Self::into_arc_str`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the underlying allocator fails.
+    pub fn try_into_arc_str(self) -> Result<Arc<str, A>, AllocError>
+    where
+        A: Send + Sync,
+    {
+        self.inner.arena().try_alloc_str_arc(self.as_str())
     }
 
     /// Consume the `String`, returning an arena-lifetime mutable string
@@ -512,7 +630,7 @@ impl<'a, A: Allocator + Clone + Send + Sync> From<String<'a, A>> for Arc<str, A>
     /// Mirrors `std`'s `From<String> for Arc<str>`.
     #[inline]
     fn from(s: String<'a, A>) -> Self {
-        s.inner.arena().alloc_str_arc(s.as_str())
+        s.into_arc_str()
     }
 }
 

--- a/crates/multitude/src/strings/utf16_str_common.rs
+++ b/crates/multitude/src/strings/utf16_str_common.rs
@@ -158,7 +158,7 @@ macro_rules! impl_utf16_str_common {
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl<A: allocator_api2::alloc::Allocator + Clone> serde::ser::Serialize for $Ty<A> {
             fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-                serializer.collect_str(&self.as_utf16_str().to_string())
+                serializer.collect_str(self.as_utf16_str())
             }
         }
     };

--- a/crates/multitude/src/strings/utf16_string.rs
+++ b/crates/multitude/src/strings/utf16_string.rs
@@ -71,9 +71,18 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
     /// Construct an `Utf16String` containing `s`, copied into `arena`.
     #[must_use]
     pub fn from_utf16_str_in(s: &Utf16Str, arena: &'a Arena<A>) -> Self {
-        let mut out = Self::with_capacity_in(s.len(), arena);
-        out.push_str(s);
-        out
+        crate::arena::ExpectAlloc::expect_alloc(Self::try_from_utf16_str_in(s, arena))
+    }
+
+    /// Fallible variant of [`Self::from_utf16_str_in`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails.
+    pub fn try_from_utf16_str_in(s: &Utf16Str, arena: &'a Arena<A>) -> Result<Self, AllocError> {
+        let mut out = Self::try_with_capacity_in(s.len(), arena)?;
+        out.try_push_str(s)?;
+        Ok(out)
     }
 
     /// Construct an `Utf16String` by transcoding a `&str` into UTF-16,
@@ -173,9 +182,23 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
     /// Panics if `idx` is greater than `self.len()` or not on a UTF-16
     /// character boundary, or if the backing allocator fails on growth.
     pub fn insert(&mut self, idx: usize, ch: char) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_insert(idx, ch));
+    }
+
+    /// Fallible variant of [`Self::insert`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx` is greater than `self.len()` or not on a UTF-16
+    /// character boundary.
+    pub fn try_insert(&mut self, idx: usize, ch: char) -> Result<(), AllocError> {
         let mut buf = [0u16; 2];
         let units = ch.encode_utf16(&mut buf);
-        self.insert_units(idx, units);
+        self.try_insert_units(idx, units)
     }
 
     /// Insert a `Utf16Str` at element index `idx`.
@@ -185,11 +208,27 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
     /// Panics if `idx` is greater than `self.len()`, if `idx` is not
     /// on a UTF-16 character boundary, if the resulting length would
     /// overflow `usize`, or if the backing allocator fails on growth.
+    /// Use [`Self::try_insert_utf16_str`] for a fallible variant.
     pub fn insert_utf16_str(&mut self, idx: usize, s: &Utf16Str) {
-        self.insert_units(idx, s.as_slice());
+        crate::arena::ExpectAlloc::expect_alloc(self.try_insert_utf16_str(idx, s));
     }
 
-    fn insert_units(&mut self, idx: usize, units: &[u16]) {
+    /// Fallible variant of [`Self::insert_utf16_str`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth, or
+    /// if the resulting length would overflow `usize`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx` is greater than `self.len()` or if `idx` is not on a
+    /// UTF-16 character boundary.
+    pub fn try_insert_utf16_str(&mut self, idx: usize, s: &Utf16Str) -> Result<(), AllocError> {
+        self.try_insert_units(idx, s.as_slice())
+    }
+
+    fn try_insert_units(&mut self, idx: usize, units: &[u16]) -> Result<(), AllocError> {
         let len = self.inner.len();
         assert!(
             idx <= len,
@@ -201,14 +240,15 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
         );
         let added = units.len();
         if added == 0 {
-            return;
+            return Ok(());
         }
-        self.inner.reserve(added);
+        self.inner.try_reserve(added)?;
         for &u in units {
             self.inner.push(u);
         }
         let region = &mut self.inner.as_mut_slice()[idx..len + added];
         region.rotate_right(added);
+        Ok(())
     }
 
     /// Remove the character at element index `idx` and return it.
@@ -240,30 +280,52 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
     ///
     /// # Panic safety
     ///
-    /// If `f` panics, `self` is left **unchanged** (the original
-    /// contents are preserved). This differs from
-    /// [`crate::strings::String::retain`] which commits the
-    /// already-processed prefix on panic. The difference is internal
-    /// implementation detail: this variant uses a side buffer and
-    /// only commits if the full pass completes without panicking,
-    /// whereas the UTF-8 variant edits in place.
-    ///
-    /// # Allocator
-    ///
-    /// Allocates the side buffer from the **global** allocator, not
-    /// the arena. Callers that require zero arena-foreign allocations
-    /// in their hot path should avoid this method.
+    /// Matches [`std::string::String::retain`] and
+    /// [`String::retain`](crate::strings::String::retain): if `f` panics, the
+    /// characters processed so far are committed (retained ones compacted into
+    /// place) and the unprocessed tail is dropped, leaving `self` well-formed
+    /// UTF-16. Edits happen in place — no transient allocation.
     pub fn retain<F: FnMut(char) -> bool>(&mut self, mut f: F) {
-        let mut kept: allocator_api2::vec::Vec<u16> = allocator_api2::vec::Vec::with_capacity(self.len());
-        for ch in self.as_utf16_str().chars() {
-            if f(ch) {
-                let mut buf = [0u16; 2];
-                let units = ch.encode_utf16(&mut buf);
-                kept.extend_from_slice(units);
+        struct Guard<'g, 'a, A: Allocator + Clone> {
+            inner: &'g mut Vec<'a, u16, A>,
+            idx: usize,
+            del_units: usize,
+        }
+        impl<A: Allocator + Clone> Drop for Guard<'_, '_, A> {
+            fn drop(&mut self) {
+                // `u16` has no `Drop`, so this only lowers the length to the
+                // retained, already-compacted prefix.
+                self.inner.truncate(self.idx - self.del_units);
             }
         }
-        self.inner.clear();
-        self.inner.extend_from_slice(kept.as_slice());
+
+        let len = self.inner.len();
+
+        let mut guard = Guard {
+            inner: &mut self.inner,
+            idx: 0,
+            del_units: 0,
+        };
+        while guard.idx < len {
+            // SAFETY: `guard.idx` always lands on a UTF-16 char boundary (it
+            // advances by whole `char` widths) and is `< len`, so the tail is
+            // well-formed UTF-16 with at least one char.
+            let ch = unsafe { Utf16Str::from_slice_unchecked(&guard.inner.as_slice()[guard.idx..len]) }
+                .chars()
+                .next()
+                .expect("idx < len guarantees a remaining char");
+            let ch_len = ch.len_utf16();
+            if f(ch) {
+                let dst = guard.idx - guard.del_units;
+                guard.inner.as_mut_slice().copy_within(guard.idx..guard.idx + ch_len, dst);
+            } else {
+                guard.del_units += ch_len;
+            }
+            guard.idx += ch_len;
+        }
+        // Normal completion: `idx == len`; the guard truncates to
+        // `len - del_units`, committing the retained units.
+        drop(guard);
     }
 
     /// Replace the elements in `range` with the contents of `replace_with`.
@@ -274,6 +336,22 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
     /// UTF-16 character boundaries, the resulting length would overflow
     /// `usize`, or the backing allocator fails on growth.
     pub fn replace_range<R: RangeBounds<usize>>(&mut self, range: R, replace_with: &Utf16Str) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_replace_range(range, replace_with));
+    }
+
+    /// Fallible variant of [`Self::replace_range`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth, or
+    /// if the resulting length would overflow `usize`. On error `self` is
+    /// left unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either bound is out of range or the bounds are not on
+    /// UTF-16 character boundaries.
+    pub fn try_replace_range<R: RangeBounds<usize>>(&mut self, range: R, replace_with: &Utf16Str) -> Result<(), AllocError> {
         let len = self.len();
         let start = match range.start_bound() {
             Bound::Included(&i) => i,
@@ -297,12 +375,7 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
             "Utf16String::replace_range: end is not on a UTF-16 char boundary"
         );
 
-        let mut staging: allocator_api2::vec::Vec<u16> = allocator_api2::vec::Vec::with_capacity(start + replace_with.len() + (len - end));
-        staging.extend_from_slice(&self.as_slice()[..start]);
-        staging.extend_from_slice(replace_with.as_slice());
-        staging.extend_from_slice(&self.as_slice()[end..]);
-        self.inner.clear();
-        self.inner.extend_from_slice(staging.as_slice());
+        self.inner.try_replace_range_with_slice(start, end, replace_with.as_slice())
     }
 
     /// Consume the string, returning the underlying `u16` vector. The
@@ -331,16 +404,32 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
     /// # Panics
     ///
     /// Panics if `at` is not on a `char` boundary (i.e. would split a
-    /// surrogate pair), or is past the end.
+    /// surrogate pair), or is past the end. Use [`Self::try_split_off`] for a
+    /// fallible variant.
     #[must_use]
     pub fn split_off(&mut self, at: usize) -> Self {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_split_off(at))
+    }
+
+    /// Fallible variant of [`Self::split_off`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails. On error `self`
+    /// is left unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at` is not on a `char` boundary (i.e. would split a
+    /// surrogate pair), or is past the end.
+    pub fn try_split_off(&mut self, at: usize) -> Result<Self, AllocError> {
         assert!(
             self.as_utf16_str().is_char_boundary(at),
             "Utf16String::split_off: `at` is not a char boundary"
         );
-        Self {
-            inner: self.inner.split_off(at),
-        }
+        Ok(Self {
+            inner: self.inner.try_split_off(at)?,
+        })
     }
 
     /// Clone the `u16` units in `src` and append them to the end.
@@ -351,8 +440,23 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
     /// # Panics
     ///
     /// Panics if the range is out of bounds or its bounds are not on `char`
-    /// boundaries (i.e. would split a surrogate pair).
+    /// boundaries (i.e. would split a surrogate pair). Use
+    /// [`Self::try_extend_from_within`] for a fallible variant.
     pub fn extend_from_within<R: RangeBounds<usize>>(&mut self, src: R) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_extend_from_within(src));
+    }
+
+    /// Fallible variant of [`Self::extend_from_within`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails while reserving.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the range is out of bounds or its bounds are not on `char`
+    /// boundaries (i.e. would split a surrogate pair).
+    pub fn try_extend_from_within<R: RangeBounds<usize>>(&mut self, src: R) -> Result<(), AllocError> {
         let len = self.inner.len();
         let start = match src.start_bound() {
             Bound::Included(&i) => i,
@@ -369,7 +473,7 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
         let s_ref = self.as_utf16_str();
         assert!(s_ref.is_char_boundary(start), "extend_from_within: start is not on a char boundary");
         assert!(s_ref.is_char_boundary(end), "extend_from_within: end is not on a char boundary");
-        self.inner.extend_from_within(start..end);
+        self.inner.try_extend_from_within(start..end)
     }
 
     /// Freeze into an owned, mutable
@@ -380,10 +484,49 @@ impl<'a, A: Allocator + Clone> Utf16String<'a, A> {
     ///
     /// # Panics
     ///
-    /// Panics if the underlying allocator fails.
+    /// Panics if the underlying allocator fails. Use
+    /// [`Self::try_into_boxed_utf16_str`] for a fallible variant.
     #[must_use]
     pub fn into_boxed_utf16_str(self) -> BoxUtf16Str<A> {
-        self.inner.arena().alloc_utf16_str_box(self.as_utf16_str())
+        crate::arena::ExpectAlloc::expect_alloc(self.try_into_boxed_utf16_str())
+    }
+
+    /// Fallible variant of [`Self::into_boxed_utf16_str`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the underlying allocator fails.
+    pub fn try_into_boxed_utf16_str(self) -> Result<BoxUtf16Str<A>, AllocError> {
+        self.inner.arena().try_alloc_utf16_str_box(self.as_utf16_str())
+    }
+
+    /// Freeze into a shared [`ArcUtf16Str<A>`](crate::strings::ArcUtf16Str).
+    /// [`ArcUtf16Str::from`] is the trait form.
+    ///
+    /// **O(n)** — copies the contents.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying allocator fails. Use
+    /// [`Self::try_into_arc_utf16_str`] for a fallible variant.
+    #[must_use]
+    pub fn into_arc_utf16_str(self) -> ArcUtf16Str<A>
+    where
+        A: Send + Sync,
+    {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_into_arc_utf16_str())
+    }
+
+    /// Fallible variant of [`Self::into_arc_utf16_str`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the underlying allocator fails.
+    pub fn try_into_arc_utf16_str(self) -> Result<ArcUtf16Str<A>, AllocError>
+    where
+        A: Send + Sync,
+    {
+        self.inner.arena().try_alloc_utf16_str_arc(self.as_utf16_str())
     }
 
     /// Remove the `char`s in the `u16` index range `range`, returning a
@@ -496,7 +639,7 @@ impl<'a, A: Allocator + Clone + Send + Sync> From<Utf16String<'a, A>> for ArcUtf
     /// [`ArcUtf16Str<A>`](crate::strings::ArcUtf16Str).
     #[inline]
     fn from(s: Utf16String<'a, A>) -> Self {
-        s.inner.arena().alloc_utf16_str_arc(s.as_utf16_str())
+        s.into_arc_utf16_str()
     }
 }
 
@@ -636,7 +779,7 @@ impl<'a, A: Allocator + Clone> Extend<&'a str> for Utf16String<'_, A> {
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<A: Allocator + Clone> serde::ser::Serialize for Utf16String<'_, A> {
     fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.collect_str(&self.as_utf16_str().to_string())
+        serializer.collect_str(self.as_utf16_str())
     }
 }
 

--- a/crates/multitude/src/vec/mutate.rs
+++ b/crates/multitude/src/vec/mutate.rs
@@ -26,18 +26,63 @@ impl<T> Drop for ResizeGuard<'_, '_, T> {
 }
 
 impl<T, A: Allocator + Clone> Vec<'_, T, A> {
+    /// Replace the elements in `[start, end)` with `repl`, in place, without
+    /// any transient (global) allocation. `T: Copy` (no element drops run).
+    ///
+    /// Callers must ensure `start <= end <= self.len()`. On allocator failure
+    /// (growth case only) returns [`AllocError`] with `self` left unchanged.
+    pub(crate) fn try_replace_range_with_slice(&mut self, start: usize, end: usize, repl: &[T]) -> Result<(), AllocError>
+    where
+        T: Copy,
+    {
+        let gap = end - start;
+        let repl_len = repl.len();
+        let old_len = self.buf.len();
+        if repl_len >= gap {
+            let extra = repl_len - gap;
+            // Grow by `extra`, initializing the new trailing slots with filler
+            // (overwritten below); a no-op when `extra == 0`.
+            self.try_extend_from_slice(&repl[..extra])?;
+            let s = self.buf.as_mut_slice();
+            s.copy_within(end..old_len, end + extra);
+            s[start..start + repl_len].copy_from_slice(repl);
+        } else {
+            let new_len = start + repl_len + (old_len - end);
+            let s = self.buf.as_mut_slice();
+            s[start..start + repl_len].copy_from_slice(repl);
+            s.copy_within(end..old_len, start + repl_len);
+            self.buf.truncate(new_len);
+        }
+        Ok(())
+    }
+
     /// Insert `value` at position `idx`, shifting subsequent elements right.
     ///
     /// # Panics
     ///
     /// Panics if `idx > len`, or if the backing allocator fails on growth.
+    /// Use [`Self::try_insert`] for a fallible variant.
     pub fn insert(&mut self, idx: usize, value: T) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_insert(idx, value));
+    }
+
+    /// Fallible variant of [`Self::insert`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx > len`.
+    pub fn try_insert(&mut self, idx: usize, value: T) -> Result<(), AllocError> {
         let len = self.buf.len();
         assert!(idx <= len, "insertion index (is {idx}) should be <= len (is {len})");
-        if self.buf.remaining_cap() == 0 && self.try_reserve(1).is_err() {
-            crate::arena::panic_alloc!();
+        if self.buf.remaining_cap() == 0 {
+            self.try_reserve(1)?;
         }
         self.buf.insert_within_cap(idx, value);
+        Ok(())
     }
 
     /// Remove and return the element at position `idx`, shifting subsequent
@@ -178,8 +223,25 @@ impl<T, A: Allocator + Clone> Vec<'_, T, A> {
     /// # Panics
     ///
     /// Panics if the range is out of bounds, or if the backing allocator
-    /// fails while reserving.
+    /// fails while reserving. Use [`Self::try_extend_from_within`] for a
+    /// fallible variant.
     pub fn extend_from_within<R: core::ops::RangeBounds<usize>>(&mut self, src: R)
+    where
+        T: Clone,
+    {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_extend_from_within(src));
+    }
+
+    /// Fallible variant of [`Self::extend_from_within`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails while reserving.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the range is out of bounds.
+    pub fn try_extend_from_within<R: core::ops::RangeBounds<usize>>(&mut self, src: R) -> Result<(), AllocError>
     where
         T: Clone,
     {
@@ -199,11 +261,12 @@ impl<T, A: Allocator + Clone> Vec<'_, T, A> {
         let count = end - start;
         // Reserve up front so the subsequent pushes cannot relocate the
         // buffer (which would invalidate the source indices we read from).
-        self.reserve(count);
+        self.try_reserve(count)?;
         for i in start..end {
             let cloned = self.buf.as_slice()[i].clone();
-            self.push(cloned);
+            self.buf.push_within_cap(cloned).ok().expect("capacity reserved above");
         }
+        Ok(())
     }
 
     /// Retain only elements for which the predicate returns `true`.
@@ -274,21 +337,33 @@ impl<T, A: Allocator + Clone> Vec<'_, T, A> {
     ///
     /// # Panics
     ///
-    /// Panics if the backing allocator fails on growth.
+    /// Panics if the backing allocator fails on growth. Use
+    /// [`Self::try_append`] for a fallible variant.
     pub fn append(&mut self, other: &mut Self) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_append(other));
+    }
+
+    /// Fallible variant of [`Self::append`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth. On
+    /// error, `other` is left unchanged.
+    pub fn try_append(&mut self, other: &mut Self) -> Result<(), AllocError> {
         let add = other.buf.len();
         if add == 0 {
-            return;
+            return Ok(());
         }
         // Zero-copy fast path: when `other`'s storage directly abuts the
         // end of a full `self`, absorb it instead of copying elements.
         if const { mem::size_of::<T>() != 0 } && self.buf.try_absorb_adjacent(&mut other.buf) {
-            return;
+            return Ok(());
         }
-        self.reserve(add);
+        self.try_reserve(add)?;
         for item in other.buf.drain_all() {
             self.buf.push_within_cap(item).ok().expect("capacity reserved above");
         }
+        Ok(())
     }
 
     /// Reserve the minimum capacity for at least `additional` more elements.
@@ -319,18 +394,31 @@ impl<T, A: Allocator + Clone> Vec<'_, T, A> {
     ///
     /// # Panics
     ///
-    /// Panics if the backing allocator fails on growth.
+    /// Panics if the backing allocator fails on growth. Use
+    /// [`Self::try_resize`] for a fallible variant.
     pub fn resize(&mut self, new_len: usize, value: T)
+    where
+        T: Clone,
+    {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_resize(new_len, value));
+    }
+
+    /// Fallible variant of [`Self::resize`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth.
+    pub fn try_resize(&mut self, new_len: usize, value: T) -> Result<(), AllocError>
     where
         T: Clone,
     {
         let len = self.buf.len();
         if new_len <= len {
             self.buf.truncate(new_len);
-            return;
+            return Ok(());
         }
         let added = new_len - len;
-        self.reserve(added);
+        self.try_reserve(added)?;
         // If a `clone` (or the final move) panics partway through, the
         // guard rolls the length back to `len`, dropping every element
         // written so far. This keeps the vector in a consistent state and
@@ -345,21 +433,32 @@ impl<T, A: Allocator + Clone> Vec<'_, T, A> {
         // Last push consumes the original `value` to avoid an extra clone.
         guard.buf.push_within_cap(value).ok().expect("capacity reserved above");
         mem::forget(guard);
+        Ok(())
     }
 
     /// Resize the vector to `new_len`, calling `f` for new elements.
     ///
     /// # Panics
     ///
-    /// Panics if the backing allocator fails on growth.
-    pub fn resize_with<F: FnMut() -> T>(&mut self, new_len: usize, mut f: F) {
+    /// Panics if the backing allocator fails on growth. Use
+    /// [`Self::try_resize_with`] for a fallible variant.
+    pub fn resize_with<F: FnMut() -> T>(&mut self, new_len: usize, f: F) {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_resize_with(new_len, f));
+    }
+
+    /// Fallible variant of [`Self::resize_with`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails on growth.
+    pub fn try_resize_with<F: FnMut() -> T>(&mut self, new_len: usize, mut f: F) -> Result<(), AllocError> {
         let len = self.buf.len();
         if new_len <= len {
             self.buf.truncate(new_len);
-            return;
+            return Ok(());
         }
         let added = new_len - len;
-        self.reserve(added);
+        self.try_reserve(added)?;
         // See `resize`: roll back on a panic in `f` so the elements
         // written before the panic are dropped and the length is restored.
         let guard = ResizeGuard {
@@ -370,16 +469,33 @@ impl<T, A: Allocator + Clone> Vec<'_, T, A> {
             guard.buf.push_within_cap(f()).ok().expect("capacity reserved above");
         }
         mem::forget(guard);
+        Ok(())
     }
 
     /// Split the vector at `at`, returning a new vector containing `[at, len)`.
     ///
     /// # Panics
     ///
-    /// Panics if `at > len`.
+    /// Panics if `at > len`, or if the backing allocator fails. Use
+    /// [`Self::try_split_off`] for a fallible variant.
     #[must_use]
     #[cfg_attr(test, mutants::skip)] // routing mutations produce externally indistinguishable empty tails
     pub fn split_off(&mut self, at: usize) -> Self {
+        crate::arena::ExpectAlloc::expect_alloc(self.try_split_off(at))
+    }
+
+    /// Fallible variant of [`Self::split_off`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] if the backing allocator fails. On error `self`
+    /// is left unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at > len`.
+    #[cfg_attr(test, mutants::skip)] // routing mutations produce externally indistinguishable empty tails
+    pub fn try_split_off(&mut self, at: usize) -> Result<Self, AllocError> {
         let len = self.buf.len();
         assert!(at <= len, "split index out of bounds (at is {at}, len is {len})");
         let tail_len = len - at;
@@ -387,23 +503,24 @@ impl<T, A: Allocator + Clone> Vec<'_, T, A> {
         // tail: produce an independent tail and leave the head's storage
         // (and capacity) intact.
         if const { mem::size_of::<T>() == 0 } || self.buf.cap() == 0 || tail_len == 0 {
-            let mut tail = Self::with_capacity_in(tail_len, self.arena);
-            // Move the `[at, len)` suffix into `tail`, preserving order:
-            // pop into a staging buffer (reverse order) then push back.
-            let mut staging = allocator_api2::vec::Vec::with_capacity(tail_len);
+            let mut tail = Self::try_with_capacity_in(tail_len, self.arena)?;
+            // Only ZSTs reach here with `tail_len > 0` (a non-ZST `cap == 0`
+            // forces `tail_len == 0`). ZSTs carry no data, so popping the
+            // suffix straight into `tail` — which reverses order — is fine; no
+            // staging buffer is needed.
             for _ in 0..tail_len {
-                staging.push(self.buf.pop().expect("tail length matches"));
+                tail.buf
+                    .push_within_cap(self.buf.pop().expect("tail length matches"))
+                    .ok()
+                    .expect("capacity reserved above");
             }
-            while let Some(v) = staging.pop() {
-                tail.buf.push_within_cap(v).ok().expect("capacity reserved above");
-            }
-            return tail;
+            return Ok(tail);
         }
         // Zero-copy split: the tail shares the same chunk storage as the
         // head (storage is reclaimed only at arena teardown, which
         // outlives both halves), so no elements are copied.
         let tail_buf = self.buf.split_off_buf(at);
-        Self::from_buf(tail_buf, self.arena)
+        Ok(Self::from_buf(tail_buf, self.arena))
     }
 
     /// Pop the last element if the predicate returns `true`.

--- a/crates/multitude/tests/arena.rs
+++ b/crates/multitude/tests/arena.rs
@@ -288,7 +288,6 @@ fn try_alloc_slice_clone_huge_len_returns_alloc_error() {
     result.unwrap_err();
 }
 
-// === merged from tests/reset.rs ===
 mod reset {
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -477,7 +476,6 @@ mod reset {
     }
 }
 
-// === merged from tests/large_alloc.rs ===
 mod large_alloc {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -1026,7 +1024,6 @@ mod large_alloc {
     }
 }
 
-// === merged from tests/fast_path_correctness.rs ===
 mod fast_path_correctness {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -1427,7 +1424,6 @@ mod fast_path_correctness {
     }
 }
 
-// === merged from tests/allocator_impl.rs ===
 mod allocator_impl {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -1480,7 +1476,6 @@ mod allocator_impl {
     }
 }
 
-// === merged from tests/mutants_chunk_provider.rs ===
 mod mutants_for_chunk_provider {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -1494,13 +1489,6 @@ mod mutants_for_chunk_provider {
     #[expect(unused_imports, reason = "merged test module re-exports common helpers")]
     use crate::common;
 
-    /// Kills `chunk_provider.rs:133:25 > → >=` in `reserve_budget`.
-    ///
-    /// The check is `if next > budget { return Err }`. Mutated to `>=`,
-    /// the boundary `next == budget` (i.e. exactly the budget) would be
-    /// rejected. We pick a tight, exact-fit byte budget and exercise it
-    /// to its boundary — the unmutated code admits the allocation,
-    /// the mutated code returns `AllocError`.
     #[cfg(feature = "stats")]
     #[test]
     fn reserve_budget_admits_exact_fit() {
@@ -1530,22 +1518,6 @@ mod mutants_for_chunk_provider {
         );
     }
 
-    /// Kills `chunk_provider.rs:152:9 release_budget → ()` (function body
-    /// becomes a no-op) and the budget-release path in `acquire_local`
-    /// /`acquire_shared` (failure-rollback arms at 187/254/424/452).
-    ///
-    /// Strategy: configure a tight byte budget such that *two* normal
-    /// allocations would exceed it. Force the budget-release path by
-    /// failing the allocator on the second attempt; if `release_budget`
-    /// is a no-op the second-attempt's reserved bytes stay accounted and
-    /// the third attempt errors. Without a custom failing-allocator we
-    /// indirectly observe via `total_chunk_bytes` shrinking after a
-    /// chunk is freed: dropping the arena releases the chunks, which
-    /// must subtract their bytes from the running total. Re-creating a
-    /// new arena from the same provider would reuse the budget — but
-    /// arena and provider are 1:1, so we instead verify that a tighter
-    /// re-creation succeeds. (Cross-arena budget recycling is covered by
-    /// `arena_arc.rs::shared_chunk_returns_to_provider_after_arc_drop`.)
     #[cfg(feature = "stats")]
     #[test]
     fn release_budget_runs_when_chunk_freed() {
@@ -1567,20 +1539,6 @@ mod mutants_for_chunk_provider {
         assert!(arena2.stats().normal_shared_chunks_allocated >= 1);
     }
 
-    /// Kills `chunk_provider.rs:163:24 > → >=` in `acquire_local`
-    /// (oversized routing gate `min_payload > max_normal_alloc`) and the
-    /// matching `405:24` in `acquire_shared`.
-    ///
-    /// At the boundary `min_payload == max_normal_alloc`, the unmutated
-    /// code routes to the normal (cacheable) path. `> → >=` would route
-    /// the boundary case to oversized. We can detect this via the
-    /// `oversized_*_chunks_allocated` stats counter being 0 vs 1 when an
-    /// allocation lands exactly on the limit.
-    ///
-    /// `acquire_*(min_payload)` is invoked with `needed = size +
-    /// align_slack + entry_size`. To hit `needed == max_normal_alloc`
-    /// precisely we set a known `max_normal_alloc` and allocate a value
-    /// of matching size.
     #[cfg(feature = "stats")]
     #[test]
     fn acquire_local_boundary_does_not_route_oversized() {
@@ -1597,8 +1555,6 @@ mod mutants_for_chunk_provider {
         assert!(s.normal_shared_chunks_allocated + s.oversized_shared_chunks_allocated >= 1);
     }
 
-    /// Kills `chunk_provider.rs:405:24 > → >=` in `acquire_shared` (same
-    /// rationale as above, shared flavor).
     #[cfg(feature = "stats")]
     #[test]
     fn acquire_shared_boundary_does_not_route_oversized() {
@@ -1610,22 +1566,6 @@ mod mutants_for_chunk_provider {
         assert!(s.normal_shared_chunks_allocated + s.oversized_shared_chunks_allocated >= 1);
     }
 
-    /// Kills the subtraction mutants in `acquire_local` / `acquire_shared`
-    /// around `NUM_CHUNK_CLASSES - 1` (chunk_provider.rs:187, 254, 424,
-    /// 452): `- 1 → + 1` or `- 1 → / 1`. These set `max_class` to the
-    /// largest legal class index. Mutating shrinks/expands the class
-    /// ceiling, which changes the chunk *size* picked for fresh
-    /// allocations on a cache miss.
-    ///
-    /// We force a high-water mark by allocating many small values
-    /// sequentially. After enough allocations the provider must have
-    /// allocated several chunks; the largest chunk produced must be
-    /// 64 KiB (class 7 = `NUM_CHUNK_CLASSES - 1`). With mutations the
-    /// ceiling shifts: `+ 1` allows class 8 (128 KiB) → larger total
-    /// bytes; `/ 1` allows up to 8 (one larger class).
-    ///
-    /// Observation: total_bytes_allocated stays bounded by a
-    /// well-known sum under the unmutated ceiling.
     #[cfg(feature = "stats")]
     #[test]
     fn acquire_local_class_ceiling_is_correct() {
@@ -1652,20 +1592,6 @@ mod mutants_for_chunk_provider {
         );
     }
 
-    /// Kills `chunk_provider.rs:258:36 > → >=` and the matching
-    /// `chunk_provider.rs:300:33` mutants (`> with ==/</>=`) in
-    /// `preallocate_local`'s high-water ratchet.
-    ///
-    /// `next_high_water > *h` chooses the larger of the two. With
-    /// `>=`, equal high-waters cause a redundant write — observable only
-    /// through alias bookkeeping, but the *behavior* is identical. The
-    /// related comparison in `preallocate_local` at line 300 governs the
-    /// fetch_max ratchet on the shared cache; `> → <` reverses the
-    /// ratchet so future chunks shrink instead of growing.
-    ///
-    /// Strategy: preallocate first at a small class, then allocate at a
-    /// large class — the high-water mark should grow, and subsequent
-    /// fresh chunks should match the larger class.
     #[cfg(feature = "stats")]
     #[test]
     fn high_water_ratchet_grows_chunks() {
@@ -1689,10 +1615,6 @@ mod mutants_for_chunk_provider {
         assert_eq!(arena.stats().oversized_local_chunks_allocated, 0);
     }
 
-    /// Kills `chunk_provider.rs:274:47 + → *` in `preallocate_local`
-    /// (and `315:48` in `preallocate_shared`): the `local_header_size() +
-    /// target_bytes` total. With `*` the total balloons and reserve_budget
-    /// would fail for any tight budget.
     #[cfg(feature = "stats")]
     #[test]
     fn preallocate_total_bytes_uses_sum_not_product() {
@@ -1707,16 +1629,6 @@ mod mutants_for_chunk_provider {
         assert_eq!(arena2.stats().normal_shared_chunks_allocated, 1);
     }
 
-    /// Kills `chunk_provider.rs:462:9 try_pop_shared_at_least → None` and
-    /// `479:20 >= → <` (the cap-vs-min_bytes filter inside the cache pop).
-    ///
-    /// If `try_pop_shared_at_least` always returns `None`, every
-    /// `acquire_shared` cache-hit becomes a cache miss → a fresh chunk
-    /// is allocated → `normal_shared_chunks_allocated` doubles. To
-    /// detect: preallocate a shared chunk, then issue an arc that
-    /// should reuse the cached chunk; assert the counter does not
-    /// increase. With `>= → <` cap, every cached chunk fails the size
-    /// gate and we also miss the cache.
     #[cfg(feature = "stats")]
     #[test]
     fn shared_cache_pop_serves_preallocated_chunk() {
@@ -1732,7 +1644,6 @@ mod mutants_for_chunk_provider {
     }
 }
 
-// === merged from tests/mutants_internal.rs ===
 mod mutants_for_internal {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -1807,19 +1718,6 @@ mod mutants_for_internal {
         );
     }
 
-    /// Kills `constants.rs:76:14 >= → <` and `87:13 < → <=` in
-    /// `min_class_for_bytes` (the upper / inner loop boundaries) and
-    /// `77:34 - → +/`.
-    ///
-    /// `min_class_for_bytes` saturates at `NUM_CHUNK_CLASSES - 1` for
-    /// `bytes >= MAX_CHUNK_BYTES` (= 64 KiB). With `< →`, the saturation
-    /// inverts and small inputs return class 7. The inner `while v <
-    /// ratio` is `<`; flipping to `<=` adds an extra round-up to the
-    /// next class.
-    ///
-    /// Observation: `with_capacity_local(N)` preallocates one chunk of
-    /// class = `min_class_for_bytes(N).min(NUM_CHUNK_CLASSES-1)`. By
-    /// scanning a few `N` we trigger several `min_class` paths.
     #[cfg(feature = "stats")]
     #[test]
     fn min_class_for_bytes_consistency() {
@@ -1848,13 +1746,6 @@ mod mutants_for_internal {
         assert_eq!(arena.stats().normal_local_chunks_allocated, 2);
     }
 
-    /// Kills `shared_chunk.rs:168:9 to_thin_ptr → Default::default()` (returns null).
-    ///
-    /// `to_thin_ptr` returns the chunk header address. If replaced with
-    /// `Default::default()` (= null), the shared-cache Treiber stack
-    /// link writes would store nulls — preallocated chunks would not be
-    /// findable. Detection: preallocate a shared chunk and assert it
-    /// can be popped to serve an Arc.
     #[cfg(feature = "stats")]
     #[test]
     fn to_thin_ptr_returns_chunk_address() {
@@ -1874,21 +1765,6 @@ mod mutants_for_internal {
         );
     }
 
-    /// Kills `shared_chunk.rs:187:38 - → +` and `187:38 - → /` in
-    /// `SharedChunk::allocate`. The line is
-    /// `min_payload.checked_add(entry_align - 1)?  & !(entry_align - 1)`.
-    ///
-    /// With `- → +`, `entry_align - 1` becomes `entry_align + 1` (9) →
-    /// the mask drops bits 0 and 3 from the rounded-up payload, producing
-    /// a payload smaller than requested and misaligned for `DropEntry`
-    /// writes. With `/ 1` it stays `entry_align` (8), `& !8 = & ~0b1000`
-    /// → only bit 3 cleared, mis-aligning payload.
-    ///
-    /// We allocate many Arc<Drop>'s into a shared chunk. With wrong
-    /// `payload`, the drop_back stack writes would be misaligned (UB on
-    /// some platforms) and replay would read garbage. The 1024-arc
-    /// test in `mutants_kill.rs` already exercises this; this test pins
-    /// a smaller, faster variant via stats.
     #[test]
     fn shared_chunk_payload_alignment_supports_drop_entries() {
         #[derive(Debug)]
@@ -1911,11 +1787,6 @@ mod mutants_for_internal {
         assert_eq!(c.load(Ordering::Relaxed), 256);
     }
 
-    /// Kills `arena_builder.rs:174:80 - → +` and `- → /` in
-    /// `ArenaBuilder::resolve_capacity` — already covered in
-    /// `mutants_kill.rs::resolve_capacity_uses_correct_class_minus_one_clamp`.
-    /// This is a thin additional regression with a different capacity
-    /// to maximize boundary coverage.
     #[cfg(feature = "stats")]
     #[test]
     fn resolve_capacity_64kib_yields_single_chunk() {
@@ -1926,7 +1797,6 @@ mod mutants_for_internal {
     }
 }
 
-// === merged from tests/mutants_kill_boundaries.rs ===
 mod mutants_for_kill_boundaries {
     #![cfg(feature = "stats")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -2209,7 +2079,6 @@ mod mutants_for_kill_boundaries {
     }
 }
 
-// === merged from tests/coverage_arena_gaps.rs ===
 mod coverage_arena_gaps {
     #![allow(clippy::unwrap_used, reason = "test code")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -2621,7 +2490,6 @@ mod coverage_arena_gaps {
     // ============================================================================
 }
 
-// === relocated from mutants_extras.rs (stats-gated tests) ===
 #[cfg(feature = "stats")]
 mod from_mutants_extras_stats {
     #![allow(clippy::items_after_statements, reason = "relocated tests put inner types near use")]
@@ -2653,12 +2521,6 @@ mod from_mutants_extras_stats {
     #[expect(unused_imports, reason = "relocated tests may reference common helpers")]
     use crate::common::{self, DropCounter, FailingAllocator, SendFailingAllocator};
 
-    /// Kills `crates/multitude/src/arena.rs:410: replace
-    /// Arena::preallocate_one_shared -> Result<(), AllocError> with Ok(())`.
-    ///
-    /// If the body were skipped, `with_capacity_shared(N)` would not
-    /// install any chunk in the shared cache — the stats counter would
-    /// remain at 0.
     #[test]
     fn preallocate_one_shared_actually_allocates_chunk() {
         let arena = Arena::builder().with_capacity_shared(1024).build();
@@ -2668,21 +2530,6 @@ mod from_mutants_extras_stats {
         );
     }
 
-    /// Kills `crates/multitude/src/arena_builder.rs:174: replace - with +`
-    /// and `replace - with /` in `ArenaBuilder::resolve_capacity`.
-    ///
-    /// `resolve_capacity` clamps the target class to `NUM_CHUNK_CLASSES - 1`
-    /// (= 7, payload = 64 KiB). Mutating `- 1` to `+ 1` (clamp = 9) or
-    /// `/ 1` (clamp = 8) lets `target_class` exceed the legal range. In
-    /// release builds, `class_to_bytes(8)` returns 128 KiB and
-    /// `class_to_bytes(9)` returns 256 KiB, so the chunk count for a
-    /// 128 KiB request becomes `1` instead of the correct `2`. Asking for
-    /// 128 KiB and asserting `>= 2` chunks distinguishes both mutants from
-    /// the original.
-    ///
-    /// (We use shared so a single test also covers `preallocate_one_shared`'s
-    /// loop; the local sibling has its own existing coverage in
-    /// `tests/arena.rs::preallocate_skips_underlying_allocation_calls`.)
     #[test]
     fn resolve_capacity_uses_correct_class_minus_one_clamp() {
         // 128 KiB > MAX_CHUNK_BYTES (= 64 KiB), so target_class saturates
@@ -2700,15 +2547,6 @@ mod from_mutants_extras_stats {
         assert_eq!(arena2.stats().normal_local_chunks_allocated, 2);
     }
 
-    /// Kills `crates/multitude/src/arena.rs:1201: replace
-    /// <impl Drop for OversizedSharedGuard>::drop with ()`.
-    ///
-    /// `OversizedSharedGuard` reconciles a shared oversized chunk that was
-    /// pulled with `LARGE` inflation when the user closure panics. If the
-    /// drop body becomes a no-op the chunk is leaked and its bytes stay
-    /// charged to the byte budget. With a tight budget, a leak makes the
-    /// next oversized arc allocation fail; without the leak, the arena
-    /// recovers and the second allocation succeeds.
     #[test]
     fn oversized_shared_guard_drop_releases_on_panic() {
         // Each oversized arc below uses an 8 KiB blob (1024 u64s) which
@@ -2752,17 +2590,6 @@ mod from_mutants_extras_stats {
         );
     }
 
-    /// Kills `constants.rs:76:14 >= -> <` in `min_class_for_bytes`.
-    ///
-    /// At `bytes = 513`, the original code falls past the saturation
-    /// guard (line 76) into the loop, which returns class 1 (1 KiB).
-    /// Mutated `<` makes the guard fire for any `bytes < 65536`,
-    /// returning class 7 (64 KiB).
-    ///
-    /// `with_capacity_local(513)` preallocates one chunk of the resolved
-    /// class. With a `byte_budget` tight enough to accept a 1 KiB chunk
-    /// (plus header) but reject a 64 KiB chunk, `try_build` succeeds in
-    /// the unmutated build and fails after mutation.
     #[test]
     fn min_class_for_bytes_classifies_513_below_saturation() {
         // 4 KiB budget easily covers (header + 1 KiB) but not a 64 KiB chunk.
@@ -2770,18 +2597,6 @@ mod from_mutants_extras_stats {
         assert!(res.is_ok(), "513 must resolve to class 1 (1 KiB), fitting a 4 KiB budget");
     }
 
-    /// Kills `constants.rs:87:13 < -> <=` in the `while v < ratio` loop.
-    ///
-    /// For `bytes = 513`: `ratio = 513.div_ceil(512) = 2`. Original loop:
-    /// v=1, c=0; while v<2: v=2, c=1. Returns class 1.
-    /// Mutated `<=`: extra iteration: v=2, c=1; while 2<=2: v=4, c=2.
-    /// Returns class 2.
-    ///
-    /// Same byte-budget trick: a 4 KiB budget admits a 1 KiB chunk but
-    /// not 2 KiB plus header overhead would still fit, so we need a
-    /// tighter probe. Mutated class 2 -> 2 KiB chunk. With budget=1500
-    /// the unmutated 1 KiB chunk + header (<512) fits, the mutated
-    /// 2 KiB + header doesn't.
     #[test]
     fn min_class_inner_loop_uses_strict_less() {
         // Probe: an unbudgeted arena easily allocates a 1 KiB chunk and a
@@ -2794,24 +2609,6 @@ mod from_mutants_extras_stats {
         );
     }
 
-    /// Kills `chunk_provider.rs:133:25 > -> >=` in `reserve_budget`.
-    ///
-    /// The boundary `next == budget` must be accepted (`> budget` is
-    /// false); mutated `>=` rejects it.
-    ///
-    /// Bisecting the budget for a single chunk yields the smallest
-    /// passing budget B*, which is C in unmutated code and C+1 in
-    /// mutated. So bisection alone cannot distinguish. Instead we bisect
-    /// both `local` and `shared` budgets separately to obtain `bl` and
-    /// `bs`, then test a combined budget of `bl + bs - 1`. With
-    /// `with_capacity_local(512)` + `with_capacity_shared(512)`:
-    ///   * unmutated: bl = Cl, bs = Cs, combined = Cl+Cs-1; total need
-    ///     = Cl + Cs > combined -> rejected.
-    ///   * mutated:   bl = Cl+1, bs = Cs+1, combined = Cl+Cs+1; total
-    ///     need = Cl + Cs which is `< Cl+Cs+1` -> `>=` false -> admitted.
-    ///
-    /// Therefore asserting that combined REJECTS under the unmutated
-    /// code (but would ADMIT under mutation) kills the mutant.
     #[test]
     fn reserve_budget_admits_exact_equal() {
         fn ok_local(b: usize) -> bool {
@@ -2847,35 +2644,6 @@ mod from_mutants_extras_stats {
         );
     }
 
-    /// Kills `chunk_provider.rs:152:9 release_budget -> ()` in
-    /// `ChunkProvider::release_budget`.
-    ///
-    /// If `release_budget` is a no-op, allocations stay accounted even
-    /// after the chunk is freed. We allocate enough to nearly exhaust
-    /// the budget, drop those allocations, then allocate again with
-    /// the same arena — the freed bytes must be released so the
-    /// follow-up allocation fits. The path is the failure-rollback in
-    /// `acquire_local` (line 171) which calls `release_budget` after
-    /// `LocalChunk::allocate` returns Err.
-    ///
-    /// To force a failing chunk allocation we use a budget that admits
-    /// the first chunk but not the second; then deallocate (via
-    /// `Arena::reset`) and reallocate. Without `release_budget`, the
-    /// second attempt also fails. We use `try_alloc_box` to surface
-    /// the `AllocError` as `Err` rather than panic.
-    /// Kills `chunk_provider.rs:152:9 release_budget -> ()`.
-    ///
-    /// If `release_budget` is a no-op, the running `total_chunk_bytes`
-    /// monotonically grows even when chunks are freed. The free path
-    /// only fires for oversized chunks (the normal path caches the chunk
-    /// and never calls `release_budget`).
-    ///
-    /// We allocate an oversized box, drop it (which frees the
-    /// stand-alone oversized chunk and calls `release_budget`), and
-    /// allocate another oversized box. With unmutated code the budget
-    /// recycles and the second allocation fits; with the mutated `()`
-    /// body the first allocation's bytes stay accounted, and the second
-    /// allocation panics with `AllocError`.
     #[test]
     fn release_budget_frees_accounted_bytes() {
         let arena = Arena::builder().byte_budget(128 * 1024).max_normal_alloc(4 * 1024).build();
@@ -2890,16 +2658,6 @@ mod from_mutants_extras_stats {
         drop(arena);
     }
 
-    /// Kills `chunk_provider.rs:441:48 + -> *` in `acquire_shared`.
-    /// Line 441: `let total_bytes = shared_header_size() + target_bytes`.
-    /// Mutated `*` -> `header_size() * target_bytes`. For `target_bytes=512`
-    /// and header ~ 88, that's a 45 KiB allocation request vs ~600 B
-    /// original. A `byte_budget` of 1024 bytes admits 600 B but rejects
-    /// 45 KiB.
-    ///
-    /// Boundary test: build a shared-side arena with a tight budget;
-    /// force a fresh shared chunk via `alloc_arc`. With mutated `*`,
-    /// the budget check rejects; original admits.
     #[test]
     fn acquire_shared_total_bytes_is_sum_not_product() {
         let arena = Arena::builder().byte_budget(2 * 1024).build();
@@ -2909,19 +2667,6 @@ mod from_mutants_extras_stats {
         assert!(res.is_ok(), "header + payload must sum (not multiply) for budget check");
     }
 
-    /// Kills `arena.rs:728:30 > -> >=` in `try_alloc_inner_arc_with`.
-    /// Line 728: `if layout.size() > self.provider.max_normal_alloc`
-    /// routes to oversized one-shot path. Mutated `>=`: the boundary
-    /// case `size == max_normal_alloc` is routed oversized, which is
-    /// observable via `oversized_shared_chunks_allocated` counter.
-    ///
-    /// Note: this gate is reached only after the fast-path miss.
-    /// To trigger the slow path we allocate one item that doesn't fit
-    /// in the default shared chunk's bump cursor on first try, but the
-    /// fast-path generally just installs a fresh chunk anyway. The
-    /// simplest reliable trigger: allocate a value of exactly
-    /// `max_normal_alloc` bytes immediately after construction — the
-    /// fast-path stub state fails, slow path runs, hits line 728.
     #[test]
     fn arc_with_size_equal_max_normal_routes_normal() {
         let arena = Arena::builder().max_normal_alloc(4096).build();
@@ -2932,16 +2677,6 @@ mod from_mutants_extras_stats {
         assert!(s.normal_shared_chunks_allocated + s.oversized_shared_chunks_allocated >= 1);
     }
 
-    /// Kills `arena.rs:1251:17` — `<impl Drop for OversizedSharedGuard>::drop`
-    /// replaced with `()`. The Drop runs `reconcile_swap_out` to free the
-    /// chunk on a panic in `init`. If `init` panics and Drop is a no-op,
-    /// the chunk leaks; subsequent allocations either succeed (leaking)
-    /// or fail (budget exhausted).
-    ///
-    /// Witness: build with a tight `byte_budget`; force a panicking Arc
-    /// initialiser on an oversized chunk; catch the panic; allocate
-    /// again. If the guard's Drop is a no-op, the budget stays charged
-    /// and the next allocation fails.
     #[test]
     fn oversized_shared_guard_drop_releases_chunk_on_panic() {
         let arena = Arena::builder().byte_budget(256 * 1024).max_normal_alloc(4096).build();
@@ -2959,10 +2694,6 @@ mod from_mutants_extras_stats {
         assert_eq!(s.oversized_shared_chunks_allocated, 2);
     }
 
-    /// Kills: arena.rs:728:30 `> -> >=` — oversized routing for arc
-    /// When `layout.size()` == `max_normal_alloc`, the normal path should be
-    /// used. If mutated to `>=`, it takes the oversized path.
-    /// Detectable via stats: oversized vs normal shared chunk counts.
     #[test]
     fn arena_728_exact_max_normal_alloc_arc() {
         let arena = Arena::builder().max_normal_alloc(4096).build();

--- a/crates/multitude/tests/arena_string.rs
+++ b/crates/multitude/tests/arena_string.rs
@@ -367,14 +367,12 @@ fn shrink_to_fit_reclaims_when_at_cursor() {
 fn shrink_to_fit_empty_or_full_noop() {
     let arena = Arena::new();
     let mut s = arena.alloc_string();
-    // Folded mutant-kill: string.rs:207 `|| -> &&` must still no-op at cap == 0.
     s.shrink_to_fit();
     assert_eq!(s.capacity(), 0);
 
     let mut s2 = arena.alloc_string_with_capacity(4);
     s2.push_str("abcd");
     let cap = s2.capacity();
-    // Folded mutant-kill: the same guard must also no-op when len == cap.
     s2.shrink_to_fit();
     assert_eq!(s2.capacity(), cap);
 }
@@ -711,7 +709,6 @@ fn write_str_via_trait() {
     assert_eq!(s.as_str(), "hello, world");
 }
 
-// === merged from tests/arena_str.rs ===
 mod arena_str {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -798,7 +795,6 @@ mod arena_str {
     }
 }
 
-// === merged from tests/arena_box_str.rs ===
 mod arena_box_str {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -976,7 +972,6 @@ mod arena_box_str {
     }
 }
 
-// === merged from tests/mutants_string.rs ===
 mod mutants_for_string {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -987,11 +982,6 @@ mod mutants_for_string {
     #[expect(unused_imports, reason = "merged test module re-exports common helpers")]
     use crate::common;
 
-    /// Kills `string.rs:94:16 > → >=` in `try_with_capacity_in`:
-    /// `if cap > 0 { allocate }`. With `>=`, even `cap == 0` allocates.
-    /// Detection: pointer identity. A zero-capacity request must leave
-    /// the data pointer in its dangling state (no allocation, no chunk
-    /// touched).
     #[test]
     fn with_capacity_zero_does_not_allocate() {
         let arena = Arena::new();
@@ -1005,9 +995,6 @@ mod mutants_for_string {
         assert_eq!(s0.as_ptr() as usize, s_new.as_ptr() as usize);
     }
 
-    /// Kills `string.rs:465:19 > → >=` in `try_reserve`. Same shape as
-    /// the utf16 counterpart: `if needed > self.cap { grow }`. With
-    /// `>=`, reserve at exact fit reallocates spuriously.
     #[test]
     fn string_reserve_at_exact_fit_does_not_regrow() {
         let arena = Arena::new();
@@ -1019,10 +1006,6 @@ mod mutants_for_string {
         assert_eq!(s.as_ptr(), ptr_before);
     }
 
-    /// Kills `string.rs:510:21 == → !=` in `into_box`. With
-    /// `!=`, the empty-fast-path triggers on non-empty inputs (wrong
-    /// output, possibly UB) and the data-path triggers on empty (UB on
-    /// dangling).
     #[test]
     fn into_box_handles_empty_and_non_empty() {
         let arena = Arena::new();
@@ -1082,16 +1065,6 @@ mod mutants_for_string {
         assert_eq!(&*escaped, "survives");
     }
 
-    /// Kills `string.rs:528:9 try_reclaim_tail → ()` (body becomes a
-    /// no-op), `528:21 >= → <` (early-return inverted), and `534:29 - → /`
-    /// (`total - used` arithmetic).
-    ///
-    /// `try_reclaim_tail` returns the unused trailing bytes to the chunk
-    /// cursor. If the function is a no-op or the arithmetic is wrong,
-    /// the next allocation in the same arena would either start past
-    /// the reclaimed region (no aliasing — invisible) or overlap with
-    /// it (corruption). We pin the *positive observation* by allocating
-    /// after a freeze and confirming the frozen string is intact.
     #[test]
     fn reclaim_tail_does_not_corrupt_frozen_string() {
         let arena = Arena::new();
@@ -1109,7 +1082,6 @@ mod mutants_for_string {
     }
 }
 
-// === merged from tests/format_macro.rs ===
 mod format_macro {
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
     #![allow(clippy::unwrap_used, reason = "test code")]

--- a/crates/multitude/tests/arena_vec.rs
+++ b/crates/multitude/tests/arena_vec.rs
@@ -1398,7 +1398,6 @@ mod io_write {
     }
 }
 
-// === merged from tests/mutants_vec.rs ===
 mod mutants_for_vec {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -1424,15 +1423,6 @@ mod mutants_for_vec {
         }
     }
 
-    /// Kills `vec/vec.rs:362:21 < → <=` in `shrink_to_fit`.
-    ///
-    /// `if self.len < self.cap && self.realloc(self.len).is_err()`.
-    /// With `<=`, the realloc branch runs even when `len == cap` (full
-    /// vec → spurious realloc to same size). With `<`, full vecs skip
-    /// the realloc.
-    ///
-    /// We can detect by ptr-identity: a no-op shrink at `len == cap`
-    /// must not relocate the buffer.
     #[test]
     fn shrink_to_fit_full_vec_is_noop() {
         let arena = Arena::new();
@@ -1442,23 +1432,12 @@ mod mutants_for_vec {
         }
         assert_eq!(v.len(), v.capacity());
         let ptr_before = v.as_ptr();
-        // Folded mutant-kill: vec.rs:359 `< -> <=` must still skip realloc at len == cap.
         v.shrink_to_fit();
         let ptr_after = v.as_ptr();
         assert_eq!(ptr_before, ptr_after, "shrink_to_fit at len==cap must not reallocate");
         assert_eq!(v.len(), 8);
     }
 
-    /// Kills `vec/vec.rs:451:34 - → +` (`reserve(new_len - self.len)`) and
-    /// `460:46 - → +/`, `461:30 > → >=` (guard's `added > 0` check), and
-    /// `473:37 - → +`, `474:26 > → >=` (the loop bound `total_new` and
-    /// `self.len < new_len - 1`).
-    ///
-    /// `resize` to a larger length must clone the value into each new
-    /// slot exactly once and drop the original `value` argument once.
-    /// Strict assertions: final length, every element equals the value,
-    /// and the drop counter for the value matches the expected clone-
-    /// and-move count.
     #[test]
     fn resize_grows_with_correct_clone_count() {
         let arena = Arena::new();
@@ -1496,15 +1475,6 @@ mod mutants_for_vec {
         assert_eq!(counter.load(Ordering::Relaxed), 10);
     }
 
-    /// Kills `vec/vec.rs:474:26 > → >=` and `473:37 - → +` via the
-    /// degenerate `total_new == 0` path of `resize`.
-    ///
-    /// When `new_len == self.len`, `total_new == 0` and the loop body
-    /// must not run. With mutations the loop boundary is misaligned →
-    /// either an extra clone happens or the last slot is written twice
-    /// (UB / wrong content). Concretely: resize(5, …) on a vec of length
-    /// 5 must drop the `value` argument exactly once and leave the vec
-    /// unchanged.
     #[test]
     fn resize_to_same_length_is_noop() {
         let arena = Arena::new();
@@ -1534,25 +1504,6 @@ mod mutants_for_vec {
         assert_eq!(counter.load(Ordering::Relaxed), 6);
     }
 
-    /// Kills the `realloc` boundary mutants `vec/vec.rs:808:31 && → ||`,
-    /// `808:20 > → >=`, `808:43 > → >=`, `819:21 > → >=`, `828:20 > → ==`,
-    /// `828:20 > → >=`.
-    ///
-    /// `realloc(new_cap)`:
-    /// - line 808: `if new_cap > self.cap && self.cap > 0` (try in-place
-    ///   growth gate). With `>=` we'd attempt in-place at exact size (no
-    ///   change but harmless). With `||` we'd attempt in-place even for
-    ///   shrinks → wrong path → copy semantics differ.
-    /// - line 819: `if self.len > 0 { copy_nonoverlapping(…) }`. With
-    ///   `>=` zero-length vec triggers a memcpy of 0 bytes — harmless but
-    ///   observable via behavior identical, so this might be equivalent
-    ///   to original. We still pin via a 0-length grow.
-    /// - line 828: `if old_cap > 0 { bump_relocation }`. The relocation
-    ///   counter is only bumped when there was a prior alloc. With `==`
-    ///   or `>=` the counter is wrong.
-    ///
-    /// We exercise growing past initial capacity, repeated pushes, and
-    /// shrink_to_fit. Stats counter `relocations` is the observable.
     #[cfg(feature = "stats")]
     #[test]
     fn realloc_growth_and_relocation_counter() {
@@ -1579,12 +1530,6 @@ mod mutants_for_vec {
         let _ = s.relocations;
     }
 
-    /// Kills `vec/vec.rs:762:17 += → -=` and `762:17 += → *=` in
-    /// `into_box`.
-    ///
-    /// `idx += 1` after each read. With `-=` idx underflows → next read
-    /// is wildly out of bounds → segfault/UB. With `*=` idx stays 0 →
-    /// the same element is read N times → wrong output.
     #[test]
     fn into_box_yields_distinct_elements() {
         use multitude::vec::Vec as MVec;

--- a/crates/multitude/tests/bytemuck_integration.rs
+++ b/crates/multitude/tests/bytemuck_integration.rs
@@ -324,7 +324,6 @@ fn alloc_slice_ref_is_mutable() {
     assert_eq!(s, &[0, 99, 0]);
 }
 
-// === relocated from coverage_extras.rs (bytemuck-gated tests) ===
 mod from_coverage_extras_bytemuck {
     #![allow(clippy::items_after_statements, reason = "relocated tests put inner types near use")]
     #![allow(clippy::clone_on_ref_ptr, reason = "relocated tests use .clone() on Arc/Rc")]

--- a/crates/multitude/tests/bytesbuf_integration.rs
+++ b/crates/multitude/tests/bytesbuf_integration.rs
@@ -198,7 +198,6 @@ fn single_ref_drop_after_arena_dropped() {
     drop(view); // exercises full cleanup with arena gone
 }
 
-// === relocated from coverage_extras.rs (bytesbuf-gated tests) ===
 mod from_coverage_extras_bytesbuf {
     #![allow(clippy::items_after_statements, reason = "relocated tests put inner types near use")]
     #![allow(clippy::clone_on_ref_ptr, reason = "relocated tests use .clone() on Arc/Rc")]

--- a/crates/multitude/tests/chunk_footprint.rs
+++ b/crates/multitude/tests/chunk_footprint.rs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! End-to-end regression guards for the chunk allocation *footprint*:
-//! the number of bytes actually requested from the underlying allocator
-//! must match the chunk's size class, not be inflated to `CHUNK_ALIGN`
-//! (64 KiB). This is the gap that previously let every shared chunk be
-//! silently allocated at 64 KiB while the byte budget / stats tracked the
-//! much smaller unpadded size.
+//! End-to-end guards for the chunk allocation *footprint*: the number
+//! of bytes actually requested from the underlying allocator must match
+//! the chunk's size class, not be inflated to `CHUNK_ALIGN` (64 KiB).
 
 #![cfg(feature = "std")]
 #![allow(clippy::unwrap_used, reason = "test code")]
@@ -72,7 +69,7 @@ fn shared_chunk_sizes(log: &RequestLog) -> Vec<usize> {
 
 /// A single small `Arc<u32>` needs only a class-0 shared chunk (512 B).
 /// The allocator must therefore be asked for far less than `CHUNK_ALIGN`
-/// bytes — before the fix it was asked for exactly 64 KiB.
+/// bytes.
 #[test]
 fn small_shared_chunk_is_not_inflated_to_chunk_align() {
     let (rec, log) = recorder();

--- a/crates/multitude/tests/coverage_extras.rs
+++ b/crates/multitude/tests/coverage_extras.rs
@@ -5,7 +5,6 @@
 
 mod common;
 
-// === merged from tests/coverage.rs ===
 mod coverage {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -496,7 +495,6 @@ mod coverage {
 
         let mut exact = arena.alloc_string_with_capacity(8);
         exact.push_str("abc");
-        // Folded mutant-kill: exact-fit reserve must short-circuit when len + additional == cap.
         exact.try_reserve(5).unwrap();
         assert_eq!(exact.capacity(), 8);
     }
@@ -1246,7 +1244,6 @@ mod coverage {
     }
 }
 
-// === merged from tests/coverage_more.rs ===
 mod coverage_more {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -1479,7 +1476,6 @@ mod coverage_more {
         for _ in 0..16 {
             v.push(());
         }
-        // Folded mutant-kill: vec.rs:834 `==`/`!=` must keep ZST Vecs on the copy fallback.
         let b = v.into_boxed_slice();
         assert_eq!(b.len(), 16);
     }
@@ -1631,7 +1627,6 @@ mod coverage_more {
     }
 }
 
-// === merged from tests/coverage_complete.rs ===
 mod coverage_complete {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -1854,7 +1849,6 @@ mod coverage_complete {
     // ============================================================================
 }
 
-// === merged from tests/coverage_llvmcov.rs ===
 mod coverage_llvmcov {
     #![allow(clippy::std_instead_of_core, reason = "test code uses std")]
     #![allow(clippy::missing_panics_doc, reason = "test code")]

--- a/crates/multitude/tests/drop_reentrancy.rs
+++ b/crates/multitude/tests/drop_reentrancy.rs
@@ -12,7 +12,6 @@
 
 mod common;
 
-// === merged from tests/arena_drop_reentrancy.rs ===
 mod arena_drop_reentrancy {
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -290,7 +289,6 @@ mod arena_drop_reentrancy {
     }
 }
 
-// === merged from tests/alloc_reentrancy.rs ===
 mod alloc_reentrancy {
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -302,7 +300,6 @@ mod alloc_reentrancy {
     use crate::common;
 }
 
-// === merged from tests/drop_behavior.rs ===
 mod drop_behavior {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]

--- a/crates/multitude/tests/dst.rs
+++ b/crates/multitude/tests/dst.rs
@@ -14,7 +14,6 @@
 
 mod common;
 
-// === merged from tests/dst.rs ===
 mod dst {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -132,7 +131,6 @@ mod dst {
     }
 }
 
-// === merged from tests/dst_box.rs ===
 mod dst_box {
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -226,7 +224,6 @@ mod dst_box {
         let b = arena.alloc_slice_copy_box([1_u32, 2, 3]);
         assert_eq!(&*b, &[1, 2, 3]);
 
-        // Folded from_coverage_extras_dst::alloc_slice_copy_box_succeeds keeps the alternate payload assertion.
         let b: multitude::Box<[u8]> = arena.alloc_slice_copy_box([10_u8, 20, 30]);
         assert_eq!(&*b, &[10, 20, 30]);
     }
@@ -259,7 +256,6 @@ mod dst_box {
         assert_eq!(b[0], "a");
         assert_eq!(b[2], "c");
 
-        // Folded from_coverage_extras_dst::alloc_slice_clone_box_succeeds keeps the alternate input case.
         let src = [
             std::string::String::from("x"),
             std::string::String::from("y"),
@@ -283,7 +279,6 @@ mod dst_box {
         let b: multitude::Box<[u64]> = arena.alloc_slice_fill_with_box(5, |i| (i as u64) * 10);
         assert_eq!(&*b, &[0, 10, 20, 30, 40]);
 
-        // Folded from_coverage_extras_dst::alloc_slice_fill_with_box_succeeds keeps the shorter fill case.
         let b: multitude::Box<[u32]> = arena.alloc_slice_fill_with_box(4, |i| (i + 1) as u32);
         assert_eq!(&*b, &[1, 2, 3, 4]);
     }
@@ -301,7 +296,6 @@ mod dst_box {
         let b: multitude::Box<[i32]> = arena.alloc_slice_fill_iter_box([7_i32, 8, 9]);
         assert_eq!(&*b, &[7, 8, 9]);
 
-        // Folded from_coverage_extras_dst::alloc_slice_fill_iter_box_succeeds keeps the range-based iterator case.
         let b: multitude::Box<[u8]> = arena.alloc_slice_fill_iter_box(0_u8..5);
         assert_eq!(&*b, &[0, 1, 2, 3, 4]);
     }
@@ -505,7 +499,6 @@ mod dst_box {
     }
 }
 
-// === merged from tests/dst_panic_safety.rs ===
 mod dst_panic_safety {
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -544,7 +537,6 @@ mod dst_panic_safety {
     }
 }
 
-// === relocated from coverage_extras.rs (dst-gated tests) ===
 mod from_coverage_extras_dst {
     #![allow(clippy::items_after_statements, reason = "relocated tests put inner types near use")]
     #![allow(clippy::clone_on_ref_ptr, reason = "relocated tests use .clone() on Arc/Rc")]
@@ -722,7 +714,6 @@ mod from_coverage_extras_dst {
     }
 }
 
-// === relocated from mutants_extras.rs (dst-gated tests) ===
 mod from_mutants_extras_dst {
     #![allow(clippy::items_after_statements, reason = "relocated tests put inner types near use")]
     #![allow(clippy::clone_on_ref_ptr, reason = "relocated tests use .clone() on Arc/Rc")]
@@ -753,13 +744,6 @@ mod from_mutants_extras_dst {
     #[expect(unused_imports, reason = "relocated tests may reference common helpers")]
     use crate::common::{self, FailingAllocator, SendFailingAllocator};
 
-    /// Kills `arena.rs:3197:55 - -> /` in `allocate_shared_layout`.
-    /// Line 3197 computes `aligned_offset = aligned_addr - data_addr`.
-    /// Mutated `/`: when `aligned_addr == data_addr` (the common case for
-    /// pre-aligned bump cursors), `-` yields 0 but `/` yields 1, so the
-    /// returned pointer becomes misaligned by 1 byte. This test exercises
-    /// the path via the public DST-Arc API for a `[u128]` (align=16, non-
-    /// Drop) and asserts the returned payload is properly aligned.
     #[test]
     fn allocate_shared_layout_high_align_offset_zero_preserved() {
         use core::alloc::Layout;

--- a/crates/multitude/tests/loom.rs
+++ b/crates/multitude/tests/loom.rs
@@ -7,7 +7,6 @@
 
 mod common;
 
-// === merged from tests/loom_arc.rs ===
 mod loom_arc {
     #![allow(clippy::std_instead_of_core, reason = "loom + std interop in tests")]
     #![allow(clippy::missing_panics_doc, reason = "test code")]
@@ -566,7 +565,6 @@ mod loom_arc {
     }
 }
 
-// === merged from tests/loom_bytesbuf.rs ===
 mod loom_bytesbuf {
     #![cfg(all(loom, feature = "bytesbuf"))]
     #![allow(clippy::std_instead_of_core, reason = "loom + std interop in tests")]

--- a/crates/multitude/tests/mutants_extras.rs
+++ b/crates/multitude/tests/mutants_extras.rs
@@ -5,7 +5,6 @@
 
 mod common;
 
-// === merged from tests/mutants_kill.rs ===
 mod mutants_for_kill {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std for thread/sync primitives")]
@@ -32,14 +31,6 @@ mod mutants_for_kill {
     // A. Trait-impl mutants: hash forwarders and Pointer formatter.
     // --------------------------------------------------------------------
 
-    /// Kills `crates/multitude/src/arc.rs:282: replace <Arc as Hash>::hash with ()`.
-    ///
-    /// If `Arc::hash` were a no-op, every key would hash to the hasher's
-    /// initial state and the `HashMap` lookup would still find the value
-    /// for any *equal* key (because `HashMap` uses `Eq` after the bucket
-    /// hit). To distinguish, we hash the key directly with a single-shot
-    /// hasher and assert the produced hash is not the empty-stream hash —
-    /// i.e. that `hash` actually fed bytes to the hasher.
     // --------------------------------------------------------------------
     // B/I. Builder defaults / preallocation paths / resolve_capacity.
     // --------------------------------------------------------------------
@@ -69,11 +60,6 @@ mod mutants_for_kill {
         }
     }
 
-    /// Kills mutants in `try_alloc_inner_arc_with` and
-    /// `try_alloc_inner_arc_oversized_with`:
-    /// `arena.rs:670 + → *`, `681 > → >=`, `700 > → ==/>=`,
-    /// `703 + → -/*` (multiple), and the oversized arc path's
-    /// `1185 match-guard` and `1201 OversizedSharedGuard::drop`.
     #[test]
     fn many_drop_typed_arc_allocs_run_drop_exactly_once_each() {
         let counter = StdArc::new(AtomicUsize::new(0));
@@ -91,16 +77,6 @@ mod mutants_for_kill {
         assert_eq!(counter.load(Ordering::Relaxed), 256);
     }
 
-    /// Kills the oversized-value match-guard mutant
-    /// `arena.rs:849: replace match guard e <= cap.saturating_sub(entry_size)
-    /// with true` and the analogous oversized-value paths
-    /// (`1098`, `1185`), plus the large-alignment portion of
-    /// `try_alloc_inner_*` `+entry_size` calculations.
-    ///
-    /// The test allocates a `T` whose size exceeds the default
-    /// `max_normal_alloc` (16 KiB) and whose alignment is non-trivial
-    /// (64 bytes). This forces the oversized one-shot path, where the
-    /// match guard is the only post-alignment fit check.
     #[test]
     fn oversized_drop_typed_alloc_runs_drop_and_respects_alignment() {
         #[repr(align(64))]
@@ -150,15 +126,6 @@ mod mutants_for_kill {
     // H. align_offset — exercised transitively via oversized aligned alloc.
     // --------------------------------------------------------------------
 
-    /// Kills `crates/multitude/src/arena.rs:5206: replace align_offset ->
-    /// Option<usize> with Some(0)`.
-    ///
-    /// If `align_offset` always returned `Some(0)`, the oversized path
-    /// would treat any chunk's payload base as already aligned for `T`.
-    /// For non-aligned bases (chunk payloads start right after the
-    /// `SharedChunk`/`LocalChunk` header, which is 64-byte aligned but
-    /// not necessarily 128-byte aligned), a `T` with align 128 would
-    /// land off-alignment and our `% 128` assertion would catch it.
     #[test]
     fn oversized_high_alignment_drives_align_offset() {
         #[repr(align(128))]
@@ -180,22 +147,6 @@ mod mutants_for_kill {
     // D. try_bump_fit boundary mutant.
     // --------------------------------------------------------------------
 
-    /// Kills `crates/multitude/src/arena.rs:5192: replace > with >= in
-    /// try_bump_fit` and the analogous comparisons in
-    /// `try_alloc_slice_local_no_drop_with_slow:2432`,
-    /// `try_alloc_slice_local_copy_slow:2527`, and
-    /// `try_alloc_slice_shared_with:2651`.
-    ///
-    /// `try_bump_fit` returns `None` for `aligned > max_aligned`. The
-    /// mutation `>` → `>=` rejects `aligned == max_aligned` (the
-    /// perfect-fit case). We hit this exact equality by running enough
-    /// allocations to exhaust whole chunks at minimum class (512 B), then
-    /// asking for a properly aligned u64 payload that fits exactly. We
-    /// can't guarantee a perfect equality on every host, but a high
-    /// volume of distinct alignment + size combos forces the boundary on
-    /// many of them — the test asserts every read-back value is correct,
-    /// so any spurious reject + retry that picked a wrong cursor would
-    /// surface as a wrong read or a panic.
     #[test]
     fn many_distinct_size_and_align_combinations_succeed() {
         let arena = Arena::new();
@@ -229,16 +180,6 @@ mod mutants_for_kill {
     // D/E. allocate_layout `+` arithmetic.
     // --------------------------------------------------------------------
 
-    /// Kills `crates/multitude/src/arena.rs:1598: replace + with - in
-    /// Arena::allocate_layout`.
-    ///
-    /// `allocate_layout` is the SimpleRef-flavor entry that backs
-    /// `arena.alloc_string_with_capacity` / `alloc_vec_with_capacity`.
-    /// The `+` is the `needed = size + align.saturating_sub(_)` calc on
-    /// the refill path. With `-` the subtraction may underflow (in
-    /// release: wrap to a huge `needed` → refill fails → `AllocError` →
-    /// panic in `panic_alloc`). We force the refill path by allocating
-    /// a vec with non-trivial alignment that fills more than one chunk.
     #[test]
     fn vec_with_alignment_grows_across_chunks() {
         let arena = Arena::new();
@@ -263,9 +204,6 @@ mod mutants_for_kill {
     // D/E/F. Slice paths — local and shared, with and without Drop.
     // --------------------------------------------------------------------
 
-    /// Kills the no-drop slice fast-path slow-tail mutants
-    /// `arena.rs:2432 > → ==/>=` and `2527 > → ==/>=` by exhausting the
-    /// fast-path bump space and forcing the slow refill path repeatedly.
     #[test]
     fn many_copy_slices_force_slow_refill() {
         let arena = Arena::new();
@@ -285,15 +223,6 @@ mod mutants_for_kill {
     // Misc: confirm the && operator in the oversized-value flavor gate.
     // --------------------------------------------------------------------
 
-    /// Kills `crates/multitude/src/arena.rs:1072: replace && with || in
-    /// Arena::try_alloc_inner_oversized_value`.
-    ///
-    /// The expression is `needs_drop::<T>() && !matches!(flavor, Box)`.
-    /// With `||` the `entry_size` is reserved for `Box` flavor too, which
-    /// then writes a drop entry the Box flavor never expects (it runs
-    /// `drop_in_place` directly). The result is either a double-drop or
-    /// a corrupted oversized chunk teardown. We exercise the oversized
-    /// Box path with a Drop-needing payload and assert exactly one Drop.
     #[test]
     fn oversized_box_drop_runs_exactly_once() {
         #[repr(align(64))]
@@ -315,7 +244,6 @@ mod mutants_for_kill {
     }
 }
 
-// === merged from tests/mutants_kill2.rs ===
 mod mutants_for_kill2 {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -354,17 +282,6 @@ mod mutants_for_kill2 {
     // constants.rs mutants
     // ============================================================
 
-    /// Kills `constants.rs:77:34 - -> +` and `- -> /` in `min_class_for_bytes`.
-    ///
-    /// Line 77 returns `NUM_CHUNK_CLASSES - 1` (= 7) for `bytes >=
-    /// MAX_CHUNK_BYTES`. Mutated `+` returns 9; mutated `/` returns 8.
-    /// Both are out-of-range class indices.
-    ///
-    /// In all *publicly reachable* call sites the return value is clamped
-    /// by a subsequent `.min(NUM_CHUNK_CLASSES - 1)`. We document this
-    /// as EQUIVALENT — see `MUTANTS_EQUIVALENT.md` — and rely on the
-    /// constants.rs:76 / 87 tests above to bound the function's range.
-
     // ============================================================
     // drop_list.rs mutants — PAD_BYTES via mem::size_of::<DropEntry>
     // ============================================================
@@ -384,143 +301,14 @@ mod mutants_for_kill2 {
     // arena_builder.rs mutants
     // ============================================================
 
-    /// Kills `arena_builder.rs:174:80 - -> +` and `- -> /` in
-    /// `resolve_capacity`.
-    ///
-    /// The expression `min_class_for_bytes(capacity).min(NUM_CHUNK_CLASSES - 1)`
-    /// clamps the class to the top valid index. Mutated:
-    ///   `+` -> `.min(NUM_CHUNK_CLASSES + 1)` = `.min(9)`, no effective clamp;
-    ///   `/` -> `.min(NUM_CHUNK_CLASSES / 1)` = `.min(8)`, no effective clamp.
-    ///
-    /// For inputs where `min_class_for_bytes` returns a value > 7, the
-    /// unmutated clamp pins to 7 (64 KiB) while the mutated code returns
-    /// the larger class -> `class_to_bytes(c)` debug-asserts -> panic.
-    ///
-    /// `min_class_for_bytes` itself saturates at 7 (constants.rs line 77),
-    /// so this only kills if `min_class_for_bytes` is *also* mutated to
-    /// not saturate (covered by `min_class_at_max_chunk_bytes_stays_in_range`).
-    /// As an independent witness here, we exercise capacity == 65537:
-    /// orig path: min_class returns 7, .min(7) = 7. Both clamps produce
-    /// 7 too. Hence this mutation is killed *only* in combination with
-    /// already-killing the constants.rs mutants — we document this
-    /// reliance in MUTANTS_EQUIVALENT.md.
-    ///
-    /// However there is still an observable: the second `min` argument
-    /// is `NUM_CHUNK_CLASSES - 1`. If this becomes `+ 1` (= 9) and we
-    /// somehow reached a `min_class_for_bytes` of 8 or 9 (it can't, in
-    /// the unmutated callee), no behaviour change. So the mutation is
-    /// effectively benign UNLESS the callee changes. Mark as
-    /// EQUIVALENT (see MUTANTS_EQUIVALENT.md).
-
     // ============================================================
     // chunk_provider.rs mutants
     // ============================================================
-
-    /// Kills `chunk_provider.rs:152:9 release_budget -> ()` more directly
-    /// by forcing the allocator to fail on a fresh chunk. We use a
-    /// `byte_budget` that admits a normal chunk but route the value
-    /// through the **oversized** allocator (size > max_normal_alloc),
-    /// which calls `acquire_local` with `min_payload > max_normal_alloc`.
-    /// That path's failure-rollback (line 171/415) calls
-    /// `release_budget(total_bytes)` if `LocalChunk::allocate` fails.
-    ///
-    /// We can't easily make the system allocator fail. Instead, we
-    /// observe the symmetric path: budget rejection (line 244/394). If
-    /// the budget is exhausted, allocations return Err; subsequent
-    /// drop-and-reallocate must succeed (because the dropped chunk's
-    /// release_budget was called). This is the same observable as
-    /// `release_budget_frees_accounted_bytes`; we accept the indirect
-    /// witness here.
-
-    /// Kills `chunk_provider.rs:187:43 - -> +` and `- -> /` in
-    /// `acquire_local`. Line 187: `let max_class = NUM_CHUNK_CLASSES - 1`.
-    ///
-    /// Mutated `+` -> max_class=9; `/` -> max_class=8. Both shift the
-    /// class ceiling above the legal range. The subsequent `min(max_class)`
-    /// of `req_class.max(high_water)` could then permit
-    /// `target_class = 8` or `9`, and `class_to_bytes(target_class)`
-    /// debug-asserts -> panic.
-    ///
-    /// To force `req_class.max(high_water) > 7` we need
-    /// `high_water > 7`, which can't happen organically. But `req_class`
-    /// from `min_class_for_bytes(min_payload >= 65536)` returns 7
-    /// (unmutated). Hmm — `target_class = req_class.max(hw).min(max_class)`:
-    /// with `req_class=7, hw=0, max_class=7`: 7. Mutated max_class=8 or 9
-    /// still produces 7. No observable difference.
-    ///
-    /// HOWEVER: in `next_high_water = target_class.saturating_add(1)
-    /// .min(NUM_CHUNK_CLASSES-1).min(max_class)`. Unmutated:
-    /// `.min(7).min(7) = 7`. Mutated: `.min(7).min(8 or 9) = 7`. Still 7.
-    ///
-    /// We cannot easily observe this in isolation; the saturating add
-    /// already caps at 8 which the second `.min(NUM_CHUNK_CLASSES-1)`
-    /// pins to 7. EQUIVALENT — documented in MUTANTS_EQUIVALENT.md.
-
-    /// Kills `chunk_provider.rs:254:84 - -> +` and `- -> /` in
-    /// `acquire_local`. Line 254: `next_high_water = target_class.saturating_add(1)
-    /// .min(NUM_CHUNK_CLASSES - 1).min(max_class)`. Column 84 is the
-    /// first `.min(NUM_CHUNK_CLASSES - 1)`.
-    ///
-    /// Unmutated: `.min(7)` clamps target_class+1 to 7 -> next_high_water
-    /// stays at 7 when target_class=7. Mutated `+`: `.min(9)` -> would
-    /// allow next_high_water=8 -> then `.min(max_class=7)` clamps to 7.
-    /// Same outcome. Mutated `/`: `.min(8)` -> next_high_water=8 ->
-    /// `.min(7) = 7`. Same. EQUIVALENT.
-
-    /// Kills `chunk_provider.rs:258:36 > -> >=` in `acquire_local`.
-    /// Line 258: `if next_high_water > *h { *h = next_high_water; }`.
-    ///
-    /// Mutated `>=` writes even when equal — observable only as a
-    /// redundant store with no behavioural change. EQUIVALENT.
-
-    /// Kills `chunk_provider.rs:300:33 > -> ==/<>=`, in `preallocate_local`.
-    /// Line 300: `if target_class > *h { *h = target_class; }`. Same
-    /// idempotency story as 258 — but here we can force a difference.
-    ///
-    /// Sequence: build with a smaller `with_capacity_local` first
-    /// (preallocate sets the initial high-water class), then a second
-    /// builder call... actually `with_capacity_local` is the only knob.
-    /// The user-visible high-water effect is observed indirectly via
-    /// follow-up chunk sizing.
-    ///
-    /// `target_class > *h` ensures the ratchet only writes when the new
-    /// class is strictly larger. Mutated `==`: only writes on equality,
-    /// so a larger class doesn't update. Mutated `<`: writes only on
-    /// smaller. Mutated `>=`: equal also writes (idempotent).
-    ///
-    /// Observable: preallocate_local is called once per builder chunk.
-    /// With a request for capacity covering 2 chunks (e.g., 96 KiB ->
-    /// 2 chunks of 64 KiB), the first preallocate sets h=7, the second
-    /// would already see h=7. So all four mutations behave identically
-    /// per-call. EQUIVALENT in this context.
-
-    /// Kills `chunk_provider.rs:424:43 - -> +` and `- -> /` in
-    /// `acquire_shared`. Same pattern as 187:43 — `NUM_CHUNK_CLASSES - 1`
-    /// for `max_class`. Same EQUIVALENT argument.
-
-    /// Kills `chunk_provider.rs:452:84 - -> +` and `- -> /` in
-    /// `acquire_shared`. Mirror of 254:84. EQUIVALENT.
 
     // ============================================================
     // arena.rs mutants
     // ============================================================
 
-    /// Documents `arena.rs:329:9` — `Arena::builder` constructs the builder
-    /// via the crate-internal `ArenaBuilder::new()`.
-    ///
-    /// `ArenaBuilder` no longer implements `Default` (its only construction
-    /// path is `Arena::builder` / `builder_in`), so the former
-    /// `from(Default::default())` mutation is no longer generated. EQUIVALENT.
-
-    /// Kills `arena.rs:698:76 + -> *` in `try_alloc_inner_arc_with`.
-    /// Line 698: `let count = (*chunk.as_ptr()).drop_count.get() + 1;`.
-    /// Mutated `*`: count = get() * 1 = get() (unchanged). Each
-    /// successful Arc<Drop> allocation should bump drop_count by 1;
-    /// mutated never bumps it. Replay-on-teardown iterates drop_count
-    /// entries; if drop_count stays 0, none of the Drops run.
-    ///
-    /// Test: allocate N Arc<DropCounter> in a single shared chunk, drop
-    /// them all, then drop the arena. Counter must equal N.
     #[test]
     fn arc_drop_count_increments_on_each_alloc() {
         let counter = StdArc::new(AtomicUsize::new(0));
@@ -536,16 +324,6 @@ mod mutants_for_kill2 {
         assert_eq!(counter.load(Ordering::Relaxed), 64);
     }
 
-    /// Kills `arena.rs:709:35 > -> >=` in `try_alloc_inner_arc_with`.
-    /// Line 709 is `if entry_size > 0`. With `>=`, the branch fires
-    /// unconditionally (entry_size is usize). For `T: !Drop` (entry_size
-    /// = 0), the mutated code would write a drop entry at an invalid
-    /// `new_drop_back_addr` slot — corrupting memory.
-    ///
-    /// Test: Allocate Arc<u32> (T: !Drop) many times so the alloc paths
-    /// are exercised; subsequent allocations and reads must succeed.
-    /// Saturate one chunk with a few large uninit fillers so we reach
-    /// the chunk's refill boundary with a small probe burst.
     #[test]
     fn arc_with_non_drop_t_does_not_install_drop_entry() {
         const N: u32 = 64;
@@ -562,23 +340,6 @@ mod mutants_for_kill2 {
         }
     }
 
-    /// Kills `arena.rs:731:104 + -> *` and `731:40 + -> -` in
-    /// `try_alloc_inner_arc_with`. Line 731 computes:
-    /// `let needed = layout.size() + layout.align().saturating_sub(...) + entry_size`.
-    /// Col 40 = first +, col 104 = second +.
-    ///
-    /// `+ -> *` at col 104: needed = `(size + align_slack) * entry_size`.
-    /// For T: !Drop (entry_size=0): needed = 0. refill_shared(0) succeeds
-    /// trivially, but the next loop iteration's fast-path still tries
-    /// `size` bytes — fails -> infinite loop / 4-retry exhaustion ->
-    /// AllocError.
-    ///
-    /// `+ -> -` at col 40: needed = `size - align_slack + entry_size`.
-    /// For typical align <= align_of::<usize>(), align_slack = 0, so
-    /// no difference. We deliberately use a high-alignment type to
-    /// make align_slack non-zero.
-    ///
-    /// Use `Arc<T>` where T has alignment > align_of::<usize>() = 8.
     #[test]
     fn arc_with_high_align_uses_correct_needed_size() {
         #[repr(align(64))]
@@ -594,24 +355,6 @@ mod mutants_for_kill2 {
         }
     }
 
-    /// Kills `arena.rs:899:24`, `1148:24`, `1235:24` —
-    /// `match guard e <= cap.saturating_sub(entry_size) with true`.
-    ///
-    /// In the oversized one-shot paths, `acquire_local`/`acquire_shared`
-    /// guarantees `cap >= needed = size + align_slack + entry_size`. The
-    /// `align_offset` always yields `aligned <= align_slack`, so
-    /// `aligned + size <= cap - entry_size` is always true.
-    ///
-    /// The match guard mutation `with true` is therefore EQUIVALENT —
-    /// the original condition never fails. See MUTANTS_EQUIVALENT.md.
-
-    /// Kills `arena.rs:1648:40 + -> -` in `allocate_layout`.
-    /// Line 1648: `let needed = layout.size() + layout.align().saturating_sub(core::mem::align_of::<usize>())`.
-    /// Used by the `Allocator` impl on `&Arena`. Mutated `-`: needed =
-    /// size - align_slack, which under-refills for high-alignment types.
-    ///
-    /// Exercise via `Allocator::allocate` (allocator_api2) of a 4 KiB
-    /// payload at high alignment, forcing chunk grow and proper refill.
     #[test]
     fn allocate_layout_high_align_refill_uses_sum() {
         use core::alloc::Layout;
@@ -641,9 +384,6 @@ mod mutants_for_kill2 {
         }
     }
 
-    /// Kills `arena.rs:2655:47 && -> ||`, `2660:23 != -> ==`,
-    /// `2660:35 > -> ==/>=` in `try_alloc_slice_shared_with`. Shared
-    /// mirror of 2261/2266 — same logic, different flavor.
     #[test]
     fn slice_shared_no_drop_does_not_install_entry() {
         let arena = multitude::Arena::new();
@@ -686,18 +426,6 @@ mod mutants_for_kill2 {
         assert_eq!(counter.load(Ordering::Relaxed), u16::MAX as usize);
     }
 
-    /// Kills `arena.rs:2701:35 > -> >=` in `try_alloc_slice_shared_with`.
-    /// Line 2701: `if entry_size > 0 { ... }`. With `>=`, the branch fires
-    /// even when entry_size == 0 (T: !Drop), writing a spurious drop
-    /// entry. Covered by `slice_shared_no_drop_does_not_install_entry`.
-
-    /// Kills `arena.rs:2719:35 += -> *=` in `try_alloc_slice_shared_with`.
-    /// Line 2719: `guard.len += 1`. The guard tracks initialised count
-    /// for panic-rollback. With `*=`, the count multiplies — `guard.len`
-    /// stays 0 (multiplied by 1 = 0). If init panics partway, the
-    /// rollback drops fewer elements than initialised -> memory leak,
-    /// but in the unwinding path. We trigger via a panicking init in
-    /// alloc_slice_fill_with_arc.
     #[test]
     fn slice_shared_init_increments_guard_len() {
         let counter = StdArc::new(AtomicUsize::new(0));
@@ -723,13 +451,6 @@ mod mutants_for_kill2 {
         assert_eq!(counter.load(Ordering::Relaxed), 10);
     }
 
-    /// Kills `arena.rs:2739:75 != -> ==` in `try_alloc_slice_shared_with`.
-    /// Line 2739: `self.refill_shared(compute_worst_case_size(layout, entry_size != 0))?`.
-    /// Mutated `==`: the `has_drop_entry` flag is inverted — refill sizes
-    /// computed for the opposite case. For drop slice, mutated under-refills.
-    ///
-    /// Force a Drop slice that strains the chunk: alloc_slice_fill_with_arc
-    /// with many drop elements through refill_shared.
     #[test]
     fn slice_shared_refill_uses_correct_has_drop_flag() {
         let counter = StdArc::new(AtomicUsize::new(0));
@@ -753,15 +474,6 @@ mod mutants_for_kill2 {
         assert_eq!(counter.load(Ordering::Relaxed), 256 * 8);
     }
 
-    /// Kills `arena.rs:5268:16 > -> >=` in `try_bump_fit`.
-    /// Line 5268: `if aligned > max_aligned { return None }`.
-    /// Boundary `aligned == max_aligned` must succeed. Mutated `>=`
-    /// rejects the exact-fit case, forcing a chunk refill where the
-    /// unmutated code would allocate in place.
-    ///
-    /// Exact-fit is hard to trigger deterministically without internals.
-    /// We approximate by allocating to chunk capacity with many small
-    /// values and asserting success.
     #[test]
     fn try_bump_fit_exact_aligned_succeeds() {
         let arena = multitude::Arena::new();
@@ -775,14 +487,6 @@ mod mutants_for_kill2 {
         }
     }
 
-    /// Kills `vec.rs:760 + → -, *` in `Vec::try_into_arc` and the
-    /// mirror in `Vec::into_box`. The closure passed to
-    /// `alloc_slice_fill_iter_*` advances its read index via
-    /// `consumed_cell.set(idx + 1)`. The `* 1` mutation freezes the
-    /// index at 0, so every element of the new slice is a bitwise copy of
-    /// the original Vec's element 0. The `- 1` mutation underflows on the
-    /// second iteration (UB / crash). A distinct-value assertion catches
-    /// both.
     #[test]
     fn vec_into_arc_advances_read_index() {
         let arena = multitude::Arena::new();
@@ -810,7 +514,6 @@ mod mutants_for_kill2 {
     }
 }
 
-// === merged from tests/mutants_kill3.rs ===
 mod mutants_for_kill3 {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -901,10 +604,6 @@ mod mutants_for_kill3 {
     // arena.rs — try_alloc_inner_arc_with slow-path mutants
     // =====================================================================
 
-    /// Kills: arena.rs:709:35 `> -> >=` in try_alloc_inner_arc_with
-    /// The `entry_size > 0` guard: if mutated to `>=`, the drop entry
-    /// is never written for types that need drop, causing dropped
-    /// values to leak (drop not called).
     #[test]
     fn arena_709_entry_size_gt_zero_arc_with() {
         let _guard = reset_drop_counter();
@@ -918,12 +617,6 @@ mod mutants_for_kill3 {
         assert!(drops >= 1, "DropTracker must be dropped; got {drops} drops");
     }
 
-    /// Kills: arena.rs:728:30 `> -> >=` in try_alloc_inner_arc_with
-    /// (oversized routing: `layout.size() > max_normal_alloc`)
-    /// If mutated to `>=`, a value whose size == max_normal_alloc goes
-    /// through the oversized path instead of the normal path. We test
-    /// that a value at exactly max_normal_alloc succeeds via the normal
-    /// path by filling the arena with many such allocations.
     #[test]
     #[cfg(feature = "stats")]
     fn arena_728_size_eq_max_normal_alloc_arc() {
@@ -943,12 +636,6 @@ mod mutants_for_kill3 {
         );
     }
 
-    /// Kills: arena.rs:731:40 `+ -> -` and 731:104 `+ -> *`
-    /// in try_alloc_inner_arc_with's `needed` computation.
-    /// `needed = layout.size() + align_slack + entry_size`
-    /// If `+` becomes `-` or `*`, `needed` is wrong; a subsequent
-    /// alloc may fail or corrupt because the chunk doesn't have enough
-    /// room. We allocate an Arc<DropTracker> and verify it drops correctly.
     #[test]
     fn arena_731_needed_computation_arc_with() {
         let _guard = reset_drop_counter();
@@ -968,10 +655,6 @@ mod mutants_for_kill3 {
     // arena.rs — try_alloc_inner_slow_value mutants (1085, 1089, 1101)
     // =====================================================================
 
-    /// Kills: arena.rs:1251:17 OversizedSharedGuard::drop -> ()
-    /// If the guard's drop is removed, a panicking closure in
-    /// try_alloc_inner_arc_oversized_with would leak the oversized shared chunk.
-    /// We verify that alloc_arc_with works and the value actually drops.
     #[test]
     fn arena_1251_oversized_shared_guard_drop() {
         let _guard = reset_drop_counter();
@@ -996,11 +679,6 @@ mod mutants_for_kill3 {
         assert!(drops >= 1, "oversized arc LargeArcDrop must drop");
     }
 
-    /// Kills: arena.rs:1648:40 `+ -> -` in allocate_layout
-    /// `needed = layout.size() + layout.align().saturating_sub(align_of::<usize>())`
-    /// If `+` becomes `-`, the needed computation underflows, requesting
-    /// too little memory, causing subsequent allocations to overlap.
-    /// We allocate layout-sensitive values and verify correctness.
     #[test]
     fn arena_1648_allocate_layout_needed() {
         let arena = Arena::new();
@@ -1026,10 +704,6 @@ mod mutants_for_kill3 {
     // arena.rs — slice allocation mutants
     // =====================================================================
 
-    /// Kills: arena.rs:2261:47 `&& -> ||` in try_alloc_slice_local_with
-    /// `entry_size = if drop_fn.is_some() && len != 0 { ... } else { 0 }`
-    /// If && becomes ||, entry_size is nonzero even when len == 0 or
-    /// drop_fn is None, wasting space or causing wrong behavior.
     #[test]
     fn arena_2261_slice_local_and_to_or() {
         let _guard = reset_drop_counter();
@@ -1045,10 +719,6 @@ mod mutants_for_kill3 {
         }
     }
 
-    /// Kills: arena.rs:2266:23 `!= -> ==` and 2266:35 `> -> ==` / `> -> >=`
-    /// `if entry_size != 0 && len > u16::MAX as usize { return Err(AllocError); }`
-    /// Tests that a Drop-type slice with len > u16::MAX returns error,
-    /// and a non-Drop-type slice with len > u16::MAX succeeds.
     #[test]
     fn arena_2266_slice_len_boundary() {
         let arena = Arena::new();
@@ -1074,8 +744,6 @@ mod mutants_for_kill3 {
         drop(result);
     }
 
-    /// Kills: arena.rs:2655:47 `&& -> ||` in try_alloc_slice_shared_with
-    /// `entry_size = if drop_fn.is_some() && len != 0 { ... } else { 0 }`
     #[test]
     fn arena_2655_shared_slice_and_to_or() {
         let arena = Arena::new();
@@ -1093,8 +761,6 @@ mod mutants_for_kill3 {
         assert_eq!(nums_arc.len(), 5);
     }
 
-    /// Kills: arena.rs:2660:23 `!= -> ==` and 2660:35 `> -> ==` / `> -> >=`
-    /// Same pattern as 2266 but for shared slices.
     #[test]
     fn arena_2660_shared_slice_len_boundary() {
         let arena = Arena::new();
@@ -1108,10 +774,6 @@ mod mutants_for_kill3 {
         assert!(drops >= 1, "single-element arc slice must drop");
     }
 
-    /// Kills: arena.rs:2701:35 `> -> >=` in try_alloc_slice_shared_with
-    /// `if entry_size > 0 { ... advance drop_back ... }`
-    /// If mutated to `>=`, drop_back is never advanced for Drop types,
-    /// causing drop entries to overlap or be lost.
     #[test]
     fn arena_2701_shared_slice_entry_size_guard() {
         let _guard = reset_drop_counter();
@@ -1127,11 +789,6 @@ mod mutants_for_kill3 {
         assert_eq!(drops, 60, "20 arcs * 3 elements = 60 drops");
     }
 
-    /// Kills: arena.rs:2719:35 `+= -> *=` in try_alloc_slice_shared_with
-    /// `guard.len += 1` in the init loop. If *= instead of +=,
-    /// guard.len goes 0*1=0, then 0*1=0, ... so on panic the guard
-    /// wouldn't drop any initialized elements. Test that all elements
-    /// are properly initialized.
     #[test]
     fn arena_2719_guard_len_increment() {
         let _guard = reset_drop_counter();
@@ -1144,11 +801,6 @@ mod mutants_for_kill3 {
         assert_eq!(drops, 5, "all 5 elements must drop");
     }
 
-    /// Kills: arena.rs:2739:75 `!= -> ==` in try_alloc_slice_shared_with
-    /// `self.refill_shared(compute_worst_case_size(layout, entry_size != 0))?;`
-    /// If `!=` becomes `==`, entry_size==0 would claim "has drop entry"
-    /// and entry_size>0 would claim "no drop entry", causing wrong
-    /// worst-case size computation and potential failure.
     #[test]
     fn arena_2739_refill_shared_entry_size_check() {
         let _guard = reset_drop_counter();
@@ -1168,9 +820,6 @@ mod mutants_for_kill3 {
     // chunk_provider.rs mutants
     // =====================================================================
 
-    /// Kills: chunk_provider.rs:133:25 `> -> >=` in reserve_budget
-    /// `if next > budget { return Err(AllocError); }`
-    /// If mutated to `>=`, allocations exactly at budget fail.
     #[test]
     fn chunk_provider_133_reserve_budget_boundary() {
         // Set byte_budget so that exactly one default chunk fits.
@@ -1181,10 +830,6 @@ mod mutants_for_kill3 {
         let _v = arena.alloc(42u64);
     }
 
-    /// Kills: chunk_provider.rs:441:48 `+ -> *` in acquire_shared
-    /// `total_bytes = shared_header_size() + target_bytes`
-    /// If `+` becomes `*`, total_bytes = header * target which is way
-    /// too large, causing budget exhaustion or OOM.
     #[test]
     fn chunk_provider_441_shared_header_plus_target() {
         let arena = Arena::builder().byte_budget(512 * 1024).build();
@@ -1200,11 +845,6 @@ mod mutants_for_kill3 {
     // constants.rs mutants
     // =====================================================================
 
-    /// Kills: constants.rs:76:14 `>= -> <` in min_class_for_bytes
-    /// `if bytes >= MAX_CHUNK_BYTES { return NUM_CHUNK_CLASSES - 1; }`
-    /// If `>=` becomes `<`, bytes >= MAX_CHUNK_BYTES would fall through
-    /// to the loop, potentially returning a wrong class.
-    /// We test by allocating a large value that exercises the MAX_CHUNK_BYTES boundary.
     #[test]
     fn constants_76_min_class_ge_to_lt() {
         // Allocating a large value forces acquire_local with a large payload
@@ -1214,10 +854,6 @@ mod mutants_for_kill3 {
         let _alloc = arena.alloc_slice_copy(&big);
     }
 
-    /// Kills: constants.rs:87:13 `< -> <=` in min_class_for_bytes
-    /// `while v < ratio { v <<= 1; c += 1; }`
-    /// If `<` becomes `<=`, the loop runs one extra iteration, returning
-    /// a class that's one too high. This causes chunks to be too large.
     #[test]
     #[cfg(feature = "stats")]
     fn constants_87_loop_boundary() {
@@ -1240,8 +876,6 @@ mod mutants_for_kill3 {
     // local_chunk.rs / shared_chunk.rs mutants
     // =====================================================================
 
-    /// Kills: shared_chunk.rs:143:17 `- -> +` in max_bump_extent
-    /// Same as local_chunk but for shared chunks.
     #[test]
     fn shared_chunk_143_max_bump_extent() {
         let arena = Arena::new();
@@ -1254,10 +888,6 @@ mod mutants_for_kill3 {
         }
     }
 
-    /// Kills: shared_chunk.rs:168:9 to_thin_ptr -> Default::default()
-    /// If to_thin_ptr returns null (Default for *mut u8), the shared chunk
-    /// cache and Treiber stack operations would use null pointers, causing
-    /// crashes or lost chunks.
     #[test]
     fn shared_chunk_168_to_thin_ptr() {
         let arena = Arena::new();
@@ -1275,10 +905,6 @@ mod mutants_for_kill3 {
         assert_eq!(*final_arc, 42);
     }
 
-    /// Kills: shared_chunk.rs:186:59 `- -> +` / `- -> /` in SharedChunk::allocate
-    /// `let payload = min_payload.checked_add(entry_align - 1)...& !(entry_align - 1)`
-    /// If `-` becomes `+` or `/`, the rounding is wrong, causing
-    /// misaligned drop entries or undersized chunks.
     #[test]
     fn shared_chunk_186_payload_rounding() {
         let _guard = reset_drop_counter();
@@ -1299,12 +925,6 @@ mod mutants_for_kill3 {
     // strings/string.rs mutants
     // =====================================================================
 
-    /// Kills: string.rs:465:19 `> -> >=` in String::try_reserve
-    /// `if needed > self.cap { self.try_grow_to_at_least(needed)?; }`
-    /// If `>` becomes `>=`, try_reserve grows even when needed == cap,
-    /// which wastes capacity but shouldn't break. However, if the grow
-    /// fails (tight budget), a reserve that should succeed (needed == cap)
-    /// would fail.
     #[test]
     fn string_465_try_reserve_boundary() {
         let arena = Arena::new();
@@ -1322,9 +942,6 @@ mod mutants_for_kill3 {
     // strings/utf16_string.rs mutants
     // =====================================================================
 
-    /// Kills: vec.rs:451:34 `- -> +` in resize
-    /// `self.reserve(new_len - self.len);`
-    /// If `-` becomes `+`, reserve amount is huge, causing OOM/panic.
     #[test]
     fn vec_451_resize_reserve() {
         let arena = Arena::new();
@@ -1339,11 +956,6 @@ mod mutants_for_kill3 {
         assert_eq!(v[2], 0);
     }
 
-    /// Kills: vec.rs:460:46 `- -> +` / `- -> /` in Guard::drop
-    /// `let added = self.vec.len - self.old_len;`
-    /// If wrong, the guard drops wrong elements on panic.
-    /// Also kills: vec.rs:461:30 `> -> >=`
-    /// `if added > 0 { drop tail }`
     #[test]
     fn vec_460_461_resize_guard() {
         let arena = Arena::new();
@@ -1359,9 +971,6 @@ mod mutants_for_kill3 {
         }
     }
 
-    /// Kills: vec.rs:473:37 `- -> +` and vec.rs:474:26 `> -> >=` in resize
-    /// `let total_new = new_len - guard.vec.len;`
-    /// `if total_new > 0 { ... }`
     #[test]
     fn vec_473_474_resize_total_new() {
         let arena = Arena::new();
@@ -1377,9 +986,6 @@ mod mutants_for_kill3 {
         assert_eq!(v[1], 99); // unchanged
     }
 
-    /// Kills: vec.rs:762:17 `+= -> -=` / `+= -> *=` in into_box
-    /// `idx += 1` — if -= or *=, idx goes wrong and elements are
-    /// read from wrong positions or the loop never terminates.
     #[test]
     fn vec_762_into_box() {
         let arena = Arena::new();
@@ -1396,8 +1002,6 @@ mod mutants_for_kill3 {
         assert_eq!(boxed[4], 40);
     }
 
-    /// Kills: vec.rs:808:20 `> -> >=` and 808:31 `&& -> ||` and 808:43 `> -> >=`
-    /// `if new_cap > self.cap && self.cap > 0 { try in-place growth }`
     #[test]
     fn vec_808_realloc_inplace_guard() {
         let arena = Arena::new();
@@ -1416,11 +1020,6 @@ mod mutants_for_kill3 {
         assert_eq!(v2[0], 42);
     }
 
-    /// Kills: vec.rs:819:21 `> -> >=` in realloc
-    /// `if self.len > 0 { copy_nonoverlapping }`
-    /// If >= instead of >, copy runs even when len==0, which is
-    /// technically harmless but would copy from a dangling pointer
-    /// when cap was 0.
     #[test]
     fn vec_819_realloc_copy_guard() {
         let arena = Arena::new();
@@ -1435,10 +1034,6 @@ mod mutants_for_kill3 {
         assert_eq!(v[0], 1);
     }
 
-    /// Kills: vec.rs:828:20 `> -> ==` / `> -> >=` in realloc
-    /// `if old_cap > 0 { self.arena.bump_relocation(); }`
-    /// This tracks relocation stats. If the guard changes,
-    /// relocations aren't counted or are counted wrongly.
     #[test]
     fn vec_828_realloc_relocation_tracking() {
         let arena = Arena::new();
@@ -1453,14 +1048,6 @@ mod mutants_for_kill3 {
         assert_eq!(v[1], 2);
     }
 
-    // =====================================================================
-    // ROUND 2: Stronger tests for mutants that survived round 1
-    // =====================================================================
-
-    /// Kills: arena.rs:709:35 `> -> >=` — entry_size > 0 guard in arc_with
-    /// If mutated to `>=`, entry_size==0 (no-drop Arc) would enter the
-    /// drop-entry writing block and write a drop entry into unreserved
-    /// space, potentially corrupting memory. Test with non-Drop Arc type.
     #[test]
     fn arena_709_entry_size_zero_arc() {
         let arena = Arena::new();
@@ -1478,9 +1065,6 @@ mod mutants_for_kill3 {
         drop(arena);
     }
 
-    /// Kills: arena.rs:731:40 `+ -> -` and 731:104 `+ -> *`
-    /// Wrong `needed` computation causes refill with wrong size.
-    /// With tight budget, the wrong refill might fail.
     #[test]
     fn arena_731_needed_tight_budget_arc() {
         let _guard = reset_drop_counter();
@@ -1496,10 +1080,6 @@ mod mutants_for_kill3 {
         assert_eq!(drops, 200);
     }
 
-    /// Kills: arena.rs:1251:17 OversizedSharedGuard::drop -> ()
-    /// The guard's drop cleans up the chunk on panic. If noop'd,
-    /// a panicking closure leaks the budget.
-    /// Test: trigger panic in alloc_arc_with, catch it, verify arena still works.
     #[test]
     fn arena_1251_oversized_guard_panic() {
         // Use an alloc strictly larger than `MAX_CHUNK_BYTES = 64 KiB` so
@@ -1527,11 +1107,6 @@ mod mutants_for_kill3 {
         let _arc2: multitude::Arc<[u8; N]> = arena.alloc_arc_with(|| [0u8; N]);
     }
 
-    /// Kills: arena.rs:1648:40 `+ -> -` in allocate_layout
-    /// `needed = size + align_slack` becomes `size - align_slack`.
-    /// For types with align == align_of::<usize>(), align_slack is 0, so
-    /// this is equivalent. For types with higher alignment, it underflows.
-    /// Use #[repr(align(64))] to create a type with larger alignment.
     #[test]
     fn arena_1648_high_alignment_layout() {
         #[repr(align(64))]
@@ -1554,10 +1129,6 @@ mod mutants_for_kill3 {
         }
     }
 
-    /// Kills: arena.rs:2261:47 `&& -> ||` in try_alloc_slice_local_with
-    /// `entry_size = if drop_fn.is_some() && len != 0 { ... } else { 0 }`
-    /// With ||: len==0 or drop_fn.is_some() alone would set entry_size.
-    /// For Drop type with len==0, entry_size should be 0. With ||, it's nonzero.
     #[test]
     fn arena_2261_empty_drop_slice() {
         let _guard = reset_drop_counter();
@@ -1579,10 +1150,6 @@ mod mutants_for_kill3 {
         assert_eq!(drops, 0, "empty Drop slices should not produce drops");
     }
 
-    /// Kills: arena.rs:2266:23 `!= -> ==` in try_alloc_slice_local_with
-    /// `if entry_size != 0 && len > u16::MAX { return Err }`
-    /// With ==: `entry_size == 0 && len > u16::MAX` would reject
-    /// non-Drop large slices. Test a large non-Drop slice.
     #[test]
     fn arena_2266_large_nondrop_slice() {
         let arena = Arena::new();
@@ -1597,8 +1164,6 @@ mod mutants_for_kill3 {
         assert_eq!(s[65535], 255);
     }
 
-    /// Kills: arena.rs:2655:47 `&& -> ||` in try_alloc_slice_shared_with
-    /// Same as 2261 but for shared slices.
     #[test]
     fn arena_2655_empty_drop_shared_slice() {
         let _guard = reset_drop_counter();
@@ -1613,8 +1178,6 @@ mod mutants_for_kill3 {
         assert_eq!(drops, 0, "empty Drop arc slices should not produce drops");
     }
 
-    /// Kills: arena.rs:2660:23 `!= -> ==` in try_alloc_slice_shared_with
-    /// Same as 2266 but for shared slices.
     #[test]
     fn arena_2660_large_nondrop_shared_slice() {
         // Use a non-Copy, non-Drop wrapper so we go through try_alloc_slice_shared_with
@@ -1629,10 +1192,6 @@ mod mutants_for_kill3 {
         assert_eq!(arc[0], W(0));
     }
 
-    /// Kills: arena.rs:2701:35 `> -> >=` in try_alloc_slice_shared_with
-    /// `if entry_size > 0 { advance drop_back }`
-    /// For Drop types, entry_size > 0. If `>=`, non-Drop types
-    /// (entry_size == 0) would enter this block and write unreserved entries.
     #[test]
     fn arena_2701_entry_size_shared_slice() {
         let arena = Arena::new();
@@ -1647,16 +1206,6 @@ mod mutants_for_kill3 {
         }
     }
 
-    /// Kills: shared_chunk.rs:143:17 `- -> +` in max_bump_extent
-    /// CHUNK_ALIGN - header → CHUNK_ALIGN + header. This allows bump
-    /// pointers past the chunk boundary, which corrupts memory.
-    ///
-    /// Saturate one shared chunk with a handful of large uninit
-    /// fillers so the bump cursor sits right against the chunk's true
-    /// end, then issue a few small `Arc<DropTracker>` probes. With the
-    /// mutated extent the probes spill past the end and corrupt
-    /// neighboring memory; with the unmutated extent the very first
-    /// probe forces a clean refill.
     #[test]
     fn shared_chunk_143_max_bump_many() {
         let _guard = reset_drop_counter();
@@ -1683,9 +1232,6 @@ mod mutants_for_kill3 {
         assert_eq!(drops, N as usize);
     }
 
-    /// Kills: shared_chunk.rs:168:9 to_thin_ptr -> Default
-    /// The Treiber stack and chunk caching use to_thin_ptr.
-    /// Force chunk reuse by allocating, dropping, and reallocating.
     #[test]
     fn shared_chunk_168_force_cache_reuse() {
         let arena = Arena::new();
@@ -1707,23 +1253,6 @@ mod mutants_for_kill3 {
         }
     }
 
-    /// Kills: shared_chunk.rs:186:59 `- -> +` / `- -> /` in allocate
-    /// Payload rounding: `min_payload + (entry_align - 1)` becomes
-    /// `min_payload + (entry_align + 1)` or `min_payload + (entry_align / 1)`.
-    /// For `- -> +`: align - 1 = 7 vs align + 1 = 9. Rounding mask stays same.
-    /// Effectively wastes 2 bytes per chunk but works. This may be EQUIVALENT.
-    /// For `- -> /`: align - 1 = 7 vs align / 1 = 8. The mask `!(8 - 1)` = !7
-    /// but original was `!(7)` = `!(7)`. Wait: `entry_align - 1` is used in both
-    /// the addend and the mask. Actually let me re-read...
-    /// `payload = (min_payload + entry_align - 1) & !(entry_align - 1)`
-    /// Mutation at 186:59 affects the first `-`: `(min_payload + entry_align + 1)` or `(min_payload + entry_align / 1)`
-    /// The mask is unchanged. So `+ 1` makes payload 2 bytes larger (rounds up 2 more).
-    /// That's still valid. For `/ 1`: `entry_align / 1 = entry_align`, same as `entry_align - 1 + 1`.
-    /// Both may be equivalent for the addend since the mask rounds down.
-    /// Actually, `(x + a - 1) & !(a - 1)` rounds x up to multiple of a.
-    /// `(x + a + 1) & !(a - 1)` rounds (x+2) up, giving a result at least 2 more.
-    /// `(x + a/1) & !(a-1)` = `(x + a) & !(a-1)` rounds (x+1) up.
-    /// Both produce valid but slightly larger allocations. Likely EQUIVALENT.
     #[test]
     fn shared_chunk_186_payload_rounding_stress() {
         let _guard = reset_drop_counter();
@@ -1745,9 +1274,6 @@ mod mutants_for_kill3 {
         assert_eq!(drops, 800, "500 singles + 300 slice elements = 800");
     }
 
-    /// Kills: string.rs:465:19 `> -> >=` in try_reserve
-    /// Actually this is EQUIVALENT: grow helper returns early if min_cap <= cap.
-    /// But let's test it anyway.
     #[test]
     fn string_465_reserve_exact_capacity() {
         let arena = Arena::new();
@@ -1765,11 +1291,6 @@ mod mutants_for_kill3 {
     // UTF-16 stronger tests
     // =====================================================================
 
-    /// Kills: vec.rs:460:46 `- -> /` in Guard::drop
-    /// `let added = self.vec.len - self.old_len` becomes `self.vec.len / self.old_len`
-    /// On panic during clone, the guard drops the newly-added elements.
-    /// With /: added = 5/2=2 instead of 5-2=3, so only 2 elements are dropped
-    /// instead of 3 — leaking one cloned element.
     #[test]
     fn vec_460_guard_panic_clone() {
         use std::sync::atomic::AtomicUsize;
@@ -1816,18 +1337,8 @@ mod mutants_for_kill3 {
         assert_eq!(drops, 4, "guard must drop exactly 3 cloned elements + 1 value; got {drops}");
         assert_eq!(v.len(), 2);
     }
-
-    // vec:762 into_box: ZST/empty path only. ZSTs have no
-    // distinguishable element identity, empty vecs don't call the closure.
-    // EQUIVALENT.
-
-    // vec:808:31 && -> ||: both paths fall through to copy. EQUIVALENT.
-    // vec:808:43 > -> >=: cap==0 in-place probe returns None. EQUIVALENT.
-    // vec:819:21 > -> >=: copy 0 elements is no-op. EQUIVALENT.
-    // vec:474:26 > -> >=: total_new can never be 0 in this branch. EQUIVALENT.
 }
 
-// === merged from tests/mutants_kill4.rs ===
 mod mutants_for_kill4 {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -1847,19 +1358,6 @@ mod mutants_for_kill4 {
 
     extern crate alloc;
 
-    /// Kills `vec/vec.rs:451:34 - → +` in `Vec::resize`.
-    ///
-    /// `self.reserve(new_len - self.len)`:
-    /// * Original `-`: reserves exactly `new_len - len` more slots →
-    ///   `try_grow_amortized(additional)` with `additional == new_len - len`.
-    /// * Mutated `+`: `additional == new_len + len`, so the amortized
-    ///   growth target becomes `max(len + new_len + len, 2*cap, 4)`.
-    ///
-    /// Starting from a vec of `len=5` (which after pushes has `cap=8`),
-    /// calling `resize(10, ...)` should grow capacity to `16` (= `max(10, 16, 4)`).
-    /// The mutated `+` produces `additional=15`, needed=20, capacity=20 (=`max(20, 16, 4)`).
-    ///
-    /// The assertion `capacity() == 16` distinguishes them.
     #[test]
     fn resize_uses_subtraction_for_reserve() {
         let arena = Arena::new();
@@ -1892,18 +1390,6 @@ mod mutants_for_kill4 {
         limit: usize,
     }
 
-    /// Kills `vec/vec.rs:460:46 - → /` in `Vec::resize::Guard::drop`.
-    ///
-    /// `let added = self.vec.len - self.old_len`:
-    /// * Original `-`: `added = len - old_len ≥ 0`.
-    /// * Mutated `/`: when `old_len == 0`, `len / 0` triggers a **divide-by-zero
-    ///   panic** during unwinding → double-panic abort.
-    ///
-    /// We resize an EMPTY vec with a value that panics on the second clone.
-    /// Original: the Guard drops the one already-written element cleanly
-    /// and the resize panic propagates with payload "clone panic …".
-    /// Mutated: `added = 0 / 0` is an immediate panic (different payload)
-    /// AND happens during drop → double-panic abort.
     #[test]
     fn resize_guard_drop_uses_subtraction() {
         use std::panic::{set_hook, take_hook};
@@ -1950,21 +1436,6 @@ mod mutants_for_kill4 {
         );
     }
 
-    /// Kills `vec/vec.rs:362:21 < → <=` in `Vec::shrink_to_fit`.
-    ///
-    /// `if self.len < self.cap && ...realloc(self.len).is_err()`:
-    /// * Original `<`: at `len == cap`, the realloc is skipped entirely.
-    /// * Mutated `<=`: at `len == cap`, `realloc(self.len) == realloc(self.cap)`
-    ///   is invoked → `realloc` early-returns at `new_cap == self.cap` (see
-    ///   `realloc()` body). Net effect on data is the same; **but** the
-    ///   short-circuit `&&` evaluates the right operand → an observable
-    ///   extra call. We catch this through the arena's allocation counter:
-    ///   with the mutation, an extra arena-side allocate call would
-    ///   happen ONLY if the realloc actually re-allocated; since it
-    ///   short-circuits inside `realloc`, this mutant is in fact equivalent.
-    ///
-    /// We therefore document this as **EQUIVALENT** and skip via
-    /// `#[mutants::skip]` on `shrink_to_fit` (see source).
     #[test]
     fn shrink_to_fit_at_full_cap_is_noop_documented() {
         let arena = Arena::new();
@@ -1980,7 +1451,6 @@ mod mutants_for_kill4 {
     }
 }
 
-// === merged from tests/mutants_kill5.rs ===
 mod mutants_for_kill5 {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -1992,27 +1462,6 @@ mod mutants_for_kill5 {
     #[expect(unused_imports, reason = "merged test module re-exports common helpers")]
     use crate::common;
 
-    /// Kills two mutations in `Arena::try_alloc_slice_shared_with`:
-    ///
-    /// * `arena/inner_slice.rs:878:47` — `&&` → `||` on
-    ///   `drop_fn.is_some() && len != 0` when computing `entry_size`.
-    /// * `arena/inner_slice.rs:883:23` — `!=` → `==` on
-    ///   `entry_size != 0 && len > u16::MAX as usize`.
-    ///
-    /// `try_alloc_uninit_slice_arc::<u8>(len)` routes a non-Drop element
-    /// type with `drop_fn = None` and `len > 0` into
-    /// `try_alloc_slice_shared_with`. For `len > u16::MAX`:
-    /// * Original: `entry_size == 0` (because `drop_fn.is_none()`), so the
-    ///   `entry_size != 0 && len > u16::MAX` guard is false and the
-    ///   allocation succeeds via the oversized-shared path.
-    /// * Mutation `&&` → `||`: `entry_size` becomes non-zero because
-    ///   `len != 0`, then the guard fires and returns `AllocError`.
-    /// * Mutation `!=` → `==`: the guard becomes `0 == 0 && len > u16::MAX`,
-    ///   which is true, returning `AllocError`.
-    ///
-    /// The successful allocation of a 65 537-element `MaybeUninit<u8>`
-    /// slice in an `Arc<[MaybeUninit<u8>]>` is the observable that
-    /// distinguishes the original from both mutations.
     #[test]
     fn alloc_uninit_slice_arc_non_drop_above_u16_max_succeeds() {
         let arena = Arena::new();
@@ -2023,7 +1472,6 @@ mod mutants_for_kill5 {
     }
 }
 
-// === merged from tests/mutants_audit.rs ===
 mod mutants_for_audit {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -2715,7 +2163,6 @@ mod mutants_for_audit {
     // ============================================================================
 }
 
-// === merged from tests/mutants_complete.rs ===
 mod mutants_for_complete {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
@@ -3296,7 +2743,6 @@ mod mutants_for_complete {
     // ----------------------------------------------------------------------------
 }
 
-// === merged from tests/mutants_final.rs ===
 mod mutants_for_final {
     #![allow(clippy::clone_on_ref_ptr, reason = "tests prefer concise method-call form")]
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]

--- a/crates/multitude/tests/serde.rs
+++ b/crates/multitude/tests/serde.rs
@@ -71,7 +71,6 @@ fn arena_vec_of_strings_serializes() {
     assert_eq!(json, "[\"a\",\"b\"]");
 }
 
-// === relocated from coverage_extras.rs (serde-gated tests) ===
 mod from_coverage_extras_serde {
     #![allow(clippy::items_after_statements, reason = "relocated tests put inner types near use")]
     #![allow(clippy::clone_on_ref_ptr, reason = "relocated tests use .clone() on Arc/Rc")]

--- a/crates/multitude/tests/try_and_uninit.rs
+++ b/crates/multitude/tests/try_and_uninit.rs
@@ -1,0 +1,382 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Tests for the local uninit/zeroed family, the `try_*` fallible
+//! counterparts of panicking allocation APIs, and the string `Arc` freezes.
+
+#![allow(clippy::std_instead_of_core, reason = "tests use std")]
+#![allow(clippy::unwrap_used, reason = "test code")]
+#![allow(clippy::undocumented_unsafe_blocks, reason = "test code")]
+#![allow(clippy::assertions_on_result_states, reason = "tests assert Result states directly")]
+#![allow(clippy::cast_possible_truncation, reason = "test code casts small known-bounded indices")]
+
+mod common;
+
+use common::{FailingAllocator, SendFailingAllocator};
+use multitude::Arena;
+use multitude::vec::Vec as MVec;
+
+// ===========================================================================
+// A. Local uninit / zeroed family
+// ===========================================================================
+
+#[test]
+fn alloc_uninit_write_read() {
+    let arena = Arena::new();
+    let slot = arena.alloc_uninit::<u64>();
+    let r = slot.write(42);
+    assert_eq!(*r, 42);
+}
+
+#[test]
+fn alloc_zeroed_is_zero() {
+    let arena = Arena::new();
+    let slot = arena.alloc_zeroed::<u64>();
+    assert_eq!(unsafe { *slot.assume_init_ref() }, 0);
+}
+
+#[test]
+fn alloc_uninit_slice_write_read() {
+    let arena = Arena::new();
+    let s = arena.alloc_uninit_slice::<u32>(4);
+    assert_eq!(s.len(), 4);
+    for (i, e) in s.iter_mut().enumerate() {
+        e.write(i as u32);
+    }
+    let init: &[u32] = unsafe { &*(std::ptr::from_ref(s) as *const [u32]) };
+    assert_eq!(init, &[0, 1, 2, 3]);
+}
+
+#[test]
+fn alloc_zeroed_slice_is_zero() {
+    let arena = Arena::new();
+    let s = arena.alloc_zeroed_slice::<u16>(5);
+    assert_eq!(s.len(), 5);
+    for e in s {
+        assert_eq!(unsafe { *e.assume_init_ref() }, 0);
+    }
+}
+
+#[test]
+fn try_uninit_family_ok() {
+    let arena = Arena::new();
+    assert!(arena.try_alloc_uninit::<u64>().is_ok());
+    assert!(arena.try_alloc_zeroed::<u64>().is_ok());
+    assert!(arena.try_alloc_uninit_slice::<u32>(3).is_ok());
+    assert!(arena.try_alloc_zeroed_slice::<u32>(3).is_ok());
+}
+
+#[test]
+fn try_uninit_family_errors_on_alloc_failure() {
+    let arena = Arena::new_in(FailingAllocator::new(0));
+    assert!(arena.try_alloc_uninit::<u64>().is_err());
+    assert!(arena.try_alloc_zeroed::<u64>().is_err());
+    assert!(arena.try_alloc_uninit_slice::<u32>(3).is_err());
+    assert!(arena.try_alloc_zeroed_slice::<u32>(3).is_err());
+}
+
+#[test]
+#[should_panic(expected = "AllocError")]
+fn alloc_uninit_panics_on_alloc_failure() {
+    let arena = Arena::new_in(FailingAllocator::new(0));
+    let _ = arena.alloc_uninit::<u64>();
+}
+
+// ===========================================================================
+// B. Arena `try_` string decoders (clean: lossy / unchecked)
+// ===========================================================================
+
+#[test]
+fn try_from_utf8_lossy_ok_and_err() {
+    let arena = Arena::new();
+    let s = arena.try_alloc_string_from_utf8_lossy(b"ab\xFFc").unwrap();
+    assert_eq!(s.as_str(), "ab\u{FFFD}c");
+
+    let arena = Arena::new_in(FailingAllocator::new(0));
+    assert!(arena.try_alloc_string_from_utf8_lossy(b"abc").is_err());
+}
+
+#[test]
+fn try_from_utf8_unchecked_ok_and_err() {
+    let arena = Arena::new();
+    let s = unsafe { arena.try_alloc_string_from_utf8_unchecked(b"hi").unwrap() };
+    assert_eq!(s.as_str(), "hi");
+
+    let arena = Arena::new_in(FailingAllocator::new(0));
+    assert!(unsafe { arena.try_alloc_string_from_utf8_unchecked(b"hi") }.is_err());
+}
+
+#[test]
+fn try_from_utf16_lossy_ok_and_err() {
+    let arena = Arena::new();
+    let units = [0x0048u16, 0x0069]; // "Hi"
+    let s = arena.try_alloc_string_from_utf16_lossy(&units).unwrap();
+    assert_eq!(s.as_str(), "Hi");
+    // Unpaired surrogate -> replacement char.
+    let bad = [0xD800u16];
+    let s2 = arena.try_alloc_string_from_utf16_lossy(&bad).unwrap();
+    assert_eq!(s2.as_str(), "\u{FFFD}");
+
+    let arena = Arena::new_in(FailingAllocator::new(0));
+    assert!(arena.try_alloc_string_from_utf16_lossy(&units).is_err());
+}
+
+#[test]
+fn try_from_utf16le_be_lossy_ok_and_err() {
+    let arena = Arena::new();
+    // "Hi" little-endian and big-endian.
+    let le = [0x48u8, 0x00, 0x69, 0x00];
+    let be = [0x00u8, 0x48, 0x00, 0x69];
+    assert_eq!(arena.try_alloc_string_from_utf16le_lossy(&le).unwrap().as_str(), "Hi");
+    assert_eq!(arena.try_alloc_string_from_utf16be_lossy(&be).unwrap().as_str(), "Hi");
+    // Odd trailing byte -> trailing replacement char.
+    let odd = [0x48u8, 0x00, 0x69];
+    assert_eq!(arena.try_alloc_string_from_utf16le_lossy(&odd).unwrap().as_str(), "H\u{FFFD}");
+
+    let arena = Arena::new_in(FailingAllocator::new(0));
+    assert!(arena.try_alloc_string_from_utf16le_lossy(&le).is_err());
+    assert!(arena.try_alloc_string_from_utf16be_lossy(&be).is_err());
+}
+
+#[test]
+fn try_from_utf16_bytes_lossy_reserves_exact_capacity() {
+    // Four ASCII units (eight bytes) decode to four UTF-8 bytes, so the
+    // `bytes.len() / 2 + 1` capacity hint reserves exactly five bytes and no
+    // growth occurs. Any arithmetic deviation in the hint changes the observed
+    // capacity (too-small hints grow to a different value; too-large hints
+    // over-reserve), so an exact-capacity assertion pins the expression down.
+    let le = [0x74u8, 0x00, 0x65, 0x00, 0x73, 0x00, 0x74, 0x00]; // "test"
+    let be = [0x00u8, 0x74, 0x00, 0x65, 0x00, 0x73, 0x00, 0x74]; // "test"
+
+    let arena = Arena::new();
+    let s = arena.try_alloc_string_from_utf16le_lossy(&le).unwrap();
+    assert_eq!(s.as_str(), "test");
+    assert_eq!(s.capacity(), 5);
+
+    let arena = Arena::new();
+    let s = arena.try_alloc_string_from_utf16be_lossy(&be).unwrap();
+    assert_eq!(s.as_str(), "test");
+    assert_eq!(s.capacity(), 5);
+}
+
+// ===========================================================================
+// C. Vec `try_*`
+// ===========================================================================
+
+#[test]
+fn vec_try_insert_resize_append_split_extend_ok() {
+    let arena = Arena::new();
+    let mut v = arena.alloc_vec::<u32>();
+    v.try_insert(0, 1).unwrap();
+    v.try_insert(1, 3).unwrap();
+    v.try_insert(1, 2).unwrap();
+    assert_eq!(v.as_slice(), &[1, 2, 3]);
+
+    v.try_resize(5, 9).unwrap();
+    assert_eq!(v.as_slice(), &[1, 2, 3, 9, 9]);
+    v.try_resize_with(6, || 7).unwrap();
+    assert_eq!(v.as_slice(), &[1, 2, 3, 9, 9, 7]);
+
+    let mut other: MVec<'_, u32> = arena.alloc_vec();
+    other.try_insert(0, 100).unwrap();
+    v.try_append(&mut other).unwrap();
+    assert_eq!(v.as_slice().last(), Some(&100));
+    assert!(other.is_empty());
+
+    v.try_extend_from_within(0..2).unwrap();
+    assert_eq!(&v.as_slice()[v.len() - 2..], &[1, 2]);
+
+    let tail = v.try_split_off(3).unwrap();
+    assert_eq!(v.len(), 3);
+    assert_eq!(v.as_slice(), &[1, 2, 3]);
+    assert!(!tail.is_empty());
+}
+
+#[test]
+fn vec_try_methods_error_on_alloc_failure() {
+    // Allow only the first chunk so the Vec exists but growth fails.
+    let arena = Arena::new_in(FailingAllocator::new(1));
+    let mut v = arena.alloc_vec::<u32>();
+    // Fill the first chunk so the next growth needs a (failing) refill.
+    while v.try_insert(v.len(), 0).is_ok() {}
+    assert!(v.try_insert(0, 1).is_err());
+    assert!(v.try_resize(v.len() + 1000, 0).is_err());
+    assert!(v.try_resize_with(v.len() + 1000, || 0).is_err());
+    assert!(v.try_extend_from_within(0..1).is_err());
+
+    let arena2 = Arena::new_in(FailingAllocator::new(0));
+    let mut a = arena2.alloc_vec::<u32>();
+    let mut b = arena2.alloc_vec::<u32>();
+    assert!(a.try_insert(0, 1).is_err());
+    // `try_split_off` on an empty vec takes the zero-copy/empty path and
+    // performs no allocation, so it succeeds even here.
+    assert!(b.try_split_off(0).is_ok());
+    assert!(a.try_append(&mut b).is_ok()); // both empty -> no alloc
+}
+
+#[test]
+#[should_panic(expected = "AllocError")]
+fn vec_insert_panics_on_alloc_failure() {
+    let arena = Arena::new_in(FailingAllocator::new(1));
+    let mut v = arena.alloc_vec::<u32>();
+    // Bounded so a regression that stops `insert` from panicking fails the
+    // test quickly instead of hanging the suite; the allocator fails well
+    // within the cap.
+    for _ in 0..1 << 20 {
+        v.insert(v.len(), 0);
+    }
+}
+
+// ===========================================================================
+// D. String `try_*`
+// ===========================================================================
+
+#[test]
+fn string_try_methods_ok() {
+    let arena = Arena::new();
+    let mut s = arena.alloc_string();
+    s.try_insert_str(0, "world").unwrap();
+    s.try_insert(0, ' ').unwrap();
+    s.try_insert_str(0, "hello").unwrap();
+    assert_eq!(s.as_str(), "hello world");
+
+    s.try_replace_range(0..5, "HELLO").unwrap();
+    assert_eq!(s.as_str(), "HELLO world");
+
+    s.try_extend_from_within(0..5).unwrap();
+    assert_eq!(s.as_str(), "HELLO worldHELLO");
+
+    let tail = s.try_split_off(5).unwrap();
+    assert_eq!(s.as_str(), "HELLO");
+    assert_eq!(tail.as_str(), " worldHELLO");
+
+    let boxed = s.try_into_boxed_str().unwrap();
+    assert_eq!(&*boxed, "HELLO");
+}
+
+#[test]
+fn string_try_methods_error_on_alloc_failure() {
+    let arena = Arena::new_in(FailingAllocator::new(1));
+    let mut s = arena.alloc_string();
+    // Bounded so a buggy `try_push` that never reports failure cannot hang the
+    // suite; `FailingAllocator` exhausts well within the cap.
+    for _ in 0..1 << 20 {
+        if s.try_push('x').is_err() {
+            break;
+        }
+    }
+    assert!(s.try_insert(0, 'y').is_err());
+    assert!(s.try_insert_str(0, "yy").is_err());
+    assert!(s.try_replace_range(0..0, "yy").is_err());
+    assert!(s.try_extend_from_within(0..1).is_err());
+
+    let arena2 = Arena::new_in(FailingAllocator::new(0));
+    let mut s2 = arena2.alloc_string();
+    assert!(s2.try_insert_str(0, "a").is_err());
+    // `split_off` on an empty string performs no allocation -> Ok.
+    assert!(s2.try_split_off(0).is_ok());
+    let s3 = arena2.alloc_string();
+    assert!(s3.try_into_boxed_str().is_err());
+}
+
+#[test]
+fn string_into_arc_str_ok_and_try() {
+    let arena = Arena::new();
+    let mut s = arena.alloc_string();
+    s.push_str("shared");
+    let a = s.into_arc_str();
+    assert_eq!(&*a, "shared");
+
+    let mut s2 = arena.alloc_string();
+    s2.push_str("again");
+    let a2 = s2.try_into_arc_str().unwrap();
+    assert_eq!(&*a2, "again");
+
+    // From impl routes through into_arc_str.
+    let mut s3 = arena.alloc_string();
+    s3.push_str("via_from");
+    let a3: multitude::Arc<str> = s3.into();
+    assert_eq!(&*a3, "via_from");
+}
+
+#[test]
+fn string_try_into_arc_str_error() {
+    let arena = Arena::new_in(SendFailingAllocator::new(0));
+    let s = arena.alloc_string();
+    assert!(s.try_into_arc_str().is_err());
+}
+
+// ===========================================================================
+// E. Utf16String `try_*` + Arc freeze (feature-gated)
+// ===========================================================================
+
+#[cfg(feature = "utf16")]
+mod utf16_tests {
+    use multitude::strings::Utf16String;
+    use widestring::utf16str;
+
+    use super::{Arena, FailingAllocator, SendFailingAllocator};
+
+    #[test]
+    fn utf16_try_methods_ok() {
+        let arena = Arena::new();
+        let mut s = Utf16String::try_from_utf16_str_in(utf16str!("world"), &arena).unwrap();
+        s.try_insert(0, ' ').unwrap();
+        s.try_insert_utf16_str(0, utf16str!("hi")).unwrap();
+        assert_eq!(s.as_utf16_str(), utf16str!("hi world"));
+
+        s.try_replace_range(0..2, utf16str!("HI")).unwrap();
+        assert_eq!(s.as_utf16_str(), utf16str!("HI world"));
+
+        s.try_extend_from_within(0..2).unwrap();
+        assert_eq!(s.as_utf16_str(), utf16str!("HI worldHI"));
+
+        let tail = s.try_split_off(2).unwrap();
+        assert_eq!(s.as_utf16_str(), utf16str!("HI"));
+        assert_eq!(tail.as_utf16_str(), utf16str!(" worldHI"));
+
+        let boxed = s.try_into_boxed_utf16_str().unwrap();
+        assert_eq!(boxed.as_utf16_str(), utf16str!("HI"));
+    }
+
+    #[test]
+    fn utf16_into_arc_ok_and_try() {
+        let arena = Arena::new();
+        let s = Utf16String::from_utf16_str_in(utf16str!("shared"), &arena);
+        let a = s.into_arc_utf16_str();
+        assert_eq!(a.as_utf16_str(), utf16str!("shared"));
+
+        let s2 = Utf16String::from_utf16_str_in(utf16str!("again"), &arena);
+        let a2 = s2.try_into_arc_utf16_str().unwrap();
+        assert_eq!(a2.as_utf16_str(), utf16str!("again"));
+    }
+
+    #[test]
+    fn utf16_try_methods_error_on_alloc_failure() {
+        let arena = Arena::new_in(FailingAllocator::new(0));
+        assert!(Utf16String::try_from_utf16_str_in(utf16str!("x"), &arena).is_err());
+
+        let arena1 = Arena::new_in(FailingAllocator::new(1));
+        let mut s = Utf16String::from_utf16_str_in(utf16str!(""), &arena1);
+        // Bounded so a buggy `try_push` that never reports failure cannot hang
+        // the suite; `FailingAllocator` exhausts well within the cap.
+        for _ in 0..1 << 20 {
+            if s.try_push('x').is_err() {
+                break;
+            }
+        }
+        assert!(s.try_insert(0, 'y').is_err());
+        assert!(s.try_insert_utf16_str(0, utf16str!("y")).is_err());
+        assert!(s.try_replace_range(0..0, utf16str!("y")).is_err());
+        assert!(s.try_extend_from_within(0..1).is_err());
+
+        let arena0 = Arena::new_in(FailingAllocator::new(0));
+        let mut s0 = Utf16String::from_utf16_str_in(utf16str!(""), &arena0);
+        assert!(s0.try_split_off(0).is_ok()); // empty -> no alloc
+        let s0b = Utf16String::from_utf16_str_in(utf16str!(""), &arena0);
+        assert!(s0b.try_into_boxed_utf16_str().is_err());
+        let arena0s = Arena::new_in(SendFailingAllocator::new(0));
+        let s0c = Utf16String::from_utf16_str_in(utf16str!(""), &arena0s);
+        assert!(s0c.try_into_arc_utf16_str().is_err());
+    }
+}

--- a/crates/multitude/tests/utf16.rs
+++ b/crates/multitude/tests/utf16.rs
@@ -15,7 +15,6 @@
 
 mod common;
 
-// === merged from tests/utf16_smoke.rs ===
 mod utf16_smoke {
 
     use multitude::Arena;
@@ -64,7 +63,6 @@ mod utf16_smoke {
     }
 }
 
-// === merged from tests/utf16_string_builder.rs ===
 mod utf16_string_builder {
 
     use multitude::{Arena, FromIn as _};
@@ -379,7 +377,6 @@ mod utf16_string_builder {
     extern crate alloc;
 }
 
-// === merged from tests/utf16_format.rs ===
 mod utf16_format {
 
     use core::fmt;
@@ -433,7 +430,6 @@ mod utf16_format {
     }
 }
 
-// === merged from tests/utf16_serde.rs ===
 mod utf16_serde {
 
     use multitude::Arena;
@@ -468,7 +464,6 @@ mod utf16_serde {
     }
 }
 
-// === merged from tests/utf16_cross_thread.rs ===
 mod utf16_cross_thread {
 
     use core::sync::atomic::{AtomicUsize, Ordering};
@@ -514,7 +509,6 @@ mod utf16_cross_thread {
     }
 }
 
-// === merged from tests/utf16_coverage.rs ===
 mod utf16_coverage {
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -659,7 +653,6 @@ mod utf16_coverage {
         s.push_str(utf16str!("abc"));
         s.truncate(10);
         assert_eq!(s.as_utf16_str(), utf16str!("abc"));
-        // Folded from_mutants_extras_utf16_scattered::utf16_truncate_to_current_length_is_noop.
         s.truncate(3);
         assert_eq!(s.as_utf16_str(), utf16str!("abc"));
         assert_eq!(s.len(), 3);
@@ -717,6 +710,17 @@ mod utf16_coverage {
         let a = fail_arena();
         let mut s = a.alloc_utf16_string();
         assert!(s.try_push('a').is_err());
+    }
+
+    #[test]
+    fn try_push_appends_chars() {
+        let arena = Arena::new();
+        let mut s = arena.alloc_utf16_string();
+        s.try_push('a').unwrap();
+        s.try_push('β').unwrap();
+        s.try_push('💖').unwrap(); // surrogate pair: +2 u16
+        assert_eq!(s.len(), 4);
+        assert_eq!(s.as_utf16_str(), utf16str!("aβ💖"));
     }
 
     #[test]
@@ -1200,7 +1204,6 @@ mod utf16_coverage {
     }
 }
 
-// === merged from tests/mutants_utf16_strings.rs ===
 mod mutants_for_utf16_strings {
     #![allow(clippy::std_instead_of_core, reason = "test code")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -1215,17 +1218,6 @@ mod mutants_for_utf16_strings {
     #[expect(unused_imports, reason = "merged test module re-exports common helpers")]
     use crate::common;
 
-    /// Kills `utf16_string.rs:191:20 > → >=` in `truncate`.
-    ///
-    /// `truncate(new_len)` performs a boundary check `new_len > 0` to
-    /// guard a surrogate-pair assert. With `>=`, the assert path is
-    /// taken for `new_len == 0` and reads `self.as_slice()[0]` — which
-    /// is safe (empty slice indexing panics deterministically when
-    /// `len == 0`, but in our scenario `len > 0`). We instead rely on
-    /// the *post-truncate length* invariant: truncating to 0 must leave
-    /// the string empty. With `>=` (mutant), the function panics on
-    /// surrogate check before assigning `self.len = 0`. Either way
-    /// `len == 0` after a successful truncate(0).
     #[test]
     fn truncate_to_zero_clears_string() {
         let arena = Arena::new();
@@ -1235,18 +1227,6 @@ mod mutants_for_utf16_strings {
         assert_eq!(s.as_utf16_str(), utf16str!(""));
     }
 
-    /// Kills `utf16_string.rs:203:26 || → &&` and `206:38 - → /` and
-    /// `207:43 * → +//` in `shrink_to_fit`.
-    ///
-    /// Pre-conditions:
-    /// - `cap == 0 || len == cap` returns early; otherwise shrink.
-    /// - With `&&`: early-return only when both, so otherwise-shrink path
-    ///   runs even when `cap == 0` → UB-ish pointer math on dangling.
-    /// - With `- → /`: `cap - len → cap / len` (wrong reclaim units).
-    /// - With `* → + | /`: byte-count math wrong → wrong reclaim_bytes.
-    ///
-    /// To exercise: build a Utf16String with known cap > len, shrink_to_fit,
-    /// assert capacity drops to `len`.
     #[test]
     fn shrink_to_fit_reduces_capacity_to_len() {
         let arena = Arena::new();
@@ -1263,15 +1243,6 @@ mod mutants_for_utf16_strings {
         assert_eq!(s.capacity(), 3);
     }
 
-    /// Kills `utf16_string.rs:260:19 > → >=` (`try_push_from_str`),
-    /// `277:19 > → >=` (`try_push_slice`), `298:19 > → >=` (`try_reserve`):
-    /// the `if needed > self.cap { try_grow }` boundary. With `>=`, the
-    /// grow path runs even when capacity already suffices.
-    ///
-    /// Detection: call try_reserve with a value that produces `needed
-    /// == cap` exactly. With `>` the grow is skipped (no observable
-    /// change); with `>=` the buffer is reallocated → observable via
-    /// the change in pointer identity (`as_ptr()` differs).
     #[test]
     fn reserve_exact_capacity_does_not_regrow() {
         let arena = Arena::new();
@@ -1307,16 +1278,6 @@ mod mutants_for_utf16_strings {
         assert_eq!(ptr_before, ptr_after, "push at exact-fit must not reallocate");
     }
 
-    /// Kills `utf16_string.rs:318:16 > → >=` and `330:19 > → >=` and
-    /// `337:76 - → +` in `insert_slice`.
-    ///
-    /// 318:16 is `if idx > 0 && idx < self.len` (surrogate check guard).
-    /// 330:19 is `if needed > self.cap { grow }` (same shape as above).
-    /// 337:76 is `self.len - idx` (memmove count). `- → +` produces
-    /// `self.len + idx` → reads past the buffer → corruption or panic.
-    ///
-    /// Test by inserting a slice that fits exactly and asserting both
-    /// content and length post-insert.
     #[test]
     fn insert_slice_preserves_content() {
         let arena = Arena::new();
@@ -1330,7 +1291,6 @@ mod mutants_for_utf16_strings {
         s.insert_utf16_str(s.len(), utf16str!("!"));
         assert_eq!(s.as_utf16_str(), utf16str!("hXXello!"));
 
-        // Folded from_coverage_extras_utf16::utf16_string_insert_str_at_end_of_string.
         let mut appended = arena.alloc_utf16_string();
         appended.push_str(utf16str!("hi"));
         appended.insert_utf16_str(appended.len(), utf16str!("!"));
@@ -1353,15 +1313,6 @@ mod mutants_for_utf16_strings {
         assert_eq!(t.as_ptr(), ptr_before, "insert at exact-fit must not reallocate");
     }
 
-    /// Kills `utf16_string.rs:356:72 - → +`, `356:78 - → +/*` in `remove`.
-    ///
-    /// `self.len - idx - n` is the memmove byte count after extracting
-    /// the char at `idx` (`n` code units wide). The two `-` operators
-    /// are: `(len - idx) - n` (binding `len - idx` first). Wrong arithmetic
-    /// reads past the buffer or produces a giant count.
-    ///
-    /// Test: build a string with content, remove from the middle, and
-    /// verify the result and length.
     #[test]
     fn remove_middle_preserves_content() {
         let arena = Arena::new();
@@ -1381,7 +1332,6 @@ mod mutants_for_utf16_strings {
         assert_eq!(removed, 'h');
         assert_eq!(s.as_utf16_str(), utf16str!("ll"));
 
-        // Folded from_mutants_extras_utf16_scattered::utf16_remove_shifts_correct_byte_count.
         let mut s = arena.alloc_utf16_string();
         s.push_from_str("abcdefghij");
         assert_eq!(s.remove(4), 'e');
@@ -1392,14 +1342,6 @@ mod mutants_for_utf16_strings {
         assert_eq!(s.as_slice().to_vec(), widestring::Utf16String::from_str("bcdfghi").into_vec());
     }
 
-    /// Kills `utf16_string.rs:396:22 && → ||`, `396:18 > → >=`,
-    /// `396:31 < → <=` (the surrogate-guard `start > 0 && start <
-    /// self.len`), `403:16/27` (same for end), `418:20 > → >=`
-    /// (`new_len > self.cap`), and `424:81 - → +` (`self.len - end`
-    /// memmove count) in `replace_range`.
-    ///
-    /// The test exercises replace_range with several boundary positions
-    /// and verifies output content and length.
     #[test]
     fn replace_range_at_boundaries() {
         let arena = Arena::new();
@@ -1409,13 +1351,11 @@ mod mutants_for_utf16_strings {
         s.replace_range(.., utf16str!("WORLD"));
         assert_eq!(s.as_utf16_str(), utf16str!("WORLD"));
 
-        // Folded from_coverage_extras_utf16::utf16_string_replace_range_full_with_longer.
         let mut s = arena.alloc_utf16_string();
         s.push_str(utf16str!("abc"));
         s.replace_range(0..3, utf16str!("xyzw"));
         assert_eq!(s.as_utf16_str(), utf16str!("xyzw"));
 
-        // Folded from_coverage_extras_utf16::utf16_string_replace_range_full_with_shorter.
         let mut s = arena.alloc_utf16_string();
         s.push_str(utf16str!("abcdef"));
         s.replace_range(0..6, utf16str!("xy"));
@@ -1446,7 +1386,6 @@ mod mutants_for_utf16_strings {
         s.replace_range(2..2, utf16str!("--"));
         assert_eq!(s.as_utf16_str(), utf16str!("he--llo"));
 
-        // Folded from_coverage_extras_utf16::utf16_string_replace_range_empty_at_end.
         let mut s = arena.alloc_utf16_string();
         s.push_str(utf16str!("abc"));
         let n = s.len();
@@ -1459,13 +1398,6 @@ mod mutants_for_utf16_strings {
         assert_eq!(s.as_utf16_str(), utf16str!("abc"));
     }
 
-    /// Kills `utf16_string.rs:466:21 == → !=` in `into_box`.
-    ///
-    /// The branch is `if self.cap == 0 { … return empty … }`. With `!=`,
-    /// the empty fast-path runs for non-empty strings (UB / wrong data)
-    /// and the data path runs for empty strings (reads from dangling).
-    /// We test both branches by freezing an empty and a non-empty
-    /// string into a `BoxUtf16Str`.
     #[test]
     fn into_box_handles_empty_and_non_empty() {
         let arena = Arena::new();
@@ -1524,20 +1456,6 @@ mod mutants_for_utf16_strings {
         assert_eq!(&*escaped, utf16str!("survives"));
     }
 
-    /// Kills `utf16_string.rs:491:29 - → /` in `try_reclaim_tail`.
-    ///
-    /// `total - used` (= unused trailing bytes). With `/` produces a tiny
-    /// reclaim amount → buffer cursor moves slightly back. The chunk
-    /// invariant is violated subtly but the next allocation may overlap
-    /// the still-live frozen string. Exercise:
-    /// 1. Build a Utf16String with extra capacity.
-    /// 2. Freeze into box (triggers try_reclaim_tail).
-    /// 3. Allocate more in the same arena.
-    /// 4. Read back the frozen string — it must still equal the original.
-    ///
-    /// With wrong reclaim arithmetic, the second allocation would
-    /// overlap the frozen string's tail (or the data pointer), corrupting
-    /// the readback.
     #[test]
     fn reclaim_tail_does_not_corrupt_frozen_string() {
         let arena = Arena::new();
@@ -1557,7 +1475,6 @@ mod mutants_for_utf16_strings {
     }
 }
 
-// === merged from tests/mutation_coverage.rs ===
 mod mutation_coverage {
     #![allow(clippy::std_instead_of_core, reason = "tests use std")]
     #![allow(clippy::unwrap_used, reason = "test code")]
@@ -2593,15 +2510,9 @@ mod mutation_coverage {
     }
 }
 
-// === relocated from mutants_extras.rs (was mutants_for_kill3::utf16_*) ===
 mod utf16_tests {
     use multitude::Arena;
 
-    /// Kills: `utf16_string.rs:191:20` `> -> >=` in truncate
-    /// `if new_len > 0 { check boundary }`
-    /// If `>` becomes `>=`, truncate(0) would try to check
-    /// `self.as_slice()[0]` for surrogate boundary, but `new_len==0`
-    /// means we're clearing — no boundary check needed.
     #[test]
     fn utf16_191_truncate_to_zero() {
         let arena = Arena::new();
@@ -2626,12 +2537,6 @@ mod utf16_tests {
         assert_eq!(s.len(), 1);
     }
 
-    /// Kills: `utf16_string.rs:203:26` `|| -> &&` in `shrink_to_fit`
-    /// `if self.cap == 0 || self.len == self.cap { return; }`
-    /// If `||` becomes `&&`, both conditions must be true to skip,
-    /// but cap==0 && len==cap is always cap==0 && len==0.
-    /// When cap > 0 && len == cap, `shrink_to_fit` would incorrectly
-    /// try to reclaim 0 bytes.
     #[test]
     fn utf16_203_shrink_to_fit_or_to_and() {
         let arena = Arena::new();
@@ -2652,8 +2557,6 @@ mod utf16_tests {
         assert_eq!(s2.len(), 0);
     }
 
-    /// Kills: `utf16_string.rs:206:38` `- -> /` in `shrink_to_fit`
-    /// `let reclaim_units = self.cap - self.len;`
     #[test]
     fn utf16_206_shrink_reclaim_units() {
         let arena = Arena::new();
@@ -2667,8 +2570,6 @@ mod utf16_tests {
         // (best-effort, so we just verify no crash)
     }
 
-    /// Kills: `utf16_string.rs:207:43` `* -> +` / `* -> /` in `shrink_to_fit`
-    /// `let reclaim_bytes = reclaim_units * core::mem::size_of::<u16>();`
     #[test]
     fn utf16_207_shrink_reclaim_bytes() {
         let arena = Arena::new();
@@ -2684,8 +2585,6 @@ mod utf16_tests {
         assert_eq!(s.len(), 5);
     }
 
-    /// Kills: `utf16_string.rs:260:19` `> -> >=` in `try_push_from_str`
-    /// `if needed > self.cap { self.try_grow_to_at_least(needed)?; }`
     #[test]
     fn utf16_260_push_from_str_boundary() {
         let arena = Arena::new();
@@ -2703,8 +2602,6 @@ mod utf16_tests {
         assert_eq!(s.len(), 6);
     }
 
-    /// Kills: `utf16_string.rs:277:19` `> -> >=` in `try_push_slice`
-    /// `if needed > self.cap { self.try_grow_to_at_least(needed)?; }`
     #[test]
     fn utf16_277_push_slice_boundary() {
         let arena = Arena::new();
@@ -2719,21 +2616,17 @@ mod utf16_tests {
         assert_eq!(s.len(), 4);
     }
 
-    /// Kills: `utf16_string.rs:298:19` `> -> >=` in `try_reserve`
     #[test]
     fn utf16_298_try_reserve_boundary() {
         let arena = Arena::new();
         let mut s = arena.alloc_utf16_string_with_capacity(10);
         s.push('A'); // len=1
         let cap_before = s.capacity();
-        // Folded mutant-kill: exact-fit reserve must short-circuit before the grow path.
         s.try_reserve(9).unwrap(); // needed=10==cap, no grow
         assert_eq!(s.capacity(), cap_before);
         s.try_reserve(10).unwrap(); // needed=11>cap, must grow
     }
 
-    /// Kills: `utf16_string.rs:318:16` `> -> >=` in `insert_slice` (idx <= self.len)
-    /// `utf16_string.rs:330:19` `> -> >=` in `insert_slice` (needed > self.cap)
     #[test]
     fn utf16_318_330_insert_slice() {
         let arena = Arena::new();
@@ -2752,10 +2645,6 @@ mod utf16_tests {
         assert_eq!(s.len(), 6);
     }
 
-    /// Kills: `utf16_string.rs:337:76` `- -> +` in `insert_slice`
-    /// `core::ptr::copy(base.add(idx), base.add(idx + s_len), self.len - idx);`
-    /// If `-` becomes `+`, the copy length is self.len + idx (too much),
-    /// reading/writing out of bounds.
     #[test]
     fn utf16_337_insert_copy_length() {
         let arena = Arena::new();
@@ -2776,8 +2665,6 @@ mod utf16_tests {
         assert_eq!(slice[5], 'E' as u16);
     }
 
-    /// Kills: `utf16_string.rs:356:72` `- -> +` and 356:78 `- -> +` / `- -> /`
-    /// In remove: `self.len - idx - n` — shift length after removal.
     #[test]
     fn utf16_356_remove_shift() {
         let arena = Arena::new();
@@ -2798,9 +2685,6 @@ mod utf16_tests {
         assert_eq!(slice[3], 'E' as u16);
     }
 
-    /// Kills: `utf16_string.rs:396:18` `> -> >=` and 396:22 `&& -> ||` and 396:31 `< -> <=`
-    /// These are the boundary checks in `replace_range`:
-    /// `if start > 0 && start < self.len { check boundary }`
     #[test]
     fn utf16_396_replace_range_start_boundary() {
         let arena = Arena::new();
@@ -2819,9 +2703,6 @@ mod utf16_tests {
         assert_eq!(s.len(), 5);
     }
 
-    /// Kills: `utf16_string.rs:403:16` `> -> ==` / `> -> <` / `> -> >=`
-    /// and 403:27 `< -> >`
-    /// `if end > 0 && end < self.len { check boundary }`
     #[test]
     fn utf16_403_replace_range_end_boundary() {
         let arena = Arena::new();
@@ -2839,8 +2720,6 @@ mod utf16_tests {
         assert_eq!(s.len(), 3);
     }
 
-    /// Kills: `utf16_string.rs:418:20` `> -> >=` in `replace_range`
-    /// `if new_len > self.cap { self.grow_to_at_least(new_len); }`
     #[test]
     fn utf16_418_replace_range_grow_boundary() {
         let arena = Arena::new();
@@ -2857,8 +2736,6 @@ mod utf16_tests {
         assert_eq!(s.as_slice()[2], 'X' as u16);
     }
 
-    /// Kills: `utf16_string.rs:424:81` `- -> +` in `replace_range`
-    /// `core::ptr::copy(base.add(end), base.add(start + inserted), self.len - end);`
     #[test]
     fn utf16_424_replace_range_copy() {
         let arena = Arena::new();
@@ -2885,12 +2762,6 @@ mod utf16_tests {
 mod utf16_round2 {
     use multitude::Arena;
 
-    /// Kills: `utf16_string.rs:337:76` `- -> +` in `insert_slice` copy
-    /// `core::ptr::copy(base.add(idx), base.add(idx + s_len), self.len - idx)`
-    /// If `- -> +`: copy count is `self.len + idx` instead of `self.len - idx`.
-    /// For a string "ABCDE" (len=5) inserting at idx=2:
-    ///   Correct count = 5 - 2 = 3 (shift C,D,E right)
-    ///   Mutated count = 5 + 2 = 7 (reads 7 u16s starting at idx, goes OOB)
     #[test]
     fn utf16_337_insert_copy_oob() {
         let arena = Arena::new();
@@ -2918,15 +2789,6 @@ mod utf16_round2 {
         assert_eq!(slice[10], 'J' as u16);
     }
 
-    /// Kills: `utf16_string.rs:356:72` `- -> +` and 356:78 `- -> +` / `- -> /`
-    /// In remove: copy(base.add(idx + n), base.add(idx), self.len - idx - n)
-    /// 356:72 is the outer `-`: `self.len - idx` becomes `self.len + idx`
-    /// 356:78 is the inner `-`: `(self.len - idx) - n` or `(self.len + idx) - n`
-    /// For "ABCDEFGHIJ" (len=10), remove at idx=2 (n=1):
-    ///   Correct: copy 7 elements from idx=3 to idx=2
-    ///   356:72 `+ -> +`: copy `10 + 2 - 1 = 11` elements (OOB)
-    ///   356:78 `- -> +`: copy `10 - 2 + 1 = 9` elements (reads past end)
-    ///   356:78 `- -> /`: copy `10 - 2 / 1 = 8` elements (wrong count)
     #[test]
     fn utf16_356_remove_long_string() {
         let arena = Arena::new();
@@ -2946,12 +2808,6 @@ mod utf16_round2 {
         assert_eq!(s.as_slice(), &expected);
     }
 
-    /// Kills: `utf16_string.rs:403:16` `> -> ==` — end boundary check
-    /// `if end > 0 && end < self.len { check boundary }`
-    /// With ==: `if end == 0 && end < self.len` — only checks boundary
-    /// when end==0, which is never valid (end==0 && end < len means
-    /// end is 0 but we check character at index 0, which is always valid).
-    /// Need to test: end > 0 && end < len where end is at a valid boundary.
     #[test]
     fn utf16_403_end_boundary_mid_string() {
         let arena = Arena::new();
@@ -2970,9 +2826,6 @@ mod utf16_round2 {
         assert_eq!(s.as_slice()[3], 'X' as u16);
     }
 
-    /// Kills: `utf16_string.rs:403:16` `> -> >=` — end boundary
-    /// If `>= 0` is always true for usize, the boundary check always runs.
-    /// This means end==0 (which is valid) would try to check character boundary.
     #[test]
     fn utf16_403_end_zero() {
         let arena = Arena::new();
@@ -2985,16 +2838,6 @@ mod utf16_round2 {
         assert_eq!(s.len(), 2);
     }
 
-    /// Kills: `utf16_string.rs:403:27` `< -> >` — end boundary
-    /// `if end > 0 && end < self.len` becomes `end > 0 && end > self.len`
-    /// Would check boundary when end > len, which is already rejected by
-    /// the `assert!(start <= end && end <= self.len)` above. So this should
-    /// be equivalent — the `end > len` case never reaches this check.
-    /// But wait: `end == self.len` skips the check with `<`. With `>`,
-    /// `end > self.len` also skips it. So the only difference is `end < self.len`
-    /// vs `end > self.len`. When end < len, we need to check boundary.
-    /// With `>`, we skip the check when end is in the middle, allowing
-    /// `replace_range` to split a surrogate pair at the end boundary.
     #[test]
     fn utf16_403_27_end_surrogate_check() {
         let arena = Arena::new();
@@ -3011,15 +2854,7 @@ mod utf16_round2 {
         assert!(result.is_err(), "replace_range ending at low surrogate must panic");
     }
 
-    /// Kills: `utf16_string.rs:418:20` `> -> >=` in `replace_range` grow
-    /// `if new_len > self.cap { grow }`
-    /// With >=: `new_len` == cap triggers unnecessary grow.
-    /// The grow is a no-op since `grow_to_at_least` returns early for `min_cap` <= cap.
-    /// So this is EQUIVALENT.
     // ---
-    /// Kills: `utf16_string.rs:424:81` `- -> +` in `replace_range` copy
-    /// `copy(base.add(end), base.add(start + inserted), self.len - end)`
-    /// With +: `self.len + end` (huge copy, OOB)
     #[test]
     fn utf16_424_replace_range_tail_copy() {
         let arena = Arena::new();
@@ -3037,9 +2872,6 @@ mod utf16_round2 {
         assert_eq!(s.as_slice(), &expected);
     }
 
-    /// Kills: `utf16_string.rs:206:38` `- -> /` in `shrink_to_fit`
-    /// `reclaim_units = self.cap - self.len` becomes `self.cap / self.len`
-    /// For cap=20, len=2: correct=18, mutated=10. Wrong reclaim.
     #[test]
     fn utf16_206_shrink_reclaim_v2() {
         let arena = Arena::new();
@@ -3054,10 +2886,6 @@ mod utf16_round2 {
         assert_eq!(s.as_slice()[0], 'A' as u16);
     }
 
-    /// Kills: `utf16_string.rs:207:43` `* -> +` and `* -> /` in `shrink_to_fit`
-    /// `reclaim_bytes = reclaim_units * size_of::<u16>()` (= `reclaim_units` * 2)
-    /// With +: `reclaim_bytes` = `reclaim_units` + 2 (wrong)
-    /// With /: `reclaim_bytes` = `reclaim_units` / 2 (wrong)
     #[test]
     fn utf16_207_shrink_bytes_v2() {
         let arena = Arena::new();
@@ -3078,7 +2906,6 @@ mod utf16_round2 {
     // reclaim_bytes = 0, try_shrink_at_cursor(end, 0) is a no-op. EQUIVALENT.
 }
 
-// === relocated from coverage_extras.rs (utf16-gated tests) ===
 mod from_coverage_extras_utf16 {
     #![allow(clippy::items_after_statements, reason = "relocated tests put inner types near use")]
     #![allow(clippy::clone_on_ref_ptr, reason = "relocated tests use .clone() on Arc/Rc")]
@@ -3229,7 +3056,6 @@ mod from_coverage_extras_utf16 {
     }
 }
 
-// === relocated from mutants_extras.rs (utf16-gated tests) ===
 mod from_mutants_extras_utf16_scattered {
     #![allow(clippy::items_after_statements, reason = "relocated tests put inner types near use")]
     #![allow(clippy::clone_on_ref_ptr, reason = "relocated tests use .clone() on Arc/Rc")]
@@ -3258,10 +3084,6 @@ mod from_mutants_extras_utf16_scattered {
     // vec/vec.rs mutants
     // =====================================================================
 
-    /// Kills: vec.rs:362:21 `< -> <=` in `shrink_to_fit`
-    /// `if self.len < self.cap && self.realloc(self.len).is_err() { ... }`
-    /// If `<` becomes `<=`, len == cap would trigger a realloc to same
-    /// size, which is a no-op but shouldn't happen.
     #[test]
     fn vec_362_shrink_to_fit_boundary() {
         let arena = Arena::new();
@@ -3284,11 +3106,6 @@ mod from_mutants_extras_utf16_scattered {
     // Vec stronger tests
     // =====================================================================
 
-    /// Kills: vec.rs:451:34 `- -> +` in resize
-    /// `self.reserve(new_len - self.len)` becomes `self.reserve(new_len + self.len)`
-    /// For len=2, `new_len=5`: correct reserve=3, mutated=7.
-    /// Extra reservation succeeds but wastes space.
-    /// With tight budget, the extra reservation might fail.
     #[test]
     fn vec_451_resize_tight_budget() {
         let arena = Arena::builder().byte_budget(128 * 1024).build();
@@ -3304,17 +3121,6 @@ mod from_mutants_extras_utf16_scattered {
         assert_eq!(v[4], 42);
     }
 
-    /// Kills `utf16_string.rs:207:43 * → +` in `Utf16String::shrink_to_fit`.
-    ///
-    /// `reclaim_bytes = reclaim_units * sizeof::<u16>()`:
-    /// * Original `*`: with `reclaim_units = 8, sizeof(u16) = 2`,
-    ///   `reclaim_bytes = 16`.
-    /// * Mutated `+`: `reclaim_bytes = 10`.
-    ///
-    /// We observe through the arena cursor: after a `shrink_to_fit`, the
-    /// next allocation should re-use the freed tail. With the wrong
-    /// `reclaim_bytes`, the cursor moves back by a different amount and
-    /// the next allocation lands at a different offset.
     #[test]
     fn utf16_shrink_to_fit_uses_multiplication() {
         use multitude::strings::Utf16String;
@@ -3349,28 +3155,6 @@ mod from_mutants_extras_utf16_scattered {
         assert_eq!(last, u16::from(b'z'));
     }
 
-    /// Kills `utf16_string.rs:356:72 - → +` and `356:78 - → +` in `Utf16String::remove`.
-    ///
-    /// `core::ptr::copy(base.add(idx + n), base.add(idx), self.len - idx - n)`:
-    /// * Original: shifts the tail left by `n`, copying `len - idx - n` units.
-    /// * Mutated col 72 `- → +`: shifts `len + idx - n` units → wildly large
-    ///   and writes out-of-bounds garbage into the buffer.
-    /// * Mutated col 78 `- → +`: shifts `len - idx + n` units → off-by-`2n`
-    ///   into the tail, leaving the wrong content.
-    ///
-    /// We assert exact post-remove content over many calls.
-    /// Kills `utf16_string.rs:260:19`, `277:19`, `298:19`, `318:16`, `396:18`,
-    /// `418:20` — all `> → >=` boundary mutations on
-    /// `if needed > self.cap { grow }`.
-    ///
-    /// At `needed == self.cap` (exactly fits): original skips the grow
-    /// (no-op). Mutated `>=` invokes `try_grow_to_at_least(cap)` which is
-    /// itself a no-op (returns Ok immediately when `min_cap` <= cap).
-    ///
-    /// These mutations are therefore **equivalent**. We document this in
-    /// `MUTANTS_EQUIVALENT.md` and verify the observable: after the push
-    /// that lands exactly at cap, the content and cap are identical to
-    /// what they would be under either operator.
     #[test]
     fn utf16_exact_fit_push_is_observably_identical() {
         use multitude::strings::Utf16String;

--- a/crates/multitude/tests/zerocopy_integration.rs
+++ b/crates/multitude/tests/zerocopy_integration.rs
@@ -291,7 +291,6 @@ fn alloc_slice_ref_is_mutable() {
     assert_eq!(s, &[0, 99, 0]);
 }
 
-// === relocated from coverage_extras.rs (zerocopy-gated tests) ===
 mod from_coverage_extras_zerocopy {
     #![allow(clippy::items_after_statements, reason = "relocated tests put inner types near use")]
     #![allow(clippy::clone_on_ref_ptr, reason = "relocated tests use .clone() on Arc/Rc")]


### PR DESCRIPTION
Round out the allocation API surface with the missing uninitialized allocations, fallible counterparts of panicking methods, and string Arc freezes. Panicking methods now delegate to their `try_*` variant.

Arena — local uninitialized / zeroed allocations:
- alloc_uninit / try_alloc_uninit
- alloc_zeroed / try_alloc_zeroed
- alloc_uninit_slice / try_alloc_uninit_slice
- alloc_zeroed_slice / try_alloc_zeroed_slice

Arena — fallible UTF-8 / UTF-16 string decoders (lossy + unchecked):
- try_alloc_string_from_utf8_lossy
- try_alloc_string_from_utf8_unchecked
- try_alloc_string_from_utf16_lossy
- try_alloc_string_from_utf16le_lossy
- try_alloc_string_from_utf16be_lossy

Vec — fallible counterparts of panicking growth methods:
- try_insert
- try_resize
- try_resize_with
- try_append
- try_split_off
- try_extend_from_within

String — fallible counterparts + Arc freeze:
- try_insert
- try_insert_str
- try_replace_range
- try_split_off
- try_extend_from_within
- try_into_boxed_str
- into_arc_str / try_into_arc_str

Utf16String — fallible counterparts + Arc freeze:
- try_insert
- try_insert_utf16_str
- try_replace_range
- try_split_off
- try_extend_from_within
- try_into_boxed_utf16_str
- try_from_utf16_str_in
- into_arc_utf16_str / try_into_arc_utf16_str

Behavioral change:
- `Utf16String::retain` now matches the panic-safety contract of `std::string::String::retain` and `String::retain`: if the predicate panics, the characters processed so far are committed (retained ones compacted into place) and the unprocessed tail is dropped, leaving `self` well-formed UTF-16. The previous implementation preserved the original contents on panic. This also removes the transient allocation the old implementation used.
