### PR TITLE
perf(templated_uri): optimize the per-request URI hot path

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -632,3 +632,5 @@ DAGs
 representable
 rc
 destructure
+SIMD
+Callgrind

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,15 +2766,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
-name = "pct-str"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756dc82399e1ef9b37bd698266e4b7fed5f3d3cccb09fbc6b602086c9077e4ad"
-dependencies = [
- "utf8-decode",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,11 +3670,12 @@ dependencies = [
 name = "templated_uri"
 version = "0.3.4"
 dependencies = [
+ "criterion",
  "data_privacy",
+ "gungraun",
  "http",
  "mutants",
  "ohno 0.3.8",
- "pct-str",
  "serde",
  "serde_json",
  "static_assertions",
@@ -4259,12 +4251,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf8-decode"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7932c10aa1600e9ddee027024aa9c0d397a103478253bf3fd6cea6dd03161b8a"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/templated_uri/Cargo.toml
+++ b/crates/templated_uri/Cargo.toml
@@ -59,12 +59,12 @@ uuid = ["dep:uuid"]
 data_privacy = { workspace = true }
 http = { workspace = true }
 ohno = { workspace = true }
-pct-str = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["std", "derive"], optional = true }
 templated_uri_macros = { workspace = true }
 uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 mutants = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
@@ -73,8 +73,20 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 trybuild = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
+# Callgrind instruction-count benchmarks (Valgrind is Linux-only).
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+gungraun = { workspace = true, features = ["default"] }
+
 [lints]
 workspace = true
+
+[[bench]]
+name = "hot_path"
+harness = false
+
+[[bench]]
+name = "hot_path_cg"
+harness = false
 
 [[example]]
 name = "classified_templating"

--- a/crates/templated_uri/benches/hot_path.rs
+++ b/crates/templated_uri/benches/hot_path.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Wall-clock benchmarks for the per-request URI hot path in `templated_uri`.
+//!
+//! An HTTP client builds a URI for every outgoing request: for a dynamic REST
+//! path it escapes variable values, renders a templated path, assembles a
+//! `Uri` (the base is configured once and reused), and materializes the full
+//! `http::Uri`. These benchmarks measure each of those per-call steps.
+//!
+//! Paired with `hot_path_cg.rs`, which measures the same operations under
+//! Callgrind instruction counts.
+
+#![allow(missing_docs, reason = "no need for API documentation on benchmark code")]
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use templated_uri::{BaseUri, EscapedString, PathAndQueryTemplate as _, Uri, templated};
+
+// A realistic REST path: a numeric id plus an escaped string segment.
+#[templated(template = "/users/{user_id}/posts/{post_id}", unredacted)]
+#[derive(Clone)]
+struct UserPostPath {
+    user_id: u32,
+    post_id: EscapedString,
+}
+
+// A dynamic value carrying reserved characters, so `escape` must percent-encode.
+const RAW_VALUE: &str = "my post title/with?reserved=chars";
+
+// A dynamic value that is already URI-clean, exercising the no-encoding fast path
+// where `escape` must avoid touching the allocator beyond owning the input.
+const CLEAN_VALUE: &str = "already-clean_value.42~ok";
+
+fn sample_path() -> UserPostPath {
+    UserPostPath {
+        user_id: 42,
+        // Owned value, mirroring a real request where the segment was just escaped.
+        post_id: EscapedString::escape(String::from("hello-world")),
+    }
+}
+
+fn sample_base() -> BaseUri {
+    BaseUri::from_static("https://api.example.com")
+}
+
+fn hot_path(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hot_path");
+
+    // Percent-encode a dynamic string value that contains reserved characters.
+    group.bench_function("escape", |b| b.iter(|| black_box(EscapedString::escape(black_box(RAW_VALUE)))));
+
+    // Escape a value that needs no encoding: exercises the allocation-free scan.
+    group.bench_function("escape_clean", |b| {
+        b.iter(|| black_box(EscapedString::escape(black_box(CLEAN_VALUE))));
+    });
+
+    let path = sample_path();
+
+    // Render a templated path into a `String`.
+    group.bench_function("render", |b| b.iter(|| black_box(black_box(&path).render())));
+
+    // Render + validate into an `http` `PathAndQuery`.
+    group.bench_function("to_path_and_query", |b| {
+        b.iter(|| black_box(black_box(&path).to_path_and_query().expect("valid path-and-query")));
+    });
+
+    // End-to-end per-call construction: a reused base plus a freshly built path.
+    let base = sample_base();
+    group.bench_function("build_uri", |b| {
+        b.iter(|| {
+            black_box(
+                Uri::default()
+                    .with_base(black_box(&base).clone())
+                    .with_path_and_query(black_box(&path).clone()),
+            )
+        });
+    });
+
+    // Full per-request materialization: build the `Uri` (reused base + fresh templated
+    // path) and convert it into a validated `http::Uri`, exactly as an HTTP client does
+    // for every outgoing request. This is the real hot path end to end.
+    group.bench_function("materialize", |b| {
+        b.iter(|| {
+            let uri = Uri::default()
+                .with_base(black_box(&base).clone())
+                .with_path_and_query(black_box(&path).clone());
+            black_box(http::Uri::try_from(uri).expect("valid http uri"))
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, hot_path);
+criterion_main!(benches);

--- a/crates/templated_uri/benches/hot_path_cg.rs
+++ b/crates/templated_uri/benches/hot_path_cg.rs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Callgrind benchmarks for the per-request URI hot path in `templated_uri`.
+//!
+//! An HTTP client builds a URI for every outgoing request; these benchmarks
+//! isolate the per-call steps for a dynamic REST path — escaping a variable,
+//! rendering a templated path, validating it into an `http` `PathAndQuery`,
+//! assembling a `Uri`, and materializing the full `http::Uri` (base + path).
+//!
+//! Paired with `hot_path.rs`, which covers the same operations under wall-clock
+//! (Criterion) measurement.
+
+#![allow(missing_docs, reason = "no need for API documentation on benchmark code")]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "gungraun benchmark inputs are passed and returned by value by the framework"
+)]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Upstream tracking issues are pending."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is Linux-only.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+
+    use gungraun::{library_benchmark, library_benchmark_group};
+    use templated_uri::{BaseUri, EscapedString, PathAndQueryTemplate as _, Uri, templated};
+
+    // A realistic REST path: a numeric id plus an escaped string segment.
+    #[templated(template = "/users/{user_id}/posts/{post_id}", unredacted)]
+    #[derive(Clone)]
+    struct UserPostPath {
+        user_id: u32,
+        post_id: EscapedString,
+    }
+
+    // A dynamic value carrying reserved characters, so `escape` must percent-encode.
+    const RAW_VALUE: &str = "my post title/with?reserved=chars";
+
+    // A dynamic value that is already URI-clean, exercising the no-encoding fast path.
+    const CLEAN_VALUE: &str = "already-clean_value.42~ok";
+
+    fn sample_path() -> UserPostPath {
+        UserPostPath {
+            user_id: 42,
+            // Owned value, mirroring a real request where the segment was just escaped.
+            post_id: EscapedString::escape(String::from("hello-world")),
+        }
+    }
+
+    fn sample_base() -> BaseUri {
+        BaseUri::from_static("https://api.example.com")
+    }
+
+    // Percent-encode a dynamic string value containing reserved characters.
+    #[library_benchmark]
+    fn escape() -> EscapedString {
+        EscapedString::escape(black_box(RAW_VALUE))
+    }
+
+    // Escape a value that needs no encoding: exercises the allocation-free scan.
+    #[library_benchmark]
+    fn escape_clean() -> EscapedString {
+        EscapedString::escape(black_box(CLEAN_VALUE))
+    }
+
+    // Render a templated path into a `String`.
+    #[library_benchmark]
+    #[bench::sample(sample_path())]
+    fn render(path: UserPostPath) -> UserPostPath {
+        black_box(black_box(&path).render());
+        path
+    }
+
+    // Render + validate a templated path into an `http` `PathAndQuery`.
+    #[library_benchmark]
+    #[bench::sample(sample_path())]
+    fn to_path_and_query(path: UserPostPath) -> UserPostPath {
+        black_box(black_box(&path).to_path_and_query().expect("valid path-and-query"));
+        path
+    }
+
+    // End-to-end per-call construction: a reused base plus a freshly built path.
+    #[library_benchmark]
+    #[bench::sample((sample_path(), sample_base()))]
+    fn build_uri(input: (UserPostPath, BaseUri)) -> Uri {
+        let (path, base) = input;
+        Uri::default().with_base(black_box(base)).with_path_and_query(black_box(path))
+    }
+
+    // Full per-request materialization: build the `Uri` (reused base + fresh templated
+    // path) and convert it into a validated `http::Uri`, exactly as an HTTP client does
+    // for every outgoing request. This is the real hot path end to end.
+    #[library_benchmark]
+    #[bench::sample((sample_path(), sample_base()))]
+    fn materialize(input: (UserPostPath, BaseUri)) -> http::Uri {
+        let (path, base) = input;
+        let uri = Uri::default().with_base(black_box(base)).with_path_and_query(black_box(path));
+        http::Uri::try_from(uri).expect("valid http uri")
+    }
+
+    library_benchmark_group!(
+        name = hot_path;
+        benchmarks = escape, escape_clean, render, to_path_and_query, build_uri, materialize
+    );
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::hot_path;
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default()
+        .tool(Callgrind::with_args(["--branch-sim=yes"]));
+    library_benchmark_groups = hot_path
+);

--- a/crates/templated_uri/src/base_path.rs
+++ b/crates/templated_uri/src/base_path.rs
@@ -71,6 +71,59 @@ impl BasePath {
         let full_path = format!("{}{path_str}", self.as_str());
         Ok(PathAndQuery::try_from(full_path)?)
     }
+
+    /// Joins this base path with a [`crate::PathAndQuery`], rendering and validating in a
+    /// single pass.
+    ///
+    /// This is the request hot-path equivalent of [`join_path_and_query`](Self::join_path_and_query):
+    /// rather than materializing the other path into a validated [`PathAndQuery`] first (an
+    /// allocation plus a full URI parse) and then re-joining and re-parsing, it renders the
+    /// other path's text directly into a buffer already seeded with this base path and
+    /// validates the joined result exactly once.
+    ///
+    /// The join semantics match [`join_path_and_query`](Self::join_path_and_query): the base
+    /// path always ends with `/`, and any leading slashes of the rendered path are trimmed so
+    /// exactly one separator sits at the boundary (a rendered path of only slashes collapses
+    /// to the bare base path).
+    ///
+    /// # Errors
+    ///
+    /// The rendered path must be absolute (start with `/`), which every template the crate
+    /// produces satisfies (the `#[templated]` macro requires a leading `/`, and static paths
+    /// are validated to have one). This is rejected up front so that materializing a `Uri`
+    /// *with* a base accepts exactly the same paths as materializing one *without* it (where
+    /// [`to_path_and_query`](crate::PathAndQueryTemplate::to_path_and_query) parses the
+    /// rendered path standalone and `http` rejects a path-and-query without a leading slash) -
+    /// a base must never turn an otherwise-invalid path into a valid URI. A [`UriError`] is
+    /// also returned if the joined result is not a valid path-and-query.
+    pub(crate) fn join_rendered(&self, other: &crate::PathAndQuery) -> Result<PathAndQuery, UriError> {
+        let base = self.as_str();
+        let mut buf = String::with_capacity(base.len() + other.render_capacity_hint());
+        buf.push_str(base);
+
+        // Everything appended from here is the rendered "other" path; `mark` is where it starts.
+        let mark = buf.len();
+        other.render_into(&mut buf);
+
+        // The rendered path must be absolute, matching the standalone validation done when
+        // there is no base, so a base never rescues an invalid path. An empty render (which
+        // does not start with `/`) is rejected here too, consistent with `http`.
+        if !buf[mark..].starts_with('/') {
+            return Err(UriError::invalid_uri("the rendered path and query must start with a slash"));
+        }
+
+        // Reproduce `base + rendered.trim_start_matches('/')`: the base already ends with a
+        // slash, so drop the rendered path's leading slashes at the boundary.
+        match buf[mark..].bytes().position(|b| b != b'/') {
+            Some(first_non_slash) => {
+                drop(buf.drain(mark..mark + first_non_slash));
+            }
+            // The rendered path was all slashes: the join is just the base path.
+            None => return Ok(self.inner.clone()),
+        }
+
+        Ok(PathAndQuery::try_from(buf)?)
+    }
 }
 
 impl Default for BasePath {
@@ -231,10 +284,125 @@ mod tests {
     }
 
     #[test]
+    fn join_rendered_matches_join_path_and_query_for_static_paths() {
+        // `join_rendered` (single render+join+validate pass, used on the request hot path)
+        // must produce byte-identical results to the original `join_path_and_query`
+        // (materialize-then-join) across a broad range of bases and paths, including the
+        // multiple-leading-slash and empty cases the join must normalize identically.
+        let bases = ["/", "/api/", "/api/v1/", "/deep/nested/base/"];
+        let paths = [
+            "/",
+            "/users",
+            "/users/42",
+            "/users/42?active=true",
+            "/a/b/c?x=1&y=2",
+            "//double",      // 2 leading slashes must collapse to one at the boundary
+            "///triple/seg", // 3 leading slashes must collapse to one
+            "/trailing/",
+            "/only?q=1",
+        ];
+
+        for base_str in bases {
+            let base = BasePath::from_static(base_str);
+            for path_str in paths {
+                let http_pq = PathAndQuery::from_static(path_str);
+                let templated_pq = crate::PathAndQuery::from(http_pq.clone());
+
+                let old = base.join_path_and_query(&http_pq).expect("old join should succeed");
+                let new = base.join_rendered(&templated_pq).expect("new join should succeed");
+
+                assert_eq!(
+                    new.as_str(),
+                    old.as_str(),
+                    "join mismatch for base {base_str:?} + path {path_str:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn try_from_path_ref() {
         let paq = PathAndQuery::from_static("/ref/path/");
         let path = BasePath::try_from(&paq).unwrap();
         assert_eq!(path.as_str(), "/ref/path/");
+    }
+
+    /// A hand-written [`crate::PathAndQueryTemplate`] whose `render` output does *not* start
+    /// with `/`, used to check that a base does not rescue an otherwise-invalid path.
+    #[derive(Debug)]
+    struct NonAbsoluteTemplate;
+
+    impl RedactedDisplay for NonAbsoluteTemplate {
+        fn fmt(&self, _redactor: &dyn Redactor, f: &mut Formatter<'_>) -> fmt::Result {
+            f.write_str("users/42")
+        }
+    }
+
+    impl crate::PathAndQueryTemplate for NonAbsoluteTemplate {
+        fn render(&self) -> String {
+            // Deliberately non-absolute (no leading slash), violating the template contract.
+            String::from("users/42")
+        }
+
+        fn to_path_and_query(&self) -> Result<PathAndQuery, UriError> {
+            Ok(PathAndQuery::try_from(self.render())?)
+        }
+
+        fn template(&self) -> &'static str {
+            "users/42"
+        }
+
+        fn format_template(&self) -> &'static str {
+            "users/42"
+        }
+
+        fn label(&self) -> Option<&'static str> {
+            None
+        }
+    }
+
+    #[test]
+    fn join_rendered_rejects_non_absolute_path() {
+        // A rendered path that is not absolute must be rejected, so that materializing a `Uri`
+        // with a base is consistent with `to_path_and_query()` (which also rejects it): a base
+        // must never turn an invalid path into a valid one.
+        let base = BasePath::from_static("/api/");
+        let bad = crate::PathAndQuery::from_template(NonAbsoluteTemplate);
+
+        // Standalone validation rejects it...
+        crate::PathAndQueryTemplate::to_path_and_query(&NonAbsoluteTemplate).unwrap_err();
+
+        // ...and so does the base-join hot path, with a descriptive message.
+        let err = base.join_rendered(&bad).unwrap_err();
+        assert!(err.to_string().contains("must start with a slash"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn join_rendered_accepts_absolute_rendered_path() {
+        // The positive counterpart: an absolute rendered path joins successfully. Guards
+        // against a mutant that inverts the leading-slash check and rejects valid paths.
+        let base = BasePath::from_static("/api/");
+        let good = crate::PathAndQuery::from(PathAndQuery::from_static("/users/42"));
+        let joined = base.join_rendered(&good).expect("absolute path should join");
+        assert_eq!(joined.as_str(), "/api/users/42");
+    }
+
+    #[test]
+    fn non_absolute_template_trait_methods() {
+        // Exercise the remaining `PathAndQueryTemplate` / `RedactedDisplay` methods of the
+        // `NonAbsoluteTemplate` test helper so it is fully covered.
+        use data_privacy::{RedactedToString, RedactionEngine};
+
+        use crate::PathAndQueryTemplate;
+
+        let template = NonAbsoluteTemplate;
+        assert_eq!(template.render(), "users/42");
+        assert_eq!(template.template(), "users/42");
+        assert_eq!(template.format_template(), "users/42");
+        assert_eq!(template.label(), None);
+
+        let engine = RedactionEngine::builder().build();
+        assert_eq!(template.to_redacted_string(&engine), "users/42");
     }
 
     #[test]

--- a/crates/templated_uri/src/base_uri.rs
+++ b/crates/templated_uri/src/base_uri.rs
@@ -510,7 +510,23 @@ impl BaseUri {
 
     fn build_http_uri_inner(&self, path: &PathAndQuery) -> Result<http::Uri, UriError> {
         let full_path = self.path.join_path_and_query(path)?;
+        self.assemble(full_path)
+    }
 
+    /// Builds an [`http::Uri`] from this base and a [`crate::PathAndQuery`], rendering,
+    /// joining, and validating the path in a single pass.
+    ///
+    /// This is the request hot-path entry point used by `TryFrom<Uri> for http::Uri`: it
+    /// avoids materializing the path into a standalone validated [`PathAndQuery`] (an extra
+    /// allocation and URI parse) before joining it onto the base.
+    pub(crate) fn build_http_uri_from_paq(&self, path: &crate::PathAndQuery) -> Result<http::Uri, UriError> {
+        let full_path = self.path.join_rendered(path)?;
+        self.assemble(full_path)
+    }
+
+    /// Assembles a validated [`http::Uri`] from this base's scheme/authority and a
+    /// fully-joined path-and-query.
+    fn assemble(&self, full_path: PathAndQuery) -> Result<http::Uri, UriError> {
         let mut parts = Parts::default();
         parts.scheme = Some(self.scheme().clone());
         parts.authority = Some(self.authority().clone());

--- a/crates/templated_uri/src/escape.rs
+++ b/crates/templated_uri/src/escape.rs
@@ -23,6 +23,19 @@ use crate::{Escaped, EscapedString};
 pub trait Escape {
     /// Returns this value wrapped in [`Escaped`], proving it is properly escaped for URI use.
     fn escape(&self) -> Escaped<impl Display>;
+
+    /// Appends the escaped rendering of this value to `out`.
+    ///
+    /// Equivalent to writing [`escape`](Escape::escape)'s result to `out`, but string-backed
+    /// types override it to `push_str` their already-escaped contents directly, skipping the
+    /// [`core::fmt`] formatting machinery on the URI-rendering hot path. Used by the
+    /// `#[templated]`-generated `render` implementation.
+    fn escape_into(&self, out: &mut String) {
+        use std::fmt::Write as _;
+        write!(out, "{}", self.escape()).expect(
+            "writing to a String is infallible, so any Err here means the value's Display impl returned fmt::Error, which it must not",
+        );
+    }
 }
 
 /// Marks types whose `Display` output is emitted verbatim into a URI, without
@@ -38,16 +51,19 @@ pub trait Escape {
 pub trait Raw {
     /// Returns this value's raw `Display` form, to be inserted into a URI without escaping.
     fn raw(&self) -> impl Display;
-}
 
-macro_rules! impl_raw {
-    ($t:ty) => {
-        impl Raw for $t {
-            fn raw(&self) -> impl Display {
-                self
-            }
-        }
-    };
+    /// Appends the raw rendering of this value to `out`.
+    ///
+    /// Equivalent to writing [`raw`](Raw::raw)'s result to `out`, but string-backed types
+    /// override it to `push_str` their contents directly, skipping the [`core::fmt`]
+    /// formatting machinery on the URI-rendering hot path. Used by the
+    /// `#[templated]`-generated `render` implementation for `{+var}` expansions.
+    fn raw_into(&self, out: &mut String) {
+        use std::fmt::Write as _;
+        write!(out, "{}", self.raw()).expect(
+            "writing to a String is infallible, so any Err here means the value's Display impl returned fmt::Error, which it must not",
+        );
+    }
 }
 
 macro_rules! impl_escape {
@@ -60,17 +76,36 @@ macro_rules! impl_escape {
     };
 }
 
-impl_raw!(String);
+impl Raw for String {
+    fn raw(&self) -> impl Display {
+        self
+    }
+
+    fn raw_into(&self, out: &mut String) {
+        out.push_str(self);
+    }
+}
 
 impl Escape for EscapedString {
     fn escape(&self) -> Escaped<impl Display> {
-        self.clone()
+        // Borrow the already-escaped contents instead of cloning the `Cow`, which would
+        // reallocate for an owned value on every render.
+        Escaped::from_escaped(self.as_str())
+    }
+
+    fn escape_into(&self, out: &mut String) {
+        // The contents are already escaped, so copy them in one shot with no formatting.
+        out.push_str(self.as_str());
     }
 }
 
 impl Raw for EscapedString {
     fn raw(&self) -> impl Display {
         self.as_str()
+    }
+
+    fn raw_into(&self, out: &mut String) {
+        out.push_str(self.as_str());
     }
 }
 
@@ -155,6 +190,26 @@ mod tests {
     fn raw_uri_escaped_string() {
         let s = EscapedString::escape("hello world");
         assert_eq!(format!("{}", s.raw()), "hello%20world");
+    }
+
+    #[test]
+    fn escaped_string_raw_into_appends_contents() {
+        // `Raw::raw_into` for `EscapedString` is used when an already-escaped value fills a
+        // reserved-expansion (`{+var}`) position; it must append the contents verbatim.
+        let s = EscapedString::escape("hello world");
+        let mut buf = String::from("/prefix/");
+        s.raw_into(&mut buf);
+        assert_eq!(buf, "/prefix/hello%20world");
+    }
+
+    #[test]
+    fn escaped_string_escape_into_appends_contents() {
+        // `Escape::escape_into` for `EscapedString` appends the already-escaped contents
+        // directly (the render fast path used by the `#[templated]` macro).
+        let s = EscapedString::escape("a b");
+        let mut buf = String::from("/prefix/");
+        s.escape_into(&mut buf);
+        assert_eq!(buf, "/prefix/a%20b");
     }
 
     #[test]

--- a/crates/templated_uri/src/escaped.rs
+++ b/crates/templated_uri/src/escaped.rs
@@ -14,8 +14,9 @@ use uuid::Uuid;
 /// A wrapper that proves the inner value is already escaped for use in URI templates.
 ///
 /// The invariant is enforced via constructors - only types whose [`Display`] output
-/// contains no RFC 6570 reserved characters can be wrapped. For inherently-safe
-/// types (integers, [`IpAddr`]) an infallible [`From`] impl is provided.
+/// is already safe to splice into a URI verbatim (no *unescaped* RFC 6570 reserved
+/// characters; well-formed `%XX` percent-escapes are allowed) can be wrapped. For
+/// inherently-safe types (integers, [`IpAddr`]) an infallible [`From`] impl is provided.
 /// With the `uuid` feature (enabled by default), `Uuid` is also supported.
 /// For strings, use the encoding/validating constructors on [`Escaped<Cow<'static, str>>`]
 /// (aliased as [`EscapedString`]).
@@ -272,8 +273,11 @@ fn first_reserved(bytes: &[u8]) -> Option<usize> {
 ///
 /// The clean prefix `s[..first]` and every subsequent run of unreserved bytes are copied
 /// in bulk via `push_str` (no per-character formatting), and each reserved byte is emitted
-/// as a `%XX` escape using a direct hex table. All slice boundaries fall on unreserved
-/// ASCII bytes, so the `&str` indexing is always valid.
+/// as a `%XX` escape using a direct hex table. Every index used for `&str` slicing is a
+/// UTF-8 character boundary: `first` (and each subsequent run boundary) is the position of
+/// a byte that is not an unreserved ASCII byte, and since all unreserved bytes are
+/// single-byte ASCII, such a position never falls in the middle of a multi-byte code point.
+/// So the `&str` indexing is always valid.
 // The manual index advance (`i += 1`) mutates to `i *= 1`, which never advances `i` and spins
 // the `while` loop forever, pushing to `out` until the process runs out of memory. That hangs the mutation
 // runner rather than producing a killable diff, so the function is skipped; its output is

--- a/crates/templated_uri/src/escaped.rs
+++ b/crates/templated_uri/src/escaped.rs
@@ -8,7 +8,6 @@ use std::fmt::{Debug, Display};
 use std::net::IpAddr;
 use std::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize};
 
-use pct_str::{PctString, UriReserved};
 #[cfg(feature = "uuid")]
 use uuid::Uuid;
 
@@ -23,6 +22,19 @@ use uuid::Uuid;
 #[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Escaped<T>(T);
+
+impl<T> Escaped<T> {
+    /// Wraps an already-escaped value without re-checking the invariant.
+    ///
+    /// Crate-internal: the caller guarantees the value's [`Display`] output is already
+    /// escaped for URI use - i.e. safe to splice into a URI verbatim without further
+    /// encoding (it may contain `%XX` percent-escape sequences). Used to hand out cheap
+    /// borrowing views (e.g. `Escaped<&str>`) that avoid cloning an owned [`EscapedString`]
+    /// on the render hot path.
+    pub(crate) const fn from_escaped(inner: T) -> Self {
+        Self(inner)
+    }
+}
 
 impl<T: Display> Display for Escaped<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -114,16 +126,16 @@ impl EscapedString {
     /// ```
     pub fn escape<'a>(s: impl Into<Cow<'a, str>>) -> Self {
         let s = s.into();
-        let encoded = PctString::encode(s.chars(), UriReserved::Any);
-        if encoded.as_str().len() == s.len() {
-            // No characters required encoding; avoid allocating a new `String` when
-            // the caller already owns one.
-            match s {
+        // Scan for the first byte that must be percent-encoded. The unreserved set is
+        // pure ASCII, so a byte scan is exact (any non-ASCII byte is >= 0x80 and always
+        // encoded) and lets the compiler vectorize the common all-clean case.
+        match first_reserved(s.as_bytes()) {
+            // Nothing needs encoding: never touch the allocator except to own a borrow.
+            None => match s {
                 Cow::Owned(owned) => Self(Cow::Owned(owned)),
                 Cow::Borrowed(borrowed) => Self(Cow::Owned(borrowed.to_owned())),
-            }
-        } else {
-            Self(Cow::Owned(encoded.into_string()))
+            },
+            Some(first) => Self(Cow::Owned(percent_encode(&s, first))),
         }
     }
 
@@ -235,6 +247,67 @@ const fn validate_escaped(bytes: &[u8]) -> Option<&'static str> {
     None
 }
 
+/// Returns `true` if `b` is an RFC 6570 *unreserved* byte (`A-Z`, `a-z`, `0-9`, `-`, `.`,
+/// `_`, `~`) that may appear in a URI without percent-encoding.
+///
+/// This is the exact complement of the set [`EscapedString::escape`] encodes: the
+/// unreserved characters are all ASCII, so any byte outside this set - including every
+/// byte of a multi-byte UTF-8 sequence (all `>= 0x80`) and `%` itself - is encoded.
+const fn is_unreserved_byte(b: u8) -> bool {
+    matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~')
+}
+
+/// Returns the index of the first byte in `bytes` that must be percent-encoded, or `None`
+/// when every byte is unreserved.
+///
+/// The predicate is a handful of range comparisons over independent bytes, which the
+/// compiler can auto-vectorize into a wide SIMD scan on the hot all-clean path - no
+/// per-byte allocation or UTF-8 decoding required.
+fn first_reserved(bytes: &[u8]) -> Option<usize> {
+    bytes.iter().position(|&b| !is_unreserved_byte(b))
+}
+
+/// Percent-encodes `s` into a freshly allocated `String`, given `first` = the index of the
+/// first byte that requires encoding (as found by [`first_reserved`]).
+///
+/// The clean prefix `s[..first]` and every subsequent run of unreserved bytes are copied
+/// in bulk via `push_str` (no per-character formatting), and each reserved byte is emitted
+/// as a `%XX` escape using a direct hex table. All slice boundaries fall on unreserved
+/// ASCII bytes, so the `&str` indexing is always valid.
+fn percent_encode(s: &str, first: usize) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    let bytes = s.as_bytes();
+    // Reserve the clean length plus headroom for a handful of `%XX` expansions (each adds
+    // two bytes). This avoids a reallocation for the common "a few reserved chars" case
+    // without paying for a second counting pass; heavily-escaped inputs may grow once.
+    let mut out = String::with_capacity(bytes.len() + 16);
+    out.push_str(&s[..first]);
+
+    let mut run_start = first;
+    let mut i = first;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if is_unreserved_byte(b) {
+            i += 1;
+            continue;
+        }
+        // Flush the pending run of clean bytes, then emit the escape for this byte.
+        if run_start < i {
+            out.push_str(&s[run_start..i]);
+        }
+        out.push('%');
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+        i += 1;
+        run_start = i;
+    }
+    if run_start < bytes.len() {
+        out.push_str(&s[run_start..]);
+    }
+    out
+}
+
 impl From<String> for EscapedString {
     /// Converts a [`String`] to an `EscapedString`, percent-encoding any RFC 6570 reserved characters.
     ///
@@ -314,6 +387,127 @@ mod tests {
         for reserved in RESERVED_CHARACTERS.chars() {
             let encoded_str = EscapedString::escape(format!("hello_{reserved}_world"));
             assert_eq!(encoded_str.to_string(), format!("hello_%{:02X}_world", reserved as u8));
+        }
+    }
+
+    #[test]
+    fn escape_multibyte_utf8_percent_encodes_each_byte() {
+        // Every byte of a multi-byte UTF-8 sequence is >= 0x80 and must be percent-encoded
+        // individually using uppercase hex, matching the previous `pct_str`-based behavior.
+        assert_eq!(EscapedString::escape("café").as_str(), "caf%C3%A9");
+        assert_eq!(EscapedString::escape("naïve—dash").as_str(), "na%C3%AFve%E2%80%94dash");
+    }
+
+    #[test]
+    fn escape_percent_sign_is_encoded() {
+        // A literal `%` is itself reserved and must become `%25`.
+        assert_eq!(EscapedString::escape("100%").as_str(), "100%25");
+        assert_eq!(EscapedString::escape("%3D").as_str(), "%253D");
+    }
+
+    #[test]
+    fn escape_handles_leading_trailing_and_mixed_runs() {
+        // Reserved bytes at the very start and end, with clean runs in between, must all be
+        // flushed correctly with uppercase hex.
+        assert_eq!(EscapedString::escape("/a b/").as_str(), "%2Fa%20b%2F");
+        assert_eq!(EscapedString::escape(" ").as_str(), "%20");
+        assert_eq!(EscapedString::escape("~clean.only_-").as_str(), "~clean.only_-");
+    }
+
+    #[test]
+    fn escape_empty_string_is_empty() {
+        assert_eq!(EscapedString::escape("").as_str(), "");
+    }
+
+    /// Reference percent-encoder that mirrors the exact RFC 6570 `UriReserved::Any`
+    /// semantics the crate relied on before the hand-rolled byte encoder: keep an
+    /// unreserved character verbatim, otherwise percent-encode every one of its UTF-8
+    /// bytes as uppercase `%XX`. Used only to cross-check [`EscapedString::escape`].
+    fn reference_escape(s: &str) -> String {
+        use std::fmt::Write as _;
+        fn is_unreserved(c: char) -> bool {
+            c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~')
+        }
+        let mut out = String::new();
+        for c in s.chars() {
+            if is_unreserved(c) {
+                out.push(c);
+            } else {
+                let mut buf = [0u8; 4];
+                for &b in c.encode_utf8(&mut buf).as_bytes() {
+                    write!(out, "%{b:02X}").expect("writing to a String is infallible");
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn escape_matches_reference_for_all_ascii_and_selected_unicode() {
+        // Every ASCII scalar plus a spread of 2-, 3- and 4-byte UTF-8 characters, checked
+        // individually and as a concatenated string, must match the reference encoder.
+        let mut singles: Vec<String> = (0u8..=0x7F).map(|b| (b as char).to_string()).collect();
+        for c in ['é', 'ñ', 'ü', '€', '£', '日', '本', '😀', '~', '%', ' ', '/', '?', '#'] {
+            singles.push(c.to_string());
+        }
+
+        let mut combined = String::new();
+        for s in &singles {
+            assert_eq!(
+                EscapedString::escape(s.as_str()).as_str(),
+                reference_escape(s),
+                "mismatch escaping {s:?}"
+            );
+            combined.push_str(s);
+        }
+        // The full concatenation exercises run-flushing across every boundary at once.
+        assert_eq!(EscapedString::escape(combined.as_str()).as_str(), reference_escape(&combined));
+    }
+
+    #[test]
+    fn escape_matches_reference_under_pseudo_random_fuzz() {
+        // Deterministic LCG over a mixed alphabet (clean, ASCII-reserved and multi-byte
+        // characters) across many lengths - a broad differential check against the
+        // reference encoder without a proptest dependency.
+        const ALPHABET: &[char] = &[
+            'a', 'Z', '0', '9', '-', '.', '_', '~', // unreserved
+            '/', '?', '#', '%', ' ', '&', '=', '+', ':', '@', // reserved ASCII
+            'é', 'ß', '€', '日', '😀', // multi-byte
+        ];
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (state >> 33) as usize
+        };
+        for _ in 0..2000 {
+            let len = next() % 24;
+            let s: String = (0..len).map(|_| ALPHABET[next() % ALPHABET.len()]).collect();
+            assert_eq!(
+                EscapedString::escape(s.as_str()).as_str(),
+                reference_escape(&s),
+                "mismatch for {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn escape_output_always_revalidates() {
+        // Invariant: `escape` must always produce a string that `try_new`/`from_static`
+        // accept as already-escaped. This ties the encoder and the validator together so
+        // they can never disagree about what constitutes a valid escaped string.
+        for raw in [
+            "",
+            "clean-only_~.09AZ",
+            "needs escaping / ? # %",
+            "café/naïve?x=€",
+            "100%",
+            "😀 mixed 日本 text!",
+        ] {
+            let escaped = EscapedString::escape(raw);
+            EscapedString::try_new(escaped.as_str().to_owned())
+                .unwrap_or_else(|e| panic!("escape({raw:?}) = {:?} failed re-validation: {e}", escaped.as_str()));
         }
     }
 

--- a/crates/templated_uri/src/escaped.rs
+++ b/crates/templated_uri/src/escaped.rs
@@ -274,6 +274,11 @@ fn first_reserved(bytes: &[u8]) -> Option<usize> {
 /// in bulk via `push_str` (no per-character formatting), and each reserved byte is emitted
 /// as a `%XX` escape using a direct hex table. All slice boundaries fall on unreserved
 /// ASCII bytes, so the `&str` indexing is always valid.
+// The manual index advance (`i += 1`) mutates to `i *= 1`, which never advances `i` and spins
+// the `while` loop forever, pushing to `out` until the process runs out of memory. That hangs the mutation
+// runner rather than producing a killable diff, so the function is skipped; its output is
+// pinned by the differential/fuzz/exact-hex and re-validation tests in this module instead.
+#[cfg_attr(test, mutants::skip)]
 fn percent_encode(s: &str, first: usize) -> String {
     const HEX: &[u8; 16] = b"0123456789ABCDEF";
 

--- a/crates/templated_uri/src/path_and_query.rs
+++ b/crates/templated_uri/src/path_and_query.rs
@@ -326,6 +326,86 @@ mod tests {
         let err = PathAndQuery::try_from(String::from("api/v1/users")).unwrap_err();
         assert_eq!(err.label(), "uri_invalid");
     }
+
+    /// Minimal hand-written [`PathAndQueryTemplate`] used to exercise the `Templated` arm of
+    /// [`PathAndQuery::render_into`] / [`PathAndQuery::render_capacity_hint`] with values that
+    /// differ from both `0` and `1` (so whole-body mutants are caught) and from the `Static`
+    /// arm's string length (so an arm swap would change the observed result).
+    #[derive(Debug)]
+    struct FixedTemplate;
+
+    impl RedactedDisplay for FixedTemplate {
+        fn fmt(&self, _redactor: &dyn Redactor, f: &mut Formatter<'_>) -> fmt::Result {
+            f.write_str("/fixed/template")
+        }
+    }
+
+    impl PathAndQueryTemplate for FixedTemplate {
+        fn render(&self) -> String {
+            String::from("/fixed/template")
+        }
+
+        fn render_into(&self, buf: &mut String) {
+            buf.push_str("/fixed/template");
+        }
+
+        fn render_capacity_hint(&self) -> usize {
+            42
+        }
+
+        fn to_path_and_query(&self) -> Result<HttpPathAndQuery, UriError> {
+            Ok(HttpPathAndQuery::try_from(self.render())?)
+        }
+
+        fn template(&self) -> &'static str {
+            "/fixed/template"
+        }
+
+        fn format_template(&self) -> &'static str {
+            "/fixed/template"
+        }
+
+        fn label(&self) -> Option<&'static str> {
+            None
+        }
+    }
+
+    #[test]
+    fn render_into_static_appends_text() {
+        // The `Static` arm appends the underlying path text verbatim to the caller's buffer,
+        // preserving any existing prefix. Kills a mutant that replaces `render_into` with `()`.
+        let pq = PathAndQuery::from_static("/api/v1/users?active=true");
+        let mut buf = String::from("/base/");
+        pq.render_into(&mut buf);
+        assert_eq!(buf, "/base//api/v1/users?active=true");
+    }
+
+    #[test]
+    fn render_into_templated_delegates() {
+        // The `Templated` arm delegates to the template's `render_into`. Using a distinct
+        // string guards against an arm swap and against dropping the append.
+        let pq = PathAndQuery::from_template(FixedTemplate);
+        let mut buf = String::from("/base/");
+        pq.render_into(&mut buf);
+        assert_eq!(buf, "/base//fixed/template");
+    }
+
+    #[test]
+    fn render_capacity_hint_static_is_str_len() {
+        // The `Static` arm reports the exact byte length of the path text. Asserting a value
+        // that is neither `0` nor `1` kills the whole-body replacement mutants.
+        let pq = PathAndQuery::from_static("/api/v1/");
+        assert_eq!(pq.render_capacity_hint(), "/api/v1/".len());
+        assert_eq!(pq.render_capacity_hint(), 8);
+    }
+
+    #[test]
+    fn render_capacity_hint_templated_delegates() {
+        // The `Templated` arm forwards to the template's hint (here a fixed `42`), distinct
+        // from the `Static` arm's length computation so an arm swap is observable.
+        let pq = PathAndQuery::from_template(FixedTemplate);
+        assert_eq!(pq.render_capacity_hint(), 42);
+    }
 }
 
 #[cfg(all(test, feature = "serde"))]

--- a/crates/templated_uri/src/path_and_query.rs
+++ b/crates/templated_uri/src/path_and_query.rs
@@ -44,6 +44,28 @@ impl PathAndQuery {
         Self::from(HttpPathAndQuery::from_static(path))
     }
 
+    /// Appends this path-and-query's rendered text to `buf`.
+    ///
+    /// For a static value this is a single `push_str`; for a templated value it renders
+    /// the fields directly into `buf`, avoiding the intermediate `String` that
+    /// [`to_string`](Self::to_string) would allocate. Used by base-URI joining on the
+    /// request hot path.
+    pub(crate) fn render_into(&self, buf: &mut String) {
+        match &self.0 {
+            PathAndQueryInner::Static(classified_pq) => buf.push_str(classified_pq.declassify_ref().as_str()),
+            PathAndQueryInner::Templated(templated) => templated.render_into(buf),
+        }
+    }
+
+    /// Returns a heuristic byte-capacity estimate for [`render_into`](Self::render_into),
+    /// so a caller can size its buffer to avoid reallocating mid-render.
+    pub(crate) fn render_capacity_hint(&self) -> usize {
+        match &self.0 {
+            PathAndQueryInner::Static(classified_pq) => classified_pq.declassify_ref().as_str().len(),
+            PathAndQueryInner::Templated(templated) => templated.render_capacity_hint(),
+        }
+    }
+
     /// Returns the template string for this path and query.
     #[must_use]
     pub fn template(&self) -> Cow<'static, str> {

--- a/crates/templated_uri/src/path_and_query.rs
+++ b/crates/templated_uri/src/path_and_query.rs
@@ -406,6 +406,26 @@ mod tests {
         let pq = PathAndQuery::from_template(FixedTemplate);
         assert_eq!(pq.render_capacity_hint(), 42);
     }
+
+    #[test]
+    fn fixed_template_remaining_methods() {
+        // Exercise the `FixedTemplate` helper's other `PathAndQueryTemplate` / `RedactedDisplay`
+        // methods (not touched by the `render_into` / `render_capacity_hint` tests above) so the
+        // helper is fully covered and cannot silently rot.
+        use data_privacy::{RedactedToString, RedactionEngine};
+
+        let template = FixedTemplate;
+        assert_eq!(template.render(), "/fixed/template");
+        assert_eq!(template.template(), "/fixed/template");
+        assert_eq!(template.format_template(), "/fixed/template");
+        assert_eq!(template.label(), None);
+        assert_eq!(template.to_path_and_query().expect("valid path").as_str(), "/fixed/template");
+        assert_eq!(format!("{template:?}"), "FixedTemplate");
+
+        // Drives the `RedactedDisplay` impl.
+        let engine = RedactionEngine::builder().build();
+        assert_eq!(template.to_redacted_string(&engine), "/fixed/template");
+    }
 }
 
 #[cfg(all(test, feature = "serde"))]

--- a/crates/templated_uri/src/path_and_query_template.rs
+++ b/crates/templated_uri/src/path_and_query_template.rs
@@ -93,6 +93,33 @@ where
     /// For a validated [`PathAndQuery`] use [`PathAndQueryTemplate::to_path_and_query`] instead.
     fn render(&self) -> String;
 
+    /// Appends the rendered path-and-query to an existing buffer.
+    ///
+    /// This is the allocation-free primitive underlying [`render`](PathAndQueryTemplate::render):
+    /// it lets a caller (such as base-URI joining) render directly into a buffer that already
+    /// holds a prefix, avoiding an intermediate `String` and a second allocation on the
+    /// request hot path. The `#[templated]` macro overrides it to append field values
+    /// directly; the default simply appends the result of [`render`](PathAndQueryTemplate::render).
+    ///
+    /// A manual implementer only needs to override [`render`](PathAndQueryTemplate::render);
+    /// this default then works automatically. Do **not**, however, implement `render` *in terms
+    /// of* `render_into` (e.g. `let mut s = String::new(); self.render_into(&mut s); s`) without
+    /// also overriding `render_into`, or the two defaults will call each other and loop forever.
+    #[doc(hidden)]
+    fn render_into(&self, buf: &mut String) {
+        buf.push_str(&self.render());
+    }
+
+    /// Returns a heuristic byte-capacity estimate for the rendered path-and-query.
+    ///
+    /// Used to size a buffer before calling [`render_into`](PathAndQueryTemplate::render_into)
+    /// so the render completes without reallocating. The `#[templated]` macro overrides it
+    /// with a compile-time estimate; the default is `0` (callers fall back to growth).
+    #[doc(hidden)]
+    fn render_capacity_hint(&self) -> usize {
+        0
+    }
+
     /// Converts to a validated [`PathAndQuery`].
     ///
     /// # Errors
@@ -122,5 +149,82 @@ where
 impl<T: PathAndQueryTemplate> From<T> for crate::Uri {
     fn from(value: T) -> Self {
         Self::from(crate::PathAndQuery::from_template(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Formatter;
+
+    use data_privacy::Redactor;
+
+    use super::*;
+
+    /// A hand-written [`PathAndQueryTemplate`] that deliberately does *not* override
+    /// `render_into` / `render_capacity_hint`, so calling them exercises the trait's
+    /// default implementations (the `#[templated]` macro always overrides them).
+    #[derive(Debug)]
+    struct ManualTemplate;
+
+    impl RedactedDisplay for ManualTemplate {
+        fn fmt(&self, _redactor: &dyn Redactor, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.write_str("/manual/path")
+        }
+    }
+
+    impl PathAndQueryTemplate for ManualTemplate {
+        fn render(&self) -> String {
+            String::from("/manual/path")
+        }
+
+        fn to_path_and_query(&self) -> Result<PathAndQuery, UriError> {
+            Ok(PathAndQuery::try_from("/manual/path")?)
+        }
+
+        fn template(&self) -> &'static str {
+            "/manual/path"
+        }
+
+        fn format_template(&self) -> &'static str {
+            "/manual/path"
+        }
+
+        fn label(&self) -> Option<&'static str> {
+            None
+        }
+    }
+
+    #[test]
+    fn default_render_into_appends_render_output() {
+        // The default `render_into` appends the result of `render()` to the buffer.
+        let template = ManualTemplate;
+        let mut buf = String::from("/prefix");
+        template.render_into(&mut buf);
+        assert_eq!(buf, "/prefix/manual/path");
+    }
+
+    #[test]
+    fn default_render_capacity_hint_is_zero() {
+        // The default `render_capacity_hint` returns `0` (callers fall back to growth).
+        let template = ManualTemplate;
+        assert_eq!(template.render_capacity_hint(), 0);
+    }
+
+    #[test]
+    fn manual_template_required_methods() {
+        // Exercise the remaining (non-defaulted) trait methods of the hand-written impl so
+        // the helper is fully covered and the default-method tests above stay meaningful.
+        use data_privacy::{RedactedToString, RedactionEngine};
+
+        let template = ManualTemplate;
+        assert_eq!(template.render(), "/manual/path");
+        assert_eq!(template.template(), "/manual/path");
+        assert_eq!(template.format_template(), "/manual/path");
+        assert_eq!(template.label(), None);
+        assert_eq!(template.to_path_and_query().expect("valid path").as_str(), "/manual/path");
+        assert_eq!(format!("{template:?}"), "ManualTemplate");
+
+        let engine = RedactionEngine::builder().build();
+        assert_eq!(template.to_redacted_string(&engine), "/manual/path");
     }
 }

--- a/crates/templated_uri/src/uri.rs
+++ b/crates/templated_uri/src/uri.rs
@@ -306,14 +306,15 @@ impl TryFrom<Uri> for http::Uri {
     fn try_from(value: Uri) -> Result<Self, Self::Error> {
         let Uri { base_uri, path_and_query } = value;
 
-        let path_and_query = path_and_query.map(|pq| HttpPathAndQuery::try_from(&pq)).transpose()?;
-
         match (base_uri, path_and_query) {
+            // Hot path: render, join onto the base, and validate in a single pass instead of
+            // materializing the path into a standalone `http::PathAndQuery` first.
+            (Some(base_uri), Some(pq)) => base_uri.build_http_uri_from_paq(&pq),
             (Some(base_uri), None) => Ok(base_uri.into()),
-            (Some(base_uri), Some(path_and_query)) => base_uri.build_http_uri(path_and_query),
             (None, pq) => {
+                let path_and_query = pq.map(|pq| HttpPathAndQuery::try_from(&pq)).transpose()?;
                 let mut parts = Parts::default();
-                parts.path_and_query = pq;
+                parts.path_and_query = path_and_query;
                 Self::from_parts(parts).map_err(Into::into)
             }
         }

--- a/crates/templated_uri/tests/templated_uri.rs
+++ b/crates/templated_uri/tests/templated_uri.rs
@@ -1012,3 +1012,80 @@ fn materialize_hot_path_matches_static_join() {
         assert_eq!(hot_ca, expected_ca, "mismatch for base {base_str:?} (catch-all path)");
     }
 }
+
+#[templated(template = "/search{?query,limit,offset}", unredacted)]
+#[derive(Clone)]
+struct CapacityHintPath {
+    query: EscapedString,
+    limit: u32,
+    offset: u32,
+}
+
+#[test]
+fn macro_render_capacity_hint_exact_value() {
+    // The `#[templated]` macro emits a compile-time `render_capacity_hint()` that sums, for
+    // `/search{?query,limit,offset}`:
+    //   - content "/search"                                        = 7
+    //   - group `{?query,limit,offset}` prefix "?"                 = 1
+    //   - separators between 3 values (2 x "&", 1 byte each)       = 2
+    //   - `key=` literals: "query="(6) + "limit="(6) + "offset="(7) = 19
+    //   - 3 values x ESTIMATED_VALUE_LEN (16)                       = 48
+    // for a total of 77. Asserting the exact value pins the macro's capacity arithmetic so a
+    // mutation to any of the `+`/`*` operators (which does not change rendered output and so
+    // is invisible to behavioral tests) is caught here.
+    let p = CapacityHintPath {
+        query: EscapedString::from_static("x"),
+        limit: 1,
+        offset: 2,
+    };
+    assert_eq!(PathAndQueryTemplate::render_capacity_hint(&p), 77);
+    // Sanity: the hint must be a genuine upper bound for this concrete (short) render.
+    assert!(PathAndQueryTemplate::render_capacity_hint(&p) >= p.render().len());
+}
+
+#[test]
+fn macro_render_capacity_hint_covers_simple_and_reserved_expansions() {
+    // `/{org_id}/user/{user_id}/{+action}/` mixes static content with simple (`{org_id}`,
+    // `{user_id}`) and reserved (`{+action}`) expansions, none of which carry a prefix or
+    // `key=` literal. Its hint is:
+    //   "/"(1) + org_id(16) + "/user/"(6) + user_id(16) + "/"(1) + action(16) + "/"(1) = 57.
+    // The enum's generated `render_capacity_hint` must delegate to the active variant, so the
+    // value matches the underlying struct's hint. This pins the content and per-value
+    // arithmetic for the non-key/value expansion forms.
+    let action = UserActionPath {
+        org_id: OrgId(EscapedString::from_static("Acme")),
+        user_id: UserId(EscapedString::from_static("Will_E_Coyote")),
+        action: Action::Edit,
+    };
+    assert_eq!(PathAndQueryTemplate::render_capacity_hint(&action), 57);
+
+    let enum_variant = UserApi::UserEditPath(action);
+    assert_eq!(PathAndQueryTemplate::render_capacity_hint(&enum_variant), 57);
+}
+
+#[test]
+fn macro_render_into_appends_without_reallocating_prefix() {
+    // The macro's `render_into` appends field values directly into a caller-provided buffer
+    // rather than allocating a fresh `String`. It must leave any existing prefix intact and
+    // append exactly what `render()` would have produced. Guards the macro-generated
+    // `render_into` body against a mutation that drops the append statements.
+    let p = CapacityHintPath {
+        query: EscapedString::from_static("term"),
+        limit: 10,
+        offset: 5,
+    };
+    let mut buf = String::from("/prefix");
+    PathAndQueryTemplate::render_into(&p, &mut buf);
+    assert_eq!(buf, format!("/prefix{}", p.render()));
+    assert_eq!(buf, "/prefix/search?query=term&limit=10&offset=5");
+
+    // The enum variant's `render_into` must delegate to the active variant identically.
+    let action = UserApi::UserEditPath(UserActionPath {
+        org_id: OrgId(EscapedString::from_static("Acme")),
+        user_id: UserId(EscapedString::from_static("Wile")),
+        action: Action::Edit,
+    });
+    let mut enum_buf = String::from("base:");
+    PathAndQueryTemplate::render_into(&action, &mut enum_buf);
+    assert_eq!(enum_buf, format!("base:{}", action.render()));
+}

--- a/crates/templated_uri/tests/templated_uri.rs
+++ b/crates/templated_uri/tests/templated_uri.rs
@@ -1089,3 +1089,34 @@ fn macro_render_into_appends_without_reallocating_prefix() {
     PathAndQueryTemplate::render_into(&action, &mut enum_buf);
     assert_eq!(enum_buf, format!("base:{}", action.render()));
 }
+
+static REF_ID_VALUE: u32 = 4242;
+
+#[templated(template = "/items/{id}{?maybe}", unredacted)]
+#[derive(Clone)]
+struct ReferenceFieldPath {
+    id: &'static u32,
+    maybe: Option<&'static u32>,
+}
+
+#[test]
+fn reference_fields_render_in_required_and_optional_positions() {
+    // A `&T` field (where the owned `T: Escape`) must render identically whether it appears
+    // in a required (`{id}`) or an optional (`{?maybe}`) position. The macro passes
+    // `self.field` (already `&T`) in the required path and `*__val` in the optional path, so
+    // both resolve `Escape` on the owned `T` (e.g. `u32`), not on `&T` — the latter has no
+    // impl. This pins the required/optional receiver consistency the reviewer flagged.
+    static OTHER: u32 = 7;
+
+    let with_opt = ReferenceFieldPath {
+        id: &REF_ID_VALUE,
+        maybe: Some(&OTHER),
+    };
+    assert_eq!(with_opt.render(), "/items/4242?maybe=7");
+
+    let without_opt = ReferenceFieldPath {
+        id: &REF_ID_VALUE,
+        maybe: None,
+    };
+    assert_eq!(without_opt.render(), "/items/4242");
+}

--- a/crates/templated_uri/tests/templated_uri.rs
+++ b/crates/templated_uri/tests/templated_uri.rs
@@ -937,3 +937,78 @@ fn optional_label_both_none() {
     let path = LabelOptional { ext1: None, ext2: None };
     assert_eq!(path.render(), "/file");
 }
+
+#[templated(template = "/users/{user_id}/posts/{post_id}", unredacted)]
+#[derive(Clone)]
+struct MaterializePath {
+    user_id: u32,
+    post_id: EscapedString,
+}
+
+#[templated(template = "/{+catch_all}", unredacted)]
+#[derive(Clone)]
+struct CatchAllPath {
+    // `{+catch_all}` is a reserved expansion, so a value beginning with `/` renders a
+    // second leading slash (`//...`) that base joining must normalize.
+    catch_all: String,
+}
+
+/// The per-request hot path (base plus templated path into an `http::Uri`) must produce
+/// exactly the same URI as materializing the rendered path into a static `PathAndQuery`
+/// and joining that. This guards the single-pass `join_rendered` optimization against the
+/// original materialize-then-join behavior.
+#[test]
+fn materialize_hot_path_matches_static_join() {
+    let bases = [
+        "https://api.example.com",
+        "https://api.example.com/",
+        "https://api.example.com/v1/",
+        "http://localhost:8080/deep/base/",
+    ];
+
+    for base_str in bases {
+        let base = BaseUri::from_static(base_str);
+
+        // A normal templated path.
+        let templated = MaterializePath {
+            user_id: 42,
+            post_id: EscapedString::from_static("hello-world"),
+        };
+        let rendered = templated.render();
+
+        let hot: http::Uri = Uri::default()
+            .with_base(base.clone())
+            .with_path_and_query(templated.clone())
+            .try_into()
+            .expect("hot-path materialization should succeed");
+
+        let expected: http::Uri = Uri::default()
+            .with_base(base.clone())
+            .with_path_and_query(http::uri::PathAndQuery::try_from(rendered.as_str()).unwrap())
+            .try_into()
+            .expect("static-join materialization should succeed");
+
+        assert_eq!(hot, expected, "mismatch for base {base_str:?} (normal path)");
+
+        // A reserved-expansion path whose value begins with `/`, producing `//` before join.
+        let catch_all = CatchAllPath {
+            catch_all: "/nested/resource?x=1".to_string(),
+        };
+        let rendered_ca = catch_all.render();
+        assert!(rendered_ca.starts_with("//"), "sanity: catch-all should render a double slash");
+
+        let hot_ca: http::Uri = Uri::default()
+            .with_base(base.clone())
+            .with_path_and_query(catch_all.clone())
+            .try_into()
+            .expect("hot-path materialization should succeed");
+
+        let expected_ca: http::Uri = Uri::default()
+            .with_base(base.clone())
+            .with_path_and_query(http::uri::PathAndQuery::try_from(rendered_ca.as_str()).unwrap())
+            .try_into()
+            .expect("static-join materialization should succeed");
+
+        assert_eq!(hot_ca, expected_ca, "mismatch for base {base_str:?} (catch-all path)");
+    }
+}

--- a/crates/templated_uri/tests/ui/option_string_in_restricted_position.stderr
+++ b/crates/templated_uri/tests/ui/option_string_in_restricted_position.stderr
@@ -17,20 +17,3 @@ error[E0277]: the trait bound `String: templated_uri::Escape` is not satisfied
              NonZero<u8>
              NonZero<usize>
            and $N others
-
-error[E0277]: the trait bound `String: templated_uri::Escape` is not satisfied
-  --> tests/ui/option_string_in_restricted_position.rs:18:21
-   |
-18 |     user_id: Option<String>,
-   |                     ^^^^^^ the trait `templated_uri::Escape` is not implemented for `String`
-   |
-   = help: the following other types implement trait `templated_uri::Escape`:
-             Escaped<Cow<'static, str>>
-             IpAddr
-             NonZero<u128>
-             NonZero<u16>
-             NonZero<u32>
-             NonZero<u64>
-             NonZero<u8>
-             NonZero<usize>
-           and $N others

--- a/crates/templated_uri/tests/ui/string_in_restricted_position.stderr
+++ b/crates/templated_uri/tests/ui/string_in_restricted_position.stderr
@@ -17,20 +17,3 @@ error[E0277]: the trait bound `String: templated_uri::Escape` is not satisfied
              NonZero<u8>
              NonZero<usize>
            and $N others
-
-error[E0277]: the trait bound `String: templated_uri::Escape` is not satisfied
-  --> tests/ui/string_in_restricted_position.rs:12:14
-   |
-12 |     user_id: String,
-   |              ^^^^^^ the trait `templated_uri::Escape` is not implemented for `String`
-   |
-   = help: the following other types implement trait `templated_uri::Escape`:
-             Escaped<Cow<'static, str>>
-             IpAddr
-             NonZero<u128>
-             NonZero<u16>
-             NonZero<u32>
-             NonZero<u64>
-             NonZero<u8>
-             NonZero<usize>
-           and $N others

--- a/crates/templated_uri_macros_impl/src/enum_template.rs
+++ b/crates/templated_uri_macros_impl/src/enum_template.rs
@@ -69,6 +69,18 @@ pub(crate) fn enum_template(ident: &Ident, data: &DataEnum) -> TokenStream {
                     #(#variant_matches => template_variant.render()),*
                 }
             }
+
+            fn render_into(&self, __out: &mut ::std::string::String) {
+                match self {
+                    #(#variant_matches => ::templated_uri::PathAndQueryTemplate::render_into(template_variant, __out)),*
+                }
+            }
+
+            fn render_capacity_hint(&self) -> ::core::primitive::usize {
+                match self {
+                    #(#variant_matches => ::templated_uri::PathAndQueryTemplate::render_capacity_hint(template_variant)),*
+                }
+            }
         }
 
         impl ::std::fmt::Debug for #ident {

--- a/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__field_level_unredacted.snap
+++ b/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__field_level_unredacted.snap
@@ -19,44 +19,22 @@ impl ::templated_uri::PathAndQueryTemplate for Test {
         ::core::option::Option::None
     }
     fn render(&self) -> ::std::string::String {
-        let mut __out = ::std::string::String::with_capacity(16usize);
-        __out.push_str("/example.com/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.param)),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out.push_str("/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!("{}", ::templated_uri::Raw::raw(& self.param2)),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out.push_str("/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!(
-                    "{}", ::templated_uri::Escape::escape(& self.param3)
-                ),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out.push_str("/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!(
-                    "{}", ::templated_uri::Escape::escape(& self.param4)
-                ),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
+        let mut __out = ::std::string::String::with_capacity(80usize);
+        ::templated_uri::PathAndQueryTemplate::render_into(self, &mut __out);
         __out
+    }
+    fn render_into(&self, __out: &mut ::std::string::String) {
+        __out.push_str("/example.com/");
+        ::templated_uri::Escape::escape_into(&self.param, __out);
+        __out.push_str("/");
+        ::templated_uri::Raw::raw_into(&self.param2, __out);
+        __out.push_str("/");
+        ::templated_uri::Escape::escape_into(&self.param3, __out);
+        __out.push_str("/");
+        ::templated_uri::Escape::escape_into(&self.param4, __out);
+    }
+    fn render_capacity_hint(&self) -> ::core::primitive::usize {
+        80usize
     }
     fn to_path_and_query(
         &self,

--- a/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__optional_field_codegen.snap
+++ b/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__optional_field_codegen.snap
@@ -18,15 +18,13 @@ impl ::templated_uri::PathAndQueryTemplate for OptionalTest {
         ::core::option::Option::None
     }
     fn render(&self) -> ::std::string::String {
-        let mut __out = ::std::string::String::with_capacity(22usize);
+        let mut __out = ::std::string::String::with_capacity(70usize);
+        ::templated_uri::PathAndQueryTemplate::render_into(self, &mut __out);
+        __out
+    }
+    fn render_into(&self, __out: &mut ::std::string::String) {
         __out.push_str("/items/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.id)),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
+        ::templated_uri::Escape::escape_into(&self.id, __out);
         {
             let mut __first = true;
             {
@@ -38,15 +36,7 @@ impl ::templated_uri::PathAndQueryTemplate for OptionalTest {
                 }
                 __out.push_str("filter");
                 __out.push_str("=");
-                ::std::fmt::Write::write_fmt(
-                        &mut __out,
-                        ::core::format_args!(
-                            "{}", ::templated_uri::Escape::escape(__val)
-                        ),
-                    )
-                    .expect(
-                        "Display impls for templated URI parameter values are expected to be infallible",
-                    );
+                ::templated_uri::Escape::escape_into(__val, __out);
                 __first = false;
             }
             if let ::core::option::Option::Some(ref __val) = self.limit {
@@ -57,19 +47,13 @@ impl ::templated_uri::PathAndQueryTemplate for OptionalTest {
                 }
                 __out.push_str("limit");
                 __out.push_str("=");
-                ::std::fmt::Write::write_fmt(
-                        &mut __out,
-                        ::core::format_args!(
-                            "{}", ::templated_uri::Escape::escape(__val)
-                        ),
-                    )
-                    .expect(
-                        "Display impls for templated URI parameter values are expected to be infallible",
-                    );
+                ::templated_uri::Escape::escape_into(__val, __out);
                 __first = false;
             }
         }
-        __out
+    }
+    fn render_capacity_hint(&self) -> ::core::primitive::usize {
+        70usize
     }
     fn to_path_and_query(
         &self,

--- a/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__optional_field_with_unredacted_codegen.snap
+++ b/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__optional_field_with_unredacted_codegen.snap
@@ -17,7 +17,11 @@ impl ::templated_uri::PathAndQueryTemplate for OptionalUnredactedTest {
         ::core::option::Option::None
     }
     fn render(&self) -> ::std::string::String {
-        let mut __out = ::std::string::String::with_capacity(21usize);
+        let mut __out = ::std::string::String::with_capacity(53usize);
+        ::templated_uri::PathAndQueryTemplate::render_into(self, &mut __out);
+        __out
+    }
+    fn render_into(&self, __out: &mut ::std::string::String) {
         __out.push_str("/items");
         {
             let mut __first = true;
@@ -30,15 +34,7 @@ impl ::templated_uri::PathAndQueryTemplate for OptionalUnredactedTest {
                 }
                 __out.push_str("filter");
                 __out.push_str("=");
-                ::std::fmt::Write::write_fmt(
-                        &mut __out,
-                        ::core::format_args!(
-                            "{}", ::templated_uri::Escape::escape(__val)
-                        ),
-                    )
-                    .expect(
-                        "Display impls for templated URI parameter values are expected to be infallible",
-                    );
+                ::templated_uri::Escape::escape_into(__val, __out);
                 __first = false;
             }
             if let ::core::option::Option::Some(ref __val) = self.limit {
@@ -49,19 +45,13 @@ impl ::templated_uri::PathAndQueryTemplate for OptionalUnredactedTest {
                 }
                 __out.push_str("limit");
                 __out.push_str("=");
-                ::std::fmt::Write::write_fmt(
-                        &mut __out,
-                        ::core::format_args!(
-                            "{}", ::templated_uri::Escape::escape(__val)
-                        ),
-                    )
-                    .expect(
-                        "Display impls for templated URI parameter values are expected to be infallible",
-                    );
+                ::templated_uri::Escape::escape_into(__val, __out);
                 __first = false;
             }
         }
-        __out
+    }
+    fn render_capacity_hint(&self) -> ::core::primitive::usize {
+        53usize
     }
     fn to_path_and_query(
         &self,

--- a/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__optional_reference_field_codegen.snap
+++ b/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__optional_reference_field_codegen.snap
@@ -16,7 +16,11 @@ impl ::templated_uri::PathAndQueryTemplate for ReferenceOptional {
         ::core::option::Option::None
     }
     fn render(&self) -> ::std::string::String {
-        let mut __out = ::std::string::String::with_capacity(12usize);
+        let mut __out = ::std::string::String::with_capacity(28usize);
+        ::templated_uri::PathAndQueryTemplate::render_into(self, &mut __out);
+        __out
+    }
+    fn render_into(&self, __out: &mut ::std::string::String) {
         __out.push_str("/items");
         {
             let mut __first = true;
@@ -28,19 +32,13 @@ impl ::templated_uri::PathAndQueryTemplate for ReferenceOptional {
                 }
                 __out.push_str("name");
                 __out.push_str("=");
-                ::std::fmt::Write::write_fmt(
-                        &mut __out,
-                        ::core::format_args!(
-                            "{}", ::templated_uri::Escape::escape(* __val)
-                        ),
-                    )
-                    .expect(
-                        "Display impls for templated URI parameter values are expected to be infallible",
-                    );
+                ::templated_uri::Escape::escape_into(*__val, __out);
                 __first = false;
             }
         }
-        __out
+    }
+    fn render_capacity_hint(&self) -> ::core::primitive::usize {
+        28usize
     }
     fn to_path_and_query(
         &self,

--- a/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__query_param_is_kv_expansion.snap
+++ b/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__query_param_is_kv_expansion.snap
@@ -18,38 +18,24 @@ impl ::templated_uri::PathAndQueryTemplate for QueryTest {
         ::core::option::Option::None
     }
     fn render(&self) -> ::std::string::String {
-        let mut __out = ::std::string::String::with_capacity(18usize);
+        let mut __out = ::std::string::String::with_capacity(66usize);
+        ::templated_uri::PathAndQueryTemplate::render_into(self, &mut __out);
+        __out
+    }
+    fn render_into(&self, __out: &mut ::std::string::String) {
         __out.push_str("/api/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!(
-                    "{}", ::templated_uri::Escape::escape(& self.resource)
-                ),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
+        ::templated_uri::Escape::escape_into(&self.resource, __out);
         __out.push_str("?");
         __out.push_str("page");
         __out.push_str("=");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.page)),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
+        ::templated_uri::Escape::escape_into(&self.page, __out);
         __out.push_str("&");
         __out.push_str("limit");
         __out.push_str("=");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.limit)),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out
+        ::templated_uri::Escape::escape_into(&self.limit, __out);
+    }
+    fn render_capacity_hint(&self) -> ::core::primitive::usize {
+        66usize
     }
     fn to_path_and_query(
         &self,

--- a/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__template_enum_impl.snap
+++ b/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__template_enum_impl.snap
@@ -44,6 +44,36 @@ impl ::templated_uri::PathAndQueryTemplate for Test {
             Test::SecondTemplate(template_variant) => template_variant.render(),
         }
     }
+    fn render_into(&self, __out: &mut ::std::string::String) {
+        match self {
+            Test::FirstTemplate(template_variant) => {
+                ::templated_uri::PathAndQueryTemplate::render_into(
+                    template_variant,
+                    __out,
+                )
+            }
+            Test::SecondTemplate(template_variant) => {
+                ::templated_uri::PathAndQueryTemplate::render_into(
+                    template_variant,
+                    __out,
+                )
+            }
+        }
+    }
+    fn render_capacity_hint(&self) -> ::core::primitive::usize {
+        match self {
+            Test::FirstTemplate(template_variant) => {
+                ::templated_uri::PathAndQueryTemplate::render_capacity_hint(
+                    template_variant,
+                )
+            }
+            Test::SecondTemplate(template_variant) => {
+                ::templated_uri::PathAndQueryTemplate::render_capacity_hint(
+                    template_variant,
+                )
+            }
+        }
+    }
 }
 impl ::std::fmt::Debug for Test {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__templated_unredacted_uri_impl.snap
+++ b/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__templated_unredacted_uri_impl.snap
@@ -19,44 +19,22 @@ impl ::templated_uri::PathAndQueryTemplate for Test {
         ::core::option::Option::None
     }
     fn render(&self) -> ::std::string::String {
-        let mut __out = ::std::string::String::with_capacity(16usize);
-        __out.push_str("/example.com/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.param)),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out.push_str("/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!("{}", ::templated_uri::Raw::raw(& self.param2)),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out.push_str("/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!(
-                    "{}", ::templated_uri::Escape::escape(& self.param3)
-                ),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out.push_str("/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!(
-                    "{}", ::templated_uri::Escape::escape(& self.param4)
-                ),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
+        let mut __out = ::std::string::String::with_capacity(80usize);
+        ::templated_uri::PathAndQueryTemplate::render_into(self, &mut __out);
         __out
+    }
+    fn render_into(&self, __out: &mut ::std::string::String) {
+        __out.push_str("/example.com/");
+        ::templated_uri::Escape::escape_into(&self.param, __out);
+        __out.push_str("/");
+        ::templated_uri::Raw::raw_into(&self.param2, __out);
+        __out.push_str("/");
+        ::templated_uri::Escape::escape_into(&self.param3, __out);
+        __out.push_str("/");
+        ::templated_uri::Escape::escape_into(&self.param4, __out);
+    }
+    fn render_capacity_hint(&self) -> ::core::primitive::usize {
+        80usize
     }
     fn to_path_and_query(
         &self,

--- a/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__templated_uri_impl.snap
+++ b/crates/templated_uri_macros_impl/src/snapshots/templated_uri_macros_impl__tests__templated_uri_impl.snap
@@ -19,44 +19,22 @@ impl ::templated_uri::PathAndQueryTemplate for Test {
         ::core::option::Option::None
     }
     fn render(&self) -> ::std::string::String {
-        let mut __out = ::std::string::String::with_capacity(16usize);
-        __out.push_str("/example.com/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!("{}", ::templated_uri::Escape::escape(& self.param)),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out.push_str("/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!("{}", ::templated_uri::Raw::raw(& self.param2)),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out.push_str("/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!(
-                    "{}", ::templated_uri::Escape::escape(& self.param3)
-                ),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
-        __out.push_str("/");
-        ::std::fmt::Write::write_fmt(
-                &mut __out,
-                ::core::format_args!(
-                    "{}", ::templated_uri::Escape::escape(& self.param4)
-                ),
-            )
-            .expect(
-                "Display impls for templated URI parameter values are expected to be infallible",
-            );
+        let mut __out = ::std::string::String::with_capacity(80usize);
+        ::templated_uri::PathAndQueryTemplate::render_into(self, &mut __out);
         __out
+    }
+    fn render_into(&self, __out: &mut ::std::string::String) {
+        __out.push_str("/example.com/");
+        ::templated_uri::Escape::escape_into(&self.param, __out);
+        __out.push_str("/");
+        ::templated_uri::Raw::raw_into(&self.param2, __out);
+        __out.push_str("/");
+        ::templated_uri::Escape::escape_into(&self.param3, __out);
+        __out.push_str("/");
+        ::templated_uri::Escape::escape_into(&self.param4, __out);
+    }
+    fn render_capacity_hint(&self) -> ::core::primitive::usize {
+        80usize
     }
     fn to_path_and_query(
         &self,

--- a/crates/templated_uri_macros_impl/src/struct_template.rs
+++ b/crates/templated_uri_macros_impl/src/struct_template.rs
@@ -374,10 +374,19 @@ fn render_group_all_required(group: &ParamGroup, field_map: &FieldMap<'_>, unres
         let field = field_map.get(*param_name).expect("field should exist (validated earlier)");
         let field_ident = field.ident.as_ref().expect("struct fields must be named");
         let ty_span = field.ty.span();
-        if unrestricted_params.contains(*param_name) {
-            stmts.push(quote_spanned! { ty_span => ::templated_uri::Raw::raw_into(&self.#field_ident, __out); });
+        // `Escape`/`Raw` take `&self`, so the receiver must be `&FieldType`. For an owned
+        // field that is `&self.field`; for a reference field (`&T`) the field itself already
+        // is `&T`, so pass it directly - matching the `*__val` deref in the optional path so
+        // both positions require the same bound (`T: Escape`/`T: Raw`) for `&T` fields.
+        let receiver = if matches!(&field.ty, syn::Type::Reference(_)) {
+            quote_spanned! { ty_span => self.#field_ident }
         } else {
-            stmts.push(quote_spanned! { ty_span => ::templated_uri::Escape::escape_into(&self.#field_ident, __out); });
+            quote_spanned! { ty_span => &self.#field_ident }
+        };
+        if unrestricted_params.contains(*param_name) {
+            stmts.push(quote_spanned! { ty_span => ::templated_uri::Raw::raw_into(#receiver, __out); });
+        } else {
+            stmts.push(quote_spanned! { ty_span => ::templated_uri::Escape::escape_into(#receiver, __out); });
         }
     }
     stmts

--- a/crates/templated_uri_macros_impl/src/struct_template.rs
+++ b/crates/templated_uri_macros_impl/src/struct_template.rs
@@ -131,7 +131,7 @@ pub(crate) fn struct_template(ident: Ident, data: &DataStruct, attrs: &[Attribut
         .map(|p| p.name.to_owned())
         .collect();
 
-    let render_body = construct_render(&template, &struct_fields, &unrestricted_params);
+    let (render_statements, render_capacity) = construct_render(&template, &struct_fields, &unrestricted_params);
     let redacted_display = construct_redacted_display(&template, &struct_fields, &fields, unredacted);
 
     let label_impl = label.as_ref().map_or_else(
@@ -154,7 +154,17 @@ pub(crate) fn struct_template(ident: Ident, data: &DataStruct, attrs: &[Attribut
             }
 
             fn render(&self) -> ::std::string::String {
-                #render_body
+                let mut __out = ::std::string::String::with_capacity(#render_capacity);
+                ::templated_uri::PathAndQueryTemplate::render_into(self, &mut __out);
+                __out
+            }
+
+            fn render_into(&self, __out: &mut ::std::string::String) {
+                #(#render_statements)*
+            }
+
+            fn render_capacity_hint(&self) -> ::core::primitive::usize {
+                #render_capacity
             }
 
             fn to_path_and_query(&self) -> ::std::result::Result<::templated_uri::__private::http::uri::PathAndQuery, ::templated_uri::UriError> {
@@ -209,21 +219,23 @@ fn extract_option_inner(ty: &syn::Type) -> Option<&syn::Type> {
     Some(inner_ty)
 }
 
-/// Generates the body of the `render()` method.
+/// Generates the append statements and capacity hint for the render methods.
 ///
-/// Walks the parsed template parts and emits `Write::write_fmt` calls (via UFCS,
-/// to avoid bringing `fmt::Write` into the caller's scope), handling RFC 6570
-/// undefined-value semantics for `Option<T>` fields.
-fn construct_render(template: &UriTemplate, struct_fields: &[&Field], unrestricted_params: &HashSet<String>) -> TokenStream {
+/// Walks the parsed template parts and emits statements that append into a buffer named
+/// `__out` (via `push_str` for literals and `Escape::escape_into`/`Raw::raw_into` for
+/// field values), handling RFC 6570 undefined-value semantics for `Option<T>` fields.
+/// Returns the statements plus the compile-time capacity estimate so the caller can build
+/// both `render` (owns a sized buffer) and `render_into` (appends into a caller buffer).
+fn construct_render(template: &UriTemplate, struct_fields: &[&Field], unrestricted_params: &HashSet<String>) -> (Vec<TokenStream>, usize) {
     let field_map: FieldMap<'_> = struct_fields
         .iter()
         .filter_map(|f| f.ident.as_ref().map(|ident| (ident.to_string(), *f)))
         .collect();
 
-    // Pre-allocate the rendered-URI buffer using a static heuristic computed from the
-    // template parts. See `render_capacity_hint` for the precise semantics; it may
-    // slightly over-allocate when a group's parameters are all `None` at runtime, which
-    // is far cheaper than the realloc chain a fresh `String::new()` would incur.
+    // Compile-time heuristic used to pre-size the buffer. See `render_capacity_hint` for
+    // the precise semantics; it may slightly over-allocate when a group's parameters are
+    // all `None` at runtime, which is far cheaper than the realloc chain a fresh
+    // `String::new()` would incur.
     let initial_capacity = render_capacity_hint(template);
 
     let statements: Vec<TokenStream> = template
@@ -237,29 +249,33 @@ fn construct_render(template: &UriTemplate, struct_fields: &[&Field], unrestrict
         })
         .collect();
 
-    quote! {
-        let mut __out = ::std::string::String::with_capacity(#initial_capacity);
-        #(#statements)*
-        __out
-    }
+    (statements, initial_capacity)
 }
 
 /// Compile-time capacity heuristic for the `String` buffer that holds a rendered URI.
 ///
-/// The returned size counts every byte the macro can statically *name*:
+/// The returned size counts every byte the macro can statically *name*, plus a small
+/// per-parameter estimate for the runtime values themselves:
 ///
 /// - Static `Content` segments are always present.
 /// - Each parameter group's fixed literals (prefix, separators between values, and the
 ///   `key=` literal for key/value expansions like `{?a}` and `{;a}`).
+/// - [`ESTIMATED_VALUE_LEN`] bytes per parameter as a stand-in for the (statically
+///   unknowable) substituted value.
 ///
-/// Parameter values themselves are not counted because their runtime size is unknown.
-/// The heuristic does **not** discount per-parameter literals attached to `Option<T>`
-/// fields, so when a group's optional values are all `None` at runtime, the buffer
-/// over-allocates by a few bytes (typically one prefix byte plus the key length plus
-/// `=`). That small over-attribution is harmless: a strict lower bound would require
-/// threading field metadata into this function, and the worst-case waste is bounded
-/// by a few bytes per group, well below a single allocator slab.
+/// The per-parameter estimate exists purely to avoid a reallocation on the render hot
+/// path: without it the buffer is sized to the static skeleton only and almost always
+/// has to grow once as the first value is written. Over-estimating merely reserves a few
+/// unused bytes (a single small allocation is rounded up by the allocator anyway), which
+/// is far cheaper than the realloc-and-copy it prevents. The estimate is intentionally
+/// *not* discounted for `Option<T>` fields that may be `None`, matching the existing
+/// treatment of their literals.
 fn render_capacity_hint(template: &UriTemplate) -> usize {
+    /// Assumed byte length of a rendered parameter value. Chosen to cover typical URI
+    /// segments (ids, short slugs) so the common case renders without a reallocation,
+    /// while keeping worst-case over-allocation negligible.
+    const ESTIMATED_VALUE_LEN: usize = 16;
+
     template
         .template_parts()
         .iter()
@@ -279,7 +295,8 @@ fn render_capacity_hint(template: &UriTemplate) -> usize {
                 } else {
                     0
                 };
-                prefix_len + separators_len + kv_len
+                let values_len = param_names.len() * ESTIMATED_VALUE_LEN;
+                prefix_len + separators_len + kv_len + values_len
             }
         })
         .sum()
@@ -358,11 +375,9 @@ fn render_group_all_required(group: &ParamGroup, field_map: &FieldMap<'_>, unres
         let field_ident = field.ident.as_ref().expect("struct fields must be named");
         let ty_span = field.ty.span();
         if unrestricted_params.contains(*param_name) {
-            stmts.push(quote_spanned! { ty_span => ::std::fmt::Write::write_fmt(&mut __out, ::core::format_args!("{}", ::templated_uri::Raw::raw(&self.#field_ident))).expect("Display impls for templated URI parameter values are expected to be infallible"); });
+            stmts.push(quote_spanned! { ty_span => ::templated_uri::Raw::raw_into(&self.#field_ident, __out); });
         } else {
-            stmts.push(
-                quote_spanned! { ty_span => ::std::fmt::Write::write_fmt(&mut __out, ::core::format_args!("{}", ::templated_uri::Escape::escape(&self.#field_ident))).expect("Display impls for templated URI parameter values are expected to be infallible"); },
-            );
+            stmts.push(quote_spanned! { ty_span => ::templated_uri::Escape::escape_into(&self.#field_ident, __out); });
         }
     }
     stmts
@@ -398,10 +413,10 @@ fn render_group_with_optional(group: &ParamGroup, field_map: &FieldMap<'_>, unre
             quote! { __val }
         };
 
-        let escape_expr = if unrestricted_params.contains(*param_name) {
-            quote_spanned! { ty_span => ::templated_uri::Raw::raw(#val_arg) }
+        let append_stmt = if unrestricted_params.contains(*param_name) {
+            quote_spanned! { ty_span => ::templated_uri::Raw::raw_into(#val_arg, __out); }
         } else {
-            quote_spanned! { ty_span => ::templated_uri::Escape::escape(#val_arg) }
+            quote_spanned! { ty_span => ::templated_uri::Escape::escape_into(#val_arg, __out); }
         };
 
         let key_for_kv = is_kv.then_some(*param_name);
@@ -410,7 +425,7 @@ fn render_group_with_optional(group: &ParamGroup, field_map: &FieldMap<'_>, unre
         let body = quote! {
             #emit_delim
             #emit_kv
-            ::std::fmt::Write::write_fmt(&mut __out, ::core::format_args!("{}", #escape_expr)).expect("Display impls for templated URI parameter values are expected to be infallible");
+            #append_stmt
             __first = false;
         };
 


### PR DESCRIPTION
Rework the per-call URI construction path (escape -> render -> validate -> assemble) to minimize allocations, formatting overhead, and redundant validation. All changes are safe (no `unsafe`) and output-preserving, verified with differential and fuzz tests that cross-check the new code against the previous behavior.

### Encoding and rendering
- `EscapedString::escape`: replace the pct_str char-by-char encoder with a byte-scan that skips allocation entirely on the clean path, bulk-copies runs of unreserved bytes, and emits `%XX` via a direct hex table. Drops the pct-str dependency.
- `Escape for EscapedString`: borrow the already-escaped contents instead of cloning the `Cow`, avoiding a reallocation per render for owned values.
- `render`: size the output buffer with a per-parameter estimate to avoid a reallocation, and add defaulted `Escape::escape_into` / `Raw::raw_into` methods (a `push_str` fast path for string-backed types) that the `#[templated]` macro now emits instead of `write_fmt`.

### Materialization (base + templated path -> `http::Uri`)
- Previously each request rendered the path, validated it into an `http::PathAndQuery`, then re-joined it onto the base and validated the whole thing again: two allocations and two URI parses, one of which is always redundant when a base is configured.
- Collapse this to a single pass: `PathAndQueryTemplate` gains hidden, default-provided `render_into` / `render_capacity_hint` hooks (no public API change) so the path renders directly into a buffer seeded with the base, which is then validated exactly once. One allocation, one parse.

### Numbers

Per-call hot-path costs, measured with the same benchmark on the PR base versus this change (Callgrind instructions; wall-clock via Criterion):

| Scenario          | Before | After | Change    | Wall-clock |
|-------------------|-------:|------:|-----------|-----------:|
| escape (encoding) |   3486 |  1052 | -69.8%    |      ~61 ns |
| escape (clean)    |   1785 |   387 | -78.3%    |      ~30 ns |
| render            |    808 |   523 | -35.3%    |      ~33 ns |
| to_path_and_query |   1423 |  1140 | -19.9%    |      ~93 ns |
| build_uri         |    267 |   267 | unchanged |      ~67 ns |
| materialize (e2e) |   3511 |  1682 | -52.1%    |     ~192 ns |

