### PR TITLE
perf(seatbelt): cache default breaker engine and drop metrics allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,6 +3354,7 @@ dependencies = [
  "fastrand",
  "futures",
  "futures-util",
+ "gungraun",
  "http",
  "insta",
  "jiff",

--- a/crates/seatbelt/Cargo.toml
+++ b/crates/seatbelt/Cargo.toml
@@ -91,6 +91,9 @@ tower-service = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "std"] }
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+gungraun = { workspace = true, features = ["default"] }
+
 [[example]]
 name = "timeout"
 required-features = ["timeout", "metrics"]
@@ -169,6 +172,31 @@ required-features = ["breaker"]
 
 [[bench]]
 name = "hedging"
+harness = false
+required-features = ["hedging"]
+
+[[bench]]
+name = "observability_cg"
+harness = false
+required-features = ["retry", "logs", "metrics"]
+
+[[bench]]
+name = "timeout_cg"
+harness = false
+required-features = ["timeout"]
+
+[[bench]]
+name = "retry_cg"
+harness = false
+required-features = ["retry"]
+
+[[bench]]
+name = "breaker_cg"
+harness = false
+required-features = ["breaker"]
+
+[[bench]]
+name = "hedging_cg"
 harness = false
 required-features = ["hedging"]
 

--- a/crates/seatbelt/benches/breaker_cg.rs
+++ b/crates/seatbelt/benches/breaker_cg.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Callgrind benchmarks for the circuit breaker middleware in the `seatbelt`
+//! crate.
+//!
+//! Paired with `breaker.rs`, which covers the same happy-path operations under
+//! wall-clock measurement. Each service is type-erased into a `DynamicService`
+//! in the unmeasured `setup` step so the concrete (unnameable) service type can
+//! be handed to the benchmark function. The dynamic dispatch adds a constant
+//! per-call cost to every scenario, so it cancels out in the baseline-vs-breaker
+//! delta that these benchmarks exist to surface.
+
+#![allow(missing_docs, reason = "no need for API documentation on benchmark code")]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "gungraun benchmark inputs are passed and returned by value by the framework"
+)]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Upstream tracking issues are pending."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is Linux-only.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+
+    use futures::executor::block_on;
+    use gungraun::{library_benchmark, library_benchmark_group};
+    use layered::{DynamicService, DynamicServiceExt, Execute, Service, Stack};
+    use seatbelt::breaker::Breaker;
+    use seatbelt::{RecoveryInfo, ResilienceContext};
+    use tick::Clock;
+
+    #[derive(Debug, Clone)]
+    pub(super) struct Input;
+
+    #[derive(Debug, Clone)]
+    pub(super) struct Output;
+
+    // Baseline: a bare service with no circuit breaker in front of it.
+    fn service_no_breaker() -> DynamicService<Input, Result<Output, Output>> {
+        Execute::new(|_input: Input| async move { Ok::<Output, Output>(Output) }).into_dynamic()
+    }
+
+    // Circuit breaker in the closed (pass-through) state: `min_throughput` is set
+    // high enough that the breaker never trips, so every call flows to the inner
+    // service.
+    fn service_with_breaker() -> DynamicService<Input, Result<Output, Output>> {
+        let context = ResilienceContext::new(Clock::new_frozen());
+        (
+            Breaker::layer("bench", &context)
+                .recovery_with(|_, _| RecoveryInfo::never())
+                .rejected_input_error(|_input, _args| Output)
+                .min_throughput(1000),
+            Execute::new(|_input: Input| async move { Ok(Output) }),
+        )
+            .into_service()
+            .into_dynamic()
+    }
+
+    #[library_benchmark]
+    #[bench::no_breaker(service_no_breaker())]
+    #[bench::with_breaker(service_with_breaker())]
+    fn execute(service: DynamicService<Input, Result<Output, Output>>) -> DynamicService<Input, Result<Output, Output>> {
+        let _result = black_box(block_on(service.execute(black_box(Input))));
+        service
+    }
+
+    library_benchmark_group!(
+        name = breaker;
+        benchmarks = execute
+    );
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::breaker;
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default()
+        .tool(Callgrind::with_args(["--branch-sim=yes"]));
+    library_benchmark_groups = breaker
+);

--- a/crates/seatbelt/benches/hedging_cg.rs
+++ b/crates/seatbelt/benches/hedging_cg.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Callgrind benchmarks for the hedging middleware in the `seatbelt` crate.
+//!
+//! Paired with `hedging.rs`, which covers the same happy-path operations under
+//! wall-clock measurement. Each service is type-erased into a `DynamicService`
+//! in the unmeasured `setup` step so the concrete (unnameable) service type can
+//! be handed to the benchmark function. The dynamic dispatch adds a constant
+//! per-call cost to every scenario, so it cancels out in the baseline-vs-hedging
+//! delta that these benchmarks exist to surface.
+
+#![allow(missing_docs, reason = "no need for API documentation on benchmark code")]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "gungraun benchmark inputs are passed and returned by value by the framework"
+)]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Upstream tracking issues are pending."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is Linux-only.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+
+    use futures::executor::block_on;
+    use gungraun::{library_benchmark, library_benchmark_group};
+    use layered::{DynamicService, DynamicServiceExt, Execute, Service, Stack};
+    use seatbelt::hedging::Hedging;
+    use seatbelt::{RecoveryInfo, ResilienceContext};
+    use tick::Clock;
+
+    #[derive(Debug, Clone)]
+    pub(super) struct Input;
+
+    #[derive(Debug, Clone)]
+    pub(super) struct Output;
+
+    impl From<Input> for Output {
+        fn from(_input: Input) -> Self {
+            Self
+        }
+    }
+
+    // Baseline: a bare service with no hedging wrapper.
+    fn service_no_hedging() -> DynamicService<Input, Output> {
+        Execute::new(|v: Input| async move { Output::from(v) }).into_dynamic()
+    }
+
+    // Hedging armed with a delay: the primary attempt completes before the
+    // hedged attempt is ever launched, so the delay path is exercised.
+    fn service_with_hedging_delay() -> DynamicService<Input, Output> {
+        let context = ResilienceContext::new(Clock::new_frozen());
+        (
+            Hedging::layer("bench", &context)
+                .clone_input()
+                .recovery_with(|_, _| RecoveryInfo::never()),
+            Execute::new(|v: Input| async move { Output::from(v) }),
+        )
+            .into_service()
+            .into_dynamic()
+    }
+
+    // Hedging disabled (`max_hedged_attempts = 0`): the pass-through path with no
+    // additional attempts ever scheduled.
+    fn service_with_hedging_passthrough() -> DynamicService<Input, Output> {
+        let context = ResilienceContext::new(Clock::new_frozen());
+        (
+            Hedging::layer("bench", &context)
+                .clone_input()
+                .recovery_with(|_, _| RecoveryInfo::never())
+                .max_hedged_attempts(0),
+            Execute::new(|v: Input| async move { Output::from(v) }),
+        )
+            .into_service()
+            .into_dynamic()
+    }
+
+    #[library_benchmark]
+    #[bench::no_hedging(service_no_hedging())]
+    #[bench::with_hedging_delay(service_with_hedging_delay())]
+    #[bench::with_hedging_passthrough(service_with_hedging_passthrough())]
+    fn execute(service: DynamicService<Input, Output>) -> DynamicService<Input, Output> {
+        black_box(block_on(service.execute(black_box(Input))));
+        service
+    }
+
+    library_benchmark_group!(
+        name = hedging;
+        benchmarks = execute
+    );
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::hedging;
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default()
+        .tool(Callgrind::with_args(["--branch-sim=yes"]));
+    library_benchmark_groups = hedging
+);

--- a/crates/seatbelt/benches/observability_cg.rs
+++ b/crates/seatbelt/benches/observability_cg.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Callgrind benchmarks for the telemetry overhead of the retry middleware in
+//! the `seatbelt` crate.
+//!
+//! Paired with `observability.rs`, which covers the same happy-path operations
+//! under wall-clock measurement, comparing no-telemetry, metrics-enabled, and
+//! logs-enabled retry pipelines. Each service is type-erased into a
+//! `DynamicService` in the unmeasured `setup` step so the concrete (unnameable)
+//! service type can be handed to the benchmark function. The dynamic dispatch
+//! adds a constant per-call cost to every scenario, so it cancels out in the
+//! no-telemetry-vs-telemetry delta that these benchmarks exist to surface.
+
+#![allow(missing_docs, reason = "no need for API documentation on benchmark code")]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "gungraun benchmark inputs are passed and returned by value by the framework"
+)]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Upstream tracking issues are pending."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is Linux-only.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+    use std::time::Duration;
+
+    use futures::executor::block_on;
+    use gungraun::{library_benchmark, library_benchmark_group};
+    use layered::{DynamicService, DynamicServiceExt, Execute, Service, Stack};
+    use opentelemetry_sdk::error::OTelSdkResult;
+    use opentelemetry_sdk::metrics::data::ResourceMetrics;
+    use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
+    use opentelemetry_sdk::metrics::{SdkMeterProvider, Temporality};
+    use seatbelt::retry::Retry;
+    use seatbelt::{RecoveryInfo, ResilienceContext};
+    use tick::Clock;
+
+    #[derive(Debug, Clone)]
+    pub(super) struct Input;
+
+    #[derive(Debug, Clone)]
+    pub(super) struct Output;
+
+    impl From<Input> for Output {
+        fn from(_input: Input) -> Self {
+            Self
+        }
+    }
+
+    struct EmptyExporter;
+
+    impl PushMetricExporter for EmptyExporter {
+        async fn export(&self, _metrics: &ResourceMetrics) -> OTelSdkResult {
+            Ok(())
+        }
+
+        fn force_flush(&self) -> OTelSdkResult {
+            Ok(())
+        }
+
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+            Ok(())
+        }
+
+        fn temporality(&self) -> Temporality {
+            Temporality::Cumulative
+        }
+    }
+
+    // Builds a retry pipeline over the given context. The context selects whether
+    // metrics, logs, or neither are recorded on the resilience event path.
+    fn retry_service(context: ResilienceContext<Input, Output>) -> DynamicService<Input, Output> {
+        (
+            Retry::layer("bench", &context)
+                .clone_input()
+                .base_delay(Duration::ZERO)
+                .recovery_with(|_, _| RecoveryInfo::retry()),
+            Execute::new(|v: Input| async move { Output::from(v) }),
+        )
+            .into_service()
+            .into_dynamic()
+    }
+
+    // Baseline: retry with no telemetry sink configured.
+    fn service_no_telemetry() -> DynamicService<Input, Output> {
+        retry_service(ResilienceContext::new(Clock::new_frozen()))
+    }
+
+    // Retry emitting OpenTelemetry metrics to an empty (no-op) exporter. The
+    // meter is cloned into the context, so the provider is dropped after setup.
+    fn service_metrics() -> DynamicService<Input, Output> {
+        let meter_provider = SdkMeterProvider::builder().with_periodic_exporter(EmptyExporter).build();
+        retry_service(ResilienceContext::new(Clock::new_frozen()).use_metrics(&meter_provider))
+    }
+
+    // Retry emitting structured logs via the `tracing` integration.
+    fn service_logs() -> DynamicService<Input, Output> {
+        retry_service(ResilienceContext::new(Clock::new_frozen()).use_logs())
+    }
+
+    #[library_benchmark]
+    #[bench::retry_no_telemetry(service_no_telemetry())]
+    #[bench::retry_metrics(service_metrics())]
+    #[bench::retry_logs(service_logs())]
+    fn execute(service: DynamicService<Input, Output>) -> DynamicService<Input, Output> {
+        black_box(block_on(service.execute(black_box(Input))));
+        service
+    }
+
+    library_benchmark_group!(
+        name = observability;
+        benchmarks = execute
+    );
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::observability;
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default()
+        .tool(Callgrind::with_args(["--branch-sim=yes"]));
+    library_benchmark_groups = observability
+);

--- a/crates/seatbelt/benches/retry_cg.rs
+++ b/crates/seatbelt/benches/retry_cg.rs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Callgrind benchmarks for the retry middleware in the `seatbelt` crate.
+//!
+//! Paired with `retry.rs`, which covers the same happy-path operations under
+//! wall-clock measurement. Each service is type-erased into a `DynamicService`
+//! in the unmeasured `setup` step so the concrete (unnameable) service type can
+//! be handed to the benchmark function. The dynamic dispatch adds a constant
+//! per-call cost to every scenario, so it cancels out in the baseline-vs-retry
+//! delta that these benchmarks exist to surface.
+
+#![allow(missing_docs, reason = "no need for API documentation on benchmark code")]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "gungraun benchmark inputs are passed and returned by value by the framework"
+)]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Upstream tracking issues are pending."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is Linux-only.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+    use std::time::Duration;
+
+    use futures::executor::block_on;
+    use gungraun::{library_benchmark, library_benchmark_group};
+    use layered::{DynamicService, DynamicServiceExt, Execute, Service, Stack};
+    use seatbelt::retry::Retry;
+    use seatbelt::{RecoveryInfo, ResilienceContext};
+    use tick::Clock;
+
+    #[derive(Debug, Clone)]
+    pub(super) struct Input;
+
+    #[derive(Debug, Clone)]
+    pub(super) struct Output;
+
+    impl From<Input> for Output {
+        fn from(_input: Input) -> Self {
+            Self
+        }
+    }
+
+    // Baseline: a bare service with no retry wrapper.
+    fn service_no_retry() -> DynamicService<Input, Output> {
+        Execute::new(|v: Input| async move { Output::from(v) }).into_dynamic()
+    }
+
+    // Retry configured to never recover: the inner service succeeds on the first
+    // attempt, so no retry is ever scheduled.
+    fn service_with_retry() -> DynamicService<Input, Output> {
+        let context = ResilienceContext::new(Clock::new_frozen());
+        (
+            Retry::layer("bench", &context)
+                .clone_input()
+                .recovery_with(|_, _| RecoveryInfo::never()),
+            Execute::new(|v: Input| async move { Output::from(v) }),
+        )
+            .into_service()
+            .into_dynamic()
+    }
+
+    // Retry configured to recover: exercises the recovery-decision path with a
+    // zero base delay and a single permitted attempt.
+    fn service_with_retry_and_recovery() -> DynamicService<Input, Output> {
+        let context = ResilienceContext::new(Clock::new_frozen());
+        (
+            Retry::layer("bench", &context)
+                .clone_input()
+                .max_retry_attempts(1)
+                .base_delay(Duration::ZERO)
+                .recovery_with(|_, _| RecoveryInfo::retry()),
+            Execute::new(|v: Input| async move { Output::from(v) }),
+        )
+            .into_service()
+            .into_dynamic()
+    }
+
+    #[library_benchmark]
+    #[bench::no_retry(service_no_retry())]
+    #[bench::with_retry(service_with_retry())]
+    #[bench::with_retry_and_recovery(service_with_retry_and_recovery())]
+    fn execute(service: DynamicService<Input, Output>) -> DynamicService<Input, Output> {
+        black_box(block_on(service.execute(black_box(Input))));
+        service
+    }
+
+    library_benchmark_group!(
+        name = retry;
+        benchmarks = execute
+    );
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::retry;
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default()
+        .tool(Callgrind::with_args(["--branch-sim=yes"]));
+    library_benchmark_groups = retry
+);

--- a/crates/seatbelt/benches/timeout_cg.rs
+++ b/crates/seatbelt/benches/timeout_cg.rs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Callgrind benchmarks for the timeout middleware in the `seatbelt` crate.
+//!
+//! Paired with `timeout.rs`, which covers the same happy-path operations under
+//! wall-clock measurement. Each service is type-erased into a `DynamicService`
+//! in the unmeasured `setup` step so the concrete (unnameable) service type can
+//! be handed to the benchmark function. The dynamic dispatch adds a constant
+//! per-call cost to every scenario, so it cancels out in the baseline-vs-timeout
+//! delta that these benchmarks exist to surface.
+
+#![allow(missing_docs, reason = "no need for API documentation on benchmark code")]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "gungraun benchmark inputs are passed and returned by value by the framework"
+)]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Upstream tracking issues are pending."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is Linux-only.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+    use std::time::Duration;
+
+    use futures::executor::block_on;
+    use gungraun::{library_benchmark, library_benchmark_group};
+    use layered::{DynamicService, DynamicServiceExt, Execute, Service, Stack};
+    use seatbelt::ResilienceContext;
+    use seatbelt::timeout::Timeout;
+    use tick::Clock;
+
+    pub(super) struct Input;
+
+    pub(super) struct Output;
+
+    impl From<Input> for Output {
+        fn from(_input: Input) -> Self {
+            Self
+        }
+    }
+
+    // Baseline: a bare service with no timeout wrapper.
+    fn service_no_timeout() -> DynamicService<Input, Output> {
+        Execute::new(|v: Input| async move { Output::from(v) }).into_dynamic()
+    }
+
+    // Timeout in the happy path: the inner service completes well within the
+    // (generous) timeout, so the deadline never fires.
+    fn service_with_timeout() -> DynamicService<Input, Output> {
+        let context = ResilienceContext::new(Clock::new_frozen());
+        (
+            Timeout::layer("bench", &context)
+                .timeout_output(|_args| Output)
+                .timeout(Duration::from_secs(10)),
+            Execute::new(|v: Input| async move { Output::from(v) }),
+        )
+            .into_service()
+            .into_dynamic()
+    }
+
+    #[library_benchmark]
+    #[bench::no_timeout(service_no_timeout())]
+    #[bench::with_timeout(service_with_timeout())]
+    fn execute(service: DynamicService<Input, Output>) -> DynamicService<Input, Output> {
+        black_box(block_on(service.execute(black_box(Input))));
+        service
+    }
+
+    library_benchmark_group!(
+        name = timeout;
+        benchmarks = execute
+    );
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::timeout;
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default()
+        .tool(Callgrind::with_args(["--branch-sim=yes"]));
+    library_benchmark_groups = timeout
+);

--- a/crates/seatbelt/src/breaker/breaker_id.rs
+++ b/crates/seatbelt/src/breaker/breaker_id.rs
@@ -62,6 +62,14 @@ impl BreakerId {
         Self(BreakerIdValue::String(Cow::Borrowed("default")))
     }
 
+    /// Returns `true` if this ID is the default breaker ID.
+    ///
+    /// Used to fast-path the common single-breaker configuration, avoiding a lock,
+    /// a hash, and a map probe when routing to the shared default engine.
+    pub(crate) fn is_default(&self) -> bool {
+        matches!(&self.0, BreakerIdValue::String(value) if value.as_ref() == "default")
+    }
+
     /// Create a breaker ID by hashing the given value.
     ///
     /// The value must implement the `Hash` trait. This is useful for creating breaker
@@ -145,6 +153,17 @@ mod tests {
         assert_eq!(a.to_string(), "hello");
         assert_eq!(b.to_string(), "hello");
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn is_default_distinguishes_default_from_others() {
+        assert!(BreakerId::default().is_default());
+        // Any string equal to "default" is treated as the default, regardless of ownership.
+        assert!(BreakerId::from(String::from("default")).is_default());
+
+        assert!(!BreakerId::from("other").is_default());
+        assert!(!BreakerId::from(42u64).is_default());
+        assert!(!BreakerId::hashed(&"value", "default").is_default());
     }
 
     #[test]

--- a/crates/seatbelt/src/breaker/engine/engines.rs
+++ b/crates/seatbelt/src/breaker/engine/engines.rs
@@ -13,6 +13,7 @@ use crate::utils::TelemetryHelper;
 /// Manages circuit breaker engines for different breaker IDs.
 #[derive(Debug)]
 pub(crate) struct Engines {
+    default_engine: Arc<Engine>,
     map: RwLock<HashMap<BreakerId, Arc<Engine>>>,
     engine_options: EngineOptions,
     clock: Clock,
@@ -21,7 +22,9 @@ pub(crate) struct Engines {
 
 impl Engines {
     pub(crate) fn new(engine_options: EngineOptions, clock: Clock, telemetry: TelemetryHelper) -> Self {
+        let default_engine = Arc::new(create_engine(&engine_options, &clock, &telemetry, &BreakerId::default()));
         Self {
+            default_engine,
             map: RwLock::new(HashMap::new()),
             engine_options,
             clock,
@@ -30,6 +33,13 @@ impl Engines {
     }
 
     pub(crate) fn get_engine(&self, key: &BreakerId) -> Arc<Engine> {
+        // Fast path: the default breaker (the common single-breaker configuration, used
+        // whenever no ID provider is configured) is served by a pre-created engine. This
+        // avoids a lock, a hash of the key, and a map probe on every call.
+        if key.is_default() {
+            return Arc::clone(&self.default_engine);
+        }
+
         // Fast path: read lock for existing engines (common case).
         {
             let map = self.map.read().expect(ERR_POISONED_LOCK);
@@ -40,7 +50,9 @@ impl Engines {
 
         // Slow path: acquire write lock to insert a new engine.
         let mut map = self.map.write().expect(ERR_POISONED_LOCK);
-        let engine = map.entry(key.clone()).or_insert_with(|| Arc::new(self.create_engine(key)));
+        let engine = map
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(create_engine(&self.engine_options, &self.clock, &self.telemetry, key)));
 
         Arc::clone(engine)
     }
@@ -50,15 +62,15 @@ impl Engines {
         let map = self.map.read().expect(ERR_POISONED_LOCK);
         map.len()
     }
+}
 
-    fn create_engine(&self, key: &BreakerId) -> Engine {
-        EngineTelemetry::new(
-            EngineCore::new(self.engine_options.clone(), self.clock.clone()),
-            self.telemetry.clone(),
-            key.clone().into(),
-            self.clock.clone(),
-        )
-    }
+fn create_engine(engine_options: &EngineOptions, clock: &Clock, telemetry: &TelemetryHelper, key: &BreakerId) -> Engine {
+    EngineTelemetry::new(
+        EngineCore::new(engine_options.clone(), clock.clone()),
+        telemetry.clone(),
+        key.clone().into(),
+        clock.clone(),
+    )
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]

--- a/crates/seatbelt/src/retry/service.rs
+++ b/crates/seatbelt/src/retry/service.rs
@@ -247,7 +247,7 @@ impl<In, Out> RetryShared<In, Out> {
                 opentelemetry::KeyValue::new(EVENT_NAME, RETRY_EVENT),
                 opentelemetry::KeyValue::new(ATTEMPT_INDEX, i64::from(attempt.index())),
                 opentelemetry::KeyValue::new(ATTEMPT_IS_LAST, attempt.is_last()),
-                opentelemetry::KeyValue::new(ATTEMPT_RECOVERY_KIND, recovery_kind.to_string()),
+                opentelemetry::KeyValue::new(ATTEMPT_RECOVERY_KIND, recovery_kind.as_str()),
             ]);
         }
     }


### PR DESCRIPTION
Add gungraun (Callgrind) instruction-count benchmarks for the timeout, retry, breaker, hedging, and observability middleware, and use them to drive two hot-path optimizations. No public API change.

- breaker: pre-create a cached default engine so the common single-breaker path (no id_provider) skips the RwLock + HashMap + SipHash lookup in Engines::get_engine.
- retry: emit the recovery-kind metric attribute as a &'static str (RecoveryKind::as_str) instead of allocating a String via to_string.

| Benchmark (instructions)      | Before | After  | Change |
| ----------------------------- | -----: | -----: | -----: |
| breaker / with_breaker        |  4,938 |  3,263 | -33.9% |
| observability / retry_metrics | 60,063 | 56,209 |  -6.4% |

All other benchmark scenarios are unchanged.


Copilot-Session: 0edbf54e-9f2c-4ad4-bd94-88aa25d68eda