### PR TITLE
test(multitude): gate feature-gated over-aligned tests behind utc_backend

### DIFF
--- a/crates/multitude/tests/bytemuck_integration.rs
+++ b/crates/multitude/tests/bytemuck_integration.rs
@@ -157,6 +157,7 @@ fn try_alloc_slice_arc_ok() {
 // stack cannot satisfy a 64 KiB-aligned frame. The non-slice
 // `try_*_over_aligned_returns_err` siblings exercise the same
 // alignment-rejection guard on every platform.
+#[cfg(not(utc_backend))]
 #[derive(Clone, Copy)]
 #[repr(C, align(65536))]
 struct OverAligned {
@@ -164,9 +165,11 @@ struct OverAligned {
 }
 
 // SAFETY: all-zeros is a valid OverAligned (it's just a u8 + padding).
+#[cfg(not(utc_backend))]
 unsafe impl Zeroable for OverAligned {}
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_box_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_box::<OverAligned>();
@@ -174,6 +177,7 @@ fn try_alloc_box_over_aligned_returns_err() {
 }
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_arc_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_arc::<OverAligned>();
@@ -181,6 +185,7 @@ fn try_alloc_arc_over_aligned_returns_err() {
 }
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_slice_box_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_slice_box::<OverAligned>(4);
@@ -188,6 +193,7 @@ fn try_alloc_slice_box_over_aligned_returns_err() {
 }
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_slice_arc_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_slice_arc::<OverAligned>(4);
@@ -195,7 +201,7 @@ fn try_alloc_slice_arc_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_box_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -203,7 +209,7 @@ fn alloc_box_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_arc_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -211,7 +217,7 @@ fn alloc_arc_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_box_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -219,7 +225,7 @@ fn alloc_slice_box_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_arc_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -256,6 +262,7 @@ fn try_alloc_ref_scalar_ok() {
 }
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_ref_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc::<OverAligned>();
@@ -263,7 +270,7 @@ fn try_alloc_ref_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_ref_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -301,7 +308,7 @@ fn try_alloc_slice_ref_ok() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 fn try_alloc_slice_ref_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_slice::<OverAligned>(4);
@@ -309,7 +316,7 @@ fn try_alloc_slice_ref_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_ref_panics_on_over_aligned() {
     let arena = Arena::new();

--- a/crates/multitude/tests/zerocopy_integration.rs
+++ b/crates/multitude/tests/zerocopy_integration.rs
@@ -127,6 +127,7 @@ fn try_alloc_slice_arc_ok() {
 // stack cannot satisfy a 64 KiB-aligned frame. The non-slice
 // `try_*_over_aligned_returns_err` siblings exercise the same
 // alignment-rejection guard on every platform.
+#[cfg(not(utc_backend))]
 #[derive(FromZeros)]
 #[repr(C, align(65536))]
 struct OverAligned {
@@ -134,6 +135,7 @@ struct OverAligned {
 }
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_box_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_box::<OverAligned>();
@@ -141,6 +143,7 @@ fn try_alloc_box_over_aligned_returns_err() {
 }
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_arc_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_arc::<OverAligned>();
@@ -148,6 +151,7 @@ fn try_alloc_arc_over_aligned_returns_err() {
 }
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_slice_box_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_slice_box::<OverAligned>(4);
@@ -155,6 +159,7 @@ fn try_alloc_slice_box_over_aligned_returns_err() {
 }
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_slice_arc_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_slice_arc::<OverAligned>(4);
@@ -162,7 +167,7 @@ fn try_alloc_slice_arc_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_box_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -170,7 +175,7 @@ fn alloc_box_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_arc_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -178,7 +183,7 @@ fn alloc_arc_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_box_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -186,7 +191,7 @@ fn alloc_slice_box_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_arc_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -223,6 +228,7 @@ fn try_alloc_ref_scalar_ok() {
 }
 
 #[test]
+#[cfg(not(utc_backend))]
 fn try_alloc_ref_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc::<OverAligned>();
@@ -230,7 +236,7 @@ fn try_alloc_ref_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_ref_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -268,7 +274,7 @@ fn try_alloc_slice_ref_ok() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 fn try_alloc_slice_ref_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_slice::<OverAligned>(4);
@@ -276,7 +282,7 @@ fn try_alloc_slice_ref_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_ref_panics_on_over_aligned() {
     let arena = Arena::new();


### PR DESCRIPTION
## Why

Follow-up to #501. That PR gated multitude's over-aligned tests behind `utc_backend`, but only covered the test files compiled under **default features**. The publish pipeline builds with `--all-features`, which also compiles `tests/bytemuck_integration.rs` and `tests/zerocopy_integration.rs` — each declaring a 64 KiB-aligned `OverAligned` type. Those slipped through and broke the UTC publish build:

```\nerror: invalid alignment for type `bytemuck_integration::OverAligned` (65536 bytes), UTC supports at most 8192B power-of-two alignment\nerror: invalid alignment for type `zerocopy_integration::OverAligned` (65536 bytes), ...\n```\n
(Seen in publish build `36891113`, `Build and Test dev on windows`.)

## What

- Gate the `OverAligned` type and every test referencing it behind `#[cfg(not(utc_backend))]` in both integration test files.
- Combine with the existing `#[cfg(not(target_os = `"`windows`"`))]` gates into `#[cfg(all(not(target_os = `"`windows`"`), not(utc_backend)))]` where present.

## Verification (ms-prod-1.95, `--cfg utc_backend`, `--all-features`)

- `cargo build -p multitude --all-targets --all-features` — clean (was 2 errors).
- `cargo clippy -p multitude --all-targets --all-features -- -D warnings` — clean (no unused-import regressions from the gated `Zeroable` / `FromZeros` impls).
- `cargo nextest run -p multitude --all-features` — 1406 passed.
- LLVM default toolchain `--all-features` build — clean (tests still present off-UTC).