### PR TITLE
feat(multitude): add arena-backed hashbrown HashMap/HashSet support

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -339,6 +339,7 @@ globals
 glommio
 grey
 growable
+hashbrown
 hasher
 hashers
 hedges
@@ -479,6 +480,7 @@ repr
 repurpose
 repurposed
 repurposing
+resizing
 retag
 retags
 retarget

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70bc5b36f4124124cdeae56ea9527e8db3e90f7ac7382c0b7a07d780163629a4"
 
 [[package]]
+name = "alloc_tracker"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160148c6badd4fb18605f8373adda8d89a43abcacf9a1b7868aa33643eacdb7"
+dependencies = [
+ "folo_utils",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,9 +319,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "automation"
@@ -430,9 +441,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blocking"
@@ -542,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -574,15 +591,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytesbuf"
 version = "0.5.5"
 dependencies = [
- "alloc_tracker",
+ "alloc_tracker 0.5.25",
  "bytes",
  "criterion",
  "infinity_pool",
@@ -616,7 +633,7 @@ dependencies = [
 name = "cachet"
 version = "0.7.1"
 dependencies = [
- "alloc_tracker",
+ "alloc_tracker 0.5.25",
  "anyspawn",
  "bytesbuf",
  "cachet_memory",
@@ -690,9 +707,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -719,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -876,13 +893,13 @@ dependencies = [
 
 [[package]]
 name = "cpulist"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f281a8b8b96e410aba53db1554154d70f39ff1f3f2c8e881368a8f34543c710c"
+checksum = "328c0b8c9cc1756ac8179a70ed4adab2ce7d317e9142a0db6d139b540fafdaff"
 dependencies = [
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "new_zealand",
- "ohno 0.3.2",
+ "ohno 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -984,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1064,12 +1081,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1098,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1159,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-io"
@@ -1214,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "fast_time"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6445afdc7f2e31971a501b22782b3f0d59b3e8518572d6b56fa2a7f6a9443aef"
+checksum = "ad188d8ad2b4f4af0659f0f23f3025063cc4b500350f5ecd219522639355f8b2"
 dependencies = [
  "libc",
  "windows",
@@ -1232,7 +1280,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 name = "fetch"
 version = "0.11.2"
 dependencies = [
- "alloc_tracker",
+ "alloc_tracker 0.5.25",
  "anyspawn",
  "argh",
  "bytes",
@@ -1393,6 +1441,16 @@ name = "folo_ffi"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9da2799288b7822cb94d4b15fb5f0eef6de0bcb9d26ce99c8512597bb0dda81"
+
+[[package]]
+name = "folo_utils"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cc135ea093a19d41324dcf04daaf9da2e9c625147e3eb19073e9869580a89db"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1602,16 +1660,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1622,9 +1678,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gungraun"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4d8da7e495043e7050236881e37c8c7cbd896a8674c2fa49b13f2ff8c9505b"
+checksum = "7dcd6043b1ff8096c10cdd5c59930139b52ba63cbd1a3452bc3ff95d996f9334"
 dependencies = [
  "bincode-next",
  "derive_more",
@@ -1634,12 +1690,12 @@ dependencies = [
 
 [[package]]
 name = "gungraun-macros"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc6269e89921872ec32af29af3a992618b9bd2ef47cbf3704af476066cb7182"
+checksum = "d7f3214bae6cfd6739f4f29edb262bae439c6393a7b7b12c4eeb96417c2e50df"
 dependencies = [
  "derive_more",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1650,18 +1706,18 @@ dependencies = [
 
 [[package]]
 name = "gungraun-runner"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d412a9c97a337ee83ab57c8e4e377cee1a519afaebbeb803c696ecd1e93173e2"
+checksum = "6965c4e60026245b5600b05ab4c4af5ae1eaf72b8ec5da86c9cc6af01258d8cc"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1718,6 +1774,10 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2 0.2.21",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1730,12 +1790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,9 +1797,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1778,7 +1832,7 @@ dependencies = [
 name = "http_extensions"
 version = "0.6.2"
 dependencies = [
- "alloc_tracker",
+ "alloc_tracker 0.5.25",
  "bytes",
  "bytesbuf",
  "criterion",
@@ -1998,12 +2052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,15 +2086,13 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "infinity_pool"
-version = "0.8.11"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e77de9e116ed8eb5d865f630a3931a9c27a51f69a50838a2f1b4c4d20043e10"
+checksum = "a4fbb4b9dfe16021f45e83c04f883fe05f7e5a7b892aae5ed8e6443e05457b9b"
 dependencies = [
  "new_zealand",
  "num-integer",
@@ -2055,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "once_cell",
  "serde",
@@ -2076,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -2091,10 +2137,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -2106,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2191,13 +2238,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2205,7 +2251,7 @@ dependencies = [
 name = "layered"
 version = "0.3.4"
 dependencies = [
- "alloc_tracker",
+ "alloc_tracker 0.5.25",
  "criterion",
  "futures",
  "infinity_pool",
@@ -2223,12 +2269,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2259,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom"
@@ -2278,16 +2318,25 @@ dependencies = [
 
 [[package]]
 name = "many_cpus"
-version = "2.4.7"
+version = "2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7a1ccae423bac97b592a258bc49a5cb772d7e43803bf4f68fd2eb2c3307256"
+checksum = "7dfce02adde6c46611a4fad32f5cbfe296e710ecdec61ee2873a6076a22c14ae"
+dependencies = [
+ "many_cpus_impl",
+]
+
+[[package]]
+name = "many_cpus_impl"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed5dc92df5274d0f0c0b5bc8edbb1807acf8b5761267c8235987cc42d5bbd2d"
 dependencies = [
  "cpulist",
  "derive_more",
  "foldhash 0.2.0",
  "folo_ffi",
  "heapless",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "new_zealand",
  "nonempty",
@@ -2307,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mio"
@@ -2370,8 +2419,10 @@ dependencies = [
 
 [[package]]
 name = "multitude"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
+ "alloc_tracker 0.6.0",
+ "allocator-api2 0.2.21",
  "allocator-api2 0.4.0",
  "bolero",
  "bumpalo",
@@ -2380,6 +2431,7 @@ dependencies = [
  "bytesbuf",
  "criterion",
  "gungraun",
+ "hashbrown 0.17.1",
  "loom",
  "mutants",
  "ptr_meta",
@@ -2420,9 +2472,18 @@ checksum = "6a1a6f5fd5c95c0c913af85fa74168f6bd49f467c3fd6b479521a2791101128f"
 
 [[package]]
 name = "nm"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656a5b2fec73d738f19cc52302bdccc99480da1607e9cacc6bd85fba70cc5ff9"
+checksum = "390e5eabbae19ce5aa1d729bb96c04f133bc8dd5dbe2e9c7e32c281cbfa9c84c"
+dependencies = [
+ "nm_impl",
+]
+
+[[package]]
+name = "nm_impl"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a24db9712ee068f2e321b6a45c2c4033d397c3fbd966043165c890dc6bc262"
 dependencies = [
  "fast_time",
  "foldhash 0.2.0",
@@ -2447,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2490,16 +2551,6 @@ dependencies = [
 
 [[package]]
 name = "ohno"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a7fa4809797026017b08adb583cf85b8e1ca2861935871f6ed62d41174469f"
-dependencies = [
- "ohno_macros 0.3.0",
- "typeid",
-]
-
-[[package]]
-name = "ohno"
 version = "0.3.6"
 dependencies = [
  "futures",
@@ -2514,14 +2565,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ohno_macros"
-version = "0.3.0"
+name = "ohno"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13afa6566040d0a66174d23ddd75fdee2c93e205cd57ff9abbecfb709014f6b"
+checksum = "79eb560d3cafa8521b27ec748f278f9b97a51d4ef1440f0c653698b9b3a6e730"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "ohno_macros 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeid",
 ]
 
 [[package]]
@@ -2531,6 +2581,17 @@ dependencies = [
  "insta",
  "mutants",
  "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ohno_macros"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd7c906df7de1bbc79f0030405c47be957227d8e0794fa0910a3403c24d4034"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -2550,11 +2611,11 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2581,9 +2642,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -2623,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
@@ -2689,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.1.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pct-str"
@@ -2897,12 +2958,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro-error2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
  "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+dependencies = [
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
  "syn",
@@ -2949,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2985,7 +3068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3048,14 +3131,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3076,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -3147,7 +3230,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3156,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3268,7 +3351,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 name = "seatbelt"
 version = "0.5.7"
 dependencies = [
- "alloc_tracker",
+ "alloc_tracker 0.5.25",
  "criterion",
  "fastrand",
  "futures",
@@ -3317,7 +3400,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3372,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3469,9 +3552,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smol"
@@ -3526,9 +3609,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3571,7 +3654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3737,12 +3820,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -3754,15 +3836,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4046,9 +4128,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
 dependencies = [
  "glob",
  "serde",
@@ -4156,9 +4238,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unty-next"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa66022bbd1ab992fad72bdedcfd07a0023b6f5ecc83d50121e39e3a3caed41"
+checksum = "16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e"
 
 [[package]]
 name = "url"
@@ -4186,11 +4268,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4240,27 +4322,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4271,9 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4281,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4294,52 +4367,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4687,97 +4726,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -4793,9 +4744,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4816,18 +4767,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4857,9 +4808,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ fundle_macros = { path = "crates/fundle_macros", default-features = false, versi
 fundle_macros_impl = { path = "crates/fundle_macros_impl", default-features = false, version = "0.3.3" }
 http_extensions = { path = "crates/http_extensions", default-features = false, version = "0.6.2" }
 layered = { path = "crates/layered", default-features = false, version = "0.3.4" }
-multitude = { path = "crates/multitude", default-features = false, version = "0.4.0" }
+multitude = { path = "crates/multitude", default-features = false, version = "0.4.1" }
 ohno = { path = "crates/ohno", default-features = false, version = "0.3.6" }
 ohno_macros = { path = "crates/ohno_macros", default-features = false, version = "0.3.4" }
 recoverable = { path = "crates/recoverable", default-features = false, version = "0.1.6" }

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "multitude"
-version = "0.4.0"
+version = "0.4.1"
 description = "Fast and flexible arena allocator."
 readme = "README.md"
 keywords = ["arena", "memory", "allocator", "bump"]
@@ -21,6 +21,7 @@ allowed_external_types = [
     "allocator_api2::*",
     "bytemuck::*",
     "bytesbuf::*",
+    "hashbrown::*",
     "ptr_meta::*",
     "ptr_meta_derive::*",
     "serde::*",
@@ -44,12 +45,18 @@ bytes = ["dep:bytes"]
 bytemuck = ["dep:bytemuck", "dst"]
 bytesbuf = ["dep:bytesbuf", "std"]
 zerocopy = ["dep:zerocopy", "dst"]
+hashbrown = ["dep:hashbrown"]
 
 [dependencies]
 allocator-api2 = { workspace = true, features = ["alloc"] }
+# Legacy `allocator-api2` 0.2 line, used by hashbrown (and other crates) that
+# have not yet migrated to the modern API. `&Arena` implements *both* this and
+# the 0.4 `Allocator` trait so it can back hashbrown collections directly.
+allocator-api2-02 = { package = "allocator-api2", version = "0.2", default-features = false, features = ["alloc"] }
 bytemuck = { workspace = true, features = ["derive"], optional = true }
 bytes = { workspace = true, optional = true }
 bytesbuf = { workspace = true, optional = true }
+hashbrown = { workspace = true, features = ["allocator-api2", "default-hasher"], optional = true }
 ptr_meta = { workspace = true }
 serde = { workspace = true, optional = true }
 widestring = { workspace = true, features = ["alloc"], optional = true }
@@ -61,6 +68,7 @@ zerocopy = { workspace = true, optional = true }
 loom = { workspace = true }
 
 [dev-dependencies]
+alloc_tracker = "0.6"
 allocator-api2 = { workspace = true, features = ["alloc"] }
 bolero = { workspace = true, features = ["std"] }
 # `std` transitively enables `bolero-engine/any`, which is required

--- a/crates/multitude/README.md
+++ b/crates/multitude/README.md
@@ -183,29 +183,49 @@ let squares: Vec<i32, _> = (1..=5).map(|i| i * i).collect_in(&arena);
 assert_eq!(squares.as_slice(), &[1, 4, 9, 16, 25]);
 ```
 
+With the `hashbrown` Cargo feature, [`Arena`][__link30] can directly back
+[`hashbrown`][__link31] collections via
+[`Arena::alloc_hash_map`][__link32], [`Arena::alloc_hash_map_with_capacity`][__link33],
+[`Arena::alloc_set`][__link34], and [`Arena::alloc_set_with_capacity`][__link35]. The returned
+`HashMap` / `HashSet` store their entries in arena chunks.
+
+```rust
+use multitude::Arena;
+
+let arena = Arena::new();
+
+let mut map = arena.alloc_hash_map::<u32, &str>();
+map.insert(1, "one");
+assert_eq!(map.get(&1), Some(&"one"));
+
+let mut set = arena.alloc_set::<u32>();
+set.insert(7);
+assert!(set.contains(&7));
+```
+
 ### Freezing
 
-[`String`][__link30] and [`Vec`][__link31] are designed as **transient
+[`String`][__link36] and [`Vec`][__link37] are designed as **transient
 builders**. They carry a data pointer + length + capacity + arena reference.
 
 Once you’re done building, you can **freeze them** into immutable smart pointers:
 
-* [`String::into_boxed_str`][__link32] →
-  [`Box<str>`][__link33] (**8 bytes**, thin), or `Box::from(string)`.
+* [`String::into_boxed_str`][__link38] →
+  [`Box<str>`][__link39] (**8 bytes**, thin), or `Box::from(string)`.
   The freeze is **O(n)** — it copies the bytes into a compact,
   length-prefixed allocation so the resulting single pointer can outlive
-  the arena. (Like any [`Box`][__link34], it is `Send`/`Sync` only when the
+  the arena. (Like any [`Box`][__link40], it is `Send`/`Sync` only when the
   allocator `A` is.)
-* [`Vec::into_boxed_slice`][__link35] →
-  [`Box<[T]>`][__link36] (**8 bytes**, thin), or `Box::from(vec)`.
+* [`Vec::into_boxed_slice`][__link41] →
+  [`Box<[T]>`][__link42] (**8 bytes**, thin), or `Box::from(vec)`.
   The freeze is **O(n)** — it moves the elements into a fresh compact,
   length-prefixed allocation so the resulting single pointer can outlive
-  the arena. (Like any [`Box`][__link37], it is `Send`/`Sync` only when `T` and the
+  the arena. (Like any [`Box`][__link43], it is `Send`/`Sync` only when `T` and the
   allocator `A` are.)
-* `Arc::from(vec)` / `Arc::from(string)` → [`Arc<[T]>`][__link38] /
-  [`Arc<str>`][__link39], the shared, reference-counted freeze
+* `Arc::from(vec)` / `Arc::from(string)` → [`Arc<[T]>`][__link44] /
+  [`Arc<str>`][__link45], the shared, reference-counted freeze
   (mirroring `std`’s `From<Vec<T>> for Arc<[T]>`).
-* [`Vec::leak`][__link40] → `&mut [T]` (or `&*v.leak()` for `&[T]`)
+* [`Vec::leak`][__link46] → `&mut [T]` (or `&*v.leak()` for `&[T]`)
   borrowed for the arena’s lifetime. For `T: !Drop`, this freeze is
   **O(1) and allocation-free** — the existing buffer is reinterpreted in
   place. Unlike the `Box`/`Arc` freezes, the slice does not outlive the arena.
@@ -236,7 +256,7 @@ slices) add up quickly across millions of items.
 ## Strings
 
 `multitude` provides a family of arena-resident string types in the
-[`strings`][__link41] module. The model is the same one used for arbitrary
+[`strings`][__link47] module. The model is the same one used for arbitrary
 values elsewhere in the crate — bump-allocation backed by a per-chunk
 refcount — but specialized for UTF-8 / UTF-16 text and a compact
 single-pointer representation.
@@ -250,30 +270,30 @@ There are two roles a string type can play:
    
    |UTF-8|UTF-16|Sharing|Mutable|Notes|
    |-----|------|-------|-------|-----|
-   |[`Arc<str>`][__link42]|`Arc<Utf16Str>`|atomic refcount; `Clone`, `Send + Sync`|no|cross-thread sharing|
-   |[`Box<str>`][__link43]|`Box<Utf16Str>`|unique owner; `Send + Sync` (not `Clone`)|yes|drops eagerly|
+   |[`Arc<str>`][__link48]|`Arc<Utf16Str>`|atomic refcount; `Clone`, `Send + Sync`|no|cross-thread sharing|
+   |[`Box<str>`][__link49]|`Box<Utf16Str>`|unique owner; `Send + Sync` (not `Clone`)|yes|drops eagerly|
    
    Like the other arena smart pointers, they keep their owning chunk
-   alive via a refcount, so they can outlive the [`Arena`][__link44] they came
+   alive via a refcount, so they can outlive the [`Arena`][__link50] they came
    from.
 
-1. **Builders (mutable, growable).** [`String`][__link45] and
-   [`Utf16String`][__link46] are transient growable
+1. **Builders (mutable, growable).** [`String`][__link51] and
+   [`Utf16String`][__link52] are transient growable
    buffers — small structs (32 bytes) carrying a data pointer +
    length + capacity + arena reference. You build them up with
-   `push_str` / `push` / [`format!`][__link47] /
-   [`format_utf16!`][__link48], then **freeze** them
+   `push_str` / `push` / [`format!`][__link53] /
+   [`format_utf16!`][__link54], then **freeze** them
    into one of the smart pointers above:
    
    |Builder|Freeze method|Result|
    |-------|-------------|------|
-   |[`String`][__link49]|[`into_boxed_str`][__link50]|[`Box<str>`][__link51]|
-   |[`Utf16String`][__link52]|[`into_boxed_utf16_str`][__link53]|`Box<Utf16Str>`|
+   |[`String`][__link55]|[`into_boxed_str`][__link56]|[`Box<str>`][__link57]|
+   |[`Utf16String`][__link58]|[`into_boxed_utf16_str`][__link59]|`Box<Utf16Str>`|
    
    The UTF-16 freeze reuses the buffer in place (O(1)) and returns
    any unused tail capacity to the chunk’s bump cursor when it can.
    The UTF-8 freeze copies the bytes (O(n)) into a compact,
-   length-prefixed allocation so [`Box<str>`][__link54] stays a
+   length-prefixed allocation so [`Box<str>`][__link60] stays a
    single, `Send`-safe pointer.
 
 UTF-16 support requires the `utf16` Cargo feature. Strict (validated)
@@ -338,16 +358,16 @@ assert_eq!(greeting.as_utf16_str(), utf16str!("Hello, Alice!"));
 
 ## Building DSTs
 
-With the `dst` Cargo feature enabled, [`Arena`][__link55] exposes
-[`Arena::alloc_dst_arc`][__link56] and
-[`Arena::alloc_dst_box`][__link57] (and their `try_*` siblings) for
+With the `dst` Cargo feature enabled, [`Arena`][__link61] exposes
+[`Arena::alloc_dst_arc`][__link62] and
+[`Arena::alloc_dst_box`][__link63] (and their `try_*` siblings) for
 constructing values whose layout is only known at runtime (custom
 DSTs, fat pointers, trait objects).
 
-Each of these takes a [`Layout`][__link58], a
+Each of these takes a [`Layout`][__link64], a
 pointer-metadata value (e.g. a slice length, a `DynMetadata`), and
 a closure that initializes the buffer through a typed fat pointer.
-For most users, the [`dst-factory`][__link59] companion crate is the
+For most users, the [`dst-factory`][__link65] companion crate is the
 recommended high-level driver; the low-level interface looks like:
 
 ```rust
@@ -378,15 +398,16 @@ existing `_arc` slice methods).
 
 |Feature|Description|
 |-------|-----------|
-|`std` *(default)*|Enables [`std::io::Write`][__link60] on [`Vec<u8>`][__link61] for use with `write!`, `std::io::copy`, `serde_json::to_writer`, and similar. Disable for `#![no_std]` environments (the crate still requires `alloc`).|
+|`std` *(default)*|Enables [`std::io::Write`][__link66] on [`Vec<u8>`][__link67] for use with `write!`, `std::io::copy`, `serde_json::to_writer`, and similar. Disable for `#![no_std]` environments (the crate still requires `alloc`).|
 |`stats`|Enables runtime instrumentation counters returned by `Arena::stats`. Disable for the tightest allocation throughput when you don’t need observability.|
-|`serde`|Adds `Serialize` impls for [`Arc<str>`][__link62], [`Box<str>`][__link63], [`String`][__link64], and [`Vec`][__link65]. With `serde + utf16`, also adds impls for the UTF-16 types (transcoded to UTF-8 on the wire).|
-|`dst`|Enables the `dst` module for constructing true dynamically-sized types and trait objects in the arena via [`Arena::alloc_dst_arc`][__link66] / [`Arena::alloc_dst_box`][__link67], plus eight `Arena::alloc_slice_*_box` methods.|
-|`utf16`|Adds a parallel UTF-16 string surface (`Arc<Utf16Str>`, `Box<Utf16Str>`, [`Utf16String`][__link68], and [`format_utf16!`][__link69]) backed by the [`widestring`][__link70] crate. Lengths are counted in `u16` elements.|
-|`zerocopy`|Provides [`ZerocopyView`][__link71] for safe zero-initialized allocation of types implementing [`zerocopy::FromZeros`][__link72]. Access via [`Arena::zerocopy()`][__link73].|
-|`bytemuck`|Provides [`BytemuckView`][__link74] for safe zero-initialized allocation of types implementing [`bytemuck::Zeroable`][__link75]. Access via [`Arena::bytemuck()`][__link76].|
-|`bytes`|Adds [`From`][__link77] conversions from [`Arc<[u8]>`][__link78] and [`Arc<str>`][__link79] into [`bytes::Bytes`][__link80], enabling zero-copy integration with the Tokio / Hyper async ecosystem.|
-|`bytesbuf`|Implements [`bytesbuf::mem::Memory`][__link81] directly on [`Arena`][__link82], so that [`BytesBuf`][__link83] buffers can be backed by arena chunks. Implies `std`.|
+|`serde`|Adds `Serialize` impls for [`Arc<str>`][__link68], [`Box<str>`][__link69], [`String`][__link70], and [`Vec`][__link71]. With `serde + utf16`, also adds impls for the UTF-16 types (transcoded to UTF-8 on the wire).|
+|`dst`|Enables the `dst` module for constructing true dynamically-sized types and trait objects in the arena via [`Arena::alloc_dst_arc`][__link72] / [`Arena::alloc_dst_box`][__link73], plus eight `Arena::alloc_slice_*_box` methods.|
+|`utf16`|Adds a parallel UTF-16 string surface (`Arc<Utf16Str>`, `Box<Utf16Str>`, [`Utf16String`][__link74], and [`format_utf16!`][__link75]) backed by the [`widestring`][__link76] crate. Lengths are counted in `u16` elements.|
+|`zerocopy`|Provides [`ZerocopyView`][__link77] for safe zero-initialized allocation of types implementing [`zerocopy::FromZeros`][__link78]. Access via [`Arena::zerocopy()`][__link79].|
+|`bytemuck`|Provides [`BytemuckView`][__link80] for safe zero-initialized allocation of types implementing [`bytemuck::Zeroable`][__link81]. Access via [`Arena::bytemuck()`][__link82].|
+|`bytes`|Adds [`From`][__link83] conversions from [`Arc<[u8]>`][__link84] and [`Arc<str>`][__link85] into [`bytes::Bytes`][__link86], enabling zero-copy integration with the Tokio / Hyper async ecosystem.|
+|`bytesbuf`|Implements [`bytesbuf::mem::Memory`][__link87] directly on [`Arena`][__link88], so that [`BytesBuf`][__link89] buffers can be backed by arena chunks. Implies `std`.|
+|`hashbrown`|Lets [`Arena`][__link90] back [`hashbrown`][__link91] collections via [`Arena::alloc_hash_map`][__link92], [`Arena::alloc_hash_map_with_capacity`][__link93], [`Arena::alloc_set`][__link94], and [`Arena::alloc_set_with_capacity`][__link95]. (`&Arena` always implements the `allocator-api2` 0.2 `Allocator` trait so it can back `hashbrown` directly; this feature adds the convenience constructors.)|
 
 
 <hr/>
@@ -394,88 +415,100 @@ existing `_arc` slice methods).
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/multitude">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbthyuxcg2AB8bi0p7i2BdeqwbfWFeq_iC9Ggb_RlacpRPgHZhZIWCaGJ5dGVtdWNrZjEuMjUuMIJlYnl0ZXNmMS4xMS4xgmhieXRlc2J1ZmUwLjUuNYJpbXVsdGl0dWRlZTAuNC4wgmh6ZXJvY29weWYwLjguNTA
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbLO4Ik_NsuVkbfbTAs8J4XykbDNsHPgRquFgbV3tjWgSvbGZhZIWCaGJ5dGVtdWNrZjEuMjUuMIJlYnl0ZXNmMS4xMi4wgmhieXRlc2J1ZmUwLjUuNYJpbXVsdGl0dWRlZTAuNC4xgmh6ZXJvY29weWYwLjguNTI
  [__link0]: https://crates.io/crates/bumpalo
- [__link1]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link10]: https://docs.rs/multitude/0.4.0/multitude/?search=vec::Vec
+ [__link1]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link10]: https://docs.rs/multitude/0.4.1/multitude/?search=vec::Vec
  [__link11]: https://crates.io/crates/dst-factory
- [__link12]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::format
- [__link13]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::Utf16String
- [__link14]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::format_utf16
+ [__link12]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::format
+ [__link13]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::Utf16String
+ [__link14]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::format_utf16
  [__link15]: https://github.com/microsoft/oxidizer/blob/main/crates/multitude/BUMPALO.md
  [__link16]: https://crates.io/crates/bumpalo
- [__link17]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link18]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link19]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena
- [__link2]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
+ [__link17]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link18]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link19]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena
+ [__link2]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
  [__link20]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html
- [__link21]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link22]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link23]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link24]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
+ [__link21]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link22]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link23]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link24]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
  [__link25]: https://doc.rust-lang.org/stable/alloc/?search=boxed::Box
- [__link26]: https://docs.rs/multitude/0.4.0/multitude/?search=vec::Vec
- [__link27]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::String
- [__link28]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::Utf16String
+ [__link26]: https://docs.rs/multitude/0.4.1/multitude/?search=vec::Vec
+ [__link27]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::String
+ [__link28]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::Utf16String
  [__link29]: https://crates.io/crates/allocator-api2
- [__link3]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link30]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::String
- [__link31]: https://docs.rs/multitude/0.4.0/multitude/?search=vec::Vec
- [__link32]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::String::into_boxed_str
- [__link33]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link34]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link35]: https://docs.rs/multitude/0.4.0/multitude/?search=vec::Vec::into_boxed_slice
- [__link36]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link37]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link38]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link39]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link4]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link40]: https://docs.rs/multitude/0.4.0/multitude/?search=vec::Vec::leak
- [__link41]: https://docs.rs/multitude/0.4.0/multitude/strings/index.html
- [__link42]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link43]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link44]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena
- [__link45]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::String
- [__link46]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::Utf16String
- [__link47]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::format
- [__link48]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::format_utf16
- [__link49]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::String
- [__link5]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link50]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::String::into_boxed_str
- [__link51]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link52]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::Utf16String
- [__link53]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::Utf16String::into_boxed_utf16_str
- [__link54]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link55]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena
- [__link56]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena::alloc_dst_arc
- [__link57]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena::alloc_dst_box
- [__link58]: https://doc.rust-lang.org/stable/core/?search=alloc::Layout
- [__link59]: https://crates.io/crates/dst-factory
- [__link6]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link60]: https://doc.rust-lang.org/stable/std/?search=io::Write
- [__link61]: https://docs.rs/multitude/0.4.0/multitude/?search=vec::Vec
- [__link62]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link63]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link64]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::String
- [__link65]: https://docs.rs/multitude/0.4.0/multitude/?search=vec::Vec
- [__link66]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena::alloc_dst_arc
- [__link67]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena::alloc_dst_box
- [__link68]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::Utf16String
- [__link69]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::format_utf16
- [__link7]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link70]: https://crates.io/crates/widestring
- [__link71]: https://docs.rs/multitude/0.4.0/multitude/?search=zerocopy::ZerocopyView
- [__link72]: https://docs.rs/zerocopy/0.8.50/zerocopy/?search=FromZeros
- [__link73]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena::zerocopy
- [__link74]: https://docs.rs/multitude/0.4.0/multitude/?search=bytemuck::BytemuckView
- [__link75]: https://docs.rs/bytemuck/1.25.0/bytemuck/?search=Zeroable
- [__link76]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena::bytemuck
- [__link77]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
- [__link78]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link79]: https://docs.rs/multitude/0.4.0/multitude/?search=Arc
- [__link8]: https://docs.rs/multitude/0.4.0/multitude/?search=Box
- [__link80]: https://docs.rs/bytes/1.11.1/bytes/?search=Bytes
- [__link81]: https://docs.rs/bytesbuf/0.5.5/bytesbuf/?search=mem::Memory
- [__link82]: https://docs.rs/multitude/0.4.0/multitude/?search=Arena
- [__link83]: https://docs.rs/bytesbuf/0.5.5/bytesbuf/?search=BytesBuf
- [__link9]: https://docs.rs/multitude/0.4.0/multitude/?search=strings::String
+ [__link3]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link30]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena
+ [__link31]: https://crates.io/crates/hashbrown
+ [__link32]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_hash_map
+ [__link33]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_hash_map_with_capacity
+ [__link34]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_set
+ [__link35]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_set_with_capacity
+ [__link36]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::String
+ [__link37]: https://docs.rs/multitude/0.4.1/multitude/?search=vec::Vec
+ [__link38]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::String::into_boxed_str
+ [__link39]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link4]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link40]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link41]: https://docs.rs/multitude/0.4.1/multitude/?search=vec::Vec::into_boxed_slice
+ [__link42]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link43]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link44]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link45]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link46]: https://docs.rs/multitude/0.4.1/multitude/?search=vec::Vec::leak
+ [__link47]: https://docs.rs/multitude/0.4.1/multitude/strings/index.html
+ [__link48]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link49]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link5]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link50]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena
+ [__link51]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::String
+ [__link52]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::Utf16String
+ [__link53]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::format
+ [__link54]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::format_utf16
+ [__link55]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::String
+ [__link56]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::String::into_boxed_str
+ [__link57]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link58]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::Utf16String
+ [__link59]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::Utf16String::into_boxed_utf16_str
+ [__link6]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link60]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link61]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena
+ [__link62]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_dst_arc
+ [__link63]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_dst_box
+ [__link64]: https://doc.rust-lang.org/stable/core/?search=alloc::Layout
+ [__link65]: https://crates.io/crates/dst-factory
+ [__link66]: https://doc.rust-lang.org/stable/std/?search=io::Write
+ [__link67]: https://docs.rs/multitude/0.4.1/multitude/?search=vec::Vec
+ [__link68]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link69]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link7]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link70]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::String
+ [__link71]: https://docs.rs/multitude/0.4.1/multitude/?search=vec::Vec
+ [__link72]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_dst_arc
+ [__link73]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_dst_box
+ [__link74]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::Utf16String
+ [__link75]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::format_utf16
+ [__link76]: https://crates.io/crates/widestring
+ [__link77]: https://docs.rs/multitude/0.4.1/multitude/?search=zerocopy::ZerocopyView
+ [__link78]: https://docs.rs/zerocopy/0.8.52/zerocopy/?search=FromZeros
+ [__link79]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::zerocopy
+ [__link8]: https://docs.rs/multitude/0.4.1/multitude/?search=Box
+ [__link80]: https://docs.rs/multitude/0.4.1/multitude/?search=bytemuck::BytemuckView
+ [__link81]: https://docs.rs/bytemuck/1.25.0/bytemuck/?search=Zeroable
+ [__link82]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::bytemuck
+ [__link83]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
+ [__link84]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link85]: https://docs.rs/multitude/0.4.1/multitude/?search=Arc
+ [__link86]: https://docs.rs/bytes/1.12.0/bytes/?search=Bytes
+ [__link87]: https://docs.rs/bytesbuf/0.5.5/bytesbuf/?search=mem::Memory
+ [__link88]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena
+ [__link89]: https://docs.rs/bytesbuf/0.5.5/bytesbuf/?search=BytesBuf
+ [__link9]: https://docs.rs/multitude/0.4.1/multitude/?search=strings::String
+ [__link90]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena
+ [__link91]: https://crates.io/crates/hashbrown
+ [__link92]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_hash_map
+ [__link93]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_hash_map_with_capacity
+ [__link94]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_set
+ [__link95]: https://docs.rs/multitude/0.4.1/multitude/?search=Arena::alloc_set_with_capacity

--- a/crates/multitude/src/allocator_impl.rs
+++ b/crates/multitude/src/allocator_impl.rs
@@ -108,3 +108,66 @@ unsafe impl<A: Allocator + Clone> Allocator for &Arena<A> {
         Ok(new)
     }
 }
+
+/// Legacy `allocator-api2` 0.2 `Allocator` impl, so `&Arena<A>` can directly
+/// back collections from crates (notably `hashbrown`) that have not yet moved
+/// to the modern allocator API. Every method forwards verbatim to the 0.4 impl
+/// above; when those crates upgrade, this impl can simply be deleted.
+// SAFETY: forwards to the 0.4 `Allocator` impl; the 0.2 and 0.4 trait contracts
+// are identical, and the only version-specific type (`AllocError`) is a
+// zero-payload marker.
+unsafe impl<A: Allocator + Clone> allocator_api2_02::alloc::Allocator for &Arena<A> {
+    #[inline]
+    #[allow(clippy::map_err_ignore, reason = "AllocError carries no payload; only the variant is bridged")]
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, allocator_api2_02::alloc::AllocError> {
+        <&Arena<A> as Allocator>::allocate(self, layout).map_err(|_| allocator_api2_02::alloc::AllocError)
+    }
+
+    #[inline]
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        // SAFETY: forwarded to the 0.4 impl under the same contract.
+        unsafe { <&Arena<A> as Allocator>::deallocate(self, ptr, layout) };
+    }
+
+    #[inline]
+    #[allow(clippy::map_err_ignore, reason = "AllocError carries no payload; only the variant is bridged")]
+    unsafe fn grow(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, allocator_api2_02::alloc::AllocError> {
+        // SAFETY: forwarded to the 0.4 impl under the same contract.
+        unsafe { <&Arena<A> as Allocator>::grow(self, ptr, old_layout, new_layout) }.map_err(|_| allocator_api2_02::alloc::AllocError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::alloc::Layout;
+
+    use allocator_api2_02::alloc::Allocator as LegacyAllocator;
+
+    use crate::Arena;
+
+    // Exercises the legacy (`allocator-api2` 0.2) `Allocator` impl directly,
+    // independent of the optional `hashbrown` feature: allocate, grow, and
+    // deallocate, plus the rejected-alignment error arm.
+    #[test]
+    fn arena_backs_legacy_allocator_api2() {
+        let arena = Arena::new();
+        let handle: &Arena = &arena;
+        let layout = Layout::from_size_align(64, 8).unwrap();
+        let p = LegacyAllocator::allocate(&handle, layout).expect("legacy allocate");
+        let new_layout = Layout::from_size_align(128, 8).unwrap();
+        // SAFETY: `p` came from `allocate` with `layout`, and `new_layout` is larger.
+        let p = unsafe { LegacyAllocator::grow(&handle, p.cast::<u8>(), layout, new_layout) }.expect("legacy grow");
+        // SAFETY: `p` came from `grow` with `new_layout`.
+        unsafe { LegacyAllocator::deallocate(&handle, p.cast::<u8>(), new_layout) };
+
+        // An alignment at/above the smart-pointer ceiling is rejected as a
+        // recoverable error through the legacy impl's `map_err` arm.
+        let over_aligned = Layout::from_size_align(8, super::MAX_SMART_PTR_ALIGN).unwrap();
+        LegacyAllocator::allocate(&handle, over_aligned).expect_err("over-aligned request must be rejected");
+    }
+}

--- a/crates/multitude/src/arena/alloc_hashbrown.rs
+++ b/crates/multitude/src/arena/alloc_hashbrown.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Arena-backed [`hashbrown`] collection builders on [`Arena`].
+//!
+//! Gated on the `hashbrown` feature. `&Arena` implements `hashbrown`'s
+//! allocator trait (see `allocator_impl`), so these helpers simply hand the
+//! arena to `hashbrown`'s `*_in` constructors. The returned collections borrow
+//! the arena for their lifetime and use `hashbrown`'s
+//! [`DefaultHashBuilder`](hashbrown::DefaultHashBuilder).
+
+use core::hash::Hash;
+
+use allocator_api2::alloc::Allocator;
+use hashbrown::{DefaultHashBuilder, HashMap, HashSet};
+
+use super::Arena;
+
+impl<A: Allocator + Clone> Arena<A> {
+    /// Create a new, empty [`hashbrown::HashMap`] backed by this arena. No
+    /// allocation is performed until the first insertion.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let arena = multitude::Arena::new();
+    /// let mut map = arena.alloc_hash_map::<u32, &str>();
+    /// map.insert(1, "one");
+    /// assert_eq!(map.get(&1), Some(&"one"));
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn alloc_hash_map<K, V>(&self) -> HashMap<K, V, DefaultHashBuilder, &Self> {
+        HashMap::new_in(self)
+    }
+
+    /// Create a new [`hashbrown::HashMap`] backed by this arena with room for
+    /// at least `capacity` entries before resizing.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let arena = multitude::Arena::new();
+    /// let mut map = arena.alloc_hash_map_with_capacity::<u32, u32>(16);
+    /// map.insert(1, 10);
+    /// assert!(map.capacity() >= 16);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn alloc_hash_map_with_capacity<K, V>(&self, capacity: usize) -> HashMap<K, V, DefaultHashBuilder, &Self> {
+        HashMap::with_capacity_in(capacity, self)
+    }
+
+    /// Create a new, empty [`hashbrown::HashSet`] backed by this arena. No
+    /// allocation is performed until the first insertion.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let arena = multitude::Arena::new();
+    /// let mut set = arena.alloc_set::<u32>();
+    /// set.insert(7);
+    /// assert!(set.contains(&7));
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn alloc_set<T: Hash + Eq>(&self) -> HashSet<T, DefaultHashBuilder, &Self> {
+        HashSet::new_in(self)
+    }
+
+    /// Create a new [`hashbrown::HashSet`] backed by this arena with room for
+    /// at least `capacity` elements before resizing.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let arena = multitude::Arena::new();
+    /// let mut set = arena.alloc_set_with_capacity::<u32>(16);
+    /// set.insert(7);
+    /// assert!(set.capacity() >= 16);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn alloc_set_with_capacity<T: Hash + Eq>(&self, capacity: usize) -> HashSet<T, DefaultHashBuilder, &Self> {
+        HashSet::with_capacity_in(capacity, self)
+    }
+}

--- a/crates/multitude/src/arena/mod.rs
+++ b/crates/multitude/src/arena/mod.rs
@@ -40,6 +40,8 @@ use crate::internal::current_chunk::CurrentChunk;
 const LARGE_SHARED_REF_SURPLUS: u32 = 1 << 30;
 
 mod alloc_growable;
+#[cfg(feature = "hashbrown")]
+mod alloc_hashbrown;
 pub(crate) mod alloc_prefixed;
 mod alloc_slice_arc;
 mod alloc_slice_box;

--- a/crates/multitude/src/lib.rs
+++ b/crates/multitude/src/lib.rs
@@ -179,6 +179,28 @@
 //! assert_eq!(squares.as_slice(), &[1, 4, 9, 16, 25]);
 //! ```
 //!
+//! With the `hashbrown` Cargo feature, [`Arena`] can directly back
+//! [`hashbrown`](https://crates.io/crates/hashbrown) collections via
+//! [`Arena::alloc_hash_map`], [`Arena::alloc_hash_map_with_capacity`],
+//! [`Arena::alloc_set`], and [`Arena::alloc_set_with_capacity`]. The returned
+//! `HashMap` / `HashSet` store their entries in arena chunks.
+//!
+//! ```
+//! # #[cfg(feature = "hashbrown")] {
+//! use multitude::Arena;
+//!
+//! let arena = Arena::new();
+//!
+//! let mut map = arena.alloc_hash_map::<u32, &str>();
+//! map.insert(1, "one");
+//! assert_eq!(map.get(&1), Some(&"one"));
+//!
+//! let mut set = arena.alloc_set::<u32>();
+//! set.insert(7);
+//! assert!(set.contains(&7));
+//! # }
+//! ```
+//!
 //! ## Freezing
 //!
 //! [`String`](strings::String) and [`Vec`](vec::Vec) are designed as **transient
@@ -387,6 +409,7 @@
 //! | `bytemuck` | Provides [`BytemuckView`](bytemuck::BytemuckView) for safe zero-initialized allocation of types implementing [`bytemuck::Zeroable`](::bytemuck::Zeroable). Access via [`Arena::bytemuck()`]. |
 //! | `bytes` | Adds [`From`] conversions from [`Arc<[u8]>`](Arc) and [`Arc<str>`](Arc) into [`bytes::Bytes`](::bytes::Bytes), enabling zero-copy integration with the Tokio / Hyper async ecosystem. |
 //! | `bytesbuf` | Implements [`bytesbuf::mem::Memory`](::bytesbuf::mem::Memory) directly on [`Arena`], so that [`BytesBuf`](::bytesbuf::BytesBuf) buffers can be backed by arena chunks. Implies `std`. |
+//! | `hashbrown` | Lets [`Arena`] back [`hashbrown`](https://crates.io/crates/hashbrown) collections via [`Arena::alloc_hash_map`], [`Arena::alloc_hash_map_with_capacity`], [`Arena::alloc_set`], and [`Arena::alloc_set_with_capacity`]. (`&Arena` always implements the `allocator-api2` 0.2 `Allocator` trait so it can back `hashbrown` directly; this feature adds the convenience constructors.) |
 
 #![no_std]
 #![doc(html_logo_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/multitude/logo.png")]

--- a/crates/multitude/tests/alloc_tracking.rs
+++ b/crates/multitude/tests/alloc_tracking.rs
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! System-allocation behaviour tests: prove the [`Arena`] reuses chunk memory
+//! and does not over-allocate from the system allocator around
+//! [`Arena::reset`] and around all `Arc`s being dropped.
+//!
+//! These use the `alloc_tracker` crate, whose `Allocator` global-allocator
+//! wrapper counts every byte the process hands to the system allocator. Each
+//! operation's thread-local span measures only the work inside it, so the
+//! `Arena`'s chunk allocations are observed in isolation (the holding vectors
+//! are pre-reserved outside the spans so their growth is never counted).
+//!
+//! The arena ratchets its chunk size class upward during a warm-up phase, so
+//! the invariant we assert is the steady state: once warmed, repeating the
+//! exact same workload reuses the arena's chunks and touches the system
+//! allocator **zero** times.
+
+// Excluded under Miri: these measure real system-allocator traffic, which Miri
+// (with its own allocator model) does not represent.
+#![cfg(not(miri))]
+#![allow(clippy::std_instead_of_core, reason = "test code uses std")]
+#![allow(clippy::unwrap_used, reason = "test code")]
+#![allow(clippy::collection_is_never_read, reason = "tests retain Arc handles only to keep chunks alive")]
+
+use alloc_tracker::{Allocator, Session};
+use multitude::{Arc, Arena};
+
+#[global_allocator]
+static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+
+/// Number of values per fill — large enough to span several chunks.
+const WORKLOAD: usize = 2_000;
+/// Warm-up cycles, generous enough to let the chunk size class fully ratchet
+/// and the cache reach steady state before we measure.
+const WARMUP_CYCLES: usize = 16;
+
+/// A session that neither prints to stdout nor writes JSON to the target dir.
+fn quiet_session() -> Session {
+    Session::new().no_stdout().no_file()
+}
+
+/// After [`Arena::reset`], re-allocating the same workload reuses the arena's
+/// chunks: the first fill allocates from the system, but once warmed, a reset
+/// + identical refill touches the system allocator zero times.
+#[test]
+fn reset_reuses_chunks_without_reallocating() {
+    let mut arena = Arena::new();
+    let session = quiet_session();
+
+    // The very first fill must obtain chunks from the system.
+    let first = session.operation("first_fill");
+    {
+        let _span = first.measure_thread();
+        for i in 0..WORKLOAD {
+            let _v: &mut u64 = arena.alloc(i as u64);
+        }
+    }
+    assert!(
+        first.total_bytes_allocated() > 0,
+        "first fill must allocate chunk(s) from the system"
+    );
+    arena.reset();
+
+    // Warm up: repeated fill+reset cycles let the size class settle.
+    for _ in 0..WARMUP_CYCLES {
+        for i in 0..WORKLOAD {
+            let _v: &mut u64 = arena.alloc(i as u64);
+        }
+        arena.reset();
+    }
+
+    // Steady state: an identical fill after reset reuses the existing chunks.
+    let reused = session.operation("refill_after_reset");
+    {
+        let _span = reused.measure_thread();
+        for i in 0..WORKLOAD {
+            let _v: &mut u64 = arena.alloc(i as u64);
+        }
+    }
+    assert_eq!(
+        reused.total_bytes_allocated(),
+        0,
+        "after warm-up, reset must reuse chunks rather than reallocate from the system"
+    );
+}
+
+/// Dropping every `Arc` lets the arena reclaim those chunks early. Once warmed,
+/// re-allocating the same workload reuses the reclaimed chunks and touches the
+/// system allocator zero times.
+#[test]
+fn dropping_all_arcs_reclaims_chunks_for_reuse() {
+    let arena = Arena::new();
+    let session = quiet_session();
+
+    // Pre-reserve the holding vector *outside* any measured span so its growth
+    // never pollutes the arena measurements.
+    let mut hold: std::vec::Vec<Arc<u64>> = std::vec::Vec::with_capacity(WORKLOAD);
+
+    // The very first fill must obtain chunks from the system.
+    let first = session.operation("arc_first_fill");
+    {
+        let _span = first.measure_thread();
+        for i in 0..WORKLOAD {
+            hold.push(arena.alloc_arc(i as u64));
+        }
+    }
+    assert!(
+        first.total_bytes_allocated() > 0,
+        "allocating arcs must allocate chunk(s) from the system"
+    );
+    // Dropping every Arc drives each chunk's strong count to zero, reclaiming
+    // it into the provider's cache (early reclamation) rather than freeing it.
+    hold.clear();
+
+    // Warm up: fill/drop cycles let the size class and cache settle.
+    for _ in 0..WARMUP_CYCLES {
+        for i in 0..WORKLOAD {
+            hold.push(arena.alloc_arc(i as u64));
+        }
+        hold.clear();
+    }
+
+    // Steady state: an identical fill after dropping all arcs reuses chunks.
+    let reused = session.operation("arc_refill");
+    {
+        let _span = reused.measure_thread();
+        for i in 0..WORKLOAD {
+            hold.push(arena.alloc_arc(i as u64));
+        }
+    }
+    assert_eq!(
+        reused.total_bytes_allocated(),
+        0,
+        "after warm-up, re-allocating dropped arcs must reuse reclaimed chunks"
+    );
+}
+
+/// A steady state of allocate-then-drop must not grow unboundedly: after
+/// warm-up, many fill/drop cycles reuse the same chunks, so the system
+/// allocator is touched zero times across all of them.
+#[test]
+fn steady_state_fill_and_drop_does_not_over_allocate() {
+    let arena = Arena::new();
+    let session = quiet_session();
+    let mut hold: std::vec::Vec<Arc<u64>> = std::vec::Vec::with_capacity(WORKLOAD);
+
+    // Warm up so the working set's chunks all exist and are cached.
+    for _ in 0..WARMUP_CYCLES {
+        for i in 0..WORKLOAD {
+            hold.push(arena.alloc_arc(i as u64));
+        }
+        hold.clear();
+    }
+
+    // Steady state: many more cycles must allocate nothing from the system.
+    let steady = session.operation("steady_state");
+    {
+        let _span = steady.measure_thread();
+        for _round in 0..16 {
+            for i in 0..WORKLOAD {
+                hold.push(arena.alloc_arc(i as u64));
+            }
+            hold.clear();
+        }
+    }
+    assert_eq!(
+        steady.total_bytes_allocated(),
+        0,
+        "steady-state fill/drop cycles must reuse chunks, not over-allocate from the system"
+    );
+}

--- a/crates/multitude/tests/hashbrown.rs
+++ b/crates/multitude/tests/hashbrown.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Tests for the arena-backed `hashbrown` collection builders, gated on the
+//! `hashbrown` feature. They cover construction plus enough churn to exercise
+//! the `&Arena` legacy-allocator path under table growth.
+
+#![cfg(feature = "hashbrown")]
+#![allow(clippy::std_instead_of_core, reason = "test code uses std")]
+#![allow(clippy::unwrap_used, reason = "test code")]
+
+use multitude::Arena;
+
+#[test]
+fn hash_map_grows_across_chunks() {
+    let arena = Arena::new();
+    let mut map = arena.alloc_hash_map::<u32, std::string::String>();
+    assert!(map.is_empty());
+    for i in 0..256_u32 {
+        map.insert(i, std::format!("v{i}"));
+    }
+    assert_eq!(map.len(), 256);
+    assert_eq!(map.get(&42).map(std::string::String::as_str), Some("v42"));
+    assert_eq!(map.get(&256), None);
+    map.remove(&42);
+    assert_eq!(map.get(&42), None);
+    assert_eq!(map.len(), 255);
+}
+
+#[test]
+fn hash_map_with_capacity_preallocates() {
+    let arena = Arena::new();
+    let mut map = arena.alloc_hash_map_with_capacity::<u32, u32>(128);
+    assert!(map.capacity() >= 128);
+    map.insert(1, 10);
+    assert_eq!(map.get(&1), Some(&10));
+}
+
+#[test]
+fn hash_set_grows_across_chunks() {
+    let arena = Arena::new();
+    let mut set = arena.alloc_set::<u32>();
+    assert!(set.is_empty());
+    for i in 0..256_u32 {
+        set.insert(i);
+    }
+    assert_eq!(set.len(), 256);
+    assert!(set.contains(&255));
+    assert!(!set.contains(&256));
+    set.remove(&255);
+    assert!(!set.contains(&255));
+}
+
+#[test]
+fn hash_set_with_capacity_preallocates() {
+    let arena = Arena::new();
+    let mut set = arena.alloc_set_with_capacity::<u32>(128);
+    assert!(set.capacity() >= 128);
+    set.insert(7);
+    assert!(set.contains(&7));
+}


### PR DESCRIPTION
Implement `allocator-api2` 0.2's `Allocator` for `&Arena` alongside the existing 0.4 impl, so `&Arena` can back hashbrown collections directly. Add `Arena::alloc_hash_map`, `alloc_hash_map_with_capacity`, `alloc_set`, and `alloc_set_with_capacity` behind a new optional `hashbrown` feature.

Also add allocation-tracking tests (via the `alloc_tracker` crate) that verify the arena reuses chunk memory and does not over-allocate from the system allocator around `Arena::reset` and around dropping all `Arc`s.