### PR TITLE
feat(http_path_template): add parser for google.api.http path templates

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -635,3 +635,5 @@ rc
 destructure
 SIMD
 Callgrind
+matcher
+AST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please see each crate's change log below:
 - [`fundle_macros`](./crates/fundle_macros/CHANGELOG.md)
 - [`fundle_macros_impl`](./crates/fundle_macros_impl/CHANGELOG.md)
 - [`http_extensions`](./crates/http_extensions/CHANGELOG.md)
+- [`http_path_template`](./crates/http_path_template/CHANGELOG.md)
 - [`layered`](./crates/layered/CHANGELOG.md)
 - [`multitude`](./crates/multitude/CHANGELOG.md)
 - [`ohno`](./crates/ohno/CHANGELOG.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http_path_template"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "gungraun",
+ "mutants",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ fundle = { path = "crates/fundle", default-features = false, version = "0.3.4" }
 fundle_macros = { path = "crates/fundle_macros", default-features = false, version = "0.3.4" }
 fundle_macros_impl = { path = "crates/fundle_macros_impl", default-features = false, version = "0.3.4" }
 http_extensions = { path = "crates/http_extensions", default-features = false, version = "0.7.0" }
+http_path_template = { path = "crates/http_path_template", default-features = false, version = "0.1.0" }
 layered = { path = "crates/layered", default-features = false, version = "0.3.5" }
 multitude = { path = "crates/multitude", default-features = false, version = "0.6.1" }
 ohno = { path = "crates/ohno", default-features = false, version = "0.3.8" }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These are the primary crates built out of this repo:
 - [`fetch_options`](./crates/fetch_options/README.md) - Options types for 'fetch' crate.
 - [`fundle`](./crates/fundle/README.md) - Compile-time safe dependency injection for Rust.
 - [`http_extensions`](./crates/http_extensions/README.md) - Shared HTTP types and extension traits for clients and servers.
+- [`http_path_template`](./crates/http_path_template/README.md) - Parser for the google.api.http path-template grammar (literals, `*`, `**`, `{field=sub}` variables, `:verb`).
 - [`layered`](./crates/layered/README.md) - A foundational service abstraction for building composable, middleware-driven systems.
 - [`multitude`](./crates/multitude/README.md) - Fast and flexible arena allocator.
 - [`ohno`](./crates/ohno/README.md) - High-quality Rust error handling.

--- a/crates/http_path_template/CHANGELOG.md
+++ b/crates/http_path_template/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial release of `http_path_template`, a dependency-free parser for the
+  `google.api.http` path-template grammar.
+- `PathTemplate::parse` validates a template string and exposes its structure
+  via `PathTemplate::segments` and `PathTemplate::verb`.
+- `Segment` and `Variable` model the parsed abstract syntax tree (literals, `*`,
+  `**`, and `{field.path=sub-template}` variable bindings).
+- `ParseError` reports every structural parse failure, with `is_*` predicates to
+  categorize it.

--- a/crates/http_path_template/Cargo.toml
+++ b/crates/http_path_template/Cargo.toml
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "http_path_template"
+description = "Parser for the google.api.http path-template grammar"
+version = "0.1.0"
+readme = "README.md"
+keywords = ["grpc", "rest", "path", "template", "http"]
+categories = ["parser-implementations", "web-programming"]
+
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+include.workspace = true
+repository = "https://github.com/microsoft/oxidizer/tree/main/crates/http_path_template"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
+
+[dependencies]
+
+[dev-dependencies]
+criterion = { workspace = true }
+mutants = { workspace = true }
+
+# Callgrind instruction-count benchmarks (Valgrind is Linux-only).
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+gungraun = { workspace = true, features = ["default"] }
+
+[lints]
+workspace = true
+
+[[bench]]
+name = "hpt_parse"
+harness = false
+
+[[bench]]
+name = "hpt_parse_cg"
+harness = false
+

--- a/crates/http_path_template/README.md
+++ b/crates/http_path_template/README.md
@@ -1,0 +1,121 @@
+<div align="center">
+ <img src="./logo.png" alt="Http Path Template Logo" width="96">
+
+# HTTP Path Template
+
+[![crate.io](https://img.shields.io/crates/v/http_path_template.svg)](https://crates.io/crates/http_path_template)
+[![docs.rs](https://docs.rs/http_path_template/badge.svg)](https://docs.rs/http_path_template)
+[![MSRV](https://img.shields.io/crates/msrv/http_path_template)](https://crates.io/crates/http_path_template)
+[![CI](https://github.com/microsoft/oxidizer/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/oxidizer/actions/workflows/main.yml)
+[![Coverage](https://codecov.io/gh/microsoft/oxidizer/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/microsoft/oxidizer)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+<a href="../.."><img src="../../logo.svg" alt="This crate was developed as part of the Oxidizer project" width="20"></a>
+
+</div>
+
+A parser for the [`google.api.http`][__link0] path-template grammar.
+
+A path template is the pattern that appears in a `google.api.http`
+annotation, for example `/shelves/{shelf}/books/{book=**}:archive`. This crate
+turns such a string into a validated, structured [`PathTemplate`][__link1] — an
+abstract syntax tree of [`Segment`][__link2]s (literals, `*`, `**`, and
+`{field.path=sub-template}` [`Variable`][__link3] bindings) plus an optional custom
+`:verb`.
+
+Parsing is zero-copy: the returned [`PathTemplate`][__link4] borrows from the input
+string (every literal, field name, and verb is a slice into it), so a parse
+copies no text and allocates only the top-level segment list.
+
+A template must begin with `/` and is a `/`-separated sequence of segments —
+each `/` delimits one segment. Literal segments, variable field names, and the
+custom `:verb` are preserved and compared **verbatim**, so the grammar is
+case-sensitive; the parser performs no case folding.
+
+The grammar mirrors the reference [`google.api.HttpRule`][__link5] path syntax:
+
+* a **literal** segment (`shelves`) must match verbatim;
+* **`*`** ([`Segment::Single`][__link6]) matches exactly one non-empty segment;
+* **`**`** ([`Segment::Rest`][__link7]) matches the remaining segments and may only
+  appear as the final element;
+* **`{field.path=sub-template}`** ([`Segment::Variable`][__link8]) captures the portion
+  of the path matched by its sub-template into a dotted message field; the
+  shorthand `{field}` is `{field=*}` and nested variables are rejected;
+* a trailing **`:verb`** declares a custom method verb.
+
+## Extended grammar
+
+[`PathTemplate::parse`][__link9] takes a [`Grammar`][__link10] argument. The default grammar is
+the strict `google.api.http` syntax above; passing a [`Grammar`][__link11] with
+[`Grammar::with_segment_affixes`][__link12] enabled additionally allows **intra-segment
+prefix/suffix parameters**: a single segment may wrap one `{field.path}`
+variable in literal text, for example `/files/{name}.json`, `/v{version}/x`,
+or `/img-{id}.png`. Such a segment parses to a [`Segment::Affix`][__link13]. The strict
+grammar rejects this syntax.
+
+## Examples
+
+Parsing `/shelves/{shelf}/books/{book=**}:archive` yields four top-level
+[`Segment`][__link14]s plus the custom verb `archive`:
+
+* `shelves` — a [`Segment::Literal`][__link15];
+* `{shelf}` — a [`Segment::Variable`][__link16] binding field `shelf` to a single
+  segment (`*`, i.e. [`Segment::Single`][__link17]);
+* `books` — a [`Segment::Literal`][__link18];
+* `{book=**}` — a [`Segment::Variable`][__link19] binding field `book` to the remaining
+  segments (`**`, i.e. [`Segment::Rest`][__link20]).
+
+```rust
+use http_path_template::{Grammar, PathTemplate, Segment};
+
+let template = PathTemplate::parse(
+    "/shelves/{shelf}/books/{book=**}:archive",
+    Grammar::default(),
+)?;
+
+assert_eq!(template.segments().len(), 4);
+assert_eq!(template.verb(), Some("archive"));
+
+assert_eq!(template.segments()[0], Segment::Literal("shelves"));
+assert_eq!(template.segments()[2], Segment::Literal("books"));
+
+let Segment::Variable(shelf) = template.segments()[1] else {
+    panic!("expected variable")
+};
+assert_eq!(shelf.field_path(), "shelf");
+assert!(shelf.segments().eq([Segment::Single]));
+
+let Segment::Variable(book) = template.segments()[3] else {
+    panic!("expected variable")
+};
+assert_eq!(book.field_path(), "book");
+assert!(book.segments().eq([Segment::Rest]));
+```
+
+
+<hr/>
+<sub>
+This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/http_path_template">source code</a>.
+</sub>
+
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbdehWW1wo3-MbQZ4f-tMBwgsbFQlyCp62fwcbNkxL2v1MviZhZIGCcmh0dHBfcGF0aF90ZW1wbGF0ZWUwLjEuMA
+ [__link0]: https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
+ [__link1]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=PathTemplate
+ [__link10]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Grammar
+ [__link11]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Grammar
+ [__link12]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Grammar::with_segment_affixes
+ [__link13]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Affix
+ [__link14]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment
+ [__link15]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Literal
+ [__link16]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Variable
+ [__link17]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Single
+ [__link18]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Literal
+ [__link19]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Variable
+ [__link2]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment
+ [__link20]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Rest
+ [__link3]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Variable
+ [__link4]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=PathTemplate
+ [__link5]: https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
+ [__link6]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Single
+ [__link7]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Rest
+ [__link8]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=Segment::Variable
+ [__link9]: https://docs.rs/http_path_template/0.1.0/http_path_template/?search=PathTemplate::parse

--- a/crates/http_path_template/benches/hpt_parse.rs
+++ b/crates/http_path_template/benches/hpt_parse.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Wall-clock benchmarks for [`PathTemplate::parse`].
+//!
+//! Parsing a `google.api.http` path template is this crate's entire value
+//! proposition: a REST-over-gRPC build step parses every annotated method's
+//! template once, and a router may re-parse templates when (re)building its
+//! route table. Each parse walks the string, splits it into segments, and
+//! allocates the resulting [`Segment`](http_path_template::Segment) AST.
+//!
+//! These benchmarks isolate a single `parse` call across the grammar's
+//! branching shapes — literal-only paths, `{variable}` bindings, a `**` rest
+//! wildcard, a trailing `:verb`, an extended-grammar intra-segment affix, and
+//! the error path — so a change in per-shape parse cost is visible.
+//!
+//! Paired with `hpt_parse_cg.rs`, which measures the same operations under
+//! Callgrind. Wall-clock cannot reliably resolve a single eliminated
+//! allocation or branch; the Callgrind instruction counts are the authoritative
+//! signal for those.
+
+#![allow(missing_docs, reason = "no need for API documentation on benchmark code")]
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use http_path_template::{Grammar, PathTemplate};
+
+// A path made only of literal segments — no variables, no wildcards.
+const LITERAL_ONLY: &str = "/v1/shelves/books/list";
+
+// A typical CRUD annotation with two `{variable}` bindings.
+const VARIABLES: &str = "/v1/shelves/{shelf}/books/{book}";
+
+// A variable whose sub-template ends in a `**` rest wildcard.
+const REST_WILDCARD: &str = "/v1/{name=books/**}";
+
+// A path with two variables and a trailing custom `:verb`.
+const VERB: &str = "/v1/shelves/{shelf}/books/{book}:archive";
+
+// An extended-grammar intra-segment affix (`{name}` wrapped in `files/` … `.json`).
+const AFFIX: &str = "/v1/files/{name}.json";
+
+// An invalid template (`**` is not the final segment) — exercises the error path.
+const INVALID: &str = "/a/**/b";
+
+fn parse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hpt_parse/parse");
+
+    let strict = Grammar::default();
+    let extended = Grammar::default().with_segment_affixes();
+
+    group.bench_function("literal_only", |b| {
+        b.iter(|| black_box(PathTemplate::parse(black_box(LITERAL_ONLY), strict)));
+    });
+    group.bench_function("variables", |b| {
+        b.iter(|| black_box(PathTemplate::parse(black_box(VARIABLES), strict)));
+    });
+    group.bench_function("rest_wildcard", |b| {
+        b.iter(|| black_box(PathTemplate::parse(black_box(REST_WILDCARD), strict)));
+    });
+    group.bench_function("verb", |b| {
+        b.iter(|| black_box(PathTemplate::parse(black_box(VERB), strict)));
+    });
+    group.bench_function("affix", |b| {
+        b.iter(|| black_box(PathTemplate::parse(black_box(AFFIX), extended)));
+    });
+    group.bench_function("invalid", |b| {
+        b.iter(|| black_box(PathTemplate::parse(black_box(INVALID), strict)));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, parse);
+criterion_main!(benches);

--- a/crates/http_path_template/benches/hpt_parse_cg.rs
+++ b/crates/http_path_template/benches/hpt_parse_cg.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Callgrind benchmarks for [`PathTemplate::parse`].
+//!
+//! Parsing a `google.api.http` path template is this crate's entire value
+//! proposition: a REST-over-gRPC build step parses every annotated method's
+//! template once, and a router may re-parse templates when (re)building its
+//! route table. Each parse walks the string, splits it into segments, and
+//! allocates the resulting [`Segment`](http_path_template::Segment) AST.
+//!
+//! These benchmarks isolate a single `parse` call across the grammar's
+//! branching shapes — literal-only paths, `{variable}` bindings, a `**` rest
+//! wildcard, a trailing `:verb`, an extended-grammar intra-segment affix, and
+//! the error path.
+//!
+//! Paired with `hpt_parse.rs`, which covers the same operations under
+//! wall-clock (Criterion) measurement. The Callgrind instruction counts here
+//! are the authoritative signal for allocation and branch changes, which
+//! wall-clock cannot reliably resolve.
+
+#![allow(missing_docs, reason = "no need for API documentation on benchmark code")]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Upstream tracking issues are pending."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is Linux-only.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+
+    use gungraun::{library_benchmark, library_benchmark_group};
+    use http_path_template::{Grammar, ParseError, PathTemplate};
+
+    // A path made only of literal segments — no variables, no wildcards.
+    const LITERAL_ONLY: &str = "/v1/shelves/books/list";
+
+    // A typical CRUD annotation with two `{variable}` bindings.
+    const VARIABLES: &str = "/v1/shelves/{shelf}/books/{book}";
+
+    // A variable whose sub-template ends in a `**` rest wildcard.
+    const REST_WILDCARD: &str = "/v1/{name=books/**}";
+
+    // A path with two variables and a trailing custom `:verb`.
+    const VERB: &str = "/v1/shelves/{shelf}/books/{book}:archive";
+
+    // An extended-grammar intra-segment affix (`{name}` wrapped in `files/` … `.json`).
+    const AFFIX: &str = "/v1/files/{name}.json";
+
+    // An invalid template (`**` is not the final segment) — exercises the error path.
+    const INVALID: &str = "/a/**/b";
+
+    #[library_benchmark]
+    fn parse_literal_only() -> Result<PathTemplate<'static>, ParseError> {
+        PathTemplate::parse(black_box(LITERAL_ONLY), black_box(Grammar::default()))
+    }
+
+    #[library_benchmark]
+    fn parse_variables() -> Result<PathTemplate<'static>, ParseError> {
+        PathTemplate::parse(black_box(VARIABLES), black_box(Grammar::default()))
+    }
+
+    #[library_benchmark]
+    fn parse_rest_wildcard() -> Result<PathTemplate<'static>, ParseError> {
+        PathTemplate::parse(black_box(REST_WILDCARD), black_box(Grammar::default()))
+    }
+
+    #[library_benchmark]
+    fn parse_verb() -> Result<PathTemplate<'static>, ParseError> {
+        PathTemplate::parse(black_box(VERB), black_box(Grammar::default()))
+    }
+
+    #[library_benchmark]
+    fn parse_affix() -> Result<PathTemplate<'static>, ParseError> {
+        PathTemplate::parse(black_box(AFFIX), black_box(Grammar::default().with_segment_affixes()))
+    }
+
+    #[library_benchmark]
+    fn parse_invalid() -> Result<PathTemplate<'static>, ParseError> {
+        PathTemplate::parse(black_box(INVALID), black_box(Grammar::default()))
+    }
+
+    library_benchmark_group!(
+        name = parse;
+        benchmarks =
+            parse_literal_only,
+            parse_variables,
+            parse_rest_wildcard,
+            parse_verb,
+            parse_affix,
+            parse_invalid
+    );
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::parse;
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default()
+        .tool(Callgrind::with_args(["--branch-sim=yes"]));
+    library_benchmark_groups = parse
+);

--- a/crates/http_path_template/favicon.ico
+++ b/crates/http_path_template/favicon.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21ceda6974d03d50b36ab461773aa3605b44c120e4708b422b08588a32949c9a
+size 198380

--- a/crates/http_path_template/logo.png
+++ b/crates/http_path_template/logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a6abfef2e7918264ab80ec4167b7b0a017205af9b9482fe823c25ef0d1e57c7
+size 66784

--- a/crates/http_path_template/src/error.rs
+++ b/crates/http_path_template/src/error.rs
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use core::fmt;
+use std::backtrace::{Backtrace, BacktraceStatus};
+
+/// The specific structural failure behind a [`ParseError`]. Kept crate-internal;
+/// callers discriminate failures through the `ParseError::is_*` predicates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ParseErrorKind {
+    /// The template did not begin with `/`.
+    MissingLeadingSlash,
+    /// The template contained an empty path segment (e.g. `a//b`).
+    EmptySegment,
+    /// A `{` or `}` was unbalanced.
+    UnbalancedBraces,
+    /// A variable sub-template contained a nested `{` variable.
+    NestedVariable,
+    /// A variable had an empty field path (e.g. `{}` or `{=*}`).
+    EmptyFieldPath,
+    /// A field-path identifier was empty or contained invalid characters.
+    InvalidFieldName,
+    /// A literal segment contained a misplaced `*` (`*`/`**` are only valid as
+    /// whole segments).
+    InvalidLiteral,
+    /// A `**` appeared somewhere other than the final position.
+    RestNotLast,
+    /// A `:` verb separator was present but the verb was empty.
+    EmptyVerb,
+    /// A `:` verb contained a `/`, `*`, `{`, or `}` (a verb must be a single
+    /// trailing literal).
+    InvalidVerb,
+    /// More than one top-level `:` verb separator was present.
+    MultipleVerbs,
+}
+
+impl ParseErrorKind {
+    const fn describe(self) -> &'static str {
+        match self {
+            Self::MissingLeadingSlash => "template must begin with '/'",
+            Self::EmptySegment => "template contains an empty path segment",
+            Self::UnbalancedBraces => "template contains unbalanced '{' or '}'",
+            Self::NestedVariable => "variable sub-templates may not contain nested variables",
+            Self::EmptyFieldPath => "variable has an empty field path",
+            Self::InvalidFieldName => "variable field path contains an invalid identifier",
+            Self::InvalidLiteral => "literal segment contains a misplaced '*'",
+            Self::RestNotLast => "'**' may only appear as the final segment",
+            Self::EmptyVerb => "custom verb after ':' is empty",
+            Self::InvalidVerb => "custom verb after ':' must be a literal (no '/', '*', '{', or '}')",
+            Self::MultipleVerbs => "template contains more than one ':' verb separator",
+        }
+    }
+}
+
+/// A lazily-allocated backtrace for a [`ParseError`].
+///
+/// A [`Backtrace`] is only allocated (boxed) when it is actually *captured* —
+/// i.e. when `RUST_BACKTRACE` (or `RUST_LIB_BACKTRACE`) is enabled. In the common
+/// case where backtraces are disabled, `Backtrace::capture()` returns a disabled
+/// backtrace that carries no data, so we store [`MaybeBacktrace::Disabled`] and
+/// avoid a heap allocation entirely. This keeps the error path allocation-free by
+/// default while still surfacing a full backtrace in `Debug` when enabled.
+#[derive(Debug)]
+enum MaybeBacktrace {
+    /// A captured backtrace, boxed to keep [`ParseError`] small. Only produced
+    /// when backtrace capture is enabled.
+    Captured(#[expect(dead_code, reason = "captured for Debug output and RUST_BACKTRACE diagnostics")] Box<Backtrace>),
+    /// Backtrace capture was disabled or unsupported, so no allocation was made.
+    Disabled,
+}
+
+impl MaybeBacktrace {
+    /// Captures a backtrace, allocating only if capture is actually enabled.
+    fn capture() -> Self {
+        Self::from_backtrace(Backtrace::capture())
+    }
+
+    /// Wraps a [`Backtrace`], boxing it only when it actually captured frames.
+    fn from_backtrace(backtrace: Backtrace) -> Self {
+        match backtrace.status() {
+            BacktraceStatus::Captured => Self::Captured(Box::new(backtrace)),
+            // `Disabled`/`Unsupported` backtraces hold no frames, so there is
+            // nothing worth allocating for.
+            _ => Self::Disabled,
+        }
+    }
+
+    /// Unconditionally captures a backtrace, ignoring the `RUST_BACKTRACE`
+    /// setting. Used only in tests to exercise the [`MaybeBacktrace::Captured`]
+    /// path regardless of the environment.
+    #[cfg(test)]
+    fn force_capture() -> Self {
+        Self::from_backtrace(Backtrace::force_capture())
+    }
+}
+
+/// An error produced while parsing a [`PathTemplate`](crate::PathTemplate).
+///
+/// # Examples
+///
+/// ```
+/// use http_path_template::{Grammar, PathTemplate};
+///
+/// let error = PathTemplate::parse("/a/**/b", Grammar::default()).expect_err("rest is not last");
+/// assert_eq!(
+///     error.to_string(),
+///     "'**' may only appear as the final segment"
+/// );
+/// ```
+#[derive(Debug)]
+pub struct ParseError {
+    kind: ParseErrorKind,
+    #[expect(dead_code, reason = "captured for Debug output and RUST_BACKTRACE diagnostics")]
+    backtrace: MaybeBacktrace,
+}
+
+impl ParseError {
+    pub(crate) fn new(kind: ParseErrorKind) -> Self {
+        Self {
+            kind,
+            backtrace: MaybeBacktrace::capture(),
+        }
+    }
+
+    /// Whether the template did not begin with `/`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_path_template::{Grammar, PathTemplate};
+    ///
+    /// let error = PathTemplate::parse("shelves/{shelf}", Grammar::default())
+    ///     .expect_err("missing leading slash");
+    /// assert!(error.is_missing_leading_slash());
+    /// ```
+    #[must_use]
+    pub const fn is_missing_leading_slash(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::MissingLeadingSlash)
+    }
+
+    /// Whether the template contained an empty path segment (e.g. `a//b`).
+    #[must_use]
+    pub const fn is_empty_segment(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::EmptySegment)
+    }
+
+    /// Whether a `{` or `}` was unbalanced.
+    #[must_use]
+    pub const fn is_unbalanced_braces(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::UnbalancedBraces)
+    }
+
+    /// Whether a variable sub-template contained a nested `{` variable.
+    #[must_use]
+    pub const fn is_nested_variable(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::NestedVariable)
+    }
+
+    /// Whether a variable had an empty field path (e.g. `{}` or `{=*}`).
+    #[must_use]
+    pub const fn is_empty_field_path(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::EmptyFieldPath)
+    }
+
+    /// Whether a field-path identifier was empty or contained invalid characters.
+    #[must_use]
+    pub const fn is_invalid_field_name(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::InvalidFieldName)
+    }
+
+    /// Whether a literal segment contained a misplaced `*`.
+    #[must_use]
+    pub const fn is_invalid_literal(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::InvalidLiteral)
+    }
+
+    /// Whether a `**` appeared somewhere other than the final position.
+    #[must_use]
+    pub const fn is_rest_not_last(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::RestNotLast)
+    }
+
+    /// Whether a `:` verb separator was present but the verb was empty.
+    #[must_use]
+    pub const fn is_empty_verb(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::EmptyVerb)
+    }
+
+    /// Whether a `:` verb contained a disallowed character (`/`, `*`, `{`, `}`).
+    #[must_use]
+    pub const fn is_invalid_verb(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::InvalidVerb)
+    }
+
+    /// Whether more than one top-level `:` verb separator was present.
+    #[must_use]
+    pub const fn is_multiple_verbs(&self) -> bool {
+        matches!(self.kind, ParseErrorKind::MultipleVerbs)
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.kind.describe())
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "Debug-formatting a captured Backtrace symbolicates frames via getcwd, unsupported under Miri isolation"
+    )]
+    fn force_capture_produces_a_captured_backtrace() {
+        // `force_capture` ignores `RUST_BACKTRACE`, so this exercises the
+        // `Captured` arm even when backtraces are disabled in the environment.
+        let backtrace = MaybeBacktrace::force_capture();
+        assert!(matches!(backtrace, MaybeBacktrace::Captured(_)));
+        // The captured backtrace surfaces in `Debug` output.
+        assert!(format!("{backtrace:?}").starts_with("Captured"));
+    }
+
+    #[test]
+    fn from_backtrace_stores_no_allocation_when_disabled() {
+        // A disabled backtrace holds no frames, so `from_backtrace` takes the
+        // `Disabled` arm and avoids boxing anything.
+        let backtrace = MaybeBacktrace::from_backtrace(Backtrace::disabled());
+        assert!(matches!(backtrace, MaybeBacktrace::Disabled));
+    }
+}

--- a/crates/http_path_template/src/grammar.rs
+++ b/crates/http_path_template/src/grammar.rs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// Selects which path-template grammar [`PathTemplate::parse`](crate::PathTemplate::parse)
+/// accepts.
+///
+/// The [`Default`] grammar is the strict `google.api.http` syntax. Non-standard
+/// extensions are opted into explicitly with the `with_*` methods, so new
+/// extensions can be added over time without breaking existing callers.
+///
+/// # Examples
+///
+/// ```
+/// use http_path_template::{Grammar, PathTemplate};
+///
+/// # fn main() -> Result<(), http_path_template::ParseError> {
+/// // The default grammar is the strict `google.api.http` syntax.
+/// let strict = Grammar::default();
+/// assert!(PathTemplate::parse("/img-{id}.png", strict).is_err());
+///
+/// // Opt into intra-segment prefix/suffix parameters.
+/// let extended = Grammar::default().with_segment_affixes();
+/// assert!(PathTemplate::parse("/img-{id}.png", extended).is_ok());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Grammar {
+    segment_affixes: bool,
+}
+
+impl Grammar {
+    /// The strict `google.api.http` grammar, equivalent to [`Grammar::default`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_path_template::Grammar;
+    ///
+    /// assert_eq!(Grammar::new(), Grammar::default());
+    /// ```
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { segment_affixes: false }
+    }
+
+    /// Enables **intra-segment prefix/suffix parameters**: a single segment may
+    /// wrap one `{field.path}` variable in literal text, for example
+    /// `/files/{name}.json`, `/v{version}/x`, or `/img-{id}.png`. Such a segment
+    /// parses to a [`Segment::Affix`](crate::Segment::Affix).
+    ///
+    /// This is a non-standard superset of the `google.api.http` grammar; the
+    /// strict grammar rejects intra-segment parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_path_template::{Grammar, PathTemplate, Segment};
+    ///
+    /// # fn main() -> Result<(), http_path_template::ParseError> {
+    /// let grammar = Grammar::default().with_segment_affixes();
+    /// let template = PathTemplate::parse("/img-{id}.png", grammar)?;
+    /// assert_eq!(
+    ///     template.segments()[0],
+    ///     Segment::Affix {
+    ///         prefix: "img-",
+    ///         name: "id",
+    ///         suffix: ".png"
+    ///     },
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub const fn with_segment_affixes(mut self) -> Self {
+        self.segment_affixes = true;
+        self
+    }
+
+    /// Whether intra-segment prefix/suffix parameters are allowed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_path_template::Grammar;
+    ///
+    /// assert!(!Grammar::default().segment_affixes());
+    /// assert!(Grammar::default().with_segment_affixes().segment_affixes());
+    /// ```
+    #[must_use]
+    pub const fn segment_affixes(self) -> bool {
+        self.segment_affixes
+    }
+}

--- a/crates/http_path_template/src/lib.rs
+++ b/crates/http_path_template/src/lib.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![forbid(unsafe_code)]
+#![doc(html_logo_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/http_path_template/logo.png")]
+#![doc(
+    html_favicon_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/http_path_template/favicon.ico"
+)]
+
+//! A parser for the [`google.api.http`] path-template grammar.
+//!
+//! A path template is the pattern that appears in a `google.api.http`
+//! annotation, for example `/shelves/{shelf}/books/{book=**}:archive`. This crate
+//! turns such a string into a validated, structured [`PathTemplate`] — an
+//! abstract syntax tree of [`Segment`]s (literals, `*`, `**`, and
+//! `{field.path=sub-template}` [`Variable`] bindings) plus an optional custom
+//! `:verb`.
+//!
+//! Parsing is zero-copy: the returned [`PathTemplate`] borrows from the input
+//! string (every literal, field name, and verb is a slice into it), so a parse
+//! copies no text and allocates only the top-level segment list.
+//!
+//! A template must begin with `/` and is a `/`-separated sequence of segments —
+//! each `/` delimits one segment. Literal segments, variable field names, and the
+//! custom `:verb` are preserved and compared **verbatim**, so the grammar is
+//! case-sensitive; the parser performs no case folding.
+//!
+//! The grammar mirrors the reference [`google.api.HttpRule`] path syntax:
+//!
+//! - a **literal** segment (`shelves`) must match verbatim;
+//! - **`*`** ([`Segment::Single`]) matches exactly one non-empty segment;
+//! - **`**`** ([`Segment::Rest`]) matches the remaining segments and may only
+//!   appear as the final element;
+//! - **`{field.path=sub-template}`** ([`Segment::Variable`]) captures the portion
+//!   of the path matched by its sub-template into a dotted message field; the
+//!   shorthand `{field}` is `{field=*}` and nested variables are rejected;
+//! - a trailing **`:verb`** declares a custom method verb.
+//!
+//! # Extended grammar
+//!
+//! [`PathTemplate::parse`] takes a [`Grammar`] argument. The default grammar is
+//! the strict `google.api.http` syntax above; passing a [`Grammar`] with
+//! [`Grammar::with_segment_affixes`] enabled additionally allows **intra-segment
+//! prefix/suffix parameters**: a single segment may wrap one `{field.path}`
+//! variable in literal text, for example `/files/{name}.json`, `/v{version}/x`,
+//! or `/img-{id}.png`. Such a segment parses to a [`Segment::Affix`]. The strict
+//! grammar rejects this syntax.
+//!
+//! # Examples
+//!
+//! Parsing `/shelves/{shelf}/books/{book=**}:archive` yields four top-level
+//! [`Segment`]s plus the custom verb `archive`:
+//!
+//! - `shelves` — a [`Segment::Literal`];
+//! - `{shelf}` — a [`Segment::Variable`] binding field `shelf` to a single
+//!   segment (`*`, i.e. [`Segment::Single`]);
+//! - `books` — a [`Segment::Literal`];
+//! - `{book=**}` — a [`Segment::Variable`] binding field `book` to the remaining
+//!   segments (`**`, i.e. [`Segment::Rest`]).
+//!
+//! ```
+//! use http_path_template::{Grammar, PathTemplate, Segment};
+//!
+//! # fn main() -> Result<(), http_path_template::ParseError> {
+//! let template = PathTemplate::parse(
+//!     "/shelves/{shelf}/books/{book=**}:archive",
+//!     Grammar::default(),
+//! )?;
+//!
+//! assert_eq!(template.segments().len(), 4);
+//! assert_eq!(template.verb(), Some("archive"));
+//!
+//! assert_eq!(template.segments()[0], Segment::Literal("shelves"));
+//! assert_eq!(template.segments()[2], Segment::Literal("books"));
+//!
+//! let Segment::Variable(shelf) = template.segments()[1] else {
+//!     panic!("expected variable")
+//! };
+//! assert_eq!(shelf.field_path(), "shelf");
+//! assert!(shelf.segments().eq([Segment::Single]));
+//!
+//! let Segment::Variable(book) = template.segments()[3] else {
+//!     panic!("expected variable")
+//! };
+//! assert_eq!(book.field_path(), "book");
+//! assert!(book.segments().eq([Segment::Rest]));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`google.api.http`]: https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
+//! [`google.api.HttpRule`]: https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
+
+mod error;
+mod grammar;
+mod path_template;
+mod segment;
+mod variable;
+
+pub use error::ParseError;
+pub use grammar::Grammar;
+pub use path_template::PathTemplate;
+pub use segment::Segment;
+pub use variable::{SegmentIter, Variable};

--- a/crates/http_path_template/src/path_template.rs
+++ b/crates/http_path_template/src/path_template.rs
@@ -1,0 +1,497 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::error::{ParseError, ParseErrorKind};
+use crate::grammar::Grammar;
+use crate::segment::Segment;
+use crate::variable::Variable;
+
+/// A parsed `google.api.http` path template.
+///
+/// Construct one with [`PathTemplate::parse`] and inspect its structure via
+/// [`PathTemplate::segments`] / [`PathTemplate::verb`].
+///
+/// # Examples
+///
+/// ```
+/// use http_path_template::{Grammar, PathTemplate};
+///
+/// # fn main() -> Result<(), http_path_template::ParseError> {
+/// let template = PathTemplate::parse("/v1/shelves/{shelf}:get", Grammar::default())?;
+/// assert_eq!(template.verb(), Some("get"));
+/// assert_eq!(template.segments().len(), 3);
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PathTemplate<'a> {
+    segments: Box<[Segment<'a>]>,
+    verb: Option<&'a str>,
+}
+
+impl<'a> PathTemplate<'a> {
+    /// Parses a `google.api.http` path template string using the given [`Grammar`].
+    ///
+    /// The returned template borrows from `template`: every literal, field name,
+    /// and verb is a slice into the input, so parsing allocates only the
+    /// top-level segment list.
+    ///
+    /// Pass [`Grammar::default`] for the strict `google.api.http` syntax, or a
+    /// [`Grammar`] with extensions enabled (e.g.
+    /// [`Grammar::with_segment_affixes`]) to accept a superset of that syntax.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_path_template::{Grammar, PathTemplate, Segment};
+    ///
+    /// # fn main() -> Result<(), http_path_template::ParseError> {
+    /// // The strict grammar.
+    /// let template = PathTemplate::parse(
+    ///     "/shelves/{shelf}/books/{book=**}:archive",
+    ///     Grammar::default(),
+    /// )?;
+    /// assert_eq!(template.verb(), Some("archive"));
+    /// assert_eq!(template.segments().len(), 4);
+    ///
+    /// // An intra-segment parameter needs the extended grammar. The strict
+    /// // grammar has no such syntax, so it rejects this.
+    /// assert!(PathTemplate::parse("/img-{id}.png", Grammar::default()).is_err());
+    ///
+    /// let template = PathTemplate::parse("/img-{id}.png", Grammar::default().with_segment_affixes())?;
+    /// assert_eq!(
+    ///     template.segments()[0],
+    ///     Segment::Affix {
+    ///         prefix: "img-",
+    ///         name: "id",
+    ///         suffix: ".png"
+    ///     },
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ParseError`] describing the first structural problem found
+    /// (missing leading slash, unbalanced braces, misplaced `**`, …).
+    pub fn parse(template: &'a str, grammar: Grammar) -> Result<Self, ParseError> {
+        Self::parse_inner(template, grammar)
+    }
+
+    fn parse_inner(template: &'a str, grammar: Grammar) -> Result<Self, ParseError> {
+        // The leading `/` is the most fundamental structural requirement, so
+        // check it before the verb split (which could otherwise surface a later
+        // error such as an unbalanced brace first).
+        if template.as_bytes().first() != Some(&b'/') {
+            return Err(ParseError::new(ParseErrorKind::MissingLeadingSlash));
+        }
+
+        let (body, verb) = split_verb(template)?;
+
+        // `body` keeps the leading `/`: the verb split only trims a trailing
+        // `:verb`, and the top-level `:` cannot be at index 0 given the check
+        // above.
+        let rest = &body[1..];
+
+        let segments = if rest.is_empty() {
+            Box::default()
+        } else {
+            split_and_parse_segments(rest, grammar.segment_affixes())?
+        };
+
+        // `**` may only be the final atom of the flattened template.
+        validate_rest_position(&segments)?;
+
+        Ok(Self { segments, verb })
+    }
+
+    /// The top-level segments of the template.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_path_template::{Grammar, PathTemplate, Segment};
+    ///
+    /// # fn main() -> Result<(), http_path_template::ParseError> {
+    /// let template = PathTemplate::parse("/v1/shelves/{shelf}", Grammar::default())?;
+    /// assert_eq!(template.segments()[0], Segment::Literal("v1"));
+    /// assert!(matches!(template.segments()[2], Segment::Variable(_)));
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn segments(&self) -> &[Segment<'a>] {
+        &self.segments
+    }
+
+    /// The custom verb (the `LITERAL` after a trailing `:`), if any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_path_template::{Grammar, PathTemplate};
+    ///
+    /// # fn main() -> Result<(), http_path_template::ParseError> {
+    /// let template = PathTemplate::parse("/v1/{name=shelves/*}:read", Grammar::default())?;
+    /// assert_eq!(template.verb(), Some("read"));
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn verb(&self) -> Option<&'a str> {
+        self.verb
+    }
+}
+
+impl core::fmt::Display for PathTemplate<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("/")?;
+        for (idx, segment) in self.segments.iter().enumerate() {
+            if idx != 0 {
+                f.write_str("/")?;
+            }
+            write_segment(f, segment)?;
+        }
+        if let Some(verb) = &self.verb {
+            write!(f, ":{verb}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Writes a single top-level segment in its template syntax.
+fn write_segment(f: &mut core::fmt::Formatter<'_>, segment: &Segment<'_>) -> core::fmt::Result {
+    match segment {
+        Segment::Literal(text) => f.write_str(text),
+        Segment::Single => f.write_str("*"),
+        Segment::Rest => f.write_str("**"),
+        Segment::Variable(variable) => write_variable(f, variable),
+        Segment::Affix { prefix, name, suffix } => {
+            f.write_str(prefix)?;
+            f.write_str("{")?;
+            f.write_str(name)?;
+            f.write_str("}")?;
+            f.write_str(suffix)
+        }
+    }
+}
+
+/// Writes a `{field.path=sub-template}` variable binding, collapsing a lone `*`
+/// sub-template to the `{field}` shorthand.
+fn write_variable(f: &mut core::fmt::Formatter<'_>, variable: &Variable<'_>) -> core::fmt::Result {
+    f.write_str("{")?;
+    f.write_str(variable.field_path())?;
+    // `sub` is the exact sub-template substring (`*` for the shorthand), so it
+    // renders verbatim. Collapse the lone-`*` shorthand back to `{field}`.
+    let sub = variable.sub();
+    if sub != "*" {
+        f.write_str("=")?;
+        f.write_str(sub)?;
+    }
+    f.write_str("}")
+}
+
+/// Validates that a `**` ([`Segment::Rest`]) appears only as the final atom of
+/// the flattened template (including atoms contributed by variable
+/// sub-templates), the only position a segment matcher can honor.
+fn validate_rest_position(segments: &[Segment]) -> Result<(), ParseError> {
+    // Walk atoms in flattened order. Once a `**` (`Rest`) atom is seen, no
+    // further atom may follow it: any atom reached while `seen_rest` is set means
+    // an earlier `**` was not last.
+    let mut seen_rest = false;
+    for seg in segments {
+        match seg {
+            Segment::Literal(_) | Segment::Single | Segment::Affix { .. } => {
+                if seen_rest {
+                    return Err(ParseError::new(ParseErrorKind::RestNotLast));
+                }
+            }
+            Segment::Rest => {
+                if seen_rest {
+                    return Err(ParseError::new(ParseErrorKind::RestNotLast));
+                }
+                seen_rest = true;
+            }
+            Segment::Variable(var) => {
+                for sub in var.segments() {
+                    if seen_rest {
+                        return Err(ParseError::new(ParseErrorKind::RestNotLast));
+                    }
+                    if matches!(sub, Segment::Rest) {
+                        seen_rest = true;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Splits a template into its body and optional verb at the first top-level `:`.
+fn split_verb(template: &str) -> Result<(&str, Option<&str>), ParseError> {
+    // The characters that matter here (`{`, `}`, `:`) are ASCII, so scan bytes.
+    let mut depth = 0_usize;
+    let mut verb_at = None;
+    for (idx, &b) in template.as_bytes().iter().enumerate() {
+        match b {
+            b'{' => depth += 1,
+            b'}' if depth > 0 => depth -= 1,
+            // A `}` with no matching `{` before the verb separator is the first
+            // structural error, so report it here rather than letting later verb
+            // validation win. After the verb separator such a `}` is part of the
+            // (invalid) verb, which the verb check below rejects.
+            b'}' if verb_at.is_none() => {
+                return Err(ParseError::new(ParseErrorKind::UnbalancedBraces));
+            }
+            b':' if depth == 0 => {
+                if verb_at.is_some() {
+                    return Err(ParseError::new(ParseErrorKind::MultipleVerbs));
+                }
+                verb_at = Some(idx);
+            }
+            _ => {}
+        }
+    }
+
+    match verb_at {
+        Some(idx) => {
+            let verb = &template[idx + 1..];
+            if verb.is_empty() {
+                return Err(ParseError::new(ParseErrorKind::EmptyVerb));
+            }
+            // A verb is a `LITERAL`, so it may not contain the structural
+            // characters `/`, `*`, `{`, or `}`. (Rejecting braces also prevents a
+            // stray `{` in the verb from unbalancing the colon-depth scan above.)
+            if verb.contains(['/', '*', '{', '}']) {
+                return Err(ParseError::new(ParseErrorKind::InvalidVerb));
+            }
+            Ok((&template[..idx], Some(verb)))
+        }
+        None => Ok((template, None)),
+    }
+}
+
+/// Splits a template body (after the leading `/`) into segments, parsing each
+/// one into the returned [`Segment`] vector and treating `/` inside `{...}` as
+/// literal.
+///
+/// All structural delimiters (`/`, `{`, `}`) are ASCII, so the byte offsets used
+/// to slice `body` always land on UTF-8 boundaries.
+fn split_and_parse_segments(body: &str, extended: bool) -> Result<Box<[Segment<'_>]>, ParseError> {
+    // Pre-size to the segment count so pushing never reallocates (a hint only;
+    // see `segment_count_hint`).
+    let mut out = Vec::with_capacity(segment_count_hint(body));
+
+    let mut depth = 0_usize;
+    let mut start = 0_usize;
+    for (idx, &b) in body.as_bytes().iter().enumerate() {
+        match b {
+            b'{' => depth += 1,
+            // `split_verb` already rejected any `}` with no matching `{`, so the
+            // body reaching here has no stray closing brace and `depth` never
+            // underflows. An unclosed `{` is caught by the `depth != 0` check
+            // after the loop.
+            b'}' => depth -= 1,
+            b'/' if depth == 0 => {
+                push_parsed_segment(&mut out, &body[start..idx], extended)?;
+                start = idx + 1;
+            }
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return Err(ParseError::new(ParseErrorKind::UnbalancedBraces));
+    }
+    push_parsed_segment(&mut out, &body[start..], extended)?;
+
+    Ok(out.into_boxed_slice())
+}
+
+/// Counts the depth-0 segments in `body` to pre-size the output vector. An
+/// incorrect count only affects whether that vector reallocates, never the
+/// parsed result.
+#[cfg_attr(test, mutants::skip)]
+fn segment_count_hint(body: &str) -> usize {
+    let mut depth = 0_usize;
+    let mut count = 1_usize;
+    for &b in body.as_bytes() {
+        match b {
+            b'{' => depth += 1,
+            b'}' => depth = depth.saturating_sub(1),
+            b'/' if depth == 0 => count += 1,
+            _ => {}
+        }
+    }
+    count
+}
+
+/// Parses one raw segment slice and appends it to `out`, rejecting an empty
+/// segment (e.g. from `a//b`).
+fn push_parsed_segment<'a>(out: &mut Vec<Segment<'a>>, seg: &'a str, extended: bool) -> Result<(), ParseError> {
+    if seg.is_empty() {
+        return Err(ParseError::new(ParseErrorKind::EmptySegment));
+    }
+    out.push(parse_segment(seg, extended)?);
+    Ok(())
+}
+
+fn parse_segment(seg: &str, extended: bool) -> Result<Segment<'_>, ParseError> {
+    if seg == "*" {
+        return Ok(Segment::Single);
+    }
+    if seg == "**" {
+        return Ok(Segment::Rest);
+    }
+    let bytes = seg.as_bytes();
+    // A pure `{...}` variable occupies the whole segment.
+    if bytes.first() == Some(&b'{') && bytes.last() == Some(&b'}') {
+        return parse_variable(&seg[1..seg.len() - 1]);
+    }
+    // Extended grammar: a single `{field}` variable wrapped in literal text
+    // (`prefix{field}suffix`).
+    if extended && bytes.contains(&b'{') {
+        return parse_affix(seg);
+    }
+    // Plain literal: reject stray braces and wildcard characters. A segment
+    // reaching here always has balanced braces (`split_and_parse_segments`
+    // guarantees it), so a `{` implies an embedded, malformed brace. Braces take
+    // priority over `*`, so return immediately on a `{` (it wins wherever it
+    // appears) and only flag a `*` for after the scan.
+    let mut has_star = false;
+    for &byte in seg.as_bytes() {
+        match byte {
+            b'{' => return Err(ParseError::new(ParseErrorKind::UnbalancedBraces)),
+            b'*' => has_star = true,
+            _ => {}
+        }
+    }
+    if has_star {
+        return Err(ParseError::new(ParseErrorKind::InvalidLiteral));
+    }
+    Ok(Segment::Literal(seg))
+}
+
+/// Parses an extended-grammar `prefix{field.path}suffix` segment into a
+/// [`Segment::Affix`]. Exactly one `{field}` variable is permitted, wrapped in
+/// literal (wildcard-free) text; at least one of prefix/suffix is non-empty
+/// (a bare `{field}` is handled as a plain variable before reaching here).
+fn parse_affix(seg: &str) -> Result<Segment<'_>, ParseError> {
+    // `split_and_parse_segments` slices this segment between depth-0 `/`s, so its
+    // braces are balanced. Record the first `{`/`}` positions and the total brace
+    // count: exactly one of each (a total of 2) is required, so a different count
+    // means a nested `{...{...}...}` and is rejected.
+    let mut open = None;
+    let mut close = None;
+    let mut braces = 0_usize;
+    for (idx, &byte) in seg.as_bytes().iter().enumerate() {
+        match byte {
+            b'{' => {
+                braces += 1;
+                if open.is_none() {
+                    open = Some(idx);
+                }
+            }
+            b'}' => {
+                braces += 1;
+                if close.is_none() {
+                    close = Some(idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    if braces != 2 {
+        return Err(ParseError::new(ParseErrorKind::UnbalancedBraces));
+    }
+    // With exactly one `{` and one `}`: `split_verb` already rejected any `}`
+    // with no matching `{` (a closing brace at brace-depth 0) during the
+    // top-level scan, so the open brace always comes first and `open < close`
+    // holds.
+    let open = open.expect("one '{' counted above");
+    let close = close.expect("one '}' counted above");
+
+    let prefix = &seg[..open];
+    let field_str = &seg[open + 1..close];
+    let suffix = &seg[close + 1..];
+
+    // Prefix and suffix are literals, so a `*` is invalid there.
+    if prefix.as_bytes().contains(&b'*') || suffix.as_bytes().contains(&b'*') {
+        return Err(ParseError::new(ParseErrorKind::InvalidLiteral));
+    }
+    if field_str.is_empty() {
+        return Err(ParseError::new(ParseErrorKind::EmptyFieldPath));
+    }
+    // An affix variable is a simple dotted field path — no `=` sub-template.
+    // Validate every identifier; the raw dotted string is stored as-is.
+    for ident in field_str.as_bytes().split(|&b| b == b'.') {
+        if !is_valid_ident(ident) {
+            return Err(ParseError::new(ParseErrorKind::InvalidFieldName));
+        }
+    }
+
+    Ok(Segment::Affix {
+        prefix,
+        name: field_str,
+        suffix,
+    })
+}
+
+fn parse_variable(inner: &str) -> Result<Segment<'_>, ParseError> {
+    // Delimiters (`=`, `.`, `/`) are ASCII, so split and scan on bytes to avoid
+    // the UTF-8-aware char searcher. Byte offsets at ASCII delimiters are valid
+    // `str` boundaries.
+    let (field_str, sub_str) = match inner.as_bytes().iter().position(|&b| b == b'=') {
+        Some(idx) => (&inner[..idx], Some(&inner[idx + 1..])),
+        None => (inner, None),
+    };
+
+    if field_str.is_empty() {
+        return Err(ParseError::new(ParseErrorKind::EmptyFieldPath));
+    }
+
+    // Validate every field-path identifier; the raw dotted string is stored as-is.
+    for ident in field_str.as_bytes().split(|&b| b == b'.') {
+        if !is_valid_ident(ident) {
+            return Err(ParseError::new(ParseErrorKind::InvalidFieldName));
+        }
+    }
+
+    // The sub-template is stored as its raw substring and re-split lazily by
+    // `Variable::segments`. Validate it here so that iteration is infallible. The
+    // `{field}` shorthand normalizes to `*` (equal to `{field=*}`), which lets
+    // the borrowed `Variable` derive `PartialEq`/`Hash`.
+    let sub = match sub_str {
+        None => "*",
+        Some(sub) => {
+            if sub.is_empty() {
+                return Err(ParseError::new(ParseErrorKind::EmptySegment));
+            }
+            for seg in sub.as_bytes().split(|&b| b == b'/') {
+                if seg.is_empty() {
+                    return Err(ParseError::new(ParseErrorKind::EmptySegment));
+                }
+                if seg.contains(&b'{') {
+                    return Err(ParseError::new(ParseErrorKind::NestedVariable));
+                }
+                // Only `*`/`**` may contain a wildcard; any other `*` is invalid.
+                if seg != b"*" && seg != b"**" && seg.contains(&b'*') {
+                    return Err(ParseError::new(ParseErrorKind::InvalidLiteral));
+                }
+            }
+            sub
+        }
+    };
+
+    Ok(Segment::Variable(Variable::new(field_str, sub)))
+}
+
+fn is_valid_ident(ident: &[u8]) -> bool {
+    // Identifiers are ASCII; a non-ASCII lead byte fails the `is_ascii_*` checks
+    // and is rejected.
+    match ident.first() {
+        Some(&b) if b == b'_' || b.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    ident[1..].iter().all(|&b| b == b'_' || b.is_ascii_alphanumeric())
+}

--- a/crates/http_path_template/src/segment.rs
+++ b/crates/http_path_template/src/segment.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::variable::Variable;
+
+/// A single element of a parsed [`PathTemplate`](crate::PathTemplate).
+///
+/// # Examples
+///
+/// ```
+/// use http_path_template::{Grammar, PathTemplate, Segment};
+///
+/// # fn main() -> Result<(), http_path_template::ParseError> {
+/// let template = PathTemplate::parse("/v1/shelves/*", Grammar::default())?;
+/// assert_eq!(template.segments()[0], Segment::Literal("v1"));
+/// assert!(matches!(template.segments()[2], Segment::Single));
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Segment<'a> {
+    /// A literal path segment that must match verbatim, e.g. `shelves`.
+    Literal(&'a str),
+    /// `*` — matches exactly one (non-empty) path segment.
+    Single,
+    /// `**` — matches the remaining path segments. Only valid as the final
+    /// element of a template or variable sub-template.
+    Rest,
+    /// `{field.path=sub}` — a variable binding capturing the portion of the
+    /// path matched by its sub-template.
+    Variable(Variable<'a>),
+    /// `<prefix>{field.path}<suffix>` — an *extended-grammar* single segment that
+    /// matches a literal `prefix` and `suffix` around a captured middle (at least
+    /// one of `prefix`/`suffix` is non-empty). Only produced when parsing with a
+    /// [`Grammar`](crate::Grammar) that has
+    /// [`with_segment_affixes`](crate::Grammar::with_segment_affixes) enabled; the
+    /// strict `google.api.http` grammar rejects it.
+    Affix {
+        /// The literal text the segment must start with (may be empty).
+        prefix: &'a str,
+        /// The captured middle's dotted field path (e.g. `shelf.id`); split on
+        /// `.` for the individual identifiers.
+        name: &'a str,
+        /// The literal text the segment must end with (may be empty).
+        suffix: &'a str,
+    },
+}

--- a/crates/http_path_template/src/variable.rs
+++ b/crates/http_path_template/src/variable.rs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::segment::Segment;
+
+/// A `{field.path=sub-template}` variable binding within a [`PathTemplate`](crate::PathTemplate).
+///
+/// The sub-template ([`Variable::segments`]) only ever yields
+/// [`Segment::Literal`], [`Segment::Single`], and [`Segment::Rest`] elements;
+/// nested variables are rejected at parse time.
+///
+/// All strings borrow from the parsed template, so a `Variable` is a lightweight
+/// [`Copy`] view that allocates nothing.
+///
+/// # Examples
+///
+/// ```
+/// use http_path_template::{Grammar, PathTemplate, Segment};
+///
+/// # fn main() -> Result<(), http_path_template::ParseError> {
+/// let template = PathTemplate::parse("/v1/{book.name=books/*}", Grammar::default())?;
+/// let Segment::Variable(variable) = template.segments()[1] else {
+///     panic!("expected variable")
+/// };
+/// assert_eq!(variable.field_path(), "book.name");
+/// assert_eq!(variable.segments().count(), 2);
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Variable<'a> {
+    /// The dotted field path, e.g. `shelf.id`.
+    field: &'a str,
+    /// The sub-template after `=`, e.g. `books/**`. The `{field}` shorthand is
+    /// normalized to `*` so that `{field}` and `{field=*}` compare equal.
+    sub: &'a str,
+}
+
+impl<'a> Variable<'a> {
+    /// Creates a variable binding from its dotted field path and (normalized)
+    /// sub-template string.
+    pub(crate) fn new(field: &'a str, sub: &'a str) -> Self {
+        Self { field, sub }
+    }
+
+    /// The dotted message-field path this variable binds into, e.g. `shelf.id`
+    /// for `{shelf.id}`. Split on `.` for the individual identifiers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_path_template::{Grammar, PathTemplate, Segment};
+    ///
+    /// # fn main() -> Result<(), http_path_template::ParseError> {
+    /// let template = PathTemplate::parse("/v1/{shelf.id}", Grammar::default())?;
+    /// let Segment::Variable(variable) = template.segments()[1] else {
+    ///     panic!("expected variable")
+    /// };
+    /// assert_eq!(variable.field_path(), "shelf.id");
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn field_path(&self) -> &'a str {
+        self.field
+    }
+
+    /// The sub-template segments this variable captures, yielded lazily. For a
+    /// shorthand `{field}` this is a single [`Segment::Single`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_path_template::{Grammar, PathTemplate, Segment};
+    ///
+    /// # fn main() -> Result<(), http_path_template::ParseError> {
+    /// let template = PathTemplate::parse("/v1/{name=shelves/*}", Grammar::default())?;
+    /// let Segment::Variable(variable) = template.segments()[1] else {
+    ///     panic!("expected variable")
+    /// };
+    /// assert!(
+    ///     variable
+    ///         .segments()
+    ///         .eq([Segment::Literal("shelves"), Segment::Single])
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn segments(&self) -> SegmentIter<'a> {
+        SegmentIter { rest: Some(self.sub) }
+    }
+
+    /// The raw sub-template substring (`*` for the `{field}` shorthand). Used by
+    /// `Display` to render the sub-template verbatim.
+    pub(crate) fn sub(&self) -> &'a str {
+        self.sub
+    }
+}
+
+/// A lazy iterator over a [`Variable`]'s sub-template [`Segment`]s.
+///
+/// Created by [`Variable::segments`]. Because the sub-template was validated at
+/// parse time, iteration is infallible and allocation-free.
+#[derive(Debug, Clone)]
+pub struct SegmentIter<'a> {
+    /// The remainder of the sub-template still to yield, or `None` once
+    /// exhausted. Splitting on the ASCII `/` byte keeps `str` boundaries valid.
+    rest: Option<&'a str>,
+}
+
+impl<'a> Iterator for SegmentIter<'a> {
+    type Item = Segment<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let rest = self.rest?;
+        let seg = if let Some(idx) = rest.as_bytes().iter().position(|&b| b == b'/') {
+            // `rest[idx]` is the ASCII `/`; split there and drop it from the tail.
+            let (seg, after) = rest.split_at(idx);
+            self.rest = Some(&after[1..]);
+            seg
+        } else {
+            self.rest = None;
+            rest
+        };
+        Some(match seg {
+            "*" => Segment::Single,
+            "**" => Segment::Rest,
+            other => Segment::Literal(other),
+        })
+    }
+}

--- a/crates/http_path_template/tests/edge_cases.rs
+++ b/crates/http_path_template/tests/edge_cases.rs
@@ -1,0 +1,432 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Exhaustive edge-case and correctness tests for `http_path_template`.
+//!
+//! These tests exercise the `google.api.http` path-template grammar
+//! ```text
+//! Template  = "/" Segments [ Verb ] ;
+//! Segments  = Segment { "/" Segment } ;
+//! Segment   = "*" | "**" | LITERAL | Variable ;
+//! Variable  = "{" FieldPath [ "=" Segments ] "}" ;
+//! FieldPath = IDENT { "." IDENT } ;
+//! Verb      = ":" LITERAL ;
+//! ```
+//! against boundary conditions, the `**`-must-be-last rule, brace balancing,
+//! field-path identifier rules, the borrowed/zero-copy invariants, and
+//! `Display` round-trip totality.
+
+// Path templates contain `{field}` braces that superficially resemble format
+// placeholders; the literals here are intentional grammar inputs, not format
+// strings.
+#![expect(
+    clippy::literal_string_with_formatting_args,
+    reason = "template literals contain `{field}` braces that are grammar input, not format args"
+)]
+
+use http_path_template::{Grammar, ParseError, PathTemplate, Segment};
+
+fn strict() -> Grammar {
+    Grammar::default()
+}
+
+fn ext() -> Grammar {
+    Grammar::default().with_segment_affixes()
+}
+
+fn parse(s: &str) -> Result<PathTemplate<'_>, ParseError> {
+    PathTemplate::parse(s, strict())
+}
+
+// ---------------------------------------------------------------------------
+// Valid templates: structural spot-checks.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn root_has_no_segments_and_no_verb() {
+    let t = parse("/").expect("root");
+    assert!(t.segments().is_empty());
+    assert_eq!(t.verb(), None);
+}
+
+#[test]
+fn root_with_only_a_verb() {
+    let t = parse("/:ping").expect("root verb");
+    assert!(t.segments().is_empty());
+    assert_eq!(t.verb(), Some("ping"));
+}
+
+#[test]
+fn single_star_and_double_star() {
+    assert_eq!(parse("/*").expect("star").segments(), &[Segment::Single]);
+    assert_eq!(parse("/**").expect("rest").segments(), &[Segment::Rest]);
+}
+
+#[test]
+fn double_star_may_be_last_after_literals() {
+    let t = parse("/a/b/**").expect("valid");
+    assert_eq!(t.segments(), &[Segment::Literal("a"), Segment::Literal("b"), Segment::Rest]);
+}
+
+#[test]
+fn double_star_last_with_a_verb_is_allowed() {
+    let t = parse("/a/**:watch").expect("valid");
+    assert_eq!(t.segments(), &[Segment::Literal("a"), Segment::Rest]);
+    assert_eq!(t.verb(), Some("watch"));
+}
+
+#[test]
+fn shorthand_equals_explicit_star() {
+    // `{v}` is exactly `{v=*}`; they must produce equal ASTs.
+    assert_eq!(parse("/{v}").expect("a"), parse("/{v=*}").expect("b"));
+}
+
+#[test]
+fn variable_field_path_is_the_raw_dotted_string() {
+    let t = parse("/{a.b.c}").expect("valid");
+    let Segment::Variable(v) = t.segments()[0] else {
+        panic!("variable")
+    };
+    assert_eq!(v.field_path(), "a.b.c");
+    assert!(v.segments().eq([Segment::Single]));
+}
+
+#[test]
+fn variable_sub_template_segments() {
+    let t = parse("/{name=shelves/*/books/**}").expect("valid");
+    let Segment::Variable(v) = t.segments()[0] else {
+        panic!("variable")
+    };
+    assert_eq!(v.field_path(), "name");
+    assert!(v.segments().eq([
+        Segment::Literal("shelves"),
+        Segment::Single,
+        Segment::Literal("books"),
+        Segment::Rest,
+    ]));
+}
+
+#[test]
+fn colon_inside_braces_is_a_literal_not_a_verb() {
+    let t = parse("/a/{b=c:d}").expect("valid");
+    assert_eq!(t.verb(), None);
+    let Segment::Variable(v) = t.segments()[1] else {
+        panic!("variable")
+    };
+    assert!(v.segments().eq([Segment::Literal("c:d")]));
+}
+
+#[test]
+fn top_level_colon_is_the_verb_separator() {
+    let t = parse("/a:b").expect("valid");
+    assert_eq!(t.segments(), &[Segment::Literal("a")]);
+    assert_eq!(t.verb(), Some("b"));
+}
+
+#[test]
+fn verb_may_contain_underscores_and_digits() {
+    assert_eq!(parse("/res:get_v2").expect("valid").verb(), Some("get_v2"));
+}
+
+#[test]
+fn literals_may_contain_non_ascii() {
+    let t = parse("/café/{shelf}").expect("valid");
+    assert_eq!(t.segments()[0], Segment::Literal("café"));
+}
+
+#[test]
+fn returned_slices_borrow_from_the_input() {
+    // The literal must be a sub-slice of the *input* buffer, not a copy.
+    let input = String::from("/alpha/{beta}");
+    let t = PathTemplate::parse(&input, strict()).expect("valid");
+    let Segment::Literal(lit) = t.segments()[0] else {
+        panic!("literal")
+    };
+    let input_start = input.as_ptr() as usize;
+    let lit_start = lit.as_ptr() as usize;
+    assert!(
+        lit_start >= input_start && lit_start < input_start + input.len(),
+        "literal must point into the input buffer"
+    );
+    assert_eq!(lit, "alpha");
+}
+
+// ---------------------------------------------------------------------------
+// Invalid templates: exact error kinds.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn invalid_templates_report_the_expected_error() {
+    type Pred = fn(&ParseError) -> bool;
+    let cases: &[(&str, Pred, &str)] = &[
+        ("", ParseError::is_missing_leading_slash, "empty string"),
+        ("v1/x", ParseError::is_missing_leading_slash, "no leading slash"),
+        // Missing leading slash is reported before any later structural error
+        // (e.g. an unbalanced brace), since it is the most fundamental problem.
+        ("a}", ParseError::is_missing_leading_slash, "no slash, stray brace"),
+        ("}", ParseError::is_missing_leading_slash, "bare close brace, no slash"),
+        ("a:b", ParseError::is_missing_leading_slash, "no slash, has verb"),
+        ("//", ParseError::is_empty_segment, "empty first segment"),
+        ("/a//b", ParseError::is_empty_segment, "empty middle segment"),
+        ("/a/", ParseError::is_empty_segment, "empty trailing segment"),
+        ("/**/a", ParseError::is_rest_not_last, "** before literal"),
+        ("/**/**", ParseError::is_rest_not_last, "** before **"),
+        ("/{a=**}/b", ParseError::is_rest_not_last, "** in var, then literal"),
+        ("/{a=b/**/c}", ParseError::is_rest_not_last, "** mid sub-template"),
+        ("/{a=**/c}", ParseError::is_rest_not_last, "** first of two sub-segments"),
+        ("/{}", ParseError::is_empty_field_path, "empty braces"),
+        ("/{=x}", ParseError::is_empty_field_path, "empty field before ="),
+        ("/{a=}", ParseError::is_empty_segment, "empty sub-template"),
+        ("/{a=b//c}", ParseError::is_empty_segment, "empty sub-segment"),
+        ("/{a.}", ParseError::is_invalid_field_name, "trailing dot"),
+        ("/{.a}", ParseError::is_invalid_field_name, "leading dot"),
+        ("/{a..b}", ParseError::is_invalid_field_name, "double dot"),
+        ("/{1a}", ParseError::is_invalid_field_name, "digit-leading ident"),
+        ("/{a-b}", ParseError::is_invalid_field_name, "hyphen in ident"),
+        ("/{a b}", ParseError::is_invalid_field_name, "space in ident"),
+        ("/{a={b}}", ParseError::is_nested_variable, "nested variable"),
+        ("/{a", ParseError::is_unbalanced_braces, "unclosed brace"),
+        ("/a}", ParseError::is_unbalanced_braces, "stray close brace"),
+        ("/}a", ParseError::is_unbalanced_braces, "leading close brace"),
+        // A stray `}` before a `:` verb separator is the first structural error
+        // and wins over the (otherwise empty) verb.
+        ("/a}:", ParseError::is_unbalanced_braces, "stray brace before empty verb"),
+        ("/a}:b", ParseError::is_unbalanced_braces, "stray brace before verb"),
+        ("/a{b}c", ParseError::is_unbalanced_braces, "embedded braces (strict)"),
+        ("/a*b", ParseError::is_invalid_literal, "star in literal"),
+        ("/*a", ParseError::is_invalid_literal, "star-prefixed literal"),
+        ("/{a=*b}", ParseError::is_invalid_literal, "star in sub-literal"),
+        ("/a:", ParseError::is_empty_verb, "empty verb"),
+        ("/a:b:c", ParseError::is_multiple_verbs, "two verbs"),
+        ("/a:b/c", ParseError::is_invalid_verb, "verb contains slash"),
+        ("/a:*", ParseError::is_invalid_verb, "verb is a star"),
+        ("/a:{b}", ParseError::is_invalid_verb, "verb contains brace"),
+        ("/a:b}", ParseError::is_invalid_verb, "trailing brace in verb"),
+    ];
+
+    for (template, pred, why) in cases {
+        let err = parse(template).expect_err(why);
+        assert!(pred(&err), "wrong error kind for {template:?} ({why}): {err}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extended grammar (intra-segment affixes).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extended_affix_variants() {
+    // suffix only, prefix only, both, and empty prefix.
+    let cases = [
+        ("/files/{name}.json", "", "name", ".json"),
+        ("/v{version}/x", "v", "version", ""),
+        ("/img-{id}.png", "img-", "id", ".png"),
+        ("/{id}.png", "", "id", ".png"),
+        ("/x-{a.b}-y", "x-", "a.b", "-y"),
+    ];
+    for (template, prefix, name, suffix) in cases {
+        let t = PathTemplate::parse(template, ext()).expect(template);
+        let seg = t.segments().iter().find(|s| matches!(s, Segment::Affix { .. })).expect("affix");
+        assert_eq!(*seg, Segment::Affix { prefix, name, suffix }, "for {template}");
+    }
+}
+
+#[test]
+fn extended_affix_rejections() {
+    type Pred = fn(&ParseError) -> bool;
+    let cases: &[(&str, Pred)] = &[
+        ("/a{x}b{y}c", ParseError::is_unbalanced_braces),
+        ("/a{}b", ParseError::is_empty_field_path),
+        ("/a{1bad}b", ParseError::is_invalid_field_name),
+        ("/a*{x}", ParseError::is_invalid_literal),
+        ("/{x}*b", ParseError::is_invalid_literal),
+        ("/a}b{c", ParseError::is_unbalanced_braces),
+    ];
+    for (template, pred) in cases {
+        let err = PathTemplate::parse(template, ext()).expect_err(template);
+        assert!(pred(&err), "wrong error kind for {template:?}: {err}");
+    }
+}
+
+#[test]
+fn grammar_new_is_the_strict_default() {
+    // `Grammar::new()` is the strict `google.api.http` grammar, identical to the
+    // `Default`. (Covered here as a regular test since doctests are excluded from
+    // coverage.)
+    let strict = Grammar::new();
+    assert_eq!(strict, Grammar::default());
+    assert!(!strict.segment_affixes());
+
+    // Enabling affixes flips the accessor and leaves the (Copy) original strict.
+    let extended = strict.with_segment_affixes();
+    assert!(extended.segment_affixes());
+    assert!(!strict.segment_affixes());
+    assert_ne!(strict, extended);
+}
+
+#[test]
+fn extended_grammar_still_accepts_everything_strict_does() {
+    for template in ["/", "/*", "/**", "/v1/{shelf}", "/{name=books/**}", "/a/{b=c:d}:verb"] {
+        let strict_result = PathTemplate::parse(template, strict()).expect(template);
+        let extended_result = PathTemplate::parse(template, ext()).expect(template);
+        assert_eq!(strict_result, extended_result, "extended grammar must be a superset for {template}");
+    }
+}
+
+#[test]
+fn strict_grammar_rejects_affixes() {
+    for template in ["/files/{name}.json", "/v{version}/x", "/img-{id}.png"] {
+        assert!(parse(template).is_err(), "strict must reject affix {template}");
+        assert!(PathTemplate::parse(template, ext()).is_ok(), "extended must accept {template}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Display round-trip totality.
+// ---------------------------------------------------------------------------
+
+const VALID_STRICT: &[&str] = &[
+    "/",
+    "/:ping",
+    "/v1",
+    "/v1/shelves",
+    "/*",
+    "/**",
+    "/a/*/b/**",
+    "/{shelf}",
+    "/{shelf.id}",
+    "/{name=*}",
+    "/{name=**}",
+    "/{name=books/*}",
+    "/{name=books/**}",
+    "/{name=a/b/c/**}",
+    "/v1/shelves/{shelf}/books/{book=**}",
+    "/v1/shelves/{shelf}/books/{book}:archive",
+    "/a/{b=c:d}",
+    "/café/{shelf}",
+    "/a:b",
+    "/x/{y}/**:read",
+];
+
+#[test]
+fn display_round_trips_and_is_idempotent() {
+    for template in VALID_STRICT {
+        let parsed = parse(template).unwrap_or_else(|e| panic!("valid {template:?}: {e}"));
+        let rendered = parsed.to_string();
+        let reparsed = parse(&rendered).unwrap_or_else(|e| panic!("reparse {rendered:?}: {e}"));
+        // The AST is stable under render→parse.
+        assert_eq!(parsed, reparsed, "AST round trip for {template:?}");
+        // Rendering is idempotent (a fixed point after the first render).
+        assert_eq!(rendered, reparsed.to_string(), "idempotent display for {template:?}");
+    }
+}
+
+#[test]
+fn display_collapses_explicit_single_star_to_shorthand() {
+    assert_eq!(parse("/{name=*}").expect("valid").to_string(), "/{name}");
+    // A dotted field path is preserved verbatim.
+    assert_eq!(parse("/{a.b.c}").expect("valid").to_string(), "/{a.b.c}");
+}
+
+#[test]
+fn extended_affix_round_trips() {
+    for template in ["/files/{name}.json", "/v{version}/x", "/img-{a.b}.png", "/{id}.tar.gz"] {
+        let parsed = PathTemplate::parse(template, ext()).expect(template);
+        assert_eq!(parsed.to_string(), template, "display for {template}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Boundary / stress.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn many_segments_parse_and_round_trip() {
+    let template: String = core::iter::once(String::new())
+        .chain((0..200).map(|i| format!("seg{i}")))
+        .collect::<Vec<_>>()
+        .join("/");
+    let parsed = PathTemplate::parse(&template, strict()).expect("many segments");
+    assert_eq!(parsed.segments().len(), 200);
+    assert_eq!(parsed.to_string(), template);
+}
+
+#[test]
+fn deeply_dotted_field_path() {
+    let field: String = (0..50).map(|i| format!("f{i}")).collect::<Vec<_>>().join(".");
+    let template = format!("/{{{field}}}");
+    let parsed = PathTemplate::parse(&template, strict()).expect("deep field path");
+    let Segment::Variable(v) = parsed.segments()[0] else {
+        panic!("variable")
+    };
+    assert_eq!(v.field_path(), field);
+}
+
+// ---------------------------------------------------------------------------
+// Exhaustive fuzzing over short strings of structural characters.
+//
+// For every string up to a bounded length over an alphabet of grammar-
+// significant characters, parsing must (1) never panic (proving all slicing is
+// UTF-8-safe and free of off-by-one bounds bugs) and (2) whenever it succeeds,
+// `Display` must round-trip to an equal AST and be idempotent. This exercises
+// the parser across its entire short-input space under both grammars.
+// ---------------------------------------------------------------------------
+
+/// Applies `f` to every string of length `0..=max_len` over `alphabet`.
+fn for_each_string(alphabet: &[char], max_len: usize, f: &mut impl FnMut(&str)) {
+    fn rec(alphabet: &[char], remaining: usize, buf: &mut String, f: &mut impl FnMut(&str)) {
+        f(buf);
+        if remaining == 0 {
+            return;
+        }
+        for &c in alphabet {
+            buf.push(c);
+            rec(alphabet, remaining - 1, buf, f);
+            buf.pop();
+        }
+    }
+    let mut buf = String::new();
+    rec(alphabet, max_len, &mut buf, f);
+}
+
+#[expect(clippy::panic, reason = "test helper: a failed re-parse is a genuine test failure")]
+fn check_no_panic_and_round_trip(template: &str, grammar: Grammar) {
+    let Ok(parsed) = PathTemplate::parse(template, grammar) else {
+        return;
+    };
+    // Whatever parsed must render and re-parse to an equal, stable AST.
+    let rendered = parsed.to_string();
+    let reparsed = PathTemplate::parse(&rendered, grammar)
+        .unwrap_or_else(|e| panic!("re-parse of rendered {rendered:?} (from {template:?}) failed: {e}"));
+    assert_eq!(parsed, reparsed, "AST round trip for {template:?} -> {rendered:?}");
+    assert_eq!(rendered, reparsed.to_string(), "idempotent display for {template:?}");
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "exhaustive sweep is too slow under Miri; no unsafe to check")]
+fn exhaustive_ascii_structural_strings_do_not_panic_and_round_trip() {
+    // Grammar-significant ASCII characters plus a plain identifier byte.
+    const ALPHABET: &[char] = &['/', '{', '}', '*', ':', '=', '.', 'a'];
+    const MAX_LEN: u32 = 6;
+    let mut count = 0_u64;
+    for_each_string(ALPHABET, MAX_LEN as usize, &mut |s| {
+        check_no_panic_and_round_trip(s, strict());
+        check_no_panic_and_round_trip(s, ext());
+        count += 1;
+    });
+    // Sanity: we actually covered the whole space (sum of 8^k for k in 0..=6).
+    assert_eq!(count, (0..=MAX_LEN).map(|k| 8_u64.pow(k)).sum());
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "exhaustive sweep is too slow under Miri; no unsafe to check")]
+fn exhaustive_multibyte_strings_do_not_panic_on_boundaries() {
+    // Include a 2-byte UTF-8 char to stress char-boundary slicing around the
+    // ASCII structural delimiters.
+    const ALPHABET: &[char] = &['/', '{', '}', '*', '=', 'é'];
+    const MAX_LEN: usize = 5;
+    for_each_string(ALPHABET, MAX_LEN, &mut |s| {
+        check_no_panic_and_round_trip(s, strict());
+        check_no_panic_and_round_trip(s, ext());
+    });
+}

--- a/crates/http_path_template/tests/parsing.rs
+++ b/crates/http_path_template/tests/parsing.rs
@@ -1,0 +1,442 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration tests for the public `http_path_template` parsing API.
+
+use http_path_template::{Grammar, ParseError, PathTemplate, Segment};
+
+/// A [`ParseError`] category predicate (e.g. [`ParseError::is_empty_verb`]), used
+/// by the table-driven parse-failure tests.
+type ParseErrorPredicate = fn(&ParseError) -> bool;
+
+/// Returns the field path and sub-template segments of the [`Segment::Variable`]
+/// a template is expected to contain at `index`, or `None` if that segment is
+/// not a variable.
+fn variable_at<'a>(template: &PathTemplate<'a>, index: usize) -> Option<(Vec<&'a str>, Vec<Segment<'a>>)> {
+    match template.segments()[index] {
+        Segment::Variable(variable) => Some((variable.field_path().split('.').collect(), variable.segments().collect())),
+        _ => None,
+    }
+}
+
+#[test]
+fn parses_simple_literals() {
+    let t = PathTemplate::parse("/v1/shelves", Grammar::default()).expect("valid");
+    assert_eq!(t.segments(), &[Segment::Literal("v1"), Segment::Literal("shelves")]);
+    assert!(t.verb().is_none());
+}
+
+#[test]
+fn parses_root() {
+    let t = PathTemplate::parse("/", Grammar::default()).expect("root is valid");
+    assert!(t.segments().is_empty());
+    assert!(t.verb().is_none());
+}
+
+#[test]
+fn parses_single_wildcard_segment() {
+    let t = PathTemplate::parse("/v1/*", Grammar::default()).expect("valid");
+    assert_eq!(t.segments(), &[Segment::Literal("v1"), Segment::Single]);
+}
+
+#[test]
+fn parses_variable_shorthand_to_single() {
+    let t = PathTemplate::parse("/v1/shelves/{shelf}", Grammar::default()).expect("valid");
+    assert_eq!(t.segments()[0], Segment::Literal("v1"));
+    assert_eq!(t.segments()[1], Segment::Literal("shelves"));
+    let (field_path, segments) = variable_at(&t, 2).expect("segment is a variable");
+    assert_eq!(field_path, ["shelf"]);
+    assert_eq!(segments, [Segment::Single]);
+}
+
+#[test]
+fn parses_nested_field_path() {
+    let t = PathTemplate::parse("/v1/{shelf.id}", Grammar::default()).expect("valid");
+    assert_eq!(t.segments()[0], Segment::Literal("v1"));
+    let (field_path, segments) = variable_at(&t, 1).expect("segment is a variable");
+    assert_eq!(field_path, ["shelf", "id"]);
+    assert_eq!(segments, [Segment::Single]);
+}
+
+#[test]
+fn parses_variable_subtemplate_and_rest() {
+    let t = PathTemplate::parse("/v1/{name=books/**}", Grammar::default()).expect("valid");
+    assert_eq!(t.segments()[0], Segment::Literal("v1"));
+    let (field_path, segments) = variable_at(&t, 1).expect("segment is a variable");
+    assert_eq!(field_path, ["name"]);
+    assert_eq!(segments, [Segment::Literal("books"), Segment::Rest]);
+}
+
+#[test]
+fn parses_trailing_rest() {
+    let t = PathTemplate::parse("/v1/files/**", Grammar::default()).expect("valid");
+    assert_eq!(t.segments().last(), Some(&Segment::Rest));
+}
+
+#[test]
+fn variable_accessors_return_field_and_subtemplate() {
+    let t = PathTemplate::parse("/v1/{shelf.id=books/*}", Grammar::default()).expect("valid");
+    let (field_path, segments) = variable_at(&t, 1).expect("segment is a variable");
+    assert_eq!(field_path, ["shelf", "id"]);
+    assert_eq!(segments, [Segment::Literal("books"), Segment::Single]);
+}
+
+#[test]
+fn parses_custom_verb() {
+    let t = PathTemplate::parse("/v1/{name=shelves/*}:read", Grammar::default()).expect("valid");
+    assert_eq!(t.verb(), Some("read"));
+}
+
+#[test]
+fn requires_leading_slash() {
+    assert!(
+        PathTemplate::parse("v1/x", Grammar::default())
+            .unwrap_err()
+            .is_missing_leading_slash()
+    );
+}
+
+#[test]
+fn rejects_empty_segment() {
+    assert!(PathTemplate::parse("/a//b", Grammar::default()).unwrap_err().is_empty_segment());
+}
+
+#[test]
+fn rejects_rest_not_last() {
+    assert!(PathTemplate::parse("/a/**/b", Grammar::default()).unwrap_err().is_rest_not_last());
+}
+
+#[test]
+fn rejects_rest_not_last_inside_variable() {
+    assert!(
+        PathTemplate::parse("/a/{x=**}/b", Grammar::default())
+            .unwrap_err()
+            .is_rest_not_last()
+    );
+}
+
+#[test]
+fn rejects_nested_variable() {
+    assert!(
+        PathTemplate::parse("/a/{x={y}}", Grammar::default())
+            .unwrap_err()
+            .is_nested_variable()
+    );
+}
+
+#[test]
+fn rejects_invalid_field_name() {
+    assert!(
+        PathTemplate::parse("/a/{1bad}", Grammar::default())
+            .unwrap_err()
+            .is_invalid_field_name()
+    );
+}
+
+#[test]
+fn rejects_empty_verb() {
+    assert!(PathTemplate::parse("/a/b:", Grammar::default()).unwrap_err().is_empty_verb());
+}
+
+#[test]
+fn rejects_multiple_verbs() {
+    assert!(PathTemplate::parse("/a:b:c", Grammar::default()).unwrap_err().is_multiple_verbs());
+}
+
+#[test]
+fn rejects_verb_containing_slash() {
+    assert!(PathTemplate::parse("/v1/a:b/c", Grammar::default()).unwrap_err().is_invalid_verb());
+}
+
+#[test]
+fn rejects_verb_with_non_literal_characters() {
+    // A verb is a LITERAL, so wildcard/brace characters are rejected. Braces are
+    // especially important: a stray `{` must not unbalance the colon-depth scan.
+    assert!(PathTemplate::parse("/a:bad*", Grammar::default()).unwrap_err().is_invalid_verb());
+    assert!(PathTemplate::parse("/a:bad}", Grammar::default()).unwrap_err().is_invalid_verb());
+    assert!(
+        PathTemplate::parse("/a:bad{:still_bad", Grammar::default())
+            .unwrap_err()
+            .is_invalid_verb()
+    );
+}
+
+#[test]
+fn rejects_unbalanced_braces() {
+    assert!(PathTemplate::parse("/a/{x", Grammar::default()).unwrap_err().is_unbalanced_braces());
+}
+
+#[test]
+fn parse_error_display_covers_every_kind() {
+    let cases: [(&str, ParseErrorPredicate, &str); 11] = [
+        (
+            "no-leading-slash",
+            ParseError::is_missing_leading_slash,
+            "template must begin with '/'",
+        ),
+        ("/a//b", ParseError::is_empty_segment, "template contains an empty path segment"),
+        ("/a/{x", ParseError::is_unbalanced_braces, "template contains unbalanced '{' or '}'"),
+        (
+            "/a/{x={y}}",
+            ParseError::is_nested_variable,
+            "variable sub-templates may not contain nested variables",
+        ),
+        ("/a/{=x}", ParseError::is_empty_field_path, "variable has an empty field path"),
+        (
+            "/a/{1bad}",
+            ParseError::is_invalid_field_name,
+            "variable field path contains an invalid identifier",
+        ),
+        ("/a*b", ParseError::is_invalid_literal, "literal segment contains a misplaced '*'"),
+        ("/a/**/b", ParseError::is_rest_not_last, "'**' may only appear as the final segment"),
+        ("/a/b:", ParseError::is_empty_verb, "custom verb after ':' is empty"),
+        (
+            "/v1/a:b/c",
+            ParseError::is_invalid_verb,
+            "custom verb after ':' must be a literal (no '/', '*', '{', or '}')",
+        ),
+        (
+            "/a:b:c",
+            ParseError::is_multiple_verbs,
+            "template contains more than one ':' verb separator",
+        ),
+    ];
+    for (template, predicate, message) in cases {
+        let err = PathTemplate::parse(template, Grammar::default()).unwrap_err();
+        assert!(predicate(&err), "kind for {template:?}");
+        assert_eq!(err.to_string(), message, "message for {template:?}");
+    }
+}
+
+#[test]
+fn each_kind_predicate_matches_only_its_own_kind() {
+    // One representative template per error kind, paired with the predicate that
+    // must recognise it.
+    let cases: [(&str, ParseErrorPredicate); 11] = [
+        ("no-leading-slash", ParseError::is_missing_leading_slash),
+        ("/a//b", ParseError::is_empty_segment),
+        ("/a/{x", ParseError::is_unbalanced_braces),
+        ("/a/{x={y}}", ParseError::is_nested_variable),
+        ("/a/{=x}", ParseError::is_empty_field_path),
+        ("/a/{1bad}", ParseError::is_invalid_field_name),
+        ("/a*b", ParseError::is_invalid_literal),
+        ("/a/**/b", ParseError::is_rest_not_last),
+        ("/a/b:", ParseError::is_empty_verb),
+        ("/v1/a:b/c", ParseError::is_invalid_verb),
+        ("/a:b:c", ParseError::is_multiple_verbs),
+    ];
+    let all_predicates: [ParseErrorPredicate; 11] = cases.map(|(_, predicate)| predicate);
+
+    for (template, predicate) in cases {
+        let err = PathTemplate::parse(template, Grammar::default()).unwrap_err();
+        // The kind's own predicate holds, and no other predicate does — so each
+        // predicate is exclusive to its kind (a predicate hard-wired to `true`
+        // would make some other kind's error match two predicates).
+        assert!(predicate(&err), "own predicate for {template:?}");
+        let matches = all_predicates.iter().filter(|check| check(&err)).count();
+        assert_eq!(matches, 1, "exactly one predicate matches {template:?}");
+    }
+}
+
+#[test]
+fn colon_inside_braces_is_not_a_verb() {
+    // The `:` sits inside the variable's braces, so it must not be read as a
+    // trailing custom verb.
+    let t = PathTemplate::parse("/a/{b=c:d}", Grammar::default()).expect("valid");
+    assert!(t.verb().is_none());
+    let (field_path, segments) = variable_at(&t, 1).expect("segment is a variable");
+    assert_eq!(field_path, ["b"]);
+    assert_eq!(segments, [Segment::Literal("c:d")]);
+}
+
+#[test]
+fn accepts_underscore_led_field_name() {
+    // Covers `_` as both the leading and a subsequent identifier character.
+    let t = PathTemplate::parse("/v1/{_my_id}", Grammar::default()).expect("underscore field name is valid");
+    let (field_path, _) = variable_at(&t, 1).expect("segment is a variable");
+    assert_eq!(field_path, ["_my_id"]);
+}
+
+#[test]
+fn rejects_stray_brace_in_literal() {
+    assert!(
+        PathTemplate::parse("/x/a{b}", Grammar::default())
+            .unwrap_err()
+            .is_unbalanced_braces()
+    );
+}
+
+#[test]
+fn rejects_trailing_chars_after_variable_close() {
+    assert!(
+        PathTemplate::parse("/v1/{a}b", Grammar::default())
+            .unwrap_err()
+            .is_unbalanced_braces()
+    );
+}
+
+#[test]
+fn rejects_unbalanced_closing_brace() {
+    assert!(PathTemplate::parse("/a/}", Grammar::default()).unwrap_err().is_unbalanced_braces());
+}
+
+#[test]
+fn rejects_empty_subtemplate() {
+    assert!(PathTemplate::parse("/a/{x=}", Grammar::default()).unwrap_err().is_empty_segment());
+}
+
+#[test]
+fn rejects_empty_subtemplate_segment() {
+    assert!(
+        PathTemplate::parse("/a/{x=a//b}", Grammar::default())
+            .unwrap_err()
+            .is_empty_segment()
+    );
+}
+
+#[test]
+fn rejects_wildcard_in_subtemplate_literal() {
+    assert!(
+        PathTemplate::parse("/a/{x=a*b}", Grammar::default())
+            .unwrap_err()
+            .is_invalid_literal()
+    );
+}
+
+#[test]
+fn display_renders_canonical_template() {
+    let cases = [
+        // Root template with no segments and no verb.
+        ("/", "/"),
+        // Root template carrying only a custom verb.
+        ("/:ping", "/:ping"),
+        // Literals, `*`, and a trailing `**`.
+        ("/v1/shelves/*/**", "/v1/shelves/*/**"),
+        // Variable shorthand stays `{field}`, dotted field paths are preserved.
+        ("/v1/shelves/{shelf.id}", "/v1/shelves/{shelf.id}"),
+        // Explicit `{field=*}` collapses to the `{field}` shorthand.
+        ("/v1/{name=*}", "/v1/{name}"),
+        // Variable sub-templates with literals, `*`, and `**`.
+        ("/v1/{name=books/*}", "/v1/{name=books/*}"),
+        ("/v1/{name=books/**}", "/v1/{name=books/**}"),
+        // A `:` inside braces is part of a literal, not a verb.
+        ("/a/{b=c:d}", "/a/{b=c:d}"),
+        // Full template combining variables, a `**` sub-template, and a verb.
+        (
+            "/shelves/{shelf}/books/{book=**}:archive",
+            "/shelves/{shelf}/books/{book=**}:archive",
+        ),
+    ];
+    for (template, expected) in cases {
+        let rendered = PathTemplate::parse(template, Grammar::default()).expect("valid").to_string();
+        assert_eq!(rendered, expected, "display for {template:?}");
+    }
+}
+
+#[test]
+fn display_round_trips_through_parse() {
+    let templates = [
+        "/",
+        "/:ping",
+        "/v1/shelves/*/**",
+        "/v1/shelves/{shelf.id}",
+        "/v1/{name=*}",
+        "/v1/{name=books/*}",
+        "/v1/{name=books/**}",
+        "/a/{b=c:d}",
+        "/shelves/{shelf}/books/{book=**}:archive",
+    ];
+    for template in templates {
+        let parsed = PathTemplate::parse(template, Grammar::default()).expect("valid");
+        let rendered = parsed.to_string();
+        let reparsed = PathTemplate::parse(&rendered, Grammar::default()).expect("rendered template is valid");
+        assert_eq!(parsed, reparsed, "round trip for {template:?}");
+    }
+}
+
+#[test]
+fn extended_parses_suffix_prefix_and_both() {
+    // Suffix only.
+    assert_eq!(
+        PathTemplate::parse("/files/{name}.json", Grammar::default().with_segment_affixes())
+            .expect("valid")
+            .segments()[1],
+        Segment::Affix {
+            prefix: "",
+            name: "name",
+            suffix: ".json",
+        }
+    );
+    // Prefix only.
+    assert_eq!(
+        PathTemplate::parse("/v{version}/x", Grammar::default().with_segment_affixes())
+            .expect("valid")
+            .segments()[0],
+        Segment::Affix {
+            prefix: "v",
+            name: "version",
+            suffix: "",
+        }
+    );
+    // Prefix and suffix, dotted field name.
+    assert_eq!(
+        PathTemplate::parse("/img-{img.id}.png", Grammar::default().with_segment_affixes())
+            .expect("valid")
+            .segments()[0],
+        Segment::Affix {
+            prefix: "img-",
+            name: "img.id",
+            suffix: ".png",
+        }
+    );
+}
+
+#[test]
+fn strict_rejects_extended_syntax() {
+    PathTemplate::parse("/files/{name}.json", Grammar::default()).expect_err("rejected");
+    PathTemplate::parse("/v{version}/x", Grammar::default()).expect_err("rejected");
+    PathTemplate::parse("/img-{id}.png", Grammar::default()).expect_err("rejected");
+}
+
+#[test]
+fn extended_still_accepts_strict_templates() {
+    let strict = "/v1/shelves/{shelf}/books/{book=**}:archive";
+    assert_eq!(
+        PathTemplate::parse(strict, Grammar::default()).expect("valid"),
+        PathTemplate::parse(strict, Grammar::default().with_segment_affixes()).expect("valid"),
+    );
+}
+
+#[test]
+fn extended_rejects_two_params_in_one_segment() {
+    PathTemplate::parse("/a{x}b{y}c", Grammar::default().with_segment_affixes()).expect_err("rejected");
+}
+
+#[test]
+fn extended_rejects_wildcard_in_affix() {
+    PathTemplate::parse("/a*{x}", Grammar::default().with_segment_affixes()).expect_err("rejected");
+    PathTemplate::parse("/{x}*b", Grammar::default().with_segment_affixes()).expect_err("rejected");
+}
+
+#[test]
+fn extended_rejects_empty_or_invalid_affix_field() {
+    PathTemplate::parse("/a{}b", Grammar::default().with_segment_affixes()).expect_err("rejected");
+    PathTemplate::parse("/a{1bad}b", Grammar::default().with_segment_affixes()).expect_err("rejected");
+}
+
+#[test]
+fn extended_affix_round_trips_through_display() {
+    for template in ["/files/{name}.json", "/v{version}/x", "/img-{img.id}.png"] {
+        let parsed = PathTemplate::parse(template, Grammar::default().with_segment_affixes()).expect("valid");
+        assert_eq!(parsed.to_string(), template, "display for {template:?}");
+        let rendered = parsed.to_string();
+        let reparsed = PathTemplate::parse(&rendered, Grammar::default().with_segment_affixes()).expect("valid");
+        assert_eq!(parsed, reparsed, "round trip for {template:?}");
+    }
+}
+
+#[test]
+fn extended_rejects_closing_brace_before_opening() {
+    // A `}` appearing before the `{` (one of each) is malformed, not an affix.
+    PathTemplate::parse("/a}b{c", Grammar::default().with_segment_affixes()).expect_err("rejected");
+}


### PR DESCRIPTION
Introduce `http_path_template`, a dependency-free, zero-copy parser for the `google.api.http` path-template grammar: literal segments, `*`, `**`, `{field.path=sub-template}` variables, and a trailing `:verb`. A parse borrows from the input string and allocates only the top-level segment list.

The accepted syntax is selected with a `Grammar` argument: the default is the strict `google.api.http` grammar, and `with_segment_affixes` opts into an extended grammar that also allows intra-segment prefix/suffix parameters (e.g. `/files/{name}.json`).


Copilot-Session: 867c37d0-9e7a-46b0-b5a9-dc9f551ed128