### PR TITLE
ci: reclaim disk space on the testing job to prevent OOM

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,10 +25,37 @@ inputs:
     description: Install Wild linker for faster linking
     required: false
     default: 'false'
+  free-disk-space:
+    description: >-
+      Remove unused pre-installed toolchains (Android SDK, Haskell/GHC, Swift,
+      Chromium) to reclaim ~18 GB on Linux runners. Guards against intermittent
+      "No space left on device" failures on the heavier build/test jobs. No-op
+      on non-Linux runners.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
   steps:
+    # GitHub only guarantees 14 GB of storage on standard runners; the heavy
+    # `cargo hack --each-feature` + `--all-features` test build peaks well above
+    # that, so we reclaim space up front. These directories are unused by our
+    # Rust builds. See https://github.com/microsoft/oxidizer (work item 7611559).
+    - name: Free Disk Space
+      if: inputs.free-disk-space == 'true' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "Disk before cleanup:"
+        df -h /
+        # Fast `rm -rf` reclaims (no slow apt purge): Android ~10 GB, Haskell
+        # ~4 GB, Swift ~3 GB, Chromium ~1 GB.
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc /usr/local/.ghcup
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/local/share/chromium /usr/local/share/edge_driver
+        echo "Disk after cleanup:"
+        df -h /
+
     - name: Loading Repo Constants
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,10 +27,11 @@ inputs:
     default: 'false'
   free-disk-space:
     description: >-
-      Remove unused pre-installed toolchains (Android SDK, Haskell/GHC, Swift,
-      Chromium) to reclaim ~18 GB on Linux runners. Guards against intermittent
-      "No space left on device" failures on the heavier build/test jobs. No-op
-      on non-Linux runners.
+      Remove unused pre-installed toolchains to reclaim disk space and guard
+      against intermittent "No space left on device" failures on the heavier
+      build/test jobs. Linux reclaims ~18 GB (Android SDK, Haskell/GHC, Swift,
+      Chromium); Windows reclaims ~17 GB (Android SDK, Haskell/GHC). No-op on
+      macOS.
     required: false
     default: 'false'
 
@@ -41,7 +42,7 @@ runs:
     # `cargo hack --each-feature` + `--all-features` test build peaks well above
     # that, so we reclaim space up front. These directories are unused by our
     # Rust builds. See https://github.com/microsoft/oxidizer (work item 7611559).
-    - name: Free Disk Space
+    - name: Free Disk Space (Linux)
       if: inputs.free-disk-space == 'true' && runner.os == 'Linux'
       shell: bash
       run: |
@@ -55,6 +56,22 @@ runs:
         sudo rm -rf /usr/local/share/chromium /usr/local/share/edge_driver
         echo "Disk after cleanup:"
         df -h /
+
+    # Windows runners start with far less free space (~34 GB vs ~89 GB on Linux)
+    # because the pre-installed tooling (Visual Studio, .NET, Android) is much
+    # larger. Reclaim the big dirs unused by our Rust builds. Visual Studio,
+    # .NET, and the hosted tool cache (holds sccache) are intentionally kept.
+    - name: Free Disk Space (Windows)
+      if: inputs.free-disk-space == 'true' && runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        function Free-GB { [math]::Round((Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'").FreeSpace / 1GB, 1) }
+        "Free before cleanup (GB): $(Free-GB)"
+        # Android SDK ~13 GB, Haskell/ghcup ~4 GB.
+        foreach ($p in 'C:\Program Files (x86)\Android', 'C:\Android', 'C:\ghcup') {
+          if (Test-Path $p) { Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+        "Free after cleanup (GB): $(Free-GB)"
 
     - name: Loading Repo Constants
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           enable-sccache: true
+          free-disk-space: true
           rust-toolchain: RUST_MSRV, RUST_NIGHTLY
           cargo-tools: CARGO_NEXTEST_VERSION, CARGO_HACK_VERSION, JUST_VERSION
 


### PR DESCRIPTION
## Problem

The `testing` job intermittently fails with `No space left on device` (work item 7611559), e.g. run 29486864461.

I investigated on real runners (temporary diagnostics workflow, since removed):

- **Documented storage floor:** GitHub only guarantees **14 GB SSD** for standard `ubuntu-latest` ([docs](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)). Observed free space is often larger (~89 GB) but **not guaranteed** and varies run-to-run.
- **Our footprint:** the full `cargo hack build --each-feature --workspace` + `nextest --all-features` + docs/doctests/examples sequence peaks at **~15 GiB** of `target/` (test binaries dominate: `target` grew to 12 GB after the nextest step).
- **Caching is not the cause:** `rust-cache` blobs are ~1.25 GiB compressed (deps only); sccache is remote (GHA) with a ~1.5% hit rate. The peak is the build's own `target/`.

So whenever a runner provides close to the documented 14 GB floor, our ~15 GiB peak overflows — matching the "random, every now and then" symptom.

## Change

Add an opt-in `free-disk-space` input to the `setup` composite action that removes pre-installed toolchains unused by our Rust builds and enable it on the `testing` job.

Measured reclaim (fast `rm -rf`, **no** slow apt purge):

| Removed | Freed | Time |
|---|---|---|
| Android SDK (`/usr/local/lib/android`) | ~10 GB | 6.3 s |
| Haskell/GHC (`/opt/ghc`, `.ghcup`) | ~4 GB | 0.6 s |
| Swift (`/usr/share/swift`) | ~3 GB | 0.1 s |
| Chromium/Edge driver | ~1 GB | ~0 s |
| **Total** | **~18 GB** | **~7 s** |

Deliberately **kept**: `.NET`, PowerShell, CodeQL, Docker images, and `/opt/hostedtoolcache` (holds sccache). No apt purge (only ~3 GB for ~26 s).

## Notes / follow-up

- Enabled only on `testing` (the confirmed failure). The same `free-disk-space: true` flag can be flipped on other heavy Linux jobs (`static-analysis`, `coverage`, `extended-analysis`) if they hit the same limit.
- This mirrors a very common CI practice (see e.g. `jlumbroso/free-disk-space`, `easimon/maximize-build-space`).