### PR TITLE
feat(fetch_grpc): add empty fetch_grpc crate scaffold

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -335,6 +335,7 @@ freezable
 frontend
 fundle
 gRPC
+grpc
 getter
 getters
 github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please see each crate's change log below:
 - [`data_privacy_macros_impl`](./crates/data_privacy_macros_impl/CHANGELOG.md)
 - [`fetch`](./crates/fetch/CHANGELOG.md)
 - [`fetch_azure`](./crates/fetch_azure/CHANGELOG.md)
+- [`fetch_grpc`](./crates/fetch_grpc/CHANGELOG.md)
 - [`fetch_hyper`](./crates/fetch_hyper/CHANGELOG.md)
 - [`fetch_options`](./crates/fetch_options/CHANGELOG.md)
 - [`fetch_tls`](./crates/fetch_tls/CHANGELOG.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "fetch_grpc"
+version = "0.1.0"
+
+[[package]]
 name = "fetch_hyper"
 version = "0.4.6"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ data_privacy_macros = { path = "crates/data_privacy_macros", default-features = 
 data_privacy_macros_impl = { path = "crates/data_privacy_macros_impl", default-features = false, version = "0.10.3" }
 fetch = { path = "crates/fetch", default-features = false, version = "0.13.0" }
 fetch_azure = { path = "crates/fetch_azure", default-features = false, version = "0.3.0" }
+fetch_grpc = { path = "crates/fetch_grpc", default-features = false, version = "0.1.0" }
 fetch_hyper = { path = "crates/fetch_hyper", default-features = false, version = "0.4.6" }
 fetch_options = { path = "crates/fetch_options", default-features = false, version = "0.2.3" }
 fetch_tls = { path = "crates/fetch_tls", default-features = false, version = "0.2.5" }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ These are the primary crates built out of this repo:
 - [`data_privacy`](./crates/data_privacy/README.md) - Mechanisms to classify, manipulate, and redact sensitive data.
 - [`fetch`](./crates/fetch/README.md) - "Universal, composable and resilient HTTP client."
 - [`fetch_azure`](./crates/fetch_azure/README.md) - Azure SDK HTTP transport backed by the fetch HTTP client.
+- [`fetch_grpc`](./crates/fetch_grpc/README.md) - gRPC transport backed by the fetch HTTP client.
 - [`fetch_hyper`](./crates/fetch_hyper/README.md) - Hyper-based HTTP transport utilities for fetch.
 - [`fetch_options`](./crates/fetch_options/README.md) - Options types for 'fetch' crate.
 - [`fundle`](./crates/fundle/README.md) - Compile-time safe dependency injection for Rust.

--- a/crates/fetch_grpc/CHANGELOG.md
+++ b/crates/fetch_grpc/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/crates/fetch_grpc/Cargo.toml
+++ b/crates/fetch_grpc/Cargo.toml
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "fetch_grpc"
+description = "gRPC transport backed by the fetch HTTP client."
+version = "0.1.0"
+readme = "README.md"
+keywords = ["oxidizer", "grpc", "fetch", "http", "transport"]
+categories = ["network-programming"]
+
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+include.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/fetch_grpc"
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+
+[dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/fetch_grpc/README.md
+++ b/crates/fetch_grpc/README.md
@@ -1,0 +1,30 @@
+<div align="center">
+ <img src="./logo.png" alt="Fetch Grpc Logo" width="96">
+
+# Fetch Grpc
+
+[![crate.io](https://img.shields.io/crates/v/fetch_grpc.svg)](https://crates.io/crates/fetch_grpc)
+[![docs.rs](https://docs.rs/fetch_grpc/badge.svg)](https://docs.rs/fetch_grpc)
+[![MSRV](https://img.shields.io/crates/msrv/fetch_grpc)](https://crates.io/crates/fetch_grpc)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
+[![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+<a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
+
+</div>
+
+A gRPC transport backed by the `fetch` HTTP client.
+
+This crate adapts a `fetch` HTTP client into a transport for the
+[`grpc`][__link0] crate, so gRPC calls run over `fetch` and
+benefit from its resilience and observability.
+
+It is currently an empty placeholder. A real implementation will follow.
+
+
+<hr/>
+<sub>
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/fetch_grpc">source code</a>.
+</sub>
+
+ [__link0]: https://docs.rs/grpc

--- a/crates/fetch_grpc/favicon.ico
+++ b/crates/fetch_grpc/favicon.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9eb58f6eca7bfa5554daab00b06c30bfd0d9d2eabc82d1ed4c9d1cede030f2f3
+size 167984

--- a/crates/fetch_grpc/logo.png
+++ b/crates/fetch_grpc/logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2500d13a5e0017dbfd0c7312411cce10cefdafabcea25692e24b8c0ca283f5f6
+size 10094

--- a/crates/fetch_grpc/src/lib.rs
+++ b/crates/fetch_grpc/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(html_logo_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/fetch_grpc/logo.png")]
+#![doc(html_favicon_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/fetch_grpc/favicon.ico")]
+
+//! A gRPC transport backed by the `fetch` HTTP client.
+//!
+//! This crate adapts a `fetch` HTTP client into a transport for the
+//! [`grpc`](https://docs.rs/grpc) crate, so gRPC calls run over `fetch` and
+//! benefit from its resilience and observability.
+//!
+//! It is currently an empty placeholder. A real implementation will follow.


### PR DESCRIPTION
Adds a new placeholder crate `fetch_grpc` that will adapt a `fetch` HTTP client into a transport for the [`grpc`](https://docs.rs/grpc) crate, mirroring the structure of the existing `fetch_azure` adapter.

The crate is an empty scaffold for now (crate-level docs only, no dependencies); a real implementation will follow in a subsequent PR. It is registered in the workspace and the root README/CHANGELOG crate lists.
