### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -94,13 +94,13 @@ runs:
 
     - name: Start Sccache
       if: inputs.enable-sccache == 'true' && !(runner.os == 'Windows' && runner.arch == 'ARM64')
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: ${{ env.SCCACHE_VERSION }}
 
     - name: Install Rust
       if: inputs.rust-toolchain != ''
-      uses: actions-rust-lang/setup-rust-toolchain@v1.16.1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
         toolchain: ${{ steps.expand.outputs.toolchain }}
         components: ${{ inputs.rust-components }}
@@ -113,4 +113,4 @@ runs:
 
     - name: Install Wild Linker
       if: inputs.enable-wild-linker == 'true'
-      uses: wild-linker/action@0.9.0
+      uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # 0.9.0

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -107,6 +107,10 @@ runs:
 
     - name: Install Cargo Tools
       if: inputs.cargo-tools != ''
+      # taiki-e/install-action publishes immutable GitHub releases (verified via the GitHub API:
+      # "immutable": true on GET /repos/taiki-e/install-action/releases/tags/v2.81.8). The tag
+      # cannot be retargeted, so this reference is intentionally left unpinned to a commit SHA.
+      # See https://github.com/taiki-e/install-action/releases/tag/v2.81.8
       uses: taiki-e/install-action@v2.81.8
       with:
         tool: ${{ steps.expand.outputs.cargo_tools }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,5 +21,8 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
+  # 7-day cooldown before Dependabot proposes a newly published Action version. This gives
+  # the community/security researchers a window to detect and report a compromised or
+  # "poisoned" release before it's automatically pulled into this repo.
   cooldown:
     default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
+  cooldown:
+    default-days: 7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,6 +66,10 @@ jobs:
     #   uses: actions/setup-example@v1
 
     # Initializes the CodeQL tools for scanning.
+    # github/codeql-action publishes immutable GitHub releases (verified via the GitHub API:
+    # "immutable": true on GET /repos/github/codeql-action/releases/tags/v4.36.2). The tag cannot
+    # be retargeted, so init/analyze below are intentionally left pinned to the tag, not a SHA.
+    # See https://github.com/github/codeql-action/releases/tag/v4.36.2
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4.36.2
       with:
@@ -95,6 +99,7 @@ jobs:
         echo '  make release'
         exit 1
 
+    # See the immutable-release note above (github/codeql-action) — same tag, same rationale.
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4.36.2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       skip: ${{ steps.compute.outputs.skip }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Setup
@@ -101,7 +101,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -141,7 +141,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -184,7 +184,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
       - name: Setup
@@ -216,7 +216,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Setup
@@ -278,7 +278,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -315,7 +315,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -335,7 +335,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -354,7 +354,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Setup
@@ -395,7 +395,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -421,7 +421,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Check PR Title
-        uses: amannn/action-semantic-pull-request@v6.1.1
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -445,7 +445,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
       - name: Setup
@@ -468,7 +468,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -495,7 +495,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         # The synthetic-workspace fixture builder shells out to `cargo metadata`,
         # so Rust must be available even though no Rust code is compiled.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -410,6 +410,11 @@ jobs:
       - name: Generate Coverage (no-default-features)
         run: cargo +${{ env.RUST_NIGHTLY }} llvm-cov --no-default-features --workspace --lcov --output-path lcov-no-def.info
       - name: Upload Coverage to Codecov
+        # codecov/codecov-action publishes immutable GitHub releases (verified via the GitHub API:
+        # "immutable": true on GET /repos/codecov/codecov-action/releases/tags/v7.0.0). An immutable
+        # release's tag can never be retargeted to a different commit, so pinning to a SHA adds no
+        # extra protection here; this reference is intentionally left as a tag.
+        # See https://github.com/codecov/codecov-action/releases/tag/v7.0.0
         uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       should_skip: ${{ steps.check.outputs.should_skip }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -67,7 +67,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -118,7 +118,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -141,7 +141,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/publish-gh-release.yml
+++ b/.github/workflows/publish-gh-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup
       uses: ./.github/actions/setup


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility, and adds a 7-day cooldown to the Dependabot configuration for GitHub Actions updates.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action), and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` and `.github/actions/setup/action.yml` that used mutable tag-based references have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v7.0.0`) using [pinact](https://github.com/suzuki-shunsuke/pinact):

| Action | Old ref | New ref |
|---|---|---|
| `actions/checkout` | `@v7.0.0` | `@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0` |
| `amannn/action-semantic-pull-request` | `@v6.1.1` | `@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1` |
| `mozilla-actions/sccache-action` | `@v0.0.10` | `@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10` |
| `actions-rust-lang/setup-rust-toolchain` | `@v1.16.1` | `@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1` |
| `wild-linker/action` | `@0.9.0` | `@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # 0.9.0` |

**Immutable-release exceptions (intentionally left as tags):** The following actions publish their releases as **GitHub immutable releases** — verified via the GitHub API (`"immutable": true` on the release), meaning the tag is cryptographically locked and can never be retargeted to a different commit after publication. Pinning these to a SHA would add no additional supply-chain protection, so they are intentionally left as mutable-looking tags, with a code comment at each usage site documenting the verification:

- [`codecov/codecov-action@v7.0.0`](https://github.com/codecov/codecov-action/releases/tag/v7.0.0) — `.github/workflows/main.yml`
- [`github/codeql-action/init@v4.36.2`](https://github.com/github/codeql-action/releases/tag/v4.36.2) — `.github/workflows/codeql.yml`
- [`github/codeql-action/analyze@v4.36.2`](https://github.com/github/codeql-action/releases/tag/v4.36.2) — `.github/workflows/codeql.yml`
- [`taiki-e/install-action@v2.81.8`](https://github.com/taiki-e/install-action/releases/tag/v2.81.8) — `.github/actions/setup/action.yml`

You can verify immutability yourself via `GET https://api.github.com/repos/<owner>/<repo>/releases/tags/<tag>` and checking the `immutable` field.

**Dependabot configuration:** `.github/dependabot.yml` now has a `github-actions` package-ecosystem section with a `cooldown` of `default-days: 7`. **The important part of this change is the 7-day cooldown itself**, not grouping: it delays newly published Action versions from being proposed by Dependabot for 7 days, giving the community/security researchers a window to detect and report a compromised or "poisoned" release before it's automatically pulled into this repo. If the file did not exist, it was created; if a `github-actions` section already existed, only the `cooldown` block was added (or its `default-days` raised to 7 if lower).

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits the existing tags pointed to. No behavioral changes are introduced. You can verify a pinned SHA via the GitHub REST API (e.g., `GET https://api.github.com/repos/actions/checkout/commits/v7` returns the `sha` matching the pin).

---

<sub>For more information, visit https://aka.ms/action-pinning</sub>
