### PR TITLE
perf(multitude): add arc_array allocation/timing benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,7 @@ dependencies = [
 name = "multitude"
 version = "0.3.0"
 dependencies = [
+ "alloc_tracker",
  "allocator-api2 0.4.0",
  "bolero",
  "bumpalo",

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -61,6 +61,7 @@ zerocopy = { workspace = true, optional = true }
 loom = { workspace = true }
 
 [dev-dependencies]
+alloc_tracker = { workspace = true }
 allocator-api2 = { workspace = true, features = ["alloc"] }
 bolero = { workspace = true, features = ["std"] }
 # `std` transitively enables `bolero-engine/any`, which is required
@@ -89,6 +90,10 @@ harness = false
 
 [[bench]]
 name = "criterion_drop"
+harness = false
+
+[[bench]]
+name = "criterion_arc_array"
 harness = false
 
 # Callgrind benches require Linux (Valgrind). The bench files are gated to compile

--- a/crates/multitude/benches/criterion_arc_array.rs
+++ b/crates/multitude/benches/criterion_arc_array.rs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Builds an `Arc<[Arc<[u8]>]>` of `PROPERTIES` binary blobs two ways and
+//! compares them: `std::sync::Arc` (global allocator) vs `multitude::Arc`
+//! (arena, `reset` and reused between iterations).
+//!
+//! Each is benchmarked with two strategies:
+//!
+//! - `*` — push freshly allocated properties through a growable vec, then
+//!   freeze it into the `Arc`.
+//! - `*_from_slice` — build directly from a pre-created slice of properties,
+//!   with no intermediate vec.
+//!
+//! Time is measured with **criterion**; per-iteration allocation volume (bytes
+//! + count) with the [`alloc_tracker`] crate, printed after the timings.
+//!
+//! Run with: `cargo bench --bench criterion_arc_array`
+#![allow(clippy::unwrap_used, reason = "benchmark code")]
+#![allow(clippy::missing_panics_doc, reason = "benchmark code")]
+#![allow(unused_results, reason = "benchmark code")]
+#![allow(clippy::std_instead_of_core, reason = "benchmark code")]
+#![allow(dead_code, reason = "array properties are held only to keep the allocation alive")]
+
+use std::hint::black_box;
+use std::sync::Arc as StdArc;
+
+use alloc_tracker::{Allocator, Session};
+use criterion::{Criterion, criterion_group, criterion_main};
+use multitude::{Arc as ArenaArc, Arena};
+
+#[global_allocator]
+static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+
+// ---------------------------------------------------------------------------
+// Array shape: `PROPERTIES` binary blobs of `PROPERTY_SIZE` bytes each.
+// ---------------------------------------------------------------------------
+
+const PROPERTIES: usize = 8;
+const PROPERTY_SIZE: usize = 16;
+
+// ---------------------------------------------------------------------------
+// Global-allocator array
+// ---------------------------------------------------------------------------
+
+fn build_global(payload: &[u8]) -> StdArc<[StdArc<[u8]>]> {
+    let mut properties = Vec::with_capacity(PROPERTIES);
+    for _ in 0..PROPERTIES {
+        properties.push(StdArc::<[u8]>::from(payload));
+    }
+    StdArc::from(properties)
+}
+
+fn build_global_from_slice(properties: &[StdArc<[u8]>]) -> StdArc<[StdArc<[u8]>]> {
+    StdArc::from(properties)
+}
+
+// ---------------------------------------------------------------------------
+// Arena-backed array
+// ---------------------------------------------------------------------------
+
+fn build_arena(arena: &Arena, payload: &[u8]) -> ArenaArc<[ArenaArc<[u8]>]> {
+    let mut properties = arena.alloc_vec_with_capacity::<ArenaArc<[u8]>>(PROPERTIES);
+    for _ in 0..PROPERTIES {
+        properties.push(arena.alloc_slice_copy_arc(payload));
+    }
+    properties.try_into_arc().unwrap()
+}
+
+fn build_arena_from_slice(arena: &Arena, properties: &[StdArc<[u8]>]) -> ArenaArc<[StdArc<[u8]>]> {
+    arena.alloc_slice_clone_arc(properties)
+}
+
+fn global_properties(payload: &[u8]) -> Vec<StdArc<[u8]>> {
+    (0..PROPERTIES).map(|_| StdArc::<[u8]>::from(payload)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Criterion timing + per-iteration allocation tracking
+// ---------------------------------------------------------------------------
+
+fn bench_arc_array(c: &mut Criterion) {
+    let payload = vec![0xABu8; PROPERTY_SIZE];
+
+    // Each `iter` takes a thread span so the per-op allocation mean is printed
+    // alongside the timings.
+    let session = Session::new();
+
+    let mut group = c.benchmark_group("arc_array");
+
+    let global_op = session.operation("global");
+    group.bench_function("global", |b| {
+        b.iter(|| {
+            let _span = global_op.measure_thread();
+            black_box(build_global(black_box(&payload)));
+        });
+    });
+
+    // Warm the arena, then reset and reuse it each iteration.
+    let mut arena = Arena::new();
+    black_box(build_arena(&arena, &payload));
+    arena.reset();
+
+    let arena_op = session.operation("arena");
+    group.bench_function("arena", |b| {
+        b.iter(|| {
+            let _span = arena_op.measure_thread();
+            black_box(build_arena(&arena, black_box(&payload)));
+            arena.reset();
+        });
+    });
+
+    // The pre-created global properties feed both `*_from_slice` variants.
+    let global_props = global_properties(&payload);
+    let global_slice_op = session.operation("global_from_slice");
+    group.bench_function("global_from_slice", |b| {
+        b.iter(|| {
+            let _span = global_slice_op.measure_thread();
+            black_box(build_global_from_slice(black_box(&global_props)));
+        });
+    });
+
+    let mut work_arena = Arena::new();
+    black_box(build_arena_from_slice(&work_arena, &global_props));
+    work_arena.reset();
+
+    let arena_slice_op = session.operation("arena_from_slice");
+    group.bench_function("arena_from_slice", |b| {
+        b.iter(|| {
+            let _span = arena_slice_op.measure_thread();
+            black_box(build_arena_from_slice(&work_arena, black_box(&global_props)));
+            work_arena.reset();
+        });
+    });
+
+    group.finish();
+
+    session.print_to_stdout();
+}
+
+criterion_group!(benches, bench_arc_array);
+criterion_main!(benches);


### PR DESCRIPTION
Add `criterion_arc_array` bench comparing construction of an `Arc<[Arc<[u8]>]>` (8 x 16B properties) via the global allocator vs the multitude arena, using the `alloc_tracker` crate for per-iteration allocation volume. Two strategies per path: build through a growable vec (`*`) and build directly from a pre-created slice (`*_from_slice`).

The bench surfaces a pathology in the arena vec-then-freeze path: under a warmed, reset-and-reused arena it re-grabs a full 64 KiB chunk every iteration and runs ~35x slower than the global allocator. The direct `alloc_slice_clone_arc` path reuses chunks correctly (0 bytes/op).



 | variant           | time      | bytes/op | allocs/op |
 |-------------------|-----------|----------|-----------|
 | global            | ~562 ns   | 528      | 10        |
 | arena             | ~20.0 µs  | 65535    | 1         |
 | global_from_slice | ~143 ns   | 144      | 1         |
 | arena_from_slice  | ~146 ns   | 0        | 0         |
