### PR TITLE
ci: give external-type-exposure headroom over the 15m slim cap

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -442,7 +442,12 @@ jobs:
   external-type-exposure:
     needs: [delta]
     if: needs.delta.outputs.skip != 'true'
-    runs-on: ubuntu-slim
+    # Runs `cargo check-external-types --all-features` sequentially over every
+    # workspace crate, which exceeds the 15-minute `ubuntu-slim` execution cap as
+    # the crate/dependency graph grows. Use a standard runner with an explicit
+    # timeout so the job has headroom.
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       # prep
       - name: Checkout


### PR DESCRIPTION
## Problem

The `external-type-exposure` job runs `cargo check-external-types --all-features` sequentially over every workspace crate. On the `ubuntu-slim` runner it inherits a **15-minute execution cap**, which the job has now outgrown:

- Previous push run: **12m12s** (already borderline)
- Latest `main` push (`828ced2`): **canceled at 15m**, which cascaded into a `required-checks` failure and a cancelled workflow run.

All checked crates reported `0 errors` — this is purely a timeout/perf issue, not an actual external-type violation.

## Fix

Move the job from `ubuntu-slim` to `ubuntu-latest` (standard runner, no 15m cap) and add an explicit `timeout-minutes: 25` for headroom.

A follow-up could speed the check itself up (e.g. warming the dependency build cache before the per-crate loop), but this unblocks `main` now.