### PR TITLE
chore(tick): bump patch version to 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "tick"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/crates/tick/Cargo.toml
+++ b/crates/tick/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "tick"
 description = "Provides primitives to interact with and manipulate machine time."
-version = "0.3.4"
+version = "0.3.5"
 readme = "README.md"
 keywords = ["time", "clock", "tick", "stopwatch"]
 categories = ["data-structures"]

--- a/crates/tick/README.md
+++ b/crates/tick/README.md
@@ -227,36 +227,36 @@ contain additional examples of how to use the time primitives.
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/tick">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbL9BDcNdcFMwb7BisAbHhDTMbCjff6Srdm8MbyVtuTcwxtz5hZIKCbHRocmVhZF9hd2FyZWUwLjcuNIJkdGlja2UwLjMuNA
- [__link0]: https://docs.rs/tick/0.3.4/tick/?search=ClockControl
- [__link1]: https://docs.rs/tick/0.3.4/tick/?search=Clock
- [__link10]: https://docs.rs/tick/0.3.4/tick/?search=FutureExt
- [__link11]: https://docs.rs/tick/0.3.4/tick/?search=SystemTimeExt
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbL9BDcNdcFMwb7BisAbHhDTMbCjff6Srdm8MbyVtuTcwxtz5hZIKCbHRocmVhZF9hd2FyZWUwLjcuNIJkdGlja2UwLjMuNQ
+ [__link0]: https://docs.rs/tick/0.3.5/tick/?search=ClockControl
+ [__link1]: https://docs.rs/tick/0.3.5/tick/?search=Clock
+ [__link10]: https://docs.rs/tick/0.3.5/tick/?search=FutureExt
+ [__link11]: https://docs.rs/tick/0.3.5/tick/?search=SystemTimeExt
  [__link12]: https://doc.rust-lang.org/stable/std/?search=time::SystemTime
  [__link13]: https://crates.io/crates/jiff
  [__link14]: https://crates.io/crates/chrono
  [__link15]: https://crates.io/crates/time
  [__link16]: https://docs.rs/thread_aware/0.7.4/thread_aware/?search=ThreadAware
- [__link17]: https://docs.rs/tick/0.3.4/tick/?search=runtime::InactiveClock
+ [__link17]: https://docs.rs/tick/0.3.5/tick/?search=runtime::InactiveClock
  [__link18]: https://docs.rs/thread_aware/0.7.4/thread_aware/?search=ThreadAware::relocate
- [__link19]: https://docs.rs/tick/0.3.4/tick/?search=Clock
- [__link2]: https://docs.rs/tick/0.3.4/tick/?search=Clock
- [__link20]: https://docs.rs/tick/0.3.4/tick/?search=runtime::ClockDriver
- [__link21]: https://docs.rs/tick/0.3.4/tick/?search=ClockControl
- [__link22]: https://docs.rs/tick/0.3.4/tick/runtime/index.html
- [__link23]: https://docs.rs/tick/0.3.4/tick/?search=Clock
- [__link24]: https://docs.rs/tick/0.3.4/tick/?search=Clock::instant
- [__link25]: https://docs.rs/tick/0.3.4/tick/?search=Stopwatch
+ [__link19]: https://docs.rs/tick/0.3.5/tick/?search=Clock
+ [__link2]: https://docs.rs/tick/0.3.5/tick/?search=Clock
+ [__link20]: https://docs.rs/tick/0.3.5/tick/?search=runtime::ClockDriver
+ [__link21]: https://docs.rs/tick/0.3.5/tick/?search=ClockControl
+ [__link22]: https://docs.rs/tick/0.3.5/tick/runtime/index.html
+ [__link23]: https://docs.rs/tick/0.3.5/tick/?search=Clock
+ [__link24]: https://docs.rs/tick/0.3.5/tick/?search=Clock::instant
+ [__link25]: https://docs.rs/tick/0.3.5/tick/?search=Stopwatch
  [__link26]: https://tokio.rs/
- [__link27]: https://docs.rs/tick/0.3.4/tick/?search=Clock::new_tokio
- [__link28]: https://docs.rs/tick/0.3.4/tick/?search=ClockControl
+ [__link27]: https://docs.rs/tick/0.3.5/tick/?search=Clock::new_tokio
+ [__link28]: https://docs.rs/tick/0.3.5/tick/?search=ClockControl
  [__link29]: https://serde.rs/
- [__link3]: https://docs.rs/tick/0.3.4/tick/?search=ClockControl
- [__link30]: https://docs.rs/tick/0.3.4/tick/fmt/index.html
+ [__link3]: https://docs.rs/tick/0.3.5/tick/?search=ClockControl
+ [__link30]: https://docs.rs/tick/0.3.5/tick/fmt/index.html
  [__link31]: https://github.com/microsoft/oxidizer/tree/main/crates/tick/examples
- [__link4]: https://docs.rs/tick/0.3.4/tick/?search=Stopwatch
- [__link5]: https://docs.rs/tick/0.3.4/tick/?search=Delay
- [__link6]: https://docs.rs/tick/0.3.4/tick/?search=PeriodicTimer
- [__link7]: https://docs.rs/tick/0.3.4/tick/?search=Error
- [__link8]: https://docs.rs/tick/0.3.4/tick/fmt/index.html
- [__link9]: https://docs.rs/tick/0.3.4/tick/runtime/index.html
+ [__link4]: https://docs.rs/tick/0.3.5/tick/?search=Stopwatch
+ [__link5]: https://docs.rs/tick/0.3.5/tick/?search=Delay
+ [__link6]: https://docs.rs/tick/0.3.5/tick/?search=PeriodicTimer
+ [__link7]: https://docs.rs/tick/0.3.5/tick/?search=Error
+ [__link8]: https://docs.rs/tick/0.3.5/tick/fmt/index.html
+ [__link9]: https://docs.rs/tick/0.3.5/tick/runtime/index.html


### PR DESCRIPTION
Bumps the `tick` crate patch version from 0.3.4 to 0.3.5.

Purpose: exercise and validate the ESRP release process. This is a no-op version bump with no functional code changes.