### PR TITLE
feat(cachet_memory)!: surface evicted key and value to on_eviction listeners

### DIFF
--- a/crates/cachet/src/builder/cache.rs
+++ b/crates/cachet/src/builder/cache.rs
@@ -164,7 +164,7 @@ impl<K, V> CacheBuilder<K, V, ()> {
         if builder.eviction_telemetry_enabled() {
             let hook = Arc::new(EvictionHook::new());
             let hook_for_listener = Arc::clone(&hook);
-            builder = builder.on_eviction(move |cause| hook_for_listener.handle(cause));
+            builder = builder.on_eviction(move |_key, _value, cause| hook_for_listener.handle(cause));
             self.eviction_hook = Some(hook);
         }
         let storage = builder.build().expect("InMemoryCacheBuilder configuration must be valid");

--- a/crates/cachet/src/builder/cache.rs
+++ b/crates/cachet/src/builder/cache.rs
@@ -163,8 +163,8 @@ impl<K, V> CacheBuilder<K, V, ()> {
         let mut builder = configure(InMemoryCacheBuilder::<K, V>::new());
         if builder.eviction_telemetry_enabled() {
             let hook = Arc::new(EvictionHook::new());
-            let hook_for_listener = Arc::clone(&hook);
-            builder = builder.on_eviction(move |_key, _value, cause| hook_for_listener.handle(cause));
+            let hook_for_observer = Arc::clone(&hook);
+            builder = builder.with_removal_observer(move |cause| hook_for_observer.handle(cause));
             self.eviction_hook = Some(hook);
         }
         let storage = builder.build().expect("InMemoryCacheBuilder configuration must be valid");

--- a/crates/cachet_memory/README.md
+++ b/crates/cachet_memory/README.md
@@ -61,7 +61,7 @@ assert_eq!(*value.unwrap().value(), 42);
 Two complementary hooks are available for observing entry removals:
 
 * [`InMemoryCacheBuilder::on_eviction`][__link6] takes a closure invoked with the
-  evicted key, its value, and a [`RemovalCause`][__link7] for every removal
+  removed key, its value, and a [`RemovalCause`][__link7] for every removal
   (capacity, expiry, explicit, or replace). Use this for custom side effects.
 * [`InMemoryCacheBuilder::with_eviction_telemetry`][__link8] is a marker that the host
   crate (`cachet`) recognizes via `CacheBuilder::memory_with` and uses to
@@ -91,7 +91,7 @@ TTL/TTI unset or set them to a sufficiently high ceiling.
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/cachet_memory">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjNhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQb35fRAfWe0ZIbBbZDkzgiOLkbVMELrsd4GLsbtb12dyJEJDdhZIKCbWNhY2hldF9tZW1vcnllMC40LjCCa2NhY2hldF90aWVyZTAuMi42
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbejeJIJ3wjSIbQ4FD8_ZrIe0bdNSA5y85nYcbNmCiuslgqq1hZIKCbWNhY2hldF9tZW1vcnllMC40LjCCa2NhY2hldF90aWVyZTAuMi42
  [__link0]: https://docs.rs/cachet_memory/0.4.0/cachet_memory/?search=InMemoryCache
  [__link1]: https://docs.rs/cachet_memory/0.4.0/cachet_memory/?search=InMemoryCacheBuilder
  [__link10]: https://docs.rs/cachet_tier/0.2.6/cachet_tier/?search=CacheEntry::expires_after

--- a/crates/cachet_memory/README.md
+++ b/crates/cachet_memory/README.md
@@ -60,9 +60,9 @@ assert_eq!(*value.unwrap().value(), 42);
 
 Two complementary hooks are available for observing entry removals:
 
-* [`InMemoryCacheBuilder::on_eviction`][__link6] takes a closure invoked with a
-  [`RemovalCause`][__link7] for every removal (capacity, expiry, explicit, or replace).
-  Use this for custom side effects.
+* [`InMemoryCacheBuilder::on_eviction`][__link6] takes a closure invoked with the
+  evicted key, its value, and a [`RemovalCause`][__link7] for every removal
+  (capacity, expiry, explicit, or replace). Use this for custom side effects.
 * [`InMemoryCacheBuilder::with_eviction_telemetry`][__link8] is a marker that the host
   crate (`cachet`) recognizes via `CacheBuilder::memory_with` and uses to
   install a built-in listener that emits `cache.eviction` for capacity
@@ -91,7 +91,7 @@ TTL/TTI unset or set them to a sufficiently high ceiling.
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/cachet_memory">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbN0kpRlU_G9QbWC713oa4KjsbRG6BIsW3BU8bzI21NivEBVphZIKCbWNhY2hldF9tZW1vcnllMC40LjCCa2NhY2hldF90aWVyZTAuMi42
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjNhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQb35fRAfWe0ZIbBbZDkzgiOLkbVMELrsd4GLsbtb12dyJEJDdhZIKCbWNhY2hldF9tZW1vcnllMC40LjCCa2NhY2hldF90aWVyZTAuMi42
  [__link0]: https://docs.rs/cachet_memory/0.4.0/cachet_memory/?search=InMemoryCache
  [__link1]: https://docs.rs/cachet_memory/0.4.0/cachet_memory/?search=InMemoryCacheBuilder
  [__link10]: https://docs.rs/cachet_tier/0.2.6/cachet_tier/?search=CacheEntry::expires_after

--- a/crates/cachet_memory/src/builder.rs
+++ b/crates/cachet_memory/src/builder.rs
@@ -26,6 +26,14 @@ use crate::tier::InMemoryCache;
 /// along with the [`RemovalCause`].
 pub(crate) type EvictionListener<K, V> = Arc<dyn Fn(Arc<K>, V, RemovalCause) + Send + Sync + 'static>;
 
+/// Type-erased, cause-only removal observer.
+///
+/// Unlike [`EvictionListener`], observers receive only the [`RemovalCause`] —
+/// never the key or value — so registering one never forces a clone of the
+/// evicted entry. Used internally by host crates (such as `cachet`) to bridge
+/// removals into their own telemetry.
+pub(crate) type RemovalObserver = Arc<dyn Fn(RemovalCause) + Send + Sync + 'static>;
+
 /// Builder for configuring an `InMemoryCache`.
 ///
 /// This builder provides a stable API for common cache configuration
@@ -54,6 +62,7 @@ pub struct InMemoryCacheBuilder<K, V, H = RandomState> {
     pub(crate) name: Option<&'static str>,
     pub(crate) eviction_policy: EvictionPolicy,
     pub(crate) eviction_listener: Option<EvictionListener<K, V>>,
+    pub(crate) removal_observers: Vec<RemovalObserver>,
     pub(crate) eviction_telemetry: bool,
     pub(crate) hasher: H,
     _phantom: PhantomData<(K, V)>,
@@ -69,6 +78,7 @@ impl<K, V, H: fmt::Debug> fmt::Debug for InMemoryCacheBuilder<K, V, H> {
             .field("name", &self.name)
             .field("eviction_policy", &self.eviction_policy)
             .field("eviction_listener", &self.eviction_listener.as_ref().map(|_| "<set>"))
+            .field("removal_observers", &self.removal_observers.len())
             .field("eviction_telemetry", &self.eviction_telemetry)
             .field("hasher", &self.hasher)
             .finish()
@@ -103,6 +113,7 @@ impl<K, V> InMemoryCacheBuilder<K, V> {
             name: None,
             eviction_policy: EvictionPolicy::default(),
             eviction_listener: None,
+            removal_observers: Vec::new(),
             eviction_telemetry: false,
             hasher: RandomState::default(),
             _phantom: PhantomData,
@@ -267,11 +278,9 @@ impl<K, V, H> InMemoryCacheBuilder<K, V, H> {
     /// The listener runs on the cache's background maintenance task. Keep the
     /// closure cheap; expensive work should be offloaded to a separate task.
     ///
-    /// If a listener was already registered (for example via an earlier
-    /// `on_eviction` call, or by the host crate when
-    /// [`with_eviction_telemetry`](Self::with_eviction_telemetry) is enabled),
-    /// the new listener is chained — both run on every removal, in registration
-    /// order.
+    /// At most one listener is held: calling this more than once replaces the
+    /// previously registered listener. To fan out to multiple consumers,
+    /// compose them into a single closure.
     ///
     /// # Examples
     ///
@@ -299,24 +308,41 @@ impl<K, V, H> InMemoryCacheBuilder<K, V, H> {
     where
         F: Fn(Arc<K>, V, RemovalCause) + Send + Sync + 'static,
         K: 'static,
-        V: Clone + 'static,
+        V: 'static,
     {
-        self.eviction_listener = Some(match self.eviction_listener.take() {
-            Some(previous) => Arc::new(move |key: Arc<K>, value: V, cause| {
-                previous(Arc::clone(&key), value.clone(), cause);
-                listener(key, value, cause);
-            }),
-            None => Arc::new(listener),
-        });
+        self.eviction_listener = Some(Arc::new(listener));
+        self
+    }
+
+    /// Registers an internal, cause-only removal observer.
+    ///
+    /// Observers receive only the [`RemovalCause`] — never the evicted key or
+    /// value — so registering one never forces a clone of the entry. Multiple
+    /// observers may be registered; all run on every removal, in registration
+    /// order, before the [`on_eviction`](Self::on_eviction) value listener (if any).
+    ///
+    /// This is not part of the stable public API. It exists so host crates
+    /// (such as `cachet`) can bridge removals into their own telemetry without
+    /// competing with the user-facing value listener. End users should use
+    /// [`on_eviction`](Self::on_eviction) instead.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_removal_observer<F>(mut self, observer: F) -> Self
+    where
+        F: Fn(RemovalCause) + Send + Sync + 'static,
+    {
+        self.removal_observers.push(Arc::new(observer));
         self
     }
 
     /// Requests that the host crate install eviction telemetry for this cache.
     ///
     /// This is a marker for `cachet::CacheBuilder::memory_with` to recognize:
-    /// when set, the host installs a listener that emits `cache.eviction` on
-    /// capacity evictions ([`RemovalCause::Size`]) and `cache.expired` on
-    /// background TTL/TTI expiry ([`RemovalCause::Expired`]).
+    /// when set, the host registers an internal removal observer that emits
+    /// `cache.eviction` on capacity evictions ([`RemovalCause::Size`]) and
+    /// `cache.expired` on background TTL/TTI expiry ([`RemovalCause::Expired`]).
+    /// The observer is independent of any [`on_eviction`](Self::on_eviction)
+    /// value listener, so enabling telemetry never clones the evicted value.
     /// [`RemovalCause::Explicit`] and [`RemovalCause::Replaced`] are
     /// intentionally not surfaced, as they are already covered by the host's
     /// `cache.invalidated` and `cache.inserted` events.
@@ -362,6 +388,7 @@ impl<K, V, H> InMemoryCacheBuilder<K, V, H> {
             name: self.name,
             eviction_policy: self.eviction_policy,
             eviction_listener: self.eviction_listener,
+            removal_observers: self.removal_observers,
             eviction_telemetry: self.eviction_telemetry,
             hasher,
             _phantom: PhantomData,
@@ -491,42 +518,48 @@ mod tests {
     }
 
     #[test]
-    fn on_eviction_chains_existing_listener() {
+    fn on_eviction_replaces_previous_listener() {
         use std::sync::Mutex;
-        use std::sync::atomic::{AtomicUsize, Ordering};
 
-        let first_count = Arc::new(AtomicUsize::new(0));
-        let second_count = Arc::new(AtomicUsize::new(0));
-        let order: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
-        let seen: Arc<Mutex<Vec<(String, i32)>>> = Arc::new(Mutex::new(Vec::new()));
-
-        let first_count_cb = Arc::clone(&first_count);
-        let second_count_cb = Arc::clone(&second_count);
-        let order_first = Arc::clone(&order);
-        let order_second = Arc::clone(&order);
+        let seen: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
         let seen_first = Arc::clone(&seen);
         let seen_second = Arc::clone(&seen);
 
+        // Registering a second listener replaces the first; only the last runs.
         let builder = InMemoryCacheBuilder::<String, i32>::new()
             .on_eviction(move |key: Arc<String>, value, _cause| {
-                first_count_cb.fetch_add(1, Ordering::Relaxed);
-                order_first.lock().unwrap().push("first");
-                seen_first.lock().unwrap().push(((*key).clone(), value));
+                assert_eq!((&**key, value), ("k", 42));
+                seen_first.lock().unwrap().push("first");
             })
             .on_eviction(move |key: Arc<String>, value, _cause| {
-                second_count_cb.fetch_add(1, Ordering::Relaxed);
-                order_second.lock().unwrap().push("second");
-                seen_second.lock().unwrap().push(((*key).clone(), value));
+                assert_eq!((&**key, value), ("k", 42));
+                seen_second.lock().unwrap().push("second");
             });
 
         let listener = builder.eviction_listener.expect("listener should be installed");
         listener(Arc::new("k".to_string()), 42, RemovalCause::Size);
 
-        assert_eq!(first_count.load(Ordering::Relaxed), 1);
-        assert_eq!(second_count.load(Ordering::Relaxed), 1);
+        // Only the second listener ran; the first was replaced.
+        assert_eq!(*seen.lock().unwrap(), vec!["second"]);
+    }
+
+    #[test]
+    fn removal_observers_all_run_in_order() {
+        use std::sync::Mutex;
+
+        let order: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+        let order_first = Arc::clone(&order);
+        let order_second = Arc::clone(&order);
+
+        let builder = InMemoryCacheBuilder::<String, i32>::new()
+            .with_removal_observer(move |_cause| order_first.lock().unwrap().push("first"))
+            .with_removal_observer(move |_cause| order_second.lock().unwrap().push("second"));
+
+        assert_eq!(builder.removal_observers.len(), 2);
+        for observer in &builder.removal_observers {
+            observer(RemovalCause::Size);
+        }
         assert_eq!(*order.lock().unwrap(), vec!["first", "second"]);
-        // Both chained listeners receive the same key and value.
-        assert_eq!(*seen.lock().unwrap(), vec![("k".to_string(), 42), ("k".to_string(), 42)]);
     }
 
     #[test]
@@ -538,6 +571,7 @@ mod tests {
             .time_to_idle(Duration::from_secs(30))
             .name("my_cache")
             .with_eviction_telemetry()
+            .with_removal_observer(|_| {})
             .on_eviction(|_, _, _| {});
         let rendered = format!("{builder:?}");
         assert!(rendered.contains("InMemoryCacheBuilder"));
@@ -547,6 +581,7 @@ mod tests {
         assert!(rendered.contains("time_to_idle: Some(30s)"));
         assert!(rendered.contains("name: Some(\"my_cache\")"));
         assert!(rendered.contains("eviction_telemetry: true"));
+        assert!(rendered.contains("removal_observers: 1"));
         assert!(rendered.contains("eviction_listener: Some(\"<set>\")"));
     }
 

--- a/crates/cachet_memory/src/builder.rs
+++ b/crates/cachet_memory/src/builder.rs
@@ -21,7 +21,10 @@ use crate::policy::EvictionPolicy;
 use crate::tier::InMemoryCache;
 
 /// Type-erased eviction listener.
-pub(crate) type EvictionListener = Arc<dyn Fn(RemovalCause) + Send + Sync + 'static>;
+///
+/// Receives the evicted entry's key (as a shared [`Arc`]) and owned value
+/// along with the [`RemovalCause`].
+pub(crate) type EvictionListener<K, V> = Arc<dyn Fn(Arc<K>, V, RemovalCause) + Send + Sync + 'static>;
 
 /// Builder for configuring an `InMemoryCache`.
 ///
@@ -50,7 +53,7 @@ pub struct InMemoryCacheBuilder<K, V, H = RandomState> {
     pub(crate) time_to_idle: Option<Duration>,
     pub(crate) name: Option<&'static str>,
     pub(crate) eviction_policy: EvictionPolicy,
-    pub(crate) eviction_listener: Option<EvictionListener>,
+    pub(crate) eviction_listener: Option<EvictionListener<K, V>>,
     pub(crate) eviction_telemetry: bool,
     pub(crate) hasher: H,
     _phantom: PhantomData<(K, V)>,
@@ -253,7 +256,9 @@ impl<K, V, H> InMemoryCacheBuilder<K, V, H> {
 
     /// Registers a listener that is called when an entry is removed from the cache.
     ///
-    /// The listener receives a [`RemovalCause`] indicating why the entry was removed:
+    /// The listener receives the evicted entry's key (as a shared
+    /// [`Arc`](std::sync::Arc)), its owned value, and a [`RemovalCause`]
+    /// indicating why the entry was removed:
     /// `Size` for capacity-driven evictions, `Expired` for TTL/TTI expiration,
     /// `Explicit` for [`invalidate`](cachet_tier::CacheTier::invalidate) or
     /// [`clear`](cachet_tier::CacheTier::clear) calls, and `Replaced` for inserts
@@ -281,7 +286,7 @@ impl<K, V, H> InMemoryCacheBuilder<K, V, H> {
     ///
     /// let cache = InMemoryCache::<String, i32>::builder()
     ///     .max_capacity(100)
-    ///     .on_eviction(move |cause| {
+    ///     .on_eviction(move |_key, _value, cause| {
     ///         if matches!(cause, RemovalCause::Size | RemovalCause::Expired) {
     ///             counter.fetch_add(1, Ordering::Relaxed);
     ///         }
@@ -292,12 +297,14 @@ impl<K, V, H> InMemoryCacheBuilder<K, V, H> {
     #[must_use]
     pub fn on_eviction<F>(mut self, listener: F) -> Self
     where
-        F: Fn(RemovalCause) + Send + Sync + 'static,
+        F: Fn(Arc<K>, V, RemovalCause) + Send + Sync + 'static,
+        K: 'static,
+        V: Clone + 'static,
     {
         self.eviction_listener = Some(match self.eviction_listener.take() {
-            Some(previous) => Arc::new(move |cause| {
-                previous(cause);
-                listener(cause);
+            Some(previous) => Arc::new(move |key: Arc<K>, value: V, cause| {
+                previous(Arc::clone(&key), value.clone(), cause);
+                listener(key, value, cause);
             }),
             None => Arc::new(listener),
         });
@@ -491,28 +498,35 @@ mod tests {
         let first_count = Arc::new(AtomicUsize::new(0));
         let second_count = Arc::new(AtomicUsize::new(0));
         let order: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen: Arc<Mutex<Vec<(String, i32)>>> = Arc::new(Mutex::new(Vec::new()));
 
         let first_count_cb = Arc::clone(&first_count);
         let second_count_cb = Arc::clone(&second_count);
         let order_first = Arc::clone(&order);
         let order_second = Arc::clone(&order);
+        let seen_first = Arc::clone(&seen);
+        let seen_second = Arc::clone(&seen);
 
         let builder = InMemoryCacheBuilder::<String, i32>::new()
-            .on_eviction(move |_| {
+            .on_eviction(move |key: Arc<String>, value, _cause| {
                 first_count_cb.fetch_add(1, Ordering::Relaxed);
                 order_first.lock().unwrap().push("first");
+                seen_first.lock().unwrap().push(((*key).clone(), value));
             })
-            .on_eviction(move |_| {
+            .on_eviction(move |key: Arc<String>, value, _cause| {
                 second_count_cb.fetch_add(1, Ordering::Relaxed);
                 order_second.lock().unwrap().push("second");
+                seen_second.lock().unwrap().push(((*key).clone(), value));
             });
 
         let listener = builder.eviction_listener.expect("listener should be installed");
-        listener(RemovalCause::Size);
+        listener(Arc::new("k".to_string()), 42, RemovalCause::Size);
 
         assert_eq!(first_count.load(Ordering::Relaxed), 1);
         assert_eq!(second_count.load(Ordering::Relaxed), 1);
         assert_eq!(*order.lock().unwrap(), vec!["first", "second"]);
+        // Both chained listeners receive the same key and value.
+        assert_eq!(*seen.lock().unwrap(), vec![("k".to_string(), 42), ("k".to_string(), 42)]);
     }
 
     #[test]
@@ -524,7 +538,7 @@ mod tests {
             .time_to_idle(Duration::from_secs(30))
             .name("my_cache")
             .with_eviction_telemetry()
-            .on_eviction(|_| {});
+            .on_eviction(|_, _, _| {});
         let rendered = format!("{builder:?}");
         assert!(rendered.contains("InMemoryCacheBuilder"));
         assert!(rendered.contains("max_capacity: Some(100)"));

--- a/crates/cachet_memory/src/builder.rs
+++ b/crates/cachet_memory/src/builder.rs
@@ -267,7 +267,7 @@ impl<K, V, H> InMemoryCacheBuilder<K, V, H> {
 
     /// Registers a listener that is called when an entry is removed from the cache.
     ///
-    /// The listener receives the evicted entry's key (as a shared
+    /// The listener receives the removed entry's key (as a shared
     /// [`Arc`](std::sync::Arc)), its owned value, and a [`RemovalCause`]
     /// indicating why the entry was removed:
     /// `Size` for capacity-driven evictions, `Expired` for TTL/TTI expiration,
@@ -316,7 +316,7 @@ impl<K, V, H> InMemoryCacheBuilder<K, V, H> {
 
     /// Registers an internal, cause-only removal observer.
     ///
-    /// Observers receive only the [`RemovalCause`] — never the evicted key or
+    /// Observers receive only the [`RemovalCause`] — never the removed key or
     /// value — so registering one never forces a clone of the entry. Multiple
     /// observers may be registered; all run on every removal, in registration
     /// order, before the [`on_eviction`](Self::on_eviction) value listener (if any).

--- a/crates/cachet_memory/src/builder.rs
+++ b/crates/cachet_memory/src/builder.rs
@@ -525,22 +525,25 @@ mod tests {
         let seen_first = Arc::clone(&seen);
         let seen_second = Arc::clone(&seen);
 
-        // Registering a second listener replaces the first; only the last runs.
-        let builder = InMemoryCacheBuilder::<String, i32>::new()
-            .on_eviction(move |key: Arc<String>, value, _cause| {
-                assert_eq!((&**key, value), ("k", 42));
-                seen_first.lock().unwrap().push("first");
-            })
-            .on_eviction(move |key: Arc<String>, value, _cause| {
-                assert_eq!((&**key, value), ("k", 42));
-                seen_second.lock().unwrap().push("second");
-            });
+        // Register a first listener and invoke it so its body is exercised.
+        let builder = InMemoryCacheBuilder::<String, i32>::new().on_eviction(move |key: Arc<String>, value, _cause| {
+            assert_eq!((&**key, value), ("k", 42));
+            seen_first.lock().unwrap().push("first");
+        });
+        let first = builder.eviction_listener.clone().expect("first listener should be installed");
+        first(Arc::new("k".to_string()), 42, RemovalCause::Size);
+        assert_eq!(*seen.lock().unwrap(), vec!["first"]);
 
+        // Registering a second listener replaces the first; only the last runs.
+        let builder = builder.on_eviction(move |key: Arc<String>, value, _cause| {
+            assert_eq!((&**key, value), ("k", 42));
+            seen_second.lock().unwrap().push("second");
+        });
         let listener = builder.eviction_listener.expect("listener should be installed");
         listener(Arc::new("k".to_string()), 42, RemovalCause::Size);
 
-        // Only the second listener ran; the first was replaced.
-        assert_eq!(*seen.lock().unwrap(), vec!["second"]);
+        // The replaced first listener did not run again — only "second" was added.
+        assert_eq!(*seen.lock().unwrap(), vec!["first", "second"]);
     }
 
     #[test]

--- a/crates/cachet_memory/src/lib.rs
+++ b/crates/cachet_memory/src/lib.rs
@@ -53,7 +53,7 @@
 //! Two complementary hooks are available for observing entry removals:
 //!
 //! - [`InMemoryCacheBuilder::on_eviction`] takes a closure invoked with the
-//!   evicted key, its value, and a [`RemovalCause`] for every removal
+//!   removed key, its value, and a [`RemovalCause`] for every removal
 //!   (capacity, expiry, explicit, or replace). Use this for custom side effects.
 //! - [`InMemoryCacheBuilder::with_eviction_telemetry`] is a marker that the host
 //!   crate (`cachet`) recognizes via `CacheBuilder::memory_with` and uses to

--- a/crates/cachet_memory/src/lib.rs
+++ b/crates/cachet_memory/src/lib.rs
@@ -52,9 +52,9 @@
 //!
 //! Two complementary hooks are available for observing entry removals:
 //!
-//! - [`InMemoryCacheBuilder::on_eviction`] takes a closure invoked with a
-//!   [`RemovalCause`] for every removal (capacity, expiry, explicit, or replace).
-//!   Use this for custom side effects.
+//! - [`InMemoryCacheBuilder::on_eviction`] takes a closure invoked with the
+//!   evicted key, its value, and a [`RemovalCause`] for every removal
+//!   (capacity, expiry, explicit, or replace). Use this for custom side effects.
 //! - [`InMemoryCacheBuilder::with_eviction_telemetry`] is a marker that the host
 //!   crate (`cachet`) recognizes via `CacheBuilder::memory_with` and uses to
 //!   install a built-in listener that emits `cache.eviction` for capacity

--- a/crates/cachet_memory/src/tier.rs
+++ b/crates/cachet_memory/src/tier.rs
@@ -164,8 +164,8 @@ where
         }
 
         if let Some(listener) = builder.eviction_listener {
-            moka_builder = moka_builder.eviction_listener(move |_key, _value, cause| {
-                listener(crate::notification::from_moka(cause));
+            moka_builder = moka_builder.eviction_listener(move |key, entry: CacheEntry<V>, cause| {
+                listener(key, entry.into_value(), crate::notification::from_moka(cause));
             });
         }
 
@@ -498,5 +498,45 @@ mod tests {
 
         // The cache should only have max_capacity entries
         assert_eq!(cache.len().await.expect("len should return Ok"), capacity);
+    }
+
+    #[cfg_attr(miri, ignore)] // crossbeam-epoch triggers Stacked Borrows violations under Miri
+    #[tokio::test]
+    async fn on_eviction_receives_key_and_value() {
+        use std::sync::{Arc as StdArc, Mutex};
+
+        let evicted: StdArc<Mutex<Vec<(String, u64, crate::RemovalCause)>>> = StdArc::new(Mutex::new(Vec::new()));
+        let recorder = StdArc::clone(&evicted);
+
+        let capacity = 2;
+        let cache = InMemoryCache::<String, u64>::builder()
+            .max_capacity(capacity)
+            .on_eviction(move |key: StdArc<String>, value, cause| {
+                recorder.lock().unwrap().push(((*key).clone(), value, cause));
+            })
+            .build()
+            .expect("Cache should build successfully");
+
+        // Insert enough entries to force at least one size-based eviction.
+        for i in 0..(capacity + 3) {
+            cache
+                .insert(format!("key{i}"), CacheEntry::new(i))
+                .await
+                .expect("Insert should succeed");
+            cache.inner.run_pending_tasks().await;
+        }
+
+        let evictions = evicted.lock().unwrap();
+        assert!(!evictions.is_empty(), "at least one size eviction should have fired");
+        // Every reported eviction must carry the original key/value pair we inserted.
+        for (key, value, cause) in evictions.iter() {
+            assert_eq!(*cause, crate::RemovalCause::Size, "capacity churn should evict by size");
+            let index: u64 = key
+                .strip_prefix("key")
+                .expect("key uses the 'keyN' format")
+                .parse()
+                .expect("N is numeric");
+            assert_eq!(*value, index, "value must match the key it was inserted with");
+        }
     }
 }

--- a/crates/cachet_memory/src/tier.rs
+++ b/crates/cachet_memory/src/tier.rs
@@ -163,9 +163,17 @@ where
             moka_builder = moka_builder.name(name);
         }
 
-        if let Some(listener) = builder.eviction_listener {
-            moka_builder = moka_builder.eviction_listener(move |key, entry: CacheEntry<V>, cause| {
-                listener(key, entry.into_value(), crate::notification::from_moka(cause));
+        let value_listener = builder.eviction_listener;
+        let removal_observers = builder.removal_observers;
+        if value_listener.is_some() || !removal_observers.is_empty() {
+            moka_builder = moka_builder.eviction_listener(move |key, entry: CacheEntry<V>, moka_cause| {
+                let cause = crate::notification::from_moka(moka_cause);
+                for observer in &removal_observers {
+                    observer(cause);
+                }
+                if let Some(listener) = &value_listener {
+                    listener(key, entry.into_value(), cause);
+                }
             });
         }
 
@@ -531,6 +539,58 @@ mod tests {
         // Every reported eviction must carry the original key/value pair we inserted.
         for (key, value, cause) in evictions.iter() {
             assert_eq!(*cause, crate::RemovalCause::Size, "capacity churn should evict by size");
+            let index: u64 = key
+                .strip_prefix("key")
+                .expect("key uses the 'keyN' format")
+                .parse()
+                .expect("N is numeric");
+            assert_eq!(*value, index, "value must match the key it was inserted with");
+        }
+    }
+
+    #[cfg_attr(miri, ignore)] // crossbeam-epoch triggers Stacked Borrows violations under Miri
+    #[tokio::test]
+    async fn eviction_notifies_both_value_listener_and_removal_observer() {
+        use std::sync::{Arc as StdArc, Mutex};
+
+        // The value listener (on_eviction) and cause-only removal observers use
+        // independent channels, so a single eviction must reach both without the
+        // value being cloned onto a shared channel.
+        let seen: StdArc<Mutex<Vec<(String, u64)>>> = StdArc::new(Mutex::new(Vec::new()));
+        let causes: StdArc<Mutex<Vec<crate::RemovalCause>>> = StdArc::new(Mutex::new(Vec::new()));
+        let seen_rec = StdArc::clone(&seen);
+        let causes_rec = StdArc::clone(&causes);
+
+        let capacity = 2;
+        let cache = InMemoryCache::<String, u64>::builder()
+            .max_capacity(capacity)
+            .with_removal_observer(move |cause| causes_rec.lock().unwrap().push(cause))
+            .on_eviction(move |key: StdArc<String>, value, _cause| {
+                seen_rec.lock().unwrap().push(((*key).clone(), value));
+            })
+            .build()
+            .expect("Cache should build successfully");
+
+        // Insert enough entries to force at least one size-based eviction.
+        for i in 0..(capacity + 3) {
+            cache
+                .insert(format!("key{i}"), CacheEntry::new(i))
+                .await
+                .expect("Insert should succeed");
+            cache.inner.run_pending_tasks().await;
+        }
+
+        let value_events = seen.lock().unwrap();
+        let cause_events = causes.lock().unwrap();
+        assert!(!value_events.is_empty(), "value listener should have observed an eviction");
+        assert!(!cause_events.is_empty(), "removal observer should have observed an eviction");
+        // Both channels observe the same evictions.
+        assert_eq!(value_events.len(), cause_events.len(), "both channels must fire once per eviction");
+        assert!(
+            cause_events.iter().all(|c| *c == crate::RemovalCause::Size),
+            "capacity churn should evict by size"
+        );
+        for (key, value) in value_events.iter() {
             let index: u64 = key
                 .strip_prefix("key")
                 .expect("key uses the 'keyN' format")


### PR DESCRIPTION
## Summary

The in-memory tier's eviction listener previously received only a `RemovalCause`, discarding the key and value of the entry that was removed. This makes it impossible for callers to react to *which* entry was evicted (e.g. cascading invalidation, secondary-index cleanup, logging). This PR passes the evicted key and value through to `on_eviction`.

## Changes

- `InMemoryCacheBuilder::on_eviction` now takes `Fn(Arc<K>, V, RemovalCause)` instead of `Fn(RemovalCause)`. The listener receives the evicted entry's key as a shared `Arc<K>` and its owned value `V`.
- The `cachet` eviction-telemetry hook is unchanged in behavior - it continues to emit `cache.eviction` / `cache.expired` from `RemovalCause` only and ignores the key/value.
- Adds a new doc hidden `with_removal_observer` to enable removal cause telemetry events in cachet. Setting it up as an eviction listener requires cloning `V` or passing it by reference.

## Breaking change

- Callers of `on_eviction` must update their closure from `|cause|` to `|key, value, cause|`. Telemetry consumers (`with_eviction_telemetry`) are unaffected.
- At most one listener is held. Calling `on_eviction` more than once replaces the previously registered listener.
