### PR TITLE
fix(deps): pin transitive ohno_macros to 0.3.3 to drop poisoned 0.3.4 from lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,7 +2555,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82948d54d99b956d012ec2b909ed4331f7064a0726942cc04f8e7ec48ebae9e8"
 dependencies = [
- "ohno_macros 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ohno_macros 0.3.3",
  "typeid",
 ]
 
@@ -2576,11 +2576,10 @@ dependencies = [
 
 [[package]]
 name = "ohno_macros"
-version = "0.3.4"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b562701c8ca9747dcece39363bdd78fe1e5abe946b6c8e3a2e47282b32149959"
 dependencies = [
- "insta",
- "mutants",
- "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
@@ -2589,9 +2588,10 @@ dependencies = [
 [[package]]
 name = "ohno_macros"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7c906df7de1bbc79f0030405c47be957227d8e0794fa0910a3403c24d4034"
 dependencies = [
+ "insta",
+ "mutants",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn",


### PR DESCRIPTION
## What

Pin the **transitive** registry `ohno_macros` (pulled by the external crate `cpulist 1.1.4` → registry `ohno 0.3.5` → `ohno_macros ^0.3.3`) down to **0.3.3**, removing the poisoned `ohno_macros 0.3.4` from `Cargo.lock`.

## Why

Follow-up to #524. That PR fixed the `ohno 0.3.6` mirror-checksum failure on the ADO `OxidizerGitHub.PublishEachCommit[.Unofficial]` pipelines by pinning transitive `ohno` to 0.3.5. The next build (`44f3257`, the #524 merge) got past `ohno` but hit the **same** `CratesIoMirror` divergence one level deeper:

```
error: checksum for `ohno_macros v0.3.4` changed between lock files
  * a replacement source in use (e.g., a mirror) returned a different checksum
```

`ohno_macros 0.3.4` was published 2026-06-19 — the same wave that poisoned `ohno 0.3.6`. Registry `ohno 0.3.5` accepts `ohno_macros ^0.3.3`, so pinning the transitive registry `ohno_macros` to the clean **0.3.3** (published 2026-06-05, pre-poisoning, checksum `b562701c…`) leaves no poisoned version in the lockfile.

Blast-radius check: `ohno` and `ohno_macros` are the only workspace crates that also appear with a registry source in `Cargo.lock` (both via `cpulist`), so after this pin no poisoned internal crate remains.

## Validation

- `cargo check --locked --workspace` passes locally.
- `Cargo.lock` contains neither poisoned checksum (`79eb560d…` / `cfd7c906…`); registry chain is now `ohno 0.3.5 → ohno_macros 0.3.3`, workspace paths remain `ohno 0.3.7` / `ohno_macros 0.3.4`.
