### PR TITLE
fix: exclude non-source artifacts from published crates via include allowlist

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -616,3 +616,10 @@ zerocopy
 ≤
 ≥
 ≪
+allowlist
+autodiscovers
+denylist
+LFS
+Markdown
+tarball
+tarballs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,17 @@ direction, change type vs version component, release set, pending
 release, elevation), the cascade-organisation invariants, and the
 workflow for `scripts/release-packages.ps1`.
 
+## Packaging
+
+What ships in each published `.crate` is controlled by an explicit `include`
+allowlist in `[workspace.package]` (each crate opts in via
+`include = { workspace = true }`). The key rule: **never place a Git LFS-tracked
+binary (logos, diagrams, etc.) in a packaged path** — it makes the package
+non-reproducible and breaks docs.rs. Reference such assets by absolute URL
+instead. See [docs/packaging-guidelines.md](docs/packaging-guidelines.md) for
+the full policy, the LFS pitfall it prevents, and how to verify a crate's
+packaged contents.
+
 ## Pull Requests
 
 Pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/) naming, e.g. `feat(bytesbuf): add new metric` or `fix(cachet): correct eviction logic`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,35 @@ authors = ["The Oxidizer Project Authors"]
 license = "MIT"
 homepage = "https://github.com/microsoft/oxidizer"
 
+# Allowlist of files packaged into published crates (`cargo package`/`publish`).
+# We use an explicit include (allowlist), not exclude, so that non-source
+# artifacts can never leak into the published `.crate` by construction.
+#
+# WARNING: never add a Git LFS-tracked file to a packaged path. `cargo` has no
+# LFS awareness: depending on whether the publishing runner smudged LFS, an
+# LFS-tracked binary is packaged either as its real bytes or as a ~130-byte
+# pointer STUB. That makes the `.crate` non-reproducible, so the checksum a
+# dependent records for this crate can differ from what crates.io ultimately
+# stores - which breaks the dependent's build on docs.rs ("checksum changed
+# between lock files"). The `.gitattributes` LFS globs (*.png, *.ico, *.jpg,
+# *.pdf, *.zip, *.dll, *.exe, ...) therefore must stay OUT of every packaged
+# path (src, examples, tests, benches, docs). Reference such assets by absolute
+# URL instead, e.g. `#![doc(html_logo_url = "https://.../logo.png")]`.
+#
+# The `docs/**/*.md` glob matches only Markdown, so compile-time `include_str!`
+# doc fragments are packaged while binary diagram assets beside them are not.
+include = [
+    "/src/**",
+    "/examples/**",
+    "/benches/**",
+    "/tests/**",
+    "/docs/**/*.md",
+    "/Cargo.toml",
+    "/README.md",
+    "/CHANGELOG.md",
+    "/LICENSE*",
+]
+
 # Adhere to the following rules when adding dependencies:
 # * All dependencies specified here need to have default-features turned off - individual crates can enable the
 #   features they need

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ include = [
     "/docs/**/*.md",
     "/Cargo.toml",
     "/README.md",
-    "/CHANGELOG.md",
     "/LICENSE*",
 ]
 

--- a/crates/anyspawn/Cargo.toml
+++ b/crates/anyspawn/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/anyspawn"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/anyspawn_azure/Cargo.toml
+++ b/crates/anyspawn_azure/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/anyspawn_azure"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/automation/Cargo.toml
+++ b/crates/automation/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/bytesbuf/Cargo.toml
+++ b/crates/bytesbuf/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/bytesbuf_io/Cargo.toml
+++ b/crates/bytesbuf_io/Cargo.toml
@@ -19,6 +19,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf_io"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/cachet/Cargo.toml
+++ b/crates/cachet/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/cachet"
 
 [package.metadata.docs.rs]

--- a/crates/cachet_memory/Cargo.toml
+++ b/crates/cachet_memory/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/cachet_memory"
 
 [package.metadata.docs.rs]

--- a/crates/cachet_service/Cargo.toml
+++ b/crates/cachet_service/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/cachet_service"
 
 [package.metadata.docs.rs]

--- a/crates/cachet_tier/Cargo.toml
+++ b/crates/cachet_tier/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/cachet_tier"
 
 [package.metadata.docs.rs]

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy"
 
 [package.metadata.docs.rs]

--- a/crates/data_privacy_core/Cargo.toml
+++ b/crates/data_privacy_core/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy_core"
 
 [package.metadata.docs.rs]

--- a/crates/data_privacy_macros/Cargo.toml
+++ b/crates/data_privacy_macros/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy_macros"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/data_privacy_macros_impl/Cargo.toml
+++ b/crates/data_privacy_macros_impl/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/data_privacy_macros_impl"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/fetch/Cargo.toml
+++ b/crates/fetch/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fetch"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/fetch_azure/Cargo.toml
+++ b/crates/fetch_azure/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fetch_azure"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/fetch_hyper/Cargo.toml
+++ b/crates/fetch_hyper/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fetch_hyper"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/fetch_options/Cargo.toml
+++ b/crates/fetch_options/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fetch_options"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/fetch_tls/Cargo.toml
+++ b/crates/fetch_tls/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fetch_tls"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/fundle/Cargo.toml
+++ b/crates/fundle/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fundle"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/fundle_macros/Cargo.toml
+++ b/crates/fundle_macros/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fundle_macros"
 
 [package.metadata.docs.rs]

--- a/crates/fundle_macros_impl/Cargo.toml
+++ b/crates/fundle_macros_impl/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fundle_macros_impl"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/http_extensions/Cargo.toml
+++ b/crates/http_extensions/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/http_extensions"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/layered/Cargo.toml
+++ b/crates/layered/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/layered"
 
 [package.metadata.docs.rs]

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/multitude"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/ohno/Cargo.toml
+++ b/crates/ohno/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/ohno"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/ohno_macros/Cargo.toml
+++ b/crates/ohno_macros/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/ohno_macros"
 
 [package.metadata.docs.rs]

--- a/crates/recoverable/Cargo.toml
+++ b/crates/recoverable/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/recoverable"
 
 [package.metadata.docs.rs]

--- a/crates/seatbelt/Cargo.toml
+++ b/crates/seatbelt/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/seatbelt"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/seatbelt_http/Cargo.toml
+++ b/crates/seatbelt_http/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/seatbelt_http"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/templated_uri/Cargo.toml
+++ b/crates/templated_uri/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/templated_uri_macros/Cargo.toml
+++ b/crates/templated_uri_macros/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri_macros"
 
 [lib]

--- a/crates/templated_uri_macros_impl/Cargo.toml
+++ b/crates/templated_uri_macros_impl/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri_macros_impl"
 
 [package.metadata.docs.rs]

--- a/crates/testing_aids/Cargo.toml
+++ b/crates/testing_aids/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 
 [dependencies]
 futures = { workspace = true, features = ["executor"] }

--- a/crates/thread_aware/Cargo.toml
+++ b/crates/thread_aware/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/thread_aware_macros/Cargo.toml
+++ b/crates/thread_aware_macros/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware_macros"
 
 [package.metadata.docs.rs]

--- a/crates/thread_aware_macros_impl/Cargo.toml
+++ b/crates/thread_aware_macros_impl/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware_macros_impl"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/tick/Cargo.toml
+++ b/crates/tick/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/tick"
 
 [package.metadata.cargo_check_external_types]

--- a/crates/uniflight/Cargo.toml
+++ b/crates/uniflight/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
+include = { workspace = true }
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/uniflight"
 
 [package.metadata.cargo_check_external_types]

--- a/docs/packaging-guidelines.md
+++ b/docs/packaging-guidelines.md
@@ -1,0 +1,120 @@
+# Packaging Guidelines
+
+This document describes what gets published to crates.io for each crate in this
+workspace, and the rules you must follow when adding files so that published
+`.crate` tarballs stay correct and reproducible.
+
+## What gets published
+
+Published crate contents are controlled by an explicit **`include` allowlist**
+defined once in the root `Cargo.toml` under `[workspace.package]`. Every crate
+opts in with `include = { workspace = true }` (or `include.workspace = true`).
+
+Only these paths are packaged:
+
+```toml
+include = [
+    "/src/**",
+    "/examples/**",
+    "/benches/**",
+    "/tests/**",
+    "/docs/**/*.md",
+    "/Cargo.toml",
+    "/README.md",
+    "/LICENSE*",
+]
+```
+
+Anything not listed (for example `logo.png`, `favicon.ico`, `AGENTS.md`,
+`CHANGELOG.md`, `docs/diagrams/*`, editable `*.graphml` sources, internal design
+notes) is **not** shipped.
+
+## What belongs in the package
+
+The package should contain exactly two things: everything **declared in
+`Cargo.toml`** and everything **required to build** it.
+
+- **Declared targets ship in full.** If a crate declares (or autodiscovers) a
+  `[[example]]`, `[[test]]`, or `[[bench]]` target, the corresponding
+  `examples/`, `tests/`, or `benches/` source must be packaged. This keeps the
+  published manifest internally consistent: `cargo build --all-targets` and
+  `cargo test` succeed against the published tarball, with no declaration
+  pointing at a missing file. (Cargo *tolerates* such "dangling" declarations,
+  but no mainstream crate ships them, and they make the manifest lie about its
+  own contents.)
+- **Build-required inputs ship.** `src/**`, plus any file compiled in via
+  `include_str!`/`include_bytes!` (see `docs/**/*.md` below).
+- **Key metadata ships.** `Cargo.toml`, `README.md` (rendered on crates.io),
+  and `LICENSE*`.
+- **Everything else is dropped.** `CHANGELOG.md` is intentionally excluded: it
+  is neither a declared target nor build-required, and crates.io does not render
+  it.
+
+## Why an allowlist instead of `exclude`
+
+The allowlist exists primarily to keep **Git LFS-tracked binaries out of the
+package**, which is a correctness requirement, not just tidiness.
+
+`cargo` has no awareness of Git LFS. Depending on whether the machine that runs
+`cargo package` has smudged LFS, an LFS-tracked file is packaged either as its
+real bytes **or as a ~130-byte pointer stub**. Either way the result is
+non-deterministic: the same crate version can produce two different `.crate`
+checksums.
+
+That breaks downstream builds. When crate `B` depends on crate `A`, `B`'s
+embedded `Cargo.lock` records a checksum for `A`. If `A` was uploaded with
+different bytes than the checksum `B` recorded, docs.rs fails `B` with:
+
+```
+error: checksum for `A vX.Y.Z` changed between lock files
+```
+
+This has taken down docs.rs builds for most of the workspace more than once. An
+allowlist prevents it **by construction**: no LFS binary is ever in a packaged
+path, so packaging is deterministic regardless of LFS state. An `exclude`
+denylist would not be robust, because any newly added binary would leak in
+until someone remembered to exclude it.
+
+## Rules when adding files
+
+1. **Never place a Git LFS-tracked file in a packaged path.** The LFS globs in
+   `.gitattributes` (`*.png`, `*.ico`, `*.jpg`, `*.pdf`, `*.zip`, `*.dll`,
+   `*.exe`, ...) must not appear under `src/`, `examples/`, `tests/`,
+   `benches/`, or `docs/`. Reference such assets by **absolute URL** instead,
+   e.g.:
+
+   ```rust
+   #![doc(html_logo_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/<crate>/logo.png")]
+   ```
+
+2. **Doc fragments compiled with `include_str!` must be Markdown under
+   `docs/`.** The allowlist packages `docs/**/*.md` (Markdown only), so a
+   fragment such as `#[doc = include_str!("../docs/snippets/foo.md")]` is
+   shipped, while a binary diagram beside it under `docs/diagrams/` is not.
+   Reference rendered diagrams by absolute URL, exactly like logos.
+
+3. **Use `docs/` (plural), not `doc/`.** `doc` collides with rustdoc's
+   `target/doc` output and is non-conventional.
+
+4. **New crates inherit the policy automatically** as long as their
+   `Cargo.toml` opts in with `include = { workspace = true }`. The crate
+   template (`scripts/crate-template`) should keep this line.
+
+## How to verify
+
+List exactly what a crate would package and confirm no binary slips in:
+
+```sh
+cargo package -p <crate> --list
+```
+
+The output must not contain any `*.png`, `*.ico`, `*.jpg`, or other binary
+asset. To prove a crate still builds from its packaged form (this is what
+docs.rs effectively does), run a verifying package, which builds the extracted
+tarball:
+
+```sh
+cargo package -p <crate>
+```
+
+If a required `include_str!` fragment was wrongly excluded, this step fails.

--- a/scripts/crate-template/Cargo.toml
+++ b/scripts/crate-template/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
+include.workspace = true
 repository = "https://github.com/microsoft/oxidizer/tree/main/crates/{{CRATE_NAME}}"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Published crates shipped Git LFS-tracked binaries (logo.png, favicon.ico, diagrams) which, depending on whether the publishing runner smudged LFS, were packaged as ~130-byte pointer stubs. That made the .crate non-reproducible and broke dependent crates' lockfile checksums on docs.rs (checksum changed between lock files), repeatedly taking down docs for most of the workspace.

Add an explicit include allowlist in [workspace.package] (opted into by every crate) so only source and build-required files are packaged. This keeps all LFS-tracked binaries out of the package by construction and also drops other non-source cruft (AGENTS.md, design docs, editable diagram sources). Logos are already referenced via absolute html_logo_url, so nothing consumes the packaged copies.

Validated by packaging and rebuilding all 38 crates from their .crate tarballs (38/38 OK) and confirming 0 crates ship any binary artifact.