### PR TITLE
feat(thread_aware): add ProcessorCount::AtMost for capped processor count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 name = "plurality"
 version = "0.1.0"
 dependencies = [
- "alloc_tracker 0.6.0",
+ "alloc_tracker",
  "allocator-api2 0.4.0",
  "bolero",
  "criterion",

--- a/crates/thread_aware/src/registry.rs
+++ b/crates/thread_aware/src/registry.rs
@@ -16,7 +16,7 @@ const POISONED_LOCK_MSG: &str = "poisoned lock means type invariants may not hol
 
 /// The number of processors to use for the registry.
 ///
-/// Use `Auto` for the default number of processors, `Manual` to require an exact
+/// Use `Auto` for the default number of processors, `Exactly` to require an exact
 /// number of processors, `AtMost` to request an upper bound that is satisfied by
 /// fewer processors when the hardware offers fewer, or `All` to use every processor.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -28,7 +28,7 @@ pub enum ProcessorCount {
     /// Use a specific number of processors.
     ///
     /// Registry construction panics if the hardware offers fewer processors than requested.
-    Manual(NonZero<usize>),
+    Exactly(NonZero<usize>),
     /// Use up to this many processors, or every available processor when the
     /// hardware offers fewer than requested.
     ///
@@ -66,7 +66,7 @@ impl ThreadRegistry {
     ///
     /// # Panics
     ///
-    /// This will panic if there are not enough processors available when using `Manual` or if no processors are available when using `Auto` or `All`.
+    /// This will panic if there are not enough processors available when using `Exactly` or if no processors are available when using `Auto` or `All`.
     /// If there are more than `u16::MAX` processors or memory regions.
     #[must_use]
     pub fn new(count: &ProcessorCount) -> Self {
@@ -80,11 +80,11 @@ impl ThreadRegistry {
 
         let processors = match count {
             ProcessorCount::Auto | ProcessorCount::All => builder.take_all(),
-            ProcessorCount::Manual(count) => builder.take(*count),
+            ProcessorCount::Exactly(count) => builder.take(*count),
             ProcessorCount::AtMost(max) => {
                 // A processor set is never empty, so taking every available processor
                 // always satisfies a ceiling that meets or exceeds what the machine
-                // offers, without failing the way `Manual` would.
+                // offers, without failing the way `Exactly` would.
                 if max.get() >= hardware.processors().len() {
                     builder.take_all()
                 } else {
@@ -238,8 +238,8 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
-    fn test_registry_manual() {
-        let registry = ThreadRegistry::new(&ProcessorCount::Manual(NonZero::new(1).unwrap()));
+    fn test_registry_exactly() {
+        let registry = ThreadRegistry::new(&ProcessorCount::Exactly(NonZero::new(1).unwrap()));
         assert_eq!(registry.num_affinities(), 1);
     }
 
@@ -251,12 +251,12 @@ mod tests {
         let iterator_count = registry.affinities().count();
         assert_eq!(registry.num_affinities(), iterator_count);
 
-        // Also test with manual processor count > 1 if available
+        // Also test with an exact processor count > 1 if available
         if iterator_count > 1 {
             let count = NonZero::new(2.min(iterator_count)).unwrap();
-            let registry_manual = ThreadRegistry::new(&ProcessorCount::Manual(count));
-            assert_eq!(registry_manual.num_affinities(), count.get());
-            assert_eq!(registry_manual.num_affinities(), registry_manual.affinities().count());
+            let registry_exactly = ThreadRegistry::new(&ProcessorCount::Exactly(count));
+            assert_eq!(registry_exactly.num_affinities(), count.get());
+            assert_eq!(registry_exactly.num_affinities(), registry_exactly.affinities().count());
         }
     }
 
@@ -360,23 +360,23 @@ mod test_fake_hardware {
     }
 
     #[test]
-    fn manual_subset_of_processors() {
-        let registry = registry_from_fake(&ProcessorCount::Manual(nz!(3)), 8, 2);
+    fn exactly_subset_of_processors() {
+        let registry = registry_from_fake(&ProcessorCount::Exactly(nz!(3)), 8, 2);
 
         assert_eq!(registry.num_affinities(), 3);
         assert_eq!(registry.affinities().count(), 3);
 
-        let registry = registry_from_fake(&ProcessorCount::Manual(nz!(1)), 8, 2);
+        let registry = registry_from_fake(&ProcessorCount::Exactly(nz!(1)), 8, 2);
         assert_eq!(registry.num_affinities(), 1);
 
-        let registry = registry_from_fake(&ProcessorCount::Manual(nz!(8)), 8, 2);
+        let registry = registry_from_fake(&ProcessorCount::Exactly(nz!(8)), 8, 2);
         assert_eq!(registry.num_affinities(), 8);
     }
 
     #[test]
     #[should_panic(expected = "Not enough processors available")]
-    fn manual_exceeds_available_panics() {
-        let _registry = registry_from_fake(&ProcessorCount::Manual(nz!(5)), 2, 1);
+    fn exactly_exceeds_available_panics() {
+        let _registry = registry_from_fake(&ProcessorCount::Exactly(nz!(5)), 2, 1);
     }
 
     #[test]
@@ -397,7 +397,7 @@ mod test_fake_hardware {
     #[test]
     fn at_most_exceeds_available_clamps_to_all() {
         // A ceiling larger than the machine provides yields every processor
-        // rather than panicking, unlike `Manual`.
+        // rather than panicking, unlike `Exactly`.
         let registry = registry_from_fake(&ProcessorCount::AtMost(nz!(32)), 4, 2);
 
         assert_eq!(registry.num_affinities(), 4);

--- a/crates/thread_aware/src/registry.rs
+++ b/crates/thread_aware/src/registry.rs
@@ -27,7 +27,7 @@ pub enum ProcessorCount {
     Auto,
     /// Use a specific number of processors.
     ///
-    /// Construction fails if the hardware offers fewer processors than requested.
+    /// Registry construction panics if the hardware offers fewer processors than requested.
     Manual(NonZero<usize>),
     /// Use up to this many processors, or every available processor when the
     /// hardware offers fewer than requested.
@@ -82,13 +82,14 @@ impl ThreadRegistry {
             ProcessorCount::Auto | ProcessorCount::All => builder.take_all(),
             ProcessorCount::Manual(count) => builder.take(*count),
             ProcessorCount::AtMost(max) => {
-                // Clamp the ceiling to what the hardware actually offers so a larger
-                // request than the machine provides is satisfied by taking every
-                // available processor instead of failing.
-                let available = hardware.processors().len();
-                let count =
-                    NonZero::new(max.get().min(available)).expect("a processor set is never empty, so the clamped count is at least one");
-                builder.take(count)
+                // A processor set is never empty, so taking every available processor
+                // always satisfies a ceiling that meets or exceeds what the machine
+                // offers, without failing the way `Manual` would.
+                if max.get() >= hardware.processors().len() {
+                    builder.take_all()
+                } else {
+                    builder.take(*max)
+                }
             }
         }
         .expect("Not enough processors available");

--- a/crates/thread_aware/src/registry.rs
+++ b/crates/thread_aware/src/registry.rs
@@ -67,8 +67,8 @@ impl ThreadRegistry {
     ///
     /// # Panics
     ///
-    /// This will panic if there are not enough processors available when using `Exactly` or if no processors are available when using `Auto` or `All`.
-    /// If there are more than `u16::MAX` processors or memory regions.
+/// This will panic if there are not enough processors available when using `Exactly`.
+/// If there are more than `u16::MAX` processors or memory regions.
     #[must_use]
     pub fn new(count: &ProcessorCount) -> Self {
         Self::with_hardware(count, SystemHardware::current())

--- a/crates/thread_aware/src/registry.rs
+++ b/crates/thread_aware/src/registry.rs
@@ -16,9 +16,9 @@ const POISONED_LOCK_MSG: &str = "poisoned lock means type invariants may not hol
 
 /// The number of processors to use for the registry.
 ///
-/// This can be set to `Auto` to use the default number of processors,
-/// or `Manual` to specify a specific number of processors.
-/// The `All` variant is used to specify that all processors should be used.
+/// Use `Auto` for the default number of processors, `Manual` to require an exact
+/// number of processors, `AtMost` to request an upper bound that is satisfied by
+/// fewer processors when the hardware offers fewer, or `All` to use every processor.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum ProcessorCount {
     /// Use the default number of processors. Right now this is equivalent to using
@@ -26,7 +26,16 @@ pub enum ProcessorCount {
     #[default]
     Auto,
     /// Use a specific number of processors.
+    ///
+    /// Construction fails if the hardware offers fewer processors than requested.
     Manual(NonZero<usize>),
+    /// Use up to this many processors, or every available processor when the
+    /// hardware offers fewer than requested.
+    ///
+    /// This suits callers that want to cap resource usage while still running on
+    /// smaller machines. For example, `AtMost(32)` uses 32 processors on a machine
+    /// with at least 32, and all of them on a machine with fewer.
+    AtMost(NonZero<usize>),
     /// Use all processors.
     All,
 }
@@ -72,6 +81,15 @@ impl ThreadRegistry {
         let processors = match count {
             ProcessorCount::Auto | ProcessorCount::All => builder.take_all(),
             ProcessorCount::Manual(count) => builder.take(*count),
+            ProcessorCount::AtMost(max) => {
+                // Clamp the ceiling to what the hardware actually offers so a larger
+                // request than the machine provides is satisfied by taking every
+                // available processor instead of failing.
+                let available = hardware.processors().len();
+                let count =
+                    NonZero::new(max.get().min(available)).expect("a processor set is never empty, so the clamped count is at least one");
+                builder.take(count)
+            }
         }
         .expect("Not enough processors available");
 
@@ -358,6 +376,31 @@ mod test_fake_hardware {
     #[should_panic(expected = "Not enough processors available")]
     fn manual_exceeds_available_panics() {
         let _registry = registry_from_fake(&ProcessorCount::Manual(nz!(5)), 2, 1);
+    }
+
+    #[test]
+    fn at_most_below_available_uses_requested_count() {
+        let registry = registry_from_fake(&ProcessorCount::AtMost(nz!(3)), 8, 2);
+
+        assert_eq!(registry.num_affinities(), 3);
+        assert_eq!(registry.affinities().count(), 3);
+    }
+
+    #[test]
+    fn at_most_equal_to_available_uses_all() {
+        let registry = registry_from_fake(&ProcessorCount::AtMost(nz!(8)), 8, 2);
+
+        assert_eq!(registry.num_affinities(), 8);
+    }
+
+    #[test]
+    fn at_most_exceeds_available_clamps_to_all() {
+        // A ceiling larger than the machine provides yields every processor
+        // rather than panicking, unlike `Manual`.
+        let registry = registry_from_fake(&ProcessorCount::AtMost(nz!(32)), 4, 2);
+
+        assert_eq!(registry.num_affinities(), 4);
+        assert_eq!(registry.affinities().count(), 4);
     }
 
     #[test]

--- a/crates/thread_aware/src/registry.rs
+++ b/crates/thread_aware/src/registry.rs
@@ -67,8 +67,8 @@ impl ThreadRegistry {
     ///
     /// # Panics
     ///
-/// This will panic if there are not enough processors available when using `Exactly`.
-/// If there are more than `u16::MAX` processors or memory regions.
+    /// This will panic if there are not enough processors available when using `Exactly`.
+    /// If there are more than `u16::MAX` processors or memory regions.
     #[must_use]
     pub fn new(count: &ProcessorCount) -> Self {
         Self::with_hardware(count, SystemHardware::current())

--- a/crates/thread_aware/src/registry.rs
+++ b/crates/thread_aware/src/registry.rs
@@ -77,7 +77,8 @@ impl ThreadRegistry {
     /// Create a new `ThreadRegistry` with the specified hardware instance.
     #[must_use]
     pub(crate) fn with_hardware(count: &ProcessorCount, hardware: &SystemHardware) -> Self {
-        let builder = hardware.processors().to_builder();
+        let all_processors = hardware.processors();
+        let builder = all_processors.to_builder();
 
         let processors = match count {
             ProcessorCount::Auto | ProcessorCount::All => builder.take_all(),
@@ -86,7 +87,7 @@ impl ThreadRegistry {
                 // A processor set is never empty, so taking every available processor
                 // always satisfies a ceiling that meets or exceeds what the machine
                 // offers, without failing the way `Exactly` would.
-                if max.get() >= hardware.processors().len() {
+                if max.get() >= all_processors.len() {
                     builder.take_all()
                 } else {
                     builder.take(*max)

--- a/crates/thread_aware/src/registry.rs
+++ b/crates/thread_aware/src/registry.rs
@@ -20,6 +20,7 @@ const POISONED_LOCK_MSG: &str = "poisoned lock means type invariants may not hol
 /// number of processors, `AtMost` to request an upper bound that is satisfied by
 /// fewer processors when the hardware offers fewer, or `All` to use every processor.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ProcessorCount {
     /// Use the default number of processors. Right now this is equivalent to using
     /// all processors, but this default may change in the future.


### PR DESCRIPTION
## What

Adds a new `ProcessorCount::AtMost(NonZero<usize>)` variant that requests an upper bound on the number of processors, clamping down to every available processor when the hardware offers fewer than requested.

Also renames the existing `ProcessorCount::Manual` variant to `ProcessorCount::Exactly`. Reviewers noted that `Manual` was easy to confuse with the newly added `AtMost` variant; `Exactly` makes the "require exactly this many processors" semantics unambiguous versus `AtMost`'s upper-bound behavior.

## Why

`Exactly(N)` requires exactly `N` processors and panics via `ThreadRegistry::new`/`with_hardware` when the machine has fewer. There was no way to express "use up to `N`, but accept fewer if that is all the machine has". `AtMost` fills that gap for callers that want to cap resource usage while still running unchanged on smaller machines. For example, `AtMost(32)` uses 32 processors on a machine with at least 32, and all of them on a machine with fewer.

## How

`ThreadRegistry::with_hardware` clamps the ceiling to `hardware.processors().len()` (the quota-enforced available count) and calls the existing `ProcessorSetBuilder::take()`. No change to `many_cpus` is required. Unlike `Exactly`, `AtMost` never fails when the machine is smaller than the ceiling.

## Testing

Added three deterministic tests using the `many_cpus::fake` hardware harness: request below available, request equal to available, and request exceeding available (clamps to all, no panic). `cargo test -p thread_aware`, `just clippy`, `just format-check`, and the docs.rs doc build all pass.
