### PR TITLE
perf(seatbelt): use a BTreeMap for circuit breaker partition lookup

### DIFF
--- a/crates/seatbelt/benches/breaker.rs
+++ b/crates/seatbelt/benches/breaker.rs
@@ -5,7 +5,7 @@ use alloc_tracker::{Allocator, Session};
 use criterion::{Criterion, criterion_group, criterion_main};
 use futures::executor::block_on;
 use layered::{Execute, Service, Stack};
-use seatbelt::breaker::Breaker;
+use seatbelt::breaker::{Breaker, BreakerId};
 use seatbelt::{RecoveryInfo, ResilienceContext};
 use tick::Clock;
 
@@ -22,7 +22,7 @@ fn entry(c: &mut Criterion) {
     group.bench_function("no-breaker", |b| {
         b.iter(|| {
             let _span = operation.measure_thread();
-            _ = block_on(service.execute(Input));
+            _ = block_on(service.execute(Input(0)));
         });
     });
 
@@ -42,7 +42,38 @@ fn entry(c: &mut Criterion) {
     group.bench_function("with-breaker", |b| {
         b.iter(|| {
             let _span = operation.measure_thread();
-            _ = block_on(service.execute(Input));
+            _ = block_on(service.execute(Input(0)));
+        });
+    });
+
+    // Partitioned breaker, single partition: every request targets the same authority
+    // (the common case). Warmed so the measured loop only resolves the existing engine.
+    let service = warmed_partitioned(0..1);
+    let operation = session.operation("with-partitioned");
+    group.bench_function("with-partitioned", |b| {
+        b.iter(|| {
+            let _span = operation.measure_thread();
+            _ = block_on(service.execute(Input(0)));
+        });
+    });
+
+    // Partitioned breaker with a moderate number of engines already created.
+    let service = warmed_partitioned(0..16);
+    let operation = session.operation("with-partitioned-many");
+    group.bench_function("with-partitioned-many", |b| {
+        b.iter(|| {
+            let _span = operation.measure_thread();
+            _ = block_on(service.execute(Input(0)));
+        });
+    });
+
+    // Partitioned breaker with a large, high-cardinality engine set (worst case).
+    let service = warmed_partitioned(0..256);
+    let operation = session.operation("with-partitioned-large");
+    group.bench_function("with-partitioned-large", |b| {
+        b.iter(|| {
+            let _span = operation.measure_thread();
+            _ = block_on(service.execute(Input(0)));
         });
     });
 
@@ -52,8 +83,31 @@ fn entry(c: &mut Criterion) {
 criterion_group!(benches, entry);
 criterion_main!(benches);
 
+fn build_partitioned() -> impl Service<Input, Out = Result<Output, Output>> + 'static {
+    let context = ResilienceContext::new(Clock::new_frozen());
+    (
+        Breaker::layer("bench", &context)
+            .breaker_id(|input: &Input| BreakerId::from(input.0))
+            .recovery_with(|_, _| RecoveryInfo::never())
+            .rejected_input_error(|_input, _args| Output)
+            .min_throughput(1000),
+        Execute::new(|_input: Input| async move { Ok(Output) }),
+    )
+        .into_service()
+}
+
+// Builds a partitioned breaker and creates an engine for each partition in `partitions`.
+// The measured loops always resolve partition 0.
+fn warmed_partitioned(partitions: impl IntoIterator<Item = u64>) -> impl Service<Input, Out = Result<Output, Output>> + 'static {
+    let service = build_partitioned();
+    for partition in partitions {
+        _ = block_on(service.execute(Input(partition)));
+    }
+    service
+}
+
 #[derive(Debug, Clone)]
-struct Input;
+struct Input(u64);
 
 #[derive(Debug, Clone)]
 struct Output;

--- a/crates/seatbelt/benches/breaker_cg.rs
+++ b/crates/seatbelt/benches/breaker_cg.rs
@@ -38,12 +38,12 @@ mod linux {
     use futures::executor::block_on;
     use gungraun::{library_benchmark, library_benchmark_group};
     use layered::{DynamicService, DynamicServiceExt, Execute, Service, Stack};
-    use seatbelt::breaker::Breaker;
+    use seatbelt::breaker::{Breaker, BreakerId};
     use seatbelt::{RecoveryInfo, ResilienceContext};
     use tick::Clock;
 
     #[derive(Debug, Clone)]
-    pub(super) struct Input;
+    pub(super) struct Input(u64);
 
     #[derive(Debug, Clone)]
     pub(super) struct Output;
@@ -69,11 +69,65 @@ mod linux {
             .into_dynamic()
     }
 
+    // Builds a partitioned circuit breaker whose ID provider keys on the request's
+    // partition. Returned un-warmed so each scenario can create the partitions it needs.
+    fn build_partitioned() -> impl Service<Input, Out = Result<Output, Output>> + 'static {
+        let context = ResilienceContext::new(Clock::new_frozen());
+        (
+            Breaker::layer("bench", &context)
+                .breaker_id(|input: &Input| BreakerId::from(input.0))
+                .recovery_with(|_, _| RecoveryInfo::never())
+                .rejected_input_error(|_input, _args| Output)
+                .min_throughput(1000),
+            Execute::new(|_input: Input| async move { Ok(Output) }),
+        )
+            .into_service()
+    }
+
+    // Creates an engine for each partition in `partitions`, then type-erases the service.
+    // The measured `execute` call always targets partition 0.
+    fn warmed(partitions: impl IntoIterator<Item = u64>) -> DynamicService<Input, Result<Output, Output>> {
+        let service = build_partitioned();
+        for partition in partitions {
+            let _warm = block_on(service.execute(Input(partition)));
+        }
+        service.into_dynamic()
+    }
+
+    // Single partition: every request targets the same authority (the common case). The
+    // measured call resolves the sole existing engine.
+    fn service_with_partitioned() -> DynamicService<Input, Result<Output, Output>> {
+        warmed(0..1)
+    }
+
+    // A moderate number of partitions already exist; the measured call resolves one of them.
+    fn service_with_partitioned_many() -> DynamicService<Input, Result<Output, Output>> {
+        warmed(0..16)
+    }
+
+    // A large, high-cardinality partition set (an anti-pattern the docs discourage, included
+    // to bound the worst case): confirms the lookup stays cheap as the map grows.
+    fn service_with_partitioned_large() -> DynamicService<Input, Result<Output, Output>> {
+        warmed(0..256)
+    }
+
+    // Miss: partitions 1..=16 exist but partition 0 (the measured request) does not, so the
+    // call falls to the write-lock path that creates and inserts a new engine. This one-shot
+    // insert has no Criterion counterpart: a Criterion loop would insert only on its first
+    // iteration and hit thereafter, so it cannot repeatably measure the miss.
+    fn service_with_partitioned_miss() -> DynamicService<Input, Result<Output, Output>> {
+        warmed(1..=16)
+    }
+
     #[library_benchmark]
     #[bench::no_breaker(service_no_breaker())]
     #[bench::with_breaker(service_with_breaker())]
+    #[bench::with_partitioned(service_with_partitioned())]
+    #[bench::with_partitioned_many(service_with_partitioned_many())]
+    #[bench::with_partitioned_large(service_with_partitioned_large())]
+    #[bench::with_partitioned_miss(service_with_partitioned_miss())]
     fn execute(service: DynamicService<Input, Result<Output, Output>>) -> DynamicService<Input, Result<Output, Output>> {
-        let _result = black_box(block_on(service.execute(black_box(Input))));
+        let _result = black_box(block_on(service.execute(black_box(Input(0)))));
         service
     }
 

--- a/crates/seatbelt/src/breaker/breaker_id.rs
+++ b/crates/seatbelt/src/breaker/breaker_id.rs
@@ -54,7 +54,7 @@ use std::hash::Hasher;
 /// for observability purposes. **Important**: Ensure that the values from which breaker IDs
 /// are created do not contain any sensitive data such as authentication tokens, personal
 /// identifiable information (PII), or other confidential data.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BreakerId(BreakerIdValue);
 
 impl BreakerId {
@@ -120,7 +120,7 @@ impl From<BreakerId> for Cow<'static, str> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum BreakerIdValue {
     Number(u64),
     Hashed(u64, &'static str),

--- a/crates/seatbelt/src/breaker/engine/engines.rs
+++ b/crates/seatbelt/src/breaker/engine/engines.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
 use tick::Clock;
@@ -14,7 +14,7 @@ use crate::utils::TelemetryHelper;
 #[derive(Debug)]
 pub(crate) struct Engines {
     default_engine: Arc<Engine>,
-    map: RwLock<HashMap<BreakerId, Arc<Engine>>>,
+    map: RwLock<BTreeMap<BreakerId, Arc<Engine>>>,
     engine_options: EngineOptions,
     clock: Clock,
     telemetry: TelemetryHelper,
@@ -25,7 +25,7 @@ impl Engines {
         let default_engine = Arc::new(create_engine(&engine_options, &clock, &telemetry, &BreakerId::default()));
         Self {
             default_engine,
-            map: RwLock::new(HashMap::new()),
+            map: RwLock::new(BTreeMap::new()),
             engine_options,
             clock,
             telemetry,
@@ -35,12 +35,15 @@ impl Engines {
     pub(crate) fn get_engine(&self, key: &BreakerId) -> Arc<Engine> {
         // Fast path: the default breaker (the common single-breaker configuration, used
         // whenever no ID provider is configured) is served by a pre-created engine. This
-        // avoids a lock, a hash of the key, and a map probe on every call.
+        // avoids a lock and the map lookup entirely on every call.
         if key.is_default() {
             return Arc::clone(&self.default_engine);
         }
 
-        // Fast path: read lock for existing engines (common case).
+        // Read-lock path for existing engines (common case). The map is a `BTreeMap`, so a
+        // lookup is a handful of key comparisons rather than a hash of `key`; partitioned
+        // breakers are low-cardinality by design, so this stays cheap and, unlike a hash
+        // map, is not exposed to hash-flooding via request-derived IDs.
         {
             let map = self.map.read().expect(ERR_POISONED_LOCK);
             if let Some(engine) = map.get(key) {


### PR DESCRIPTION
Partitioned circuit breakers keep their per-partition engines in a map keyed by `BreakerId`. Switching that map from `HashMap` to `BTreeMap` resolves engines by ordered key comparison instead of hashing the `BreakerId` on every call. Partition sets are low-cardinality by design, so a handful of comparisons is cheaper than a SipHash across every size, and — unlike a hash map — the lookup is not exposed to hash-flooding via request-derived IDs. `BreakerId` gains `PartialOrd`/`Ord` (a compatible addition).

Adds breaker Callgrind and Criterion benchmarks covering the default, single-partition, many-partition, high-cardinality, and miss/insert cases so lookup regressions are visible across the full range.

| Benchmark (instructions)          | HashMap | BTreeMap | Change |
| --------------------------------- | ------: | -------: | -----: |
| breaker / with_partitioned (n=1)  |   2,927 |    2,713 |  -7.3% |
| breaker / with_partitioned (n=16) |   2,927 |    2,741 |  -6.4% |
| breaker / with_partitioned (n=256)|   3,050 |    2,769 |  -9.2% |
| breaker / with_partitioned_miss   |   4,291 |    3,994 |  -6.9% |
