### PR TITLE
chore: run pwsh with -NoProfile in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Required by [script]
-set unstable
-
 set windows-shell := ["pwsh.exe", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
-set script-interpreter := ["pwsh"]
+set shell := ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
+set script-interpreter := ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive"]
 
 # Constants shared by Just commands and GitHub workflows.
 set dotenv-path := "./constants.env"


### PR DESCRIPTION
Run `pwsh` with `-NoProfile` in the root justfile so recipes no longer load the user's PowerShell profile. These recipes are pre-baked scripts unrelated to any personal profile, so loading it just wastes time.

This aligns the oxidizer PowerShell configuration with the ox-sdk justfile:
- Add `-NoProfile` (plus `-NoLogo`/`-NonInteractive`) to the `script-interpreter`.
- Add a `pwsh` `shell` so non-Windows platforms use PowerShell too.
- Drop the outdated `set unstable`, no longer required by current `just` for `[script]` recipes.