### PR TITLE
fix(ci): use pinned RUST_NIGHTLY toolchain in Publish GitHub Release workflow

### DIFF
--- a/.github/workflows/publish-gh-release.yml
+++ b/.github/workflows/publish-gh-release.yml
@@ -28,10 +28,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7.0.0
 
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@v1
+    - name: Setup
+      uses: ./.github/actions/setup
+      with:
+        rust-toolchain: RUST_NIGHTLY
 
     - name: Create GitHub Release
       env:
         GH_TOKEN: ${{ github.token }}
-      run: cargo +nightly -Zscript scripts/publish-gh-release.rs --repo "${{ github.repository }}" "${{ inputs.tag || github.ref_name }}"
+      run: cargo +${{ env.RUST_NIGHTLY }} -Zscript scripts/publish-gh-release.rs --repo "${{ github.repository }}" "${{ inputs.tag || github.ref_name }}"


### PR DESCRIPTION
The 'Install Rust' step in publish-gh-release.yml called dtolnay/rust-toolchain@v1 with no toolchain input, which the action requires and does not default. Every tag-triggered release run failed immediately with 'toolchain' is a required input
(see run 27985665025 / job 82826381521).

Switch to the repo's standard ./.github/actions/setup composite action with rust-toolchain: RUST_NIGHTLY, matching every other workflow (main.yml, nightly.yml). This installs the pinned nightly version from constants.env instead of a floating ightly, keeping the release build reproducible and consistent with the rest of CI.

Fixes AB#7584801


Successful run: https://github.com/microsoft/oxidizer/actions/runs/29001726998/job/86063652559
published version: https://github.com/microsoft/oxidizer/releases/tag/tick-v0.4.0