### PR TITLE
fix(bytesbuf)!: replace generic num_traits numeric API with concrete-typed methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,6 @@ dependencies = [
  "mutants",
  "new_zealand",
  "nm",
- "num-traits",
  "smallvec",
  "static_assertions",
  "testing_aids",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,6 @@ mutants = { version = "0.0.3", default-features = false }
 native-tls = { version = "0.2.18", default-features = false }
 new_zealand = { version = "1.0.4", default-features = false }
 nm = { version = "0.1.21", default-features = false }
-num-traits = { version = "0.2.19", default-features = false }
 object-pool = { version = "0.6.0", default-features = false }
 once_cell = { version = "1.21.3", default-features = false }
 opentelemetry = { version = "0.32.0", default-features = false }

--- a/crates/bytesbuf/Cargo.toml
+++ b/crates/bytesbuf/Cargo.toml
@@ -23,8 +23,6 @@ allowed_external_types = [
     "bytes::buf::buf_impl::Buf",
     "bytes::buf::uninit_slice::UninitSlice",
     "bytes::buf::buf_mut::BufMut",
-    "num_traits::ops::bytes::FromBytes",
-    "num_traits::ops::bytes::ToBytes",
     "thread_aware::affinity::MemoryAffinity",
     "thread_aware::affinity::PinnedAffinity",
     "thread_aware::core::ThreadAware",
@@ -44,7 +42,6 @@ bytes = { workspace = true, features = ["std"], optional = true }
 infinity_pool = { workspace = true }
 new_zealand = { workspace = true }
 nm = { workspace = true }
-num-traits = { workspace = true }
 smallvec = { workspace = true, features = ["const_new", "union"] }
 thread_aware = { workspace = true, features = ["derive"] }
 

--- a/crates/bytesbuf/README.md
+++ b/crates/bytesbuf/README.md
@@ -38,7 +38,9 @@ removed from the front of the view, shrinking it to only the remaining bytes.
 
 There are many helper methods on this type for easily consuming bytes from the view:
 
-* [`get_num_le::<T>()`][__link3] reads numbers. Big-endian/native-endian variants also exist.
+* [`get_u64_le()`][__link3] and the sibling `get_<type>_<endianness>()` methods read numbers of a
+  specific primitive type (`u16`/`i16` through `u128`/`i128`, plus `f32`/`f64`) in little-,
+  big-, or native-endian byte order.
 * [`get_byte()`][__link4] reads a single byte.
 * [`copy_to_slice()`][__link5] copies bytes into a provided slice.
 * [`copy_to_uninit_slice()`][__link6] copies bytes into a provided uninitialized slice.
@@ -53,7 +55,7 @@ fn consume_message(mut message: BytesView) {
     let mut sum: u64 = 0;
 
     while !message.is_empty() {
-        let word = message.get_num_le::<u64>();
+        let word = message.get_u64_le();
         sum = sum.saturating_add(word);
     }
 
@@ -102,7 +104,7 @@ let mut bytes_clone = bytes.clone();
 assert_eq!(bytes_clone.len(), 16);
 
 // Consume 8 bytes from the front.
-_ = bytes_clone.get_num_le::<u64>();
+_ = bytes_clone.get_u64_le();
 assert_eq!(bytes_clone.len(), 8);
 
 // Operations on the clone have no effect on the original view.
@@ -146,7 +148,9 @@ append-only process - you can only add data to the end of the buffered sequence.
 
 There are many helper methods on [`BytesBuf`][__link26] for easily appending bytes to the buffer:
 
-* [`put_num_le::<T>()`][__link27] appends numbers. Big-endian/native-endian variants also exist.
+* [`put_u64_le()`][__link27] and the sibling `put_<type>_<endianness>()` methods append numbers of a
+  specific primitive type (`u16`/`i16` through `u128`/`i128`, plus `f32`/`f64`) in little-,
+  big-, or native-endian byte order.
 * [`put_slice()`][__link28] appends a slice of bytes.
 * [`put_byte()`][__link29] appends a single byte.
 * [`put_byte_repeated()`][__link30] appends multiple repetitions of a byte.
@@ -159,8 +163,8 @@ let memory = connection.memory();
 
 let mut buf = memory.reserve(100);
 
-buf.put_num_be(1234_u64);
-buf.put_num_be(5678_u64);
+buf.put_u64_be(1234);
+buf.put_u64_be(5678);
 buf.put_slice(*b"Hello, world!");
 ```
 
@@ -208,8 +212,8 @@ let memory = connection.memory();
 
 let mut buf = memory.reserve(100);
 
-buf.put_num_be(1234_u64);
-buf.put_num_be(5678_u64);
+buf.put_u64_be(1234);
+buf.put_u64_be(5678);
 buf.put_slice(*b"Hello, world!");
 
 let message = buf.consume_all();
@@ -225,8 +229,8 @@ let memory = connection.memory();
 
 let mut buf = memory.reserve(100);
 
-buf.put_num_be(1234_u64);
-buf.put_num_be(5678_u64);
+buf.put_u64_be(1234);
+buf.put_u64_be(5678);
 
 let first_8_bytes = buf.consume(8);
 let second_8_bytes = buf.consume(8);
@@ -246,7 +250,7 @@ use bytesbuf::mem::Memory;
 let memory = connection.memory();
 
 let mut header_builder = memory.reserve(16);
-header_builder.put_num_be(1234_u64);
+header_builder.put_u64_be(1234);
 let header = header_builder.consume_all();
 
 let mut buf = memory.reserve(128);
@@ -470,7 +474,7 @@ See the `mem::testing` module for details (requires `test-util` Cargo feature).
 This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbJ1n5emfG9rYb9IJBtfUIpXYbaB5j18j1RxEbDiXhMXybg_xhZIGCaGJ5dGVzYnVmZTAuNi4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQbLiTyV0MU86EbZU15e0PmecoboQ9jo59bnAEbyDXw04U13GlhYvRhcoQbvoc1LZxTdZ0bwD6tOCnz9mMbRK42K6IkEecbA1i1D0CL4_hhZIGCaGJ5dGVzYnVmZTAuNi4w
  [__link0]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf
  [__link1]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesView
  [__link10]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesView
@@ -491,10 +495,10 @@ This crate was developed as part of <a href="../..">The Oxidizer Project</a>. Br
  [__link24]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf
  [__link25]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf
  [__link26]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf
- [__link27]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf::put_num_le
+ [__link27]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf::put_u64_le
  [__link28]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf::put_slice
  [__link29]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf::put_byte
- [__link3]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesView::get_num_le
+ [__link3]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesView::get_u64_le
  [__link30]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf::put_byte_repeated
  [__link31]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesBuf::put_bytes
  [__link32]: https://docs.rs/bytesbuf/0.6.0/bytesbuf/?search=BytesView

--- a/crates/bytesbuf/benches/buf.rs
+++ b/crates/bytesbuf/benches/buf.rs
@@ -363,7 +363,7 @@ fn entrypoint(c: &mut Criterion) {
 
     // Repeatedly writes a u32 into pre-reserved single-block capacity, exercising the fused
     // put_small fast path for numeric writes.
-    group.bench_function("put_num_le", |b| {
+    group.bench_function("put_u32_le", |b| {
         const WRITES: usize = 32;
 
         b.iter_batched_ref(
@@ -374,7 +374,7 @@ fn entrypoint(c: &mut Criterion) {
             },
             |buf| {
                 for _ in 0..WRITES {
-                    buf.put_num_le(black_box(0x1234_5678_u32));
+                    buf.put_u32_le(black_box(0x1234_5678_u32));
                 }
             },
             BatchSize::SmallInput,

--- a/crates/bytesbuf/benches/buf_cg.rs
+++ b/crates/bytesbuf/benches/buf_cg.rs
@@ -4,8 +4,8 @@
 //! Callgrind benchmarks for `BytesBuf` write fast paths in the `bytesbuf` package.
 //!
 //! Paired with `buf.rs`, which covers the same operations under wall-clock measurement. The
-//! `put_slice` and `put_num_le` benchmarks pair with the Criterion `BytesBuf/put_slice` and
-//! `BytesBuf/put_num_le` benchmarks (the Callgrind variants isolate a single write).
+//! `put_slice` and `put_u32_le` benchmarks pair with the Criterion `BytesBuf/put_slice` and
+//! `BytesBuf/put_u32_le` benchmarks (the Callgrind variants isolate a single write).
 //!
 //! Each setup function reserves the destination capacity outside the measured region so the
 //! timed body exercises only the fused write into the first unfilled slice, never allocation.
@@ -57,14 +57,14 @@ mod linux {
     // Fused single-slice numeric write.
     #[library_benchmark]
     #[bench::single_span(reserved())]
-    fn bytes_buf_put_num_le(mut buf: BytesBuf) -> BytesBuf {
-        buf.put_num_le(black_box(0x1234_5678_u32));
+    fn bytes_buf_put_u32_le(mut buf: BytesBuf) -> BytesBuf {
+        buf.put_u32_le(black_box(0x1234_5678_u32));
         buf
     }
 
     library_benchmark_group!(
         name = bytes_buf;
-        benchmarks = bytes_buf_put_slice, bytes_buf_put_num_le
+        benchmarks = bytes_buf_put_slice, bytes_buf_put_u32_le
     );
 }
 

--- a/crates/bytesbuf/benches/bytesbuf_vs_bytes.rs
+++ b/crates/bytesbuf/benches/bytesbuf_vs_bytes.rs
@@ -177,21 +177,6 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let allocs_op = allocs.operation("put_u8");
-    group.bench_function("put_u8", |b| {
-        b.iter_custom(|iters| {
-            let mut buffers: Vec<_> = (0..iters).map(|_| memory.reserve(1)).collect();
-
-            let _span = allocs_op.measure_thread().iterations(iters);
-            let start = Instant::now();
-            for buf in &mut buffers {
-                buf.put_num_ne::<u8>(black_box(0xAB));
-                black_box(buf);
-            }
-            start.elapsed()
-        });
-    });
-
     group.finish();
 
     let mut group = c.benchmark_group("bytesbuf_vs_put_u8_repeated");
@@ -238,7 +223,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for buf in &mut buffers {
-                buf.put_num_le::<u16>(black_box(0xABCD));
+                buf.put_u16_le(black_box(0xABCD));
                 black_box(buf);
             }
             start.elapsed()
@@ -268,7 +253,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for buf in &mut buffers {
-                buf.put_num_le::<u32>(black_box(0xABCD_EF01));
+                buf.put_u32_le(black_box(0xABCD_EF01));
                 black_box(buf);
             }
             start.elapsed()
@@ -298,7 +283,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for buf in &mut buffers {
-                buf.put_num_le::<u64>(black_box(0xABCD_EF01_2345_6789));
+                buf.put_u64_le(black_box(0xABCD_EF01_2345_6789));
                 black_box(buf);
             }
             start.elapsed()
@@ -328,7 +313,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for buf in &mut buffers {
-                buf.put_num_le::<f64>(black_box(f64::consts::PI));
+                buf.put_f64_le(black_box(f64::consts::PI));
                 black_box(buf);
             }
             start.elapsed()
@@ -358,7 +343,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for buf in &mut buffers {
-                buf.put_num_be::<u16>(black_box(0xABCD));
+                buf.put_u16_be(black_box(0xABCD));
                 black_box(buf);
             }
             start.elapsed()
@@ -388,7 +373,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for buf in &mut buffers {
-                buf.put_num_be::<u32>(black_box(0xABCD_EF01));
+                buf.put_u32_be(black_box(0xABCD_EF01));
                 black_box(buf);
             }
             start.elapsed()
@@ -418,7 +403,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for buf in &mut buffers {
-                buf.put_num_be::<u64>(black_box(0xABCD_EF01_2345_6789));
+                buf.put_u64_be(black_box(0xABCD_EF01_2345_6789));
                 black_box(buf);
             }
             start.elapsed()
@@ -448,7 +433,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for buf in &mut buffers {
-                buf.put_num_be::<f64>(black_box(f64::consts::PI));
+                buf.put_f64_be(black_box(f64::consts::PI));
                 black_box(buf);
             }
             start.elapsed()
@@ -474,7 +459,6 @@ fn entrypoint(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("bytesbuf_vs_put_u8");
 
-    // get_byte is a "manual specialization" of get_num_le::<u8>()
     let allocs_op = allocs.operation("get_byte");
     group.bench_function("get_byte", |b| {
         b.iter_custom(|iters| {
@@ -484,20 +468,6 @@ fn entrypoint(c: &mut Criterion) {
             let start = Instant::now();
             for bytes in &mut inputs {
                 black_box(bytes.get_byte());
-            }
-            start.elapsed()
-        });
-    });
-
-    let allocs_op = allocs.operation("get_u8");
-    group.bench_function("get_u8", |b| {
-        b.iter_custom(|iters| {
-            let mut inputs: Vec<_> = (0..iters).map(|_| many_as_view.clone()).collect();
-
-            let _span = allocs_op.measure_thread().iterations(iters);
-            let start = Instant::now();
-            for bytes in &mut inputs {
-                black_box(bytes.get_num_le::<u8>());
             }
             start.elapsed()
         });
@@ -529,7 +499,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for bytes in &mut inputs {
-                black_box(bytes.get_num_le::<u16>());
+                black_box(bytes.get_u16_le());
             }
             start.elapsed()
         });
@@ -557,7 +527,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for bytes in &mut inputs {
-                black_box(bytes.get_num_le::<u32>());
+                black_box(bytes.get_u32_le());
             }
             start.elapsed()
         });
@@ -585,7 +555,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for bytes in &mut inputs {
-                black_box(bytes.get_num_le::<u64>());
+                black_box(bytes.get_u64_le());
             }
             start.elapsed()
         });
@@ -613,7 +583,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for bytes in &mut inputs {
-                black_box(bytes.get_num_le::<f64>());
+                black_box(bytes.get_f64_le());
             }
             start.elapsed()
         });
@@ -641,7 +611,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for bytes in &mut inputs {
-                black_box(bytes.get_num_be::<u16>());
+                black_box(bytes.get_u16_be());
             }
             start.elapsed()
         });
@@ -669,7 +639,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for bytes in &mut inputs {
-                black_box(bytes.get_num_be::<u32>());
+                black_box(bytes.get_u32_be());
             }
             start.elapsed()
         });
@@ -697,7 +667,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for bytes in &mut inputs {
-                black_box(bytes.get_num_be::<u64>());
+                black_box(bytes.get_u64_be());
             }
             start.elapsed()
         });
@@ -725,7 +695,7 @@ fn entrypoint(c: &mut Criterion) {
             let _span = allocs_op.measure_thread().iterations(iters);
             let start = Instant::now();
             for bytes in &mut inputs {
-                black_box(bytes.get_num_be::<f64>());
+                black_box(bytes.get_f64_be());
             }
             start.elapsed()
         });

--- a/crates/bytesbuf/benches/view.rs
+++ b/crates/bytesbuf/benches/view.rs
@@ -188,14 +188,14 @@ fn entrypoint(c: &mut Criterion) {
         );
     });
 
-    // Drains a single-span view as u32 values, exercising the fused single-span get_num path
+    // Drains a single-span view as u32 values, exercising the fused single-span numeric read path
     // (the value never straddles a span boundary, so the buffered fallback is never taken).
-    group.bench_function("get_num_le_drain", |b| {
+    group.bench_function("get_u32_le_drain", |b| {
         b.iter_batched_ref(
             || test_data_as_view.clone(),
             |seq| {
                 while seq.len() >= size_of::<u32>() {
-                    black_box(seq.get_num_le::<u32>());
+                    black_box(seq.get_u32_le());
                 }
             },
             BatchSize::SmallInput,

--- a/crates/bytesbuf/benches/view_cg.rs
+++ b/crates/bytesbuf/benches/view_cg.rs
@@ -5,8 +5,8 @@
 //!
 //! Paired with `view.rs`, which covers the same operations under wall-clock measurement.
 //! The `slice_*` benchmarks pair with the Criterion `BytesView/slice_*` benchmarks; `get_byte`
-//! and `get_num_le` pair with the per-element `BytesView/get_byte_drain` and
-//! `BytesView/get_num_le_drain` benchmarks (the Callgrind variants isolate a single call).
+//! and `get_u32_le` pair with the per-element `BytesView/get_byte_drain` and
+//! `BytesView/get_u32_le_drain` benchmarks (the Callgrind variants isolate a single call).
 //!
 //! Each setup function builds the view outside the measured region and the benchmark returns its
 //! state so the view's drop (and the `BlockRef` refcount traffic it triggers) is not counted.
@@ -91,8 +91,8 @@ mod linux {
     // Fused single-span numeric read: the value never straddles a span boundary.
     #[library_benchmark]
     #[bench::single_span(single_span())]
-    fn bytes_view_get_num_le(mut view: BytesView) -> (BytesView, u32) {
-        let value = view.get_num_le::<u32>();
+    fn bytes_view_get_u32_le(mut view: BytesView) -> (BytesView, u32) {
+        let value = view.get_u32_le();
         (view, black_box(value))
     }
 
@@ -100,7 +100,7 @@ mod linux {
         name = bytes_view;
         benchmarks =
             bytes_view_slice_near, bytes_view_slice_far, bytes_view_slice_very_far,
-            bytes_view_get_byte, bytes_view_get_num_le
+            bytes_view_get_byte, bytes_view_get_u32_le
     );
 }
 

--- a/crates/bytesbuf/examples/bb_basic.rs
+++ b/crates/bytesbuf/examples/bb_basic.rs
@@ -35,7 +35,7 @@ fn produce_message(memory: &impl Memory) -> BytesView {
 
     // Each word is just an incrementing binary-serialized number, starting from 0.
     (0..MESSAGE_LEN_WORDS).for_each(|word| {
-        buf.put_num_le(word as u64);
+        buf.put_u64_le(word as u64);
     });
 
     // Creates a BytesView over all the data written into the BytesBuf.
@@ -47,7 +47,7 @@ fn consume_message(mut message: BytesView) {
     let mut sum: u64 = 0;
 
     while !message.is_empty() {
-        let word = message.get_num_le::<u64>();
+        let word = message.get_u64_le();
         sum = sum.saturating_add(word);
     }
 

--- a/crates/bytesbuf/examples/bb_has_memory_optimizing.rs
+++ b/crates/bytesbuf/examples/bb_has_memory_optimizing.rs
@@ -18,8 +18,8 @@ fn main() {
     // Prepare a packet to send and send it.
     let mut buf = connection.memory().reserve(1 + 8 + 16);
     buf.put_byte(42);
-    buf.put_num_be(43_u64);
-    buf.put_num_be(44_u128);
+    buf.put_u64_be(43);
+    buf.put_u128_be(44);
 
     let packet = buf.consume_all();
 

--- a/crates/bytesbuf/src/buf.rs
+++ b/crates/bytesbuf/src/buf.rs
@@ -62,9 +62,9 @@ use crate::{BytesBufWriter, BytesView, MAX_INLINE_SPANS, MemoryGuard, Span, Span
 ///
 /// // Build a message from various pieces.
 /// buf.put_slice(HEADER_MAGIC);
-/// buf.put_num_be(1_u16); // Version
-/// buf.put_num_be(42_u32); // Payload length
-/// buf.put_num_be(0xDEAD_BEEF_u64); // Checksum
+/// buf.put_u16_be(1); // Version
+/// buf.put_u32_be(42); // Payload length
+/// buf.put_u64_be(0xDEAD_BEEF); // Checksum
 ///
 /// // Consume the buffered data as an immutable BytesView.
 /// let message = buf.consume_all();
@@ -217,7 +217,7 @@ impl BytesBuf {
     /// buf.reserve(16, &memory);
     /// assert!(buf.remaining_capacity() >= 16);
     ///
-    /// buf.put_num_be(0x1234_5678_u32);
+    /// buf.put_u32_be(0x1234_5678);
     ///
     /// // Can reserve more capacity at any time.
     /// buf.reserve(100, &memory);
@@ -367,13 +367,13 @@ impl BytesBuf {
     /// use bytesbuf::mem::Memory;
     ///
     /// let mut buf = memory.reserve(16);
-    /// buf.put_num_be(0x1234_u16);
-    /// buf.put_num_be(0x5678_u16);
+    /// buf.put_u16_be(0x1234);
+    /// buf.put_u16_be(0x5678);
     ///
     /// // Peek at the data without consuming it.
     /// let mut peeked = buf.peek();
-    /// assert_eq!(peeked.get_num_be::<u16>(), 0x1234);
-    /// assert_eq!(peeked.get_num_be::<u16>(), 0x5678);
+    /// assert_eq!(peeked.get_u16_be(), 0x1234);
+    /// assert_eq!(peeked.get_u16_be(), 0x5678);
     ///
     /// // Despite consuming from peeked, the buffer still contains all data.
     /// assert_eq!(buf.len(), 4);
@@ -419,7 +419,7 @@ impl BytesBuf {
     /// let mut buf = memory.reserve(32);
     /// assert_eq!(buf.len(), 0);
     ///
-    /// buf.put_num_be(0x1234_5678_u32);
+    /// buf.put_u32_be(0x1234_5678);
     /// assert_eq!(buf.len(), 4);
     ///
     /// buf.put_slice(*b"Hello");
@@ -541,20 +541,20 @@ impl BytesBuf {
     ///
     /// let mut buf = memory.reserve(32);
     ///
-    /// buf.put_num_be(0x1111_u16);
-    /// buf.put_num_be(0x2222_u16);
+    /// buf.put_u16_be(0x1111);
+    /// buf.put_u16_be(0x2222);
     ///
     /// // Consume first part.
     /// let mut first = buf.consume(2);
-    /// assert_eq!(first.get_num_be::<u16>(), 0x1111);
+    /// assert_eq!(first.get_u16_be(), 0x1111);
     ///
     /// // Write more data.
-    /// buf.put_num_be(0x3333_u16);
+    /// buf.put_u16_be(0x3333);
     ///
     /// // Consume remaining data.
     /// let mut rest = buf.consume(4);
-    /// assert_eq!(rest.get_num_be::<u16>(), 0x2222);
-    /// assert_eq!(rest.get_num_be::<u16>(), 0x3333);
+    /// assert_eq!(rest.get_u16_be(), 0x2222);
+    /// assert_eq!(rest.get_u16_be(), 0x3333);
     /// ```
     ///
     /// # Panics
@@ -664,7 +664,7 @@ impl BytesBuf {
     /// let mut buf = memory.reserve(32);
     /// buf.put_slice(*b"Hello, ");
     /// buf.put_slice(*b"world!");
-    /// buf.put_num_be(0x2121_u16); // "!!"
+    /// buf.put_u16_be(0x2121); // "!!"
     ///
     /// let message = buf.consume_all();
     ///
@@ -694,7 +694,7 @@ impl BytesBuf {
     ///
     /// let mut buf = memory.reserve(64);
     ///
-    /// buf.put_num_be(0xDEAD_u16);
+    /// buf.put_u16_be(0xDEAD);
     ///
     /// let remaining_before = buf.remaining_capacity();
     /// let mut split = buf.split_off_remaining(20);
@@ -708,7 +708,7 @@ impl BytesBuf {
     /// assert_eq!(buf.len(), 2);
     ///
     /// // The split-off buffer can be used independently.
-    /// split.put_num_be(0xBEEF_u16);
+    /// split.put_u16_be(0xBEEF);
     /// assert_eq!(split.len(), 2);
     /// ```
     ///
@@ -1416,10 +1416,10 @@ mod tests {
         assert_eq!(buf.len(), 0);
         assert!(buf.is_empty());
 
-        buf.put_num_ne(1234_u64);
-        buf.put_num_ne(5678_u64);
-        buf.put_num_ne(1234_u64);
-        buf.put_num_ne(5678_u64);
+        buf.put_u64_ne(1234);
+        buf.put_u64_ne(5678);
+        buf.put_u64_ne(1234);
+        buf.put_u64_ne(5678);
 
         assert_eq!(buf.len(), 32);
         assert!(!buf.is_empty());
@@ -1436,13 +1436,13 @@ mod tests {
         assert_eq!(second_two.len(), 16);
         assert_eq!(buf.len(), 0);
 
-        assert_eq!(first_two.get_num_ne::<u64>(), 1234);
-        assert_eq!(first_two.get_num_ne::<u64>(), 5678);
+        assert_eq!(first_two.get_u64_ne(), 1234);
+        assert_eq!(first_two.get_u64_ne(), 5678);
 
-        assert_eq!(second_two.get_num_ne::<u64>(), 1234);
-        assert_eq!(second_two.get_num_ne::<u64>(), 5678);
+        assert_eq!(second_two.get_u64_ne(), 1234);
+        assert_eq!(second_two.get_u64_ne(), 5678);
 
-        buf.put_num_ne(1111_u64);
+        buf.put_u64_ne(1111);
 
         assert_eq!(buf.len(), 8);
 
@@ -1451,7 +1451,7 @@ mod tests {
         assert_eq!(last.len(), 8);
         assert_eq!(buf.len(), 0);
 
-        assert_eq!(last.get_num_ne::<u64>(), 1111);
+        assert_eq!(last.get_u64_ne(), 1111);
 
         assert!(buf.consume_checked(1).is_none());
         assert!(buf.consume_all().is_empty());
@@ -1473,8 +1473,8 @@ mod tests {
         assert_eq!(buf.remaining_capacity(), 100);
 
         // Write 10 bytes of data just to verify that it does not affect "capacity" logic.
-        buf.put_num_ne(1234_u64);
-        buf.put_num_ne(5678_u16);
+        buf.put_u64_ne(1234);
+        buf.put_u16_ne(5678);
 
         assert_eq!(buf.len(), 10);
         assert_eq!(buf.remaining_capacity(), 90);
@@ -1508,17 +1508,17 @@ mod tests {
         let mut target_buffer = memory.reserve(min_length);
 
         // First we make a couple pieces to append.
-        payload_buffer.put_num_ne(1111_u64);
-        payload_buffer.put_num_ne(2222_u64);
-        payload_buffer.put_num_ne(3333_u64);
-        payload_buffer.put_num_ne(4444_u64);
+        payload_buffer.put_u64_ne(1111);
+        payload_buffer.put_u64_ne(2222);
+        payload_buffer.put_u64_ne(3333);
+        payload_buffer.put_u64_ne(4444);
 
         let payload1 = payload_buffer.consume(TWO_U64_SIZE);
         let payload2 = payload_buffer.consume(TWO_U64_SIZE);
 
         // Then we prefill some data to start us off.
-        target_buffer.put_num_ne(5555_u64);
-        target_buffer.put_num_ne(6666_u64);
+        target_buffer.put_u64_ne(5555);
+        target_buffer.put_u64_ne(6666);
 
         // Consume a little just for extra complexity.
         let _ = target_buffer.consume(U64_SIZE);
@@ -1531,18 +1531,18 @@ mod tests {
         target_buffer.put_bytes(BytesView::default());
 
         // Add some custom data at the end.
-        target_buffer.put_num_ne(7777_u64);
+        target_buffer.put_u64_ne(7777);
 
         assert_eq!(target_buffer.len(), 48);
 
         let mut result = target_buffer.consume(48);
 
-        assert_eq!(result.get_num_ne::<u64>(), 6666);
-        assert_eq!(result.get_num_ne::<u64>(), 1111);
-        assert_eq!(result.get_num_ne::<u64>(), 2222);
-        assert_eq!(result.get_num_ne::<u64>(), 3333);
-        assert_eq!(result.get_num_ne::<u64>(), 4444);
-        assert_eq!(result.get_num_ne::<u64>(), 7777);
+        assert_eq!(result.get_u64_ne(), 6666);
+        assert_eq!(result.get_u64_ne(), 1111);
+        assert_eq!(result.get_u64_ne(), 2222);
+        assert_eq!(result.get_u64_ne(), 3333);
+        assert_eq!(result.get_u64_ne(), 4444);
+        assert_eq!(result.get_u64_ne(), 7777);
     }
 
     #[test]
@@ -1552,8 +1552,8 @@ mod tests {
 
         // Reserve some capacity and add initial data.
         buf.reserve(16, &memory);
-        buf.put_num_ne(1111_u64);
-        buf.put_num_ne(2222_u64);
+        buf.put_u64_ne(1111);
+        buf.put_u64_ne(2222);
 
         // Consume some data (the 1111).
         let _ = buf.consume(8);
@@ -1561,21 +1561,21 @@ mod tests {
         // Append a sequence (the 3333).
         let mut append_buf = BytesBuf::new();
         append_buf.reserve(8, &memory);
-        append_buf.put_num_ne(3333_u64);
+        append_buf.put_u64_ne(3333);
         let reused_bytes_to_append = append_buf.consume_all();
         buf.append(reused_bytes_to_append);
 
         // Add more data (the 4444).
         buf.reserve(8, &memory);
-        buf.put_num_ne(4444_u64);
+        buf.put_u64_ne(4444);
 
         // Consume all data and validate we got all the pieces.
         let mut result = buf.consume_all();
 
         assert_eq!(result.len(), 24);
-        assert_eq!(result.get_num_ne::<u64>(), 2222);
-        assert_eq!(result.get_num_ne::<u64>(), 3333);
-        assert_eq!(result.get_num_ne::<u64>(), 4444);
+        assert_eq!(result.get_u64_ne(), 2222);
+        assert_eq!(result.get_u64_ne(), 3333);
+        assert_eq!(result.get_u64_ne(), 4444);
     }
 
     #[test]
@@ -1596,22 +1596,22 @@ mod tests {
 
         assert_eq!(buf.capacity(), 100);
 
-        buf.put_num_ne(1111_u64);
+        buf.put_u64_ne(1111);
 
         // We have 0 frozen spans and 10 span builders,
         // the first of which has 8 bytes of filled content.
         let mut peeked = buf.peek();
         assert_eq!(peeked.first_slice().len(), 8);
-        assert_eq!(peeked.get_num_ne::<u64>(), 1111);
+        assert_eq!(peeked.get_u64_ne(), 1111);
         assert_eq!(peeked.len(), 0);
 
-        buf.put_num_ne(2222_u64);
-        buf.put_num_ne(3333_u64);
-        buf.put_num_ne(4444_u64);
-        buf.put_num_ne(5555_u64);
-        buf.put_num_ne(6666_u64);
-        buf.put_num_ne(7777_u64);
-        buf.put_num_ne(8888_u64);
+        buf.put_u64_ne(2222);
+        buf.put_u64_ne(3333);
+        buf.put_u64_ne(4444);
+        buf.put_u64_ne(5555);
+        buf.put_u64_ne(6666);
+        buf.put_u64_ne(7777);
+        buf.put_u64_ne(8888);
         // These will cross a span boundary so we can also observe
         // crossing that boundary during peeking.
         buf.put_byte_repeated(9, 8);
@@ -1629,8 +1629,8 @@ mod tests {
         // This should be the first frozen span of 10 bytes.
         assert_eq!(peeked.first_slice().len(), 10);
 
-        assert_eq!(peeked.get_num_ne::<u64>(), 1111);
-        assert_eq!(peeked.get_num_ne::<u64>(), 2222);
+        assert_eq!(peeked.get_u64_ne(), 1111);
+        assert_eq!(peeked.get_u64_ne(), 2222);
 
         // The length of the buffer does not change just because we peek at its data.
         assert_eq!(buf.len(), 72);
@@ -1638,12 +1638,12 @@ mod tests {
         // We consumed 16 bytes from the peeked view, so should be looking at the remaining 4 bytes in the 2nd span.
         assert_eq!(peeked.first_slice().len(), 4);
 
-        assert_eq!(peeked.get_num_ne::<u64>(), 3333);
-        assert_eq!(peeked.get_num_ne::<u64>(), 4444);
-        assert_eq!(peeked.get_num_ne::<u64>(), 5555);
-        assert_eq!(peeked.get_num_ne::<u64>(), 6666);
-        assert_eq!(peeked.get_num_ne::<u64>(), 7777);
-        assert_eq!(peeked.get_num_ne::<u64>(), 8888);
+        assert_eq!(peeked.get_u64_ne(), 3333);
+        assert_eq!(peeked.get_u64_ne(), 4444);
+        assert_eq!(peeked.get_u64_ne(), 5555);
+        assert_eq!(peeked.get_u64_ne(), 6666);
+        assert_eq!(peeked.get_u64_ne(), 7777);
+        assert_eq!(peeked.get_u64_ne(), 8888);
 
         for _ in 0..8 {
             assert_eq!(peeked.get_byte(), 9);
@@ -1678,19 +1678,19 @@ mod tests {
 
         assert_eq!(buf.capacity(), 100);
 
-        buf.put_num_ne(1111_u64);
+        buf.put_u64_ne(1111);
         // This freezes the first span of 10, as we filled it all up.
-        buf.put_num_ne(2222_u64);
+        buf.put_u64_ne(2222);
 
         let mut first8 = buf.consume(U64_SIZE);
-        assert_eq!(first8.get_num_ne::<u64>(), 1111);
+        assert_eq!(first8.get_u64_ne(), 1111);
         assert!(first8.is_empty());
 
-        buf.put_num_ne(3333_u64);
+        buf.put_u64_ne(3333);
 
         let mut second16 = buf.consume(16);
-        assert_eq!(second16.get_num_ne::<u64>(), 2222);
-        assert_eq!(second16.get_num_ne::<u64>(), 3333);
+        assert_eq!(second16.get_u64_ne(), 2222);
+        assert_eq!(second16.get_u64_ne(), 3333);
         assert!(second16.is_empty());
     }
 
@@ -1756,7 +1756,7 @@ mod tests {
 
         // We write an u64 - this fills half the capacity and should result in
         // the first span builder being frozen and the second remaining in its entirety.
-        buf.put_num_ne(1234_u64);
+        buf.put_u64_ne(1234);
 
         assert_eq!(buf.len(), 8);
         assert_eq!(buf.remaining_capacity(), 8);
@@ -1767,7 +1767,7 @@ mod tests {
 
         // We write a u32 - this fills half the remaining capacity, which results
         // in a half-filled span builder remaining in the buffer.
-        buf.put_num_ne(5678_u32);
+        buf.put_u32_ne(5678);
 
         assert_eq!(buf.len(), 12);
         assert_eq!(buf.remaining_capacity(), 4);
@@ -1777,7 +1777,7 @@ mod tests {
         assert_eq!(available_slices[0].len(), 4);
 
         // We write a final u32 to use up all the capacity.
-        buf.put_num_ne(9012_u32);
+        buf.put_u32_ne(9012);
 
         assert_eq!(buf.len(), 16);
         assert_eq!(buf.remaining_capacity(), 0);
@@ -1853,7 +1853,7 @@ mod tests {
         assert_eq!(buf.capacity(), 8);
 
         let mut result = buf.consume(U64_SIZE);
-        assert_eq!(result.get_num_ne::<u64>(), 0x3333_3333_3333_3333);
+        assert_eq!(result.get_u64_ne(), 0x3333_3333_3333_3333);
     }
 
     #[test]
@@ -1915,10 +1915,10 @@ mod tests {
         assert_eq!(buf.capacity(), 24);
 
         let mut result = buf.consume(THREE_U64_SIZE);
-        assert_eq!(result.get_num_ne::<u64>(), 0x3333_3333_3333_3333);
-        assert_eq!(result.get_num_ne::<u32>(), 0x4444_4444);
-        assert_eq!(result.get_num_ne::<u32>(), 0x5555_5555);
-        assert_eq!(result.get_num_ne::<u64>(), 0x6666_6666_6666_6666);
+        assert_eq!(result.get_u64_ne(), 0x3333_3333_3333_3333);
+        assert_eq!(result.get_u32_ne(), 0x4444_4444);
+        assert_eq!(result.get_u32_ne(), 0x5555_5555);
+        assert_eq!(result.get_u64_ne(), 0x6666_6666_6666_6666);
     }
 
     #[test]
@@ -1979,10 +1979,10 @@ mod tests {
         assert_eq!(buf.capacity(), 24);
 
         let mut result = buf.consume(THREE_U64_SIZE);
-        assert_eq!(result.get_num_ne::<u64>(), 0x3333_3333_3333_3333);
-        assert_eq!(result.get_num_ne::<u32>(), 0x4444_4444);
-        assert_eq!(result.get_num_ne::<u32>(), 0x5555_5555);
-        assert_eq!(result.get_num_ne::<u64>(), 0x6666_6666_6666_6666);
+        assert_eq!(result.get_u64_ne(), 0x3333_3333_3333_3333);
+        assert_eq!(result.get_u32_ne(), 0x4444_4444);
+        assert_eq!(result.get_u32_ne(), 0x5555_5555);
+        assert_eq!(result.get_u64_ne(), 0x6666_6666_6666_6666);
     }
 
     #[test]
@@ -2081,7 +2081,7 @@ mod tests {
             let mut buf = BytesBuf::from_blocks([block1, block2]);
 
             // Freezes first span of 8, retains one span builder.
-            buf.put_num_ne(1234_u64);
+            buf.put_u64_ne(1234);
 
             assert_eq!(buf.frozen_spans.len(), 1);
             assert_eq!(buf.span_builders_reversed.len(), 1);
@@ -2125,7 +2125,7 @@ mod tests {
             let mut buf = BytesBuf::from_blocks([block1, block2]);
 
             // Freezes first span of 8, retains one span builder.
-            buf.put_num_ne(1234_u64);
+            buf.put_u64_ne(1234);
 
             assert_eq!(buf.frozen_spans.len(), 1);
             assert_eq!(buf.span_builders_reversed.len(), 1);
@@ -2169,10 +2169,10 @@ mod tests {
         buf.reserve(100, &memory);
 
         // 32 bytes in 3 spans.
-        buf.put_num_ne(1111_u64);
-        buf.put_num_ne(1111_u64);
-        buf.put_num_ne(1111_u64);
-        buf.put_num_ne(1111_u64);
+        buf.put_u64_ne(1111);
+        buf.put_u64_ne(1111);
+        buf.put_u64_ne(1111);
+        buf.put_u64_ne(1111);
 
         // Freeze it all - a precondition to consuming is to freeze everything first.
         buf.ensure_frozen(32);
@@ -2240,16 +2240,16 @@ mod tests {
         let mut buf = BytesBuf::new();
 
         buf.reserve(20, &memory);
-        buf.put_num_ne(0x1111_1111_1111_1111_u64);
-        buf.put_num_ne(0x2222_2222_2222_2222_u64);
+        buf.put_u64_ne(0x1111_1111_1111_1111);
+        buf.put_u64_ne(0x2222_2222_2222_2222);
         // Both blocks are now frozen (filled completely)
         assert_eq!(buf.len(), 16);
 
         let mut peeked = buf.peek();
 
         assert_eq!(peeked.len(), 16);
-        assert_eq!(peeked.get_num_ne::<u64>(), 0x1111_1111_1111_1111);
-        assert_eq!(peeked.get_num_ne::<u64>(), 0x2222_2222_2222_2222);
+        assert_eq!(peeked.get_u64_ne(), 0x1111_1111_1111_1111);
+        assert_eq!(peeked.get_u64_ne(), 0x2222_2222_2222_2222);
 
         // Original builder still has the data
         assert_eq!(buf.len(), 16);
@@ -2261,16 +2261,16 @@ mod tests {
         let mut buf = BytesBuf::new();
 
         buf.reserve(10, &memory);
-        buf.put_num_ne(0x3333_3333_3333_3333_u64);
-        buf.put_num_ne(0x4444_u16);
+        buf.put_u64_ne(0x3333_3333_3333_3333);
+        buf.put_u16_ne(0x4444);
         // We have 10 bytes filled in a 10-byte block
         assert_eq!(buf.len(), 10);
 
         let mut peeked = buf.peek();
 
         assert_eq!(peeked.len(), 10);
-        assert_eq!(peeked.get_num_ne::<u64>(), 0x3333_3333_3333_3333);
-        assert_eq!(peeked.get_num_ne::<u16>(), 0x4444);
+        assert_eq!(peeked.get_u64_ne(), 0x3333_3333_3333_3333);
+        assert_eq!(peeked.get_u16_ne(), 0x4444);
 
         // Original builder still has the data
         assert_eq!(buf.len(), 10);
@@ -2282,7 +2282,7 @@ mod tests {
         let mut buf = BytesBuf::new();
 
         buf.reserve(20, &memory);
-        buf.put_num_ne(0x5555_5555_5555_5555_u64);
+        buf.put_u64_ne(0x5555_5555_5555_5555);
 
         // We have 8 bytes filled and 12 bytes remaining capacity
         assert_eq!(buf.len(), 8);
@@ -2291,22 +2291,22 @@ mod tests {
         let mut peeked = buf.peek();
 
         assert_eq!(peeked.len(), 8);
-        assert_eq!(peeked.get_num_ne::<u64>(), 0x5555_5555_5555_5555);
+        assert_eq!(peeked.get_u64_ne(), 0x5555_5555_5555_5555);
 
         // CRITICAL TEST: Capacity should be preserved
         assert_eq!(buf.len(), 8);
         assert_eq!(buf.remaining_capacity(), 12);
 
         // We should still be able to write more data
-        buf.put_num_ne(0x6666_6666_u32);
+        buf.put_u32_ne(0x6666_6666);
         assert_eq!(buf.len(), 12);
         assert_eq!(buf.remaining_capacity(), 8);
 
         // And we can peek again to see the updated data
         let mut peeked2 = buf.peek();
         assert_eq!(peeked2.len(), 12);
-        assert_eq!(peeked2.get_num_ne::<u64>(), 0x5555_5555_5555_5555);
-        assert_eq!(peeked2.get_num_ne::<u32>(), 0x6666_6666);
+        assert_eq!(peeked2.get_u64_ne(), 0x5555_5555_5555_5555);
+        assert_eq!(peeked2.get_u32_ne(), 0x6666_6666);
     }
 
     #[test]
@@ -2317,15 +2317,15 @@ mod tests {
         buf.reserve(30, &memory);
 
         // Fill first block completely (10 bytes) - will be frozen
-        buf.put_num_ne(0x1111_1111_1111_1111_u64);
-        buf.put_num_ne(0x2222_u16);
+        buf.put_u64_ne(0x1111_1111_1111_1111);
+        buf.put_u16_ne(0x2222);
 
         // Fill second block completely (10 bytes) - will be frozen
-        buf.put_num_ne(0x3333_3333_3333_3333_u64);
-        buf.put_num_ne(0x4444_u16);
+        buf.put_u64_ne(0x3333_3333_3333_3333);
+        buf.put_u16_ne(0x4444);
 
         // Partially fill third block (only 4 bytes) - will remain unfrozen
-        buf.put_num_ne(0x5555_5555_u32);
+        buf.put_u32_ne(0x5555_5555);
 
         assert_eq!(buf.len(), 24);
         assert_eq!(buf.remaining_capacity(), 6);
@@ -2333,11 +2333,11 @@ mod tests {
         let mut peeked = buf.peek();
 
         assert_eq!(peeked.len(), 24);
-        assert_eq!(peeked.get_num_ne::<u64>(), 0x1111_1111_1111_1111);
-        assert_eq!(peeked.get_num_ne::<u16>(), 0x2222);
-        assert_eq!(peeked.get_num_ne::<u64>(), 0x3333_3333_3333_3333);
-        assert_eq!(peeked.get_num_ne::<u16>(), 0x4444);
-        assert_eq!(peeked.get_num_ne::<u32>(), 0x5555_5555);
+        assert_eq!(peeked.get_u64_ne(), 0x1111_1111_1111_1111);
+        assert_eq!(peeked.get_u16_ne(), 0x2222);
+        assert_eq!(peeked.get_u64_ne(), 0x3333_3333_3333_3333);
+        assert_eq!(peeked.get_u16_ne(), 0x4444);
+        assert_eq!(peeked.get_u32_ne(), 0x5555_5555);
         // Original builder still has all the data and capacity
         assert_eq!(buf.len(), 24);
         assert_eq!(buf.remaining_capacity(), 6);
@@ -2349,21 +2349,21 @@ mod tests {
         let mut buf = BytesBuf::new();
 
         buf.reserve(20, &memory);
-        buf.put_num_ne(0x7777_7777_7777_7777_u64);
-        buf.put_num_ne(0x8888_8888_u32);
+        buf.put_u64_ne(0x7777_7777_7777_7777);
+        buf.put_u32_ne(0x8888_8888);
         assert_eq!(buf.len(), 12);
 
         // Peek at the data
         let mut peeked = buf.peek();
         assert_eq!(peeked.len(), 12);
-        assert_eq!(peeked.get_num_ne::<u64>(), 0x7777_7777_7777_7777);
+        assert_eq!(peeked.get_u64_ne(), 0x7777_7777_7777_7777);
 
         // Original builder still has the data
         assert_eq!(buf.len(), 12);
 
         // Now consume some of it
         let mut consumed = buf.consume(8);
-        assert_eq!(consumed.get_num_ne::<u64>(), 0x7777_7777_7777_7777);
+        assert_eq!(consumed.get_u64_ne(), 0x7777_7777_7777_7777);
 
         // Builder should have less data now
         assert_eq!(buf.len(), 4);
@@ -2371,7 +2371,7 @@ mod tests {
         // Peek again should show the remaining data
         let mut peeked2 = buf.peek();
         assert_eq!(peeked2.len(), 4);
-        assert_eq!(peeked2.get_num_ne::<u32>(), 0x8888_8888);
+        assert_eq!(peeked2.get_u32_ne(), 0x8888_8888);
     }
 
     #[test]
@@ -2380,14 +2380,14 @@ mod tests {
         let mut buf = BytesBuf::new();
 
         buf.reserve(20, &memory);
-        buf.put_num_ne(0xAAAA_AAAA_AAAA_AAAA_u64);
+        buf.put_u64_ne(0xAAAA_AAAA_AAAA_AAAA);
 
         // Peek multiple times - each should work independently
         let mut peeked1 = buf.peek();
         let mut peeked2 = buf.peek();
 
-        assert_eq!(peeked1.get_num_ne::<u64>(), 0xAAAA_AAAA_AAAA_AAAA);
-        assert_eq!(peeked2.get_num_ne::<u64>(), 0xAAAA_AAAA_AAAA_AAAA);
+        assert_eq!(peeked1.get_u64_ne(), 0xAAAA_AAAA_AAAA_AAAA);
+        assert_eq!(peeked2.get_u64_ne(), 0xAAAA_AAAA_AAAA_AAAA);
 
         // Original builder still intact
         assert_eq!(buf.len(), 8);
@@ -2442,7 +2442,7 @@ mod tests {
         let memory = FixedBlockMemory::new(nz!(100));
         let mut buf = memory.reserve(100);
 
-        buf.put_num_ne(1234_u64);
+        buf.put_u64_ne(1234);
 
         let remaining_before_split = buf.remaining_capacity();
 
@@ -2462,23 +2462,23 @@ mod tests {
         let memory = FixedBlockMemory::new(nz!(100));
         let mut buf = memory.reserve(100);
 
-        buf.put_num_ne(1111_u64);
+        buf.put_u64_ne(1111);
 
         let mut split = buf.split_off_remaining(40);
 
         // Write into the split-off buffer.
-        split.put_num_ne(2222_u64);
-        split.put_num_ne(3333_u64);
+        split.put_u64_ne(2222);
+        split.put_u64_ne(3333);
 
         assert_eq!(split.len(), TWO_U64_SIZE);
 
         let mut split_view = split.consume_all();
-        assert_eq!(split_view.get_num_ne::<u64>(), 2222);
-        assert_eq!(split_view.get_num_ne::<u64>(), 3333);
+        assert_eq!(split_view.get_u64_ne(), 2222);
+        assert_eq!(split_view.get_u64_ne(), 3333);
 
         // Original buffer data is unaffected.
         let mut original_view = buf.consume_all();
-        assert_eq!(original_view.get_num_ne::<u64>(), 1111);
+        assert_eq!(original_view.get_u64_ne(), 1111);
     }
 
     #[test]
@@ -2513,7 +2513,7 @@ mod tests {
         // Reserve enough to trigger multiple blocks.
         let mut buf = memory.reserve(30);
 
-        buf.put_num_ne(1234_u64);
+        buf.put_u64_ne(1234);
 
         let original_remaining = buf.remaining_capacity();
 
@@ -2529,7 +2529,7 @@ mod tests {
 
         // Original data is unaffected.
         let mut original_view = buf.consume(U64_SIZE);
-        assert_eq!(original_view.get_num_ne::<u64>(), 1234);
+        assert_eq!(original_view.get_u64_ne(), 1234);
     }
 
     #[test]

--- a/crates/bytesbuf/src/buf_put.rs
+++ b/crates/bytesbuf/src/buf_put.rs
@@ -6,9 +6,45 @@
 use std::borrow::Borrow;
 use std::ptr;
 
-use num_traits::ToBytes;
-
 use crate::{BytesBuf, BytesView};
+
+/// Generates the little-, big-, and native-endian write accessors for a primitive numeric type.
+///
+/// Each generated method serializes the value with the primitive's inherent `to_*_bytes` method
+/// and appends the resulting bytes via [`BytesBuf::put_slice`].
+macro_rules! put_num_accessors {
+    ($t:ty, $le:ident, $be:ident, $ne:ident) => {
+        #[doc = concat!("Appends a `", stringify!($t), "` to the buffer in little-endian byte order.")]
+        ///
+        /// # Panics
+        ///
+        /// Panics if there is insufficient remaining capacity in the buffer.
+        #[inline]
+        pub fn $le(&mut self, value: $t) {
+            self.put_slice(value.to_le_bytes());
+        }
+
+        #[doc = concat!("Appends a `", stringify!($t), "` to the buffer in big-endian byte order.")]
+        ///
+        /// # Panics
+        ///
+        /// Panics if there is insufficient remaining capacity in the buffer.
+        #[inline]
+        pub fn $be(&mut self, value: $t) {
+            self.put_slice(value.to_be_bytes());
+        }
+
+        #[doc = concat!("Appends a `", stringify!($t), "` to the buffer in native-endian byte order.")]
+        ///
+        /// # Panics
+        ///
+        /// Panics if there is insufficient remaining capacity in the buffer.
+        #[inline]
+        pub fn $ne(&mut self, value: $t) {
+            self.put_slice(value.to_ne_bytes());
+        }
+    };
+}
 
 impl BytesBuf {
     /// Appends a slice of bytes to the buffer.
@@ -129,7 +165,7 @@ impl BytesBuf {
     ///
     /// Panics if there is insufficient remaining capacity in the buffer.
     pub fn put_byte(&mut self, value: u8) {
-        self.put_num_ne(value);
+        self.put_slice([value]);
     }
 
     /// Appends multiple repetitions of a `u8` to the buffer.
@@ -186,87 +222,16 @@ impl BytesBuf {
         debug_assert!(self.len() >= count);
     }
 
-    /// Appends a number of type `T` in little-endian representation to the buffer.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # let memory = bytesbuf::mem::GlobalPool::new();
-    /// use bytesbuf::mem::Memory;
-    ///
-    /// let mut buf = memory.reserve(16);
-    ///
-    /// buf.put_num_le(0x1234_u16);
-    /// buf.put_num_le(0xDEAD_BEEF_u32);
-    ///
-    /// let data = buf.consume_all();
-    /// // Little-endian: least significant byte first.
-    /// assert_eq!(data.first_slice(), &[0x34, 0x12, 0xEF, 0xBE, 0xAD, 0xDE]);
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if there is insufficient remaining capacity in the buffer.
-    #[expect(clippy::needless_pass_by_value, reason = "tiny numeric types, fine to always pass by value")]
-    pub fn put_num_le<T: ToBytes>(&mut self, value: T) {
-        let bytes = value.to_le_bytes();
-        self.put_slice(bytes.borrow());
-    }
-
-    /// Appends a number of type `T` in big-endian representation to the buffer.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # let memory = bytesbuf::mem::GlobalPool::new();
-    /// use bytesbuf::mem::Memory;
-    ///
-    /// let mut buf = memory.reserve(16);
-    ///
-    /// buf.put_num_be(0xCAFE_u16);
-    /// buf.put_num_be(0xBABE_u16);
-    ///
-    /// let data = buf.consume_all();
-    /// // Big-endian: most significant byte first.
-    /// assert_eq!(data, &[0xCA, 0xFE, 0xBA, 0xBE]);
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if there is insufficient remaining capacity in the buffer.
-    #[expect(clippy::needless_pass_by_value, reason = "tiny numeric types, fine to always pass by value")]
-    pub fn put_num_be<T: ToBytes>(&mut self, value: T) {
-        let bytes = value.to_be_bytes();
-        self.put_slice(bytes.borrow());
-    }
-
-    /// Appends a number of type `T` in native-endian representation to the buffer.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # let memory = bytesbuf::mem::GlobalPool::new();
-    /// use bytesbuf::mem::Memory;
-    ///
-    /// let mut buf = memory.reserve(16);
-    ///
-    /// buf.put_num_ne(0xABCD_u16);
-    /// buf.put_num_ne(0x1234_5678_9ABC_DEF0_u64);
-    ///
-    /// let mut view = buf.consume_all();
-    /// // Reading back in native-endian gives the original values.
-    /// assert_eq!(view.get_num_ne::<u16>(), 0xABCD);
-    /// assert_eq!(view.get_num_ne::<u64>(), 0x1234_5678_9ABC_DEF0);
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if there is insufficient remaining capacity in the buffer.
-    #[expect(clippy::needless_pass_by_value, reason = "tiny numeric types, fine to always pass by value")]
-    pub fn put_num_ne<T: ToBytes>(&mut self, value: T) {
-        let bytes = value.to_ne_bytes();
-        self.put_slice(bytes.borrow());
-    }
+    put_num_accessors!(u16, put_u16_le, put_u16_be, put_u16_ne);
+    put_num_accessors!(i16, put_i16_le, put_i16_be, put_i16_ne);
+    put_num_accessors!(u32, put_u32_le, put_u32_be, put_u32_ne);
+    put_num_accessors!(i32, put_i32_le, put_i32_be, put_i32_ne);
+    put_num_accessors!(u64, put_u64_le, put_u64_be, put_u64_ne);
+    put_num_accessors!(i64, put_i64_le, put_i64_be, put_i64_ne);
+    put_num_accessors!(u128, put_u128_le, put_u128_be, put_u128_ne);
+    put_num_accessors!(i128, put_i128_le, put_i128_be, put_i128_ne);
+    put_num_accessors!(f32, put_f32_le, put_f32_be, put_f32_ne);
+    put_num_accessors!(f64, put_f64_le, put_f64_be, put_f64_ne);
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -472,9 +437,9 @@ mod tests {
         let memory = TransparentMemory::new();
         let mut buf = memory.reserve(16);
 
-        buf.put_num_le(0x1234_5678_u32);
-        buf.put_num_be(0x9ABC_DEF0_u32);
-        buf.put_num_ne(0x1122_3344_5566_7788_u64);
+        buf.put_u32_le(0x1234_5678);
+        buf.put_u32_be(0x9ABC_DEF0);
+        buf.put_u64_ne(0x1122_3344_5566_7788);
 
         assert_eq!(buf.len(), 16);
         assert_eq!(buf.remaining_capacity(), 0);
@@ -502,5 +467,28 @@ mod tests {
                 ]
             );
         }
+    }
+
+    #[test]
+    fn put_num_signed_and_float_round_trip() {
+        let memory = TransparentMemory::new();
+        let mut buf = memory.reserve(64);
+
+        buf.put_i16_le(-12345);
+        buf.put_i32_be(-2_000_000_000);
+        buf.put_i64_le(-9_000_000_000_000);
+        buf.put_i128_be(i128::MIN);
+        buf.put_f32_le(std::f32::consts::PI);
+        buf.put_f64_be(std::f64::consts::E);
+
+        let mut view = buf.consume_all();
+
+        assert_eq!(view.get_i16_le(), -12345);
+        assert_eq!(view.get_i32_be(), -2_000_000_000);
+        assert_eq!(view.get_i64_le(), -9_000_000_000_000);
+        assert_eq!(view.get_i128_be(), i128::MIN);
+        assert_eq!(view.get_f32_le().to_bits(), std::f32::consts::PI.to_bits());
+        assert_eq!(view.get_f64_be().to_bits(), std::f64::consts::E.to_bits());
+        assert!(view.is_empty());
     }
 }

--- a/crates/bytesbuf/src/lib.rs
+++ b/crates/bytesbuf/src/lib.rs
@@ -29,7 +29,9 @@
 //!
 //! There are many helper methods on this type for easily consuming bytes from the view:
 //!
-//! * [`get_num_le::<T>()`] reads numbers. Big-endian/native-endian variants also exist.
+//! * [`get_u64_le()`] and the sibling `get_<type>_<endianness>()` methods read numbers of a
+//!   specific primitive type (`u16`/`i16` through `u128`/`i128`, plus `f32`/`f64`) in little-,
+//!   big-, or native-endian byte order.
 //! * [`get_byte()`] reads a single byte.
 //! * [`copy_to_slice()`] copies bytes into a provided slice.
 //! * [`copy_to_uninit_slice()`] copies bytes into a provided uninitialized slice.
@@ -46,7 +48,7 @@
 //!     let mut sum: u64 = 0;
 //!
 //!     while !message.is_empty() {
-//!         let word = message.get_num_le::<u64>();
+//!         let word = message.get_u64_le();
 //!         sum = sum.saturating_add(word);
 //!     }
 //!
@@ -100,7 +102,7 @@
 //! assert_eq!(bytes_clone.len(), 16);
 //!
 //! // Consume 8 bytes from the front.
-//! _ = bytes_clone.get_num_le::<u64>();
+//! _ = bytes_clone.get_u64_le();
 //! assert_eq!(bytes_clone.len(), 8);
 //!
 //! // Operations on the clone have no effect on the original view.
@@ -147,7 +149,9 @@
 //!
 //! There are many helper methods on [`BytesBuf`] for easily appending bytes to the buffer:
 //!
-//! * [`put_num_le::<T>()`] appends numbers. Big-endian/native-endian variants also exist.
+//! * [`put_u64_le()`] and the sibling `put_<type>_<endianness>()` methods append numbers of a
+//!   specific primitive type (`u16`/`i16` through `u128`/`i128`, plus `f32`/`f64`) in little-,
+//!   big-, or native-endian byte order.
 //! * [`put_slice()`] appends a slice of bytes.
 //! * [`put_byte()`] appends a single byte.
 //! * [`put_byte_repeated()`] appends multiple repetitions of a byte.
@@ -163,8 +167,8 @@
 //!
 //! let mut buf = memory.reserve(100);
 //!
-//! buf.put_num_be(1234_u64);
-//! buf.put_num_be(5678_u64);
+//! buf.put_u64_be(1234);
+//! buf.put_u64_be(5678);
 //! buf.put_slice(*b"Hello, world!");
 //! ```
 //!
@@ -218,8 +222,8 @@
 //!
 //! let mut buf = memory.reserve(100);
 //!
-//! buf.put_num_be(1234_u64);
-//! buf.put_num_be(5678_u64);
+//! buf.put_u64_be(1234);
+//! buf.put_u64_be(5678);
 //! buf.put_slice(*b"Hello, world!");
 //!
 //! let message = buf.consume_all();
@@ -238,8 +242,8 @@
 //!
 //! let mut buf = memory.reserve(100);
 //!
-//! buf.put_num_be(1234_u64);
-//! buf.put_num_be(5678_u64);
+//! buf.put_u64_be(1234);
+//! buf.put_u64_be(5678);
 //!
 //! let first_8_bytes = buf.consume(8);
 //! let second_8_bytes = buf.consume(8);
@@ -262,7 +266,7 @@
 //! let memory = connection.memory();
 //!
 //! let mut header_builder = memory.reserve(16);
-//! header_builder.put_num_be(1234_u64);
+//! header_builder.put_u64_be(1234);
 //! let header = header_builder.consume_all();
 //!
 //! let mut buf = memory.reserve(128);
@@ -529,13 +533,13 @@
 //!
 //! See the `mem::testing` module for details (requires `test-util` Cargo feature).
 //!
-//! [`get_num_le::<T>()`]: crate::BytesView::get_num_le
+//! [`get_u64_le()`]: crate::BytesView::get_u64_le
 //! [`get_byte()`]: crate::BytesView::get_byte
 //! [`copy_to_slice()`]: crate::BytesView::copy_to_slice
 //! [`copy_to_uninit_slice()`]: crate::BytesView::copy_to_uninit_slice
 //! [`first_slice()`]: crate::BytesView::first_slice
 //! [ViewAdvance]: crate::BytesView::advance
-//! [`put_num_le::<T>()`]: crate::BytesBuf::put_num_le
+//! [`put_u64_le()`]: crate::BytesBuf::put_u64_le
 //! [`put_slice()`]: crate::BytesBuf::put_slice
 //! [`put_byte()`]: crate::BytesBuf::put_byte
 //! [`put_byte_repeated()`]: crate::BytesBuf::put_byte_repeated

--- a/crates/bytesbuf/src/view.rs
+++ b/crates/bytesbuf/src/view.rs
@@ -213,7 +213,7 @@ impl BytesView {
     /// _ = view.get_byte();
     /// assert_eq!(view.len(), 4);
     ///
-    /// _ = view.get_num_le::<u16>();
+    /// _ = view.get_u16_le();
     /// assert_eq!(view.len(), 2);
     /// ```
     #[cfg_attr(test, mutants::skip)] // Mutating this can cause infinite loops.
@@ -1052,14 +1052,14 @@ mod tests {
         assert_eq!(4, slice.len());
 
         // We read 8 bytes here, so should land straight inside span3.
-        assert_eq!(view.get_num_ne::<u64>(), 1234);
+        assert_eq!(view.get_u64_ne(), 1234);
 
         assert_eq!(2, view.len());
 
         let slice = view.first_slice();
         assert_eq!(2, slice.len());
 
-        assert_eq!(view.get_num_ne::<u16>(), 16);
+        assert_eq!(view.get_u16_ne(), 16);
 
         assert_eq!(0, view.len());
         assert!(view.is_empty());
@@ -1080,8 +1080,8 @@ mod tests {
 
         assert_eq!(10, view.len());
 
-        assert_eq!(view.get_num_ne::<u64>(), 1234);
-        assert_panic!(_ = view.get_num_ne::<u32>()); // Reads 4 but only has 2 remaining.
+        assert_eq!(view.get_u64_ne(), 1234);
+        assert_panic!(_ = view.get_u32_ne()); // Reads 4 but only has 2 remaining.
     }
 
     #[test]
@@ -1145,8 +1145,8 @@ mod tests {
 
         assert_eq!(16, combined_view.len());
 
-        assert_eq!(combined_view.get_num_ne::<u64>(), 1234);
-        assert_eq!(combined_view.get_num_ne::<u64>(), 5678);
+        assert_eq!(combined_view.get_u64_ne(), 1234);
+        assert_eq!(combined_view.get_u64_ne(), 5678);
     }
 
     #[test]

--- a/crates/bytesbuf/src/view_get.rs
+++ b/crates/bytesbuf/src/view_get.rs
@@ -6,9 +6,54 @@
 use std::mem::MaybeUninit;
 use std::ptr;
 
-use num_traits::FromBytes;
-
 use crate::BytesView;
+
+/// Generates the little-, big-, and native-endian read accessors for a primitive numeric type.
+///
+/// The generated methods delegate to [`BytesView::get_array`] for the shared span traversal and
+/// only select the byte order via the primitive's inherent `from_*_bytes` associated function.
+macro_rules! get_num_accessors {
+    ($t:ty, $le:ident, $be:ident, $ne:ident) => {
+        #[doc = concat!("Consumes a `", stringify!($t), "` from the view in little-endian byte order.")]
+        ///
+        /// The bytes are dropped from the view, moving any remaining bytes to the front.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the view does not cover enough bytes of data.
+        #[inline]
+        #[must_use]
+        pub fn $le(&mut self) -> $t {
+            <$t>::from_le_bytes(self.get_array())
+        }
+
+        #[doc = concat!("Consumes a `", stringify!($t), "` from the view in big-endian byte order.")]
+        ///
+        /// The bytes are dropped from the view, moving any remaining bytes to the front.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the view does not cover enough bytes of data.
+        #[inline]
+        #[must_use]
+        pub fn $be(&mut self) -> $t {
+            <$t>::from_be_bytes(self.get_array())
+        }
+
+        #[doc = concat!("Consumes a `", stringify!($t), "` from the view in native-endian byte order.")]
+        ///
+        /// The bytes are dropped from the view, moving any remaining bytes to the front.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the view does not cover enough bytes of data.
+        #[inline]
+        #[must_use]
+        pub fn $ne(&mut self) -> $t {
+            <$t>::from_ne_bytes(self.get_array())
+        }
+    };
+}
 
 impl BytesView {
     /// Consumes a `u8` from the byte sequence.
@@ -150,318 +195,92 @@ impl BytesView {
         }
     }
 
-    /// Reads a `T` directly from the first span when that span fully contains it, consuming the
-    /// bytes in a single span lookup. Returns `None` when the value straddles a span boundary, in
-    /// which case the caller must fall back to buffered assembly.
+    /// Consumes exactly `N` bytes from the front of the view and returns them as an array.
     ///
-    /// The caller must have already verified that the view covers at least `size_of::<T::Bytes>()`
-    /// bytes.
+    /// The numeric accessors delegate here; `N` is the byte width of the primitive, and the caller
+    /// decodes the array with the primitive's `from_{le,be,ne}_bytes` associated function.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the view does not cover at least `N` bytes.
     #[inline]
-    // This is a behavior-preserving fast path: returning `None` (or declining the value that exactly
-    // fills the first span) routes the caller to `get_num_*_buffered`, which produces an identical
-    // result. Mutations that disable the fast path or shift its span-boundary check are therefore
-    // functionally equivalent and cannot be observed by behavioral tests.
-    #[cfg_attr(test, mutants::skip)]
-    fn get_num_in_first_span<T, F>(&mut self, convert: F) -> Option<T>
-    where
-        T: FromBytes,
-        T::Bytes: Sized,
-        F: FnOnce(&T::Bytes) -> T,
-    {
-        let size = size_of::<T::Bytes>();
+    fn get_array<const N: usize>(&mut self) -> [u8; N] {
+        assert!(self.len() >= N);
 
+        if let Some(array) = self.get_array_from_first_span::<N>() {
+            return array;
+        }
+
+        // The bytes straddle a span boundary, so we gather them into a buffer instead.
+        self.get_array_buffered::<N>()
+    }
+
+    /// Reads `N` bytes directly from the first span when that span fully contains them. Returns
+    /// `None` when the bytes straddle a span boundary, in which case the caller must fall back to
+    /// buffered assembly.
+    ///
+    /// The caller must have already verified that the view covers at least `N` bytes.
+    #[inline]
+    // The span-fit decision is an optimization: when it declines (returns `None`), the caller falls
+    // back to `get_array_buffered`, which yields an identical result. Mutation testing cannot
+    // distinguish a fast path that declines more eagerly from one that never declines, so we skip
+    // this function to avoid reporting those equivalent mutants. The read itself (the byte copy and
+    // span consumption) is instead exercised by the single-span behavioral tests below, and the
+    // `get_array` / `get_array_buffered` wrappers remain mutation-tested.
+    #[cfg_attr(test, mutants::skip)]
+    fn get_array_from_first_span<const N: usize>(&mut self) -> Option<[u8; N]> {
         let front = self.spans_reversed.last_mut()?;
         let front_len = front.len() as usize;
 
-        if size > front_len {
+        if N > front_len {
             return None;
         }
 
-        // SAFETY: the first span holds at least `size_of::<T::Bytes>()` bytes, so reading a
-        // `T::Bytes` from its start stays in bounds. We use an unaligned read because the span is
-        // backed by a byte buffer with no alignment guarantee, while `T::Bytes` may demand a larger
-        // alignment; the read materializes a properly aligned local that we then borrow.
-        let bytes_array = unsafe { ptr::read_unaligned(front.as_ptr().cast::<T::Bytes>()) };
-        let result = convert(&bytes_array);
+        // A byte-wise copy tolerates the span's lack of alignment, and reading into a `[u8; N]`
+        // can never construct an invalid value regardless of the source bytes. The zero-init is
+        // optimized away: `copy_from_slice` fully overwrites the array, so the compiler elides it
+        // (verified via Callgrind - identical to a `MaybeUninit` variant, which we avoid to keep
+        // this path free of `unsafe`).
+        let mut array = [0_u8; N];
+        array.copy_from_slice(&front[..N]);
 
-        if front_len == size {
+        if front_len == N {
             self.spans_reversed.pop();
         } else {
-            // SAFETY: `size < front_len`, so advancing the span by `size` stays in bounds.
+            // SAFETY: `N < front_len`, so advancing the span by `N` stays in bounds.
             unsafe {
-                front.advance(size);
+                front.advance(N);
             }
         }
 
-        // The caller verified the view covers at least `size` bytes, which we just removed.
-        self.shrink_len(size);
+        // The caller verified the view covers at least `N` bytes, which we just removed.
+        self.shrink_len(N);
 
-        Some(result)
+        Some(array)
     }
 
-    /// Consumes a number of type `T` in little-endian representation.
+    /// Assembles `N` bytes gathered across one or more span boundaries.
     ///
-    /// The bytes of the `T` are dropped from the view, moving any remaining bytes to the front.
-    ///
-    /// If permitted by memory layout considerations and reference counts, the memory capacity
-    /// backing the dropped bytes is released back to the memory provider.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # let memory = bytesbuf::mem::GlobalPool::new();
-    /// use bytesbuf::BytesView;
-    ///
-    /// // Little-endian: least significant byte first.
-    /// let data: &[u8] = &[
-    ///     0x34, 0x12, // u16: 0x1234
-    ///     0x78, 0x56, 0x34, 0x12, // u32: 0x12345678
-    /// ];
-    /// let mut view = BytesView::copied_from_slice(data, &memory);
-    ///
-    /// assert_eq!(view.get_num_le::<u16>(), 0x1234);
-    /// assert_eq!(view.get_num_le::<u32>(), 0x12345678);
-    /// assert!(view.is_empty());
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the view does not cover enough bytes of data.
-    #[inline]
-    #[must_use]
-    pub fn get_num_le<T: FromBytes>(&mut self) -> T
-    where
-        T::Bytes: Sized,
-    {
-        let size = size_of::<T::Bytes>();
-        assert!(self.len() >= size);
-
-        if let Some(result) = self.get_num_in_first_span::<T, _>(T::from_le_bytes) {
-            return result;
-        }
-
-        // The value straddles a span boundary, so we collect bytes into an intermediate buffer
-        // and deserialize from there.
-        // SAFETY: We guarantee the view covers enough bytes - we checked it above.
-        unsafe { self.get_num_le_buffered() }
-    }
-
-    /// # Safety
-    ///
-    /// The caller is responsible for ensuring that the view covers enough bytes.
-    /// We do not duplicate length checking as this method is only assumed to be
-    /// called as a fallback when non-buffered reading proved impossible.
+    /// Only reached as a fallback when the bytes are not contiguous in the first span. The caller
+    /// must have already verified that the view covers at least `N` bytes.
     #[cold] // Most reads will not straddle a slice boundary and not require buffering.
-    unsafe fn get_num_le_buffered<T: FromBytes>(&mut self) -> T
-    where
-        T::Bytes: Sized,
-    {
-        let mut buffer: MaybeUninit<T::Bytes> = MaybeUninit::uninit();
-        let mut buffer_cursor = buffer.as_mut_ptr().cast::<u8>();
-
-        let mut bytes_remaining = size_of::<T::Bytes>();
-
-        while bytes_remaining > 0 {
-            let first_slice = self.first_slice();
-            let bytes_to_copy = bytes_remaining.min(first_slice.len());
-
-            // SAFETY: The caller has guaranteed that the view covers enough bytes.
-            // We only copy up to bytes_remaining, which is at most size_of::<T::Bytes>(),
-            // so we will not overflow the buffer.
-            // Both sides are byte arrays/slices so there are no alignment concerns.
-            unsafe {
-                ptr::copy_nonoverlapping(first_slice.as_ptr(), buffer_cursor, bytes_to_copy);
-            }
-
-            // This cannot overflow because we it is guarded by min() above.
-            bytes_remaining = bytes_remaining.wrapping_sub(bytes_to_copy);
-
-            // SAFETY: We are advancing the cursor in-bounds of the buffer.
-            buffer_cursor = unsafe { buffer_cursor.add(bytes_to_copy) };
-
-            self.advance(bytes_to_copy);
-        }
-
-        // SAFETY: We have filled the buffer with data, initializing it fully.
-        T::from_le_bytes(&unsafe { buffer.assume_init() })
+    #[inline(never)] // Keep the buffered loop out of the hot path's stack frame (avoids extra register spills).
+    fn get_array_buffered<const N: usize>(&mut self) -> [u8; N] {
+        let mut array = [0_u8; N];
+        self.copy_to_slice(&mut array);
+        array
     }
 
-    /// Consumes a number of type `T` in big-endian representation.
-    ///
-    /// The bytes of the `T` are dropped from the view, moving any remaining bytes to the front.
-    ///
-    /// If permitted by memory layout considerations and reference counts, the memory capacity
-    /// backing the dropped bytes is released back to the memory provider.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # let memory = bytesbuf::mem::GlobalPool::new();
-    /// use bytesbuf::BytesView;
-    ///
-    /// // Big-endian: most significant byte first.
-    /// let data: &[u8] = &[
-    ///     0x12, 0x34, 0x56, 0x78, // u32: 0x12345678
-    ///     0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, // u64: 0x0123456789ABCDEF
-    /// ];
-    /// let mut view = BytesView::copied_from_slice(data, &memory);
-    ///
-    /// assert_eq!(view.get_num_be::<u32>(), 0x12345678);
-    /// assert_eq!(view.get_num_be::<u64>(), 0x0123456789ABCDEF);
-    /// assert!(view.is_empty());
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the view does not cover enough bytes of data.
-    #[inline]
-    #[must_use]
-    pub fn get_num_be<T: FromBytes>(&mut self) -> T
-    where
-        T::Bytes: Sized,
-    {
-        let size = size_of::<T::Bytes>();
-        assert!(self.len() >= size);
-
-        if let Some(result) = self.get_num_in_first_span::<T, _>(T::from_be_bytes) {
-            return result;
-        }
-
-        // The value straddles a span boundary, so we collect bytes into an intermediate buffer
-        // and deserialize from there.
-        // SAFETY: We guarantee the view covers enough bytes - we checked it above.
-        unsafe { self.get_num_be_buffered() }
-    }
-
-    /// # Safety
-    ///
-    /// The caller is responsible for ensuring that the view covers enough bytes.
-    /// We do not duplicate length checking as this method is only assumed to be
-    /// called as a fallback when non-buffered reading proved impossible.
-    #[cold] // Most reads will not straddle a slice boundary and not require buffering.
-    unsafe fn get_num_be_buffered<T: FromBytes>(&mut self) -> T
-    where
-        T::Bytes: Sized,
-    {
-        let mut buffer: MaybeUninit<T::Bytes> = MaybeUninit::uninit();
-        let mut buffer_cursor = buffer.as_mut_ptr().cast::<u8>();
-
-        let mut bytes_remaining = size_of::<T::Bytes>();
-
-        while bytes_remaining > 0 {
-            let first_slice = self.first_slice();
-            let bytes_to_copy = bytes_remaining.min(first_slice.len());
-
-            // SAFETY: The caller has guaranteed that the view covers enough bytes.
-            // We only copy up to bytes_remaining, which is at most size_of::<T::Bytes>(),
-            // so we will not overflow the buffer.
-            // Both sides are byte arrays/slices so there are no alignment concerns.
-            unsafe {
-                ptr::copy_nonoverlapping(first_slice.as_ptr(), buffer_cursor, bytes_to_copy);
-            }
-
-            // This cannot overflow because we it is guarded by min() above.
-            bytes_remaining = bytes_remaining.wrapping_sub(bytes_to_copy);
-
-            // SAFETY: We are advancing the cursor in-bounds of the buffer.
-            buffer_cursor = unsafe { buffer_cursor.add(bytes_to_copy) };
-
-            self.advance(bytes_to_copy);
-        }
-
-        // SAFETY: We have filled the buffer with data, initializing it fully.
-        T::from_be_bytes(&unsafe { buffer.assume_init() })
-    }
-
-    /// Consumes a number of type `T` in native-endian representation.
-    ///
-    /// The bytes of the `T` are dropped from the view, moving any remaining bytes to the front.
-    ///
-    /// If permitted by memory layout considerations and reference counts, the memory capacity
-    /// backing the dropped bytes is released back to the memory provider.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # let memory = bytesbuf::mem::GlobalPool::new();
-    /// use bytesbuf::BytesView;
-    ///
-    /// // Native-endian: byte order matches the platform.
-    /// let value1: u16 = 0x1234;
-    /// let value2: u64 = 0x0123456789ABCDEF;
-    ///
-    /// let mut data = Vec::new();
-    /// data.extend_from_slice(&value1.to_ne_bytes());
-    /// data.extend_from_slice(&value2.to_ne_bytes());
-    ///
-    /// let mut view = BytesView::copied_from_slice(&data, &memory);
-    ///
-    /// assert_eq!(view.get_num_ne::<u16>(), 0x1234);
-    /// assert_eq!(view.get_num_ne::<u64>(), 0x0123456789ABCDEF);
-    /// assert!(view.is_empty());
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the view does not cover enough bytes of data.
-    #[inline]
-    #[must_use]
-    pub fn get_num_ne<T: FromBytes>(&mut self) -> T
-    where
-        T::Bytes: Sized,
-    {
-        let size = size_of::<T::Bytes>();
-        assert!(self.len() >= size);
-
-        if let Some(result) = self.get_num_in_first_span::<T, _>(T::from_ne_bytes) {
-            return result;
-        }
-
-        // The value straddles a span boundary, so we collect bytes into an intermediate buffer
-        // and deserialize from there.
-        // SAFETY: We guarantee the view covers enough bytes - we checked it above.
-        unsafe { self.get_num_ne_buffered() }
-    }
-
-    /// # Safety
-    ///
-    /// The caller is responsible for ensuring that the view covers enough bytes.
-    /// We do not duplicate length checking as this method is only assumed to be
-    /// called as a fallback when non-buffered reading proved impossible.
-    #[cold] // Most reads will not straddle a slice boundary and not require buffering.
-    unsafe fn get_num_ne_buffered<T: FromBytes>(&mut self) -> T
-    where
-        T::Bytes: Sized,
-    {
-        let mut buffer: MaybeUninit<T::Bytes> = MaybeUninit::uninit();
-        let mut buffer_cursor = buffer.as_mut_ptr().cast::<u8>();
-
-        let mut bytes_remaining = size_of::<T::Bytes>();
-
-        while bytes_remaining > 0 {
-            let first_slice = self.first_slice();
-            let bytes_to_copy = bytes_remaining.min(first_slice.len());
-
-            // SAFETY: The caller has guaranteed that the view covers enough bytes.
-            // We only copy up to bytes_remaining, which is at most size_of::<T::Bytes>(),
-            // so we will not overflow the buffer.
-            // Both sides are byte arrays/slices so there are no alignment concerns.
-            unsafe {
-                ptr::copy_nonoverlapping(first_slice.as_ptr(), buffer_cursor, bytes_to_copy);
-            }
-
-            // This cannot overflow because we it is guarded by min() above.
-            bytes_remaining = bytes_remaining.wrapping_sub(bytes_to_copy);
-
-            // SAFETY: We are advancing the cursor in-bounds of the buffer.
-            buffer_cursor = unsafe { buffer_cursor.add(bytes_to_copy) };
-
-            self.advance(bytes_to_copy);
-        }
-
-        // SAFETY: We have filled the buffer with data, initializing it fully.
-        T::from_ne_bytes(&unsafe { buffer.assume_init() })
-    }
+    get_num_accessors!(u16, get_u16_le, get_u16_be, get_u16_ne);
+    get_num_accessors!(i16, get_i16_le, get_i16_be, get_i16_ne);
+    get_num_accessors!(u32, get_u32_le, get_u32_be, get_u32_ne);
+    get_num_accessors!(i32, get_i32_le, get_i32_be, get_i32_ne);
+    get_num_accessors!(u64, get_u64_le, get_u64_be, get_u64_ne);
+    get_num_accessors!(i64, get_i64_le, get_i64_be, get_i64_ne);
+    get_num_accessors!(u128, get_u128_le, get_u128_be, get_u128_ne);
+    get_num_accessors!(i128, get_i128_le, get_i128_be, get_i128_ne);
+    get_num_accessors!(f32, get_f32_le, get_f32_be, get_f32_ne);
+    get_num_accessors!(f64, get_f64_le, get_f64_be, get_f64_ne);
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -592,308 +411,144 @@ mod tests {
     }
 
     #[test]
-    fn get_num_le() {
+    fn get_u16_le() {
         let memory = TransparentMemory::new();
         let mut view = BytesView::copied_from_slice(&[0x34, 0x12, 0x78, 0x56], &memory);
 
-        assert_eq!(view.get_num_le::<u16>(), 0x1234);
-        assert_eq!(view.get_num_le::<u16>(), 0x5678);
+        assert_eq!(view.get_u16_le(), 0x1234);
+        assert_eq!(view.get_u16_le(), 0x5678);
 
         assert!(view.is_empty());
     }
 
     #[test]
-    fn get_num_le_multi_span() {
+    fn get_u32_le_multi_span() {
         let memory = TransparentMemory::new();
-        let data_part1 = [0x78_u8, 0x56];
-        let data_part2 = [0x34_u8, 0x12];
-        let view_part1 = BytesView::copied_from_slice(&data_part1, &memory);
-        let view_part2 = BytesView::copied_from_slice(&data_part2, &memory);
+        let view_part1 = BytesView::copied_from_slice(&[0x78_u8, 0x56], &memory);
+        let view_part2 = BytesView::copied_from_slice(&[0x34_u8, 0x12], &memory);
         let mut view_combined = BytesView::from_views([view_part1, view_part2]);
 
-        assert_eq!(view_combined.get_num_le::<u32>(), 0x1234_5678);
+        assert_eq!(view_combined.get_u32_le(), 0x1234_5678);
 
         assert!(view_combined.is_empty());
     }
 
     #[test]
-    fn get_num_be() {
+    fn get_u16_be() {
         let memory = TransparentMemory::new();
         let mut view = BytesView::copied_from_slice(&[0x12, 0x34, 0x56, 0x78], &memory);
 
-        assert_eq!(view.get_num_be::<u16>(), 0x1234);
-        assert_eq!(view.get_num_be::<u16>(), 0x5678);
+        assert_eq!(view.get_u16_be(), 0x1234);
+        assert_eq!(view.get_u16_be(), 0x5678);
 
         assert!(view.is_empty());
     }
 
     #[test]
-    fn get_num_be_multi_span() {
+    fn get_u32_be_multi_span() {
         let memory = TransparentMemory::new();
-        let data_part1 = [0x12_u8, 0x34];
-        let data_part2 = [0x56_u8, 0x78];
-        let view_part1 = BytesView::copied_from_slice(&data_part1, &memory);
-        let view_part2 = BytesView::copied_from_slice(&data_part2, &memory);
+        let view_part1 = BytesView::copied_from_slice(&[0x12_u8, 0x34], &memory);
+        let view_part2 = BytesView::copied_from_slice(&[0x56_u8, 0x78], &memory);
         let mut view_combined = BytesView::from_views([view_part1, view_part2]);
 
-        assert_eq!(view_combined.get_num_be::<u32>(), 0x1234_5678);
+        assert_eq!(view_combined.get_u32_be(), 0x1234_5678);
 
         assert!(view_combined.is_empty());
     }
 
     #[test]
-    fn get_num_ne() {
+    fn get_u16_ne() {
         let memory = TransparentMemory::new();
         let mut view = BytesView::copied_from_slice(&[0x34, 0x12, 0x78, 0x56], &memory);
 
         if cfg!(target_endian = "big") {
-            assert_eq!(view.get_num_ne::<u16>(), 0x3412);
-            assert_eq!(view.get_num_ne::<u16>(), 0x7856);
+            assert_eq!(view.get_u16_ne(), 0x3412);
+            assert_eq!(view.get_u16_ne(), 0x7856);
         } else {
-            assert_eq!(view.get_num_ne::<u16>(), 0x1234);
-            assert_eq!(view.get_num_ne::<u16>(), 0x5678);
+            assert_eq!(view.get_u16_ne(), 0x1234);
+            assert_eq!(view.get_u16_ne(), 0x5678);
         }
 
         assert!(view.is_empty());
     }
 
     #[test]
-    fn get_num_ne_multi_span() {
+    fn get_u32_ne_multi_span() {
         let memory = TransparentMemory::new();
-        let data_part1 = [0x78_u8, 0x56];
-        let data_part2 = [0x34_u8, 0x12];
-        let view_part1 = BytesView::copied_from_slice(&data_part1, &memory);
-        let view_part2 = BytesView::copied_from_slice(&data_part2, &memory);
+        let view_part1 = BytesView::copied_from_slice(&[0x78_u8, 0x56], &memory);
+        let view_part2 = BytesView::copied_from_slice(&[0x34_u8, 0x12], &memory);
         let mut view_combined = BytesView::from_views([view_part1, view_part2]);
 
         if cfg!(target_endian = "big") {
-            assert_eq!(view_combined.get_num_ne::<u32>(), 0x7856_3412);
+            assert_eq!(view_combined.get_u32_ne(), 0x7856_3412);
         } else {
-            assert_eq!(view_combined.get_num_ne::<u32>(), 0x1234_5678);
+            assert_eq!(view_combined.get_u32_ne(), 0x1234_5678);
         }
 
         assert!(view_combined.is_empty());
     }
 
-    /// Soundness coverage for `FromBytes` implementations whose `Bytes` associated type does not
-    /// match the value type `T` in size or alignment.
-    ///
-    /// The standard integer and float types use `Bytes = [u8; size_of::<T>()]`, so for them
-    /// `size_of::<T>() == size_of::<T::Bytes>()` and `align_of::<T::Bytes>() == 1`. The numeric
-    /// reads must size, advance, and bound by `T::Bytes` (not `T`) and must tolerate any source
-    /// alignment, which only these custom types can exercise.
-    #[cfg_attr(coverage_nightly, coverage(off))]
-    mod from_bytes_soundness {
-        use std::borrow::{Borrow, BorrowMut};
+    #[test]
+    fn get_signed_and_float_round_trip() {
+        let memory = TransparentMemory::new();
 
-        use num_traits::FromBytes;
+        let mut data = Vec::new();
+        data.extend_from_slice(&(-12345_i16).to_le_bytes());
+        data.extend_from_slice(&(-2_000_000_000_i32).to_be_bytes());
+        data.extend_from_slice(&(-9_000_000_000_000_i64).to_le_bytes());
+        data.extend_from_slice(&i128::MIN.to_be_bytes());
+        data.extend_from_slice(&std::f32::consts::PI.to_le_bytes());
+        data.extend_from_slice(&std::f64::consts::E.to_be_bytes());
 
-        use crate::BytesView;
-        use crate::mem::testing::TransparentMemory;
+        let mut view = BytesView::copied_from_slice(&data, &memory);
 
-        /// `Bytes` is wider than the value it produces: `size_of::<NarrowValue>() == 1` while the
-        /// serialized form is four bytes. Sizing reads by `size_of::<T>()` would read past a
-        /// one-byte first-span slice and leave the buffered path's `MaybeUninit<[u8; 4]>` only
-        /// partially initialized before `assume_init`.
-        #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-        struct NarrowValue(u8);
+        assert_eq!(view.get_i16_le(), -12345);
+        assert_eq!(view.get_i32_be(), -2_000_000_000);
+        assert_eq!(view.get_i64_le(), -9_000_000_000_000);
+        assert_eq!(view.get_i128_be(), i128::MIN);
+        assert_eq!(view.get_f32_le().to_bits(), std::f32::consts::PI.to_bits());
+        assert_eq!(view.get_f64_be().to_bits(), std::f64::consts::E.to_bits());
+        assert!(view.is_empty());
+    }
 
-        impl FromBytes for NarrowValue {
-            type Bytes = [u8; 4];
+    #[test]
+    fn get_wide_value_multi_span() {
+        let memory = TransparentMemory::new();
+        let value: u128 = 0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210;
+        let bytes = value.to_le_bytes();
 
-            fn from_le_bytes(bytes: &[u8; 4]) -> Self {
-                Self(bytes[0])
-            }
+        // Split at an odd offset so the value straddles the span boundary and exercises buffering.
+        let view_part1 = BytesView::copied_from_slice(&bytes[..5], &memory);
+        let view_part2 = BytesView::copied_from_slice(&bytes[5..], &memory);
+        let mut view = BytesView::from_views([view_part1, view_part2]);
 
-            fn from_be_bytes(bytes: &[u8; 4]) -> Self {
-                Self(bytes[3])
-            }
-        }
+        assert_eq!(view.get_u128_le(), value);
+        assert!(view.is_empty());
+    }
 
-        /// `Bytes` is narrower than the value it produces: `size_of::<WideValue>() == 8` while the
-        /// serialized form is two bytes. Sizing reads by `size_of::<T>()` would over-advance the
-        /// view and, in the buffered path, copy eight bytes into a two-byte `MaybeUninit<[u8; 2]>`
-        /// buffer.
-        #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-        struct WideValue(u64);
+    #[test]
+    fn get_misaligned_single_span() {
+        let memory = TransparentMemory::new();
 
-        impl FromBytes for WideValue {
-            type Bytes = [u8; 2];
+        // Drop a single leading byte so the eight value bytes sit at an odd offset from the
+        // allocation base, exercising the fast path against a misaligned source.
+        let value: u64 = 0x0123_4567_89AB_CDEF;
+        let mut data = vec![0xFF_u8];
+        data.extend_from_slice(&value.to_le_bytes());
+        let mut view = BytesView::copied_from_slice(&data, &memory);
 
-            fn from_le_bytes(bytes: &[u8; 2]) -> Self {
-                Self(u16::from_le_bytes(*bytes).into())
-            }
+        assert_eq!(view.get_byte(), 0xFF);
+        assert_eq!(view.get_u64_le(), value);
+        assert!(view.is_empty());
+    }
 
-            fn from_be_bytes(bytes: &[u8; 2]) -> Self {
-                Self(u16::from_be_bytes(*bytes).into())
-            }
-        }
+    #[test]
+    #[should_panic]
+    fn get_num_insufficient_bytes_panics() {
+        let memory = TransparentMemory::new();
+        let mut view = BytesView::copied_from_slice(&[0x00, 0x01, 0x02], &memory);
 
-        /// A `Bytes` type whose alignment exceeds one. Constructing a `&OverAligned` reference from
-        /// an unaligned byte-slice pointer is undefined behavior, so the read must materialize the
-        /// value through an alignment-agnostic copy. `NumBytes` is satisfied via its blanket impl
-        /// over the manual `AsRef`/`AsMut`/`Borrow`/`BorrowMut` and the derived comparison traits.
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-        #[repr(align(8))]
-        struct OverAligned([u8; 8]);
-
-        impl AsRef<[u8]> for OverAligned {
-            fn as_ref(&self) -> &[u8] {
-                &self.0
-            }
-        }
-
-        impl AsMut<[u8]> for OverAligned {
-            fn as_mut(&mut self) -> &mut [u8] {
-                &mut self.0
-            }
-        }
-
-        impl Borrow<[u8]> for OverAligned {
-            fn borrow(&self) -> &[u8] {
-                &self.0
-            }
-        }
-
-        impl BorrowMut<[u8]> for OverAligned {
-            fn borrow_mut(&mut self) -> &mut [u8] {
-                &mut self.0
-            }
-        }
-
-        #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-        struct OverAlignedValue(u64);
-
-        impl FromBytes for OverAlignedValue {
-            type Bytes = OverAligned;
-
-            fn from_le_bytes(bytes: &OverAligned) -> Self {
-                Self(u64::from_le_bytes(bytes.0))
-            }
-
-            fn from_be_bytes(bytes: &OverAligned) -> Self {
-                Self(u64::from_be_bytes(bytes.0))
-            }
-        }
-
-        #[test]
-        fn narrow_bytes_le_single_span() {
-            let memory = TransparentMemory::new();
-            let mut view = BytesView::copied_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD], &memory);
-
-            // Four bytes are consumed even though the value occupies a single byte.
-            assert_eq!(view.get_num_le::<NarrowValue>(), NarrowValue(0xAA));
-            assert!(view.is_empty());
-        }
-
-        #[test]
-        fn narrow_bytes_be_single_span() {
-            let memory = TransparentMemory::new();
-            let mut view = BytesView::copied_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD], &memory);
-
-            assert_eq!(view.get_num_be::<NarrowValue>(), NarrowValue(0xDD));
-            assert!(view.is_empty());
-        }
-
-        #[test]
-        fn narrow_bytes_le_multi_span() {
-            let memory = TransparentMemory::new();
-            let view_part1 = BytesView::copied_from_slice(&[0xAA, 0xBB], &memory);
-            let view_part2 = BytesView::copied_from_slice(&[0xCC, 0xDD], &memory);
-            let mut view = BytesView::from_views([view_part1, view_part2]);
-
-            // The value straddles the span boundary, forcing the buffered path to fill all four
-            // bytes of the `MaybeUninit<[u8; 4]>` before `assume_init`.
-            assert_eq!(view.get_num_le::<NarrowValue>(), NarrowValue(0xAA));
-            assert!(view.is_empty());
-        }
-
-        #[test]
-        fn wide_bytes_le_single_span() {
-            let memory = TransparentMemory::new();
-            let mut view = BytesView::copied_from_slice(&[0x34, 0x12, 0x78, 0x56], &memory);
-
-            // Each read advances by exactly two bytes (the size of `Bytes`), not eight.
-            assert_eq!(view.get_num_le::<WideValue>(), WideValue(0x1234));
-            assert_eq!(view.get_num_le::<WideValue>(), WideValue(0x5678));
-            assert!(view.is_empty());
-        }
-
-        #[test]
-        fn wide_bytes_be_single_span() {
-            let memory = TransparentMemory::new();
-            let mut view = BytesView::copied_from_slice(&[0x12, 0x34, 0x56, 0x78], &memory);
-
-            assert_eq!(view.get_num_be::<WideValue>(), WideValue(0x1234));
-            assert_eq!(view.get_num_be::<WideValue>(), WideValue(0x5678));
-            assert!(view.is_empty());
-        }
-
-        #[test]
-        fn wide_bytes_le_multi_span() {
-            let memory = TransparentMemory::new();
-            let view_part1 = BytesView::copied_from_slice(&[0x34], &memory);
-            let view_part2 = BytesView::copied_from_slice(&[0x12], &memory);
-            let mut view = BytesView::from_views([view_part1, view_part2]);
-
-            // The buffered path must size its copy by `Bytes` (two bytes), not by the eight-byte
-            // value type, to avoid overflowing the `MaybeUninit<[u8; 2]>` buffer.
-            assert_eq!(view.get_num_le::<WideValue>(), WideValue(0x1234));
-            assert!(view.is_empty());
-        }
-
-        const OVER_ALIGNED_VALUE: u64 = 0x0123_4567_89AB_CDEF;
-
-        #[test]
-        fn over_aligned_le_single_span() {
-            let memory = TransparentMemory::new();
-            let mut view = BytesView::copied_from_slice(&OVER_ALIGNED_VALUE.to_le_bytes(), &memory);
-
-            assert_eq!(view.get_num_le::<OverAlignedValue>(), OverAlignedValue(OVER_ALIGNED_VALUE));
-            assert!(view.is_empty());
-        }
-
-        #[test]
-        fn over_aligned_le_misaligned_single_span() {
-            let memory = TransparentMemory::new();
-
-            // A single leading byte that we drop, leaving the eight value bytes at an odd offset
-            // from the allocation base. Whenever that base is itself eight-byte aligned (the
-            // common case for the global allocator), the value bytes are misaligned for an
-            // eight-byte read, so the fast path must not assume the source is aligned.
-            let mut data = vec![0xFF_u8];
-            data.extend_from_slice(&OVER_ALIGNED_VALUE.to_le_bytes());
-            let mut view = BytesView::copied_from_slice(&data, &memory);
-
-            assert_eq!(view.get_byte(), 0xFF);
-            assert_eq!(view.get_num_le::<OverAlignedValue>(), OverAlignedValue(OVER_ALIGNED_VALUE));
-            assert!(view.is_empty());
-        }
-
-        #[test]
-        fn over_aligned_le_multi_span() {
-            let memory = TransparentMemory::new();
-            let bytes = OVER_ALIGNED_VALUE.to_le_bytes();
-            let view_part1 = BytesView::copied_from_slice(&bytes[..3], &memory);
-            let view_part2 = BytesView::copied_from_slice(&bytes[3..], &memory);
-            let mut view = BytesView::from_views([view_part1, view_part2]);
-
-            // The buffered path assembles the value in a properly aligned `MaybeUninit<OverAligned>`.
-            assert_eq!(view.get_num_le::<OverAlignedValue>(), OverAlignedValue(OVER_ALIGNED_VALUE));
-            assert!(view.is_empty());
-        }
-
-        #[test]
-        fn over_aligned_ne_misaligned_single_span() {
-            let memory = TransparentMemory::new();
-
-            let mut data = vec![0xFF_u8];
-            data.extend_from_slice(&OVER_ALIGNED_VALUE.to_ne_bytes());
-            let mut view = BytesView::copied_from_slice(&data, &memory);
-
-            assert_eq!(view.get_byte(), 0xFF);
-            assert_eq!(view.get_num_ne::<OverAlignedValue>(), OverAlignedValue(OVER_ALIGNED_VALUE));
-            assert!(view.is_empty());
-        }
+        // Only three bytes are available, so reading a four-byte value must panic.
+        let _ = view.get_u32_le();
     }
 }

--- a/crates/http_path_template/README.md
+++ b/crates/http_path_template/README.md
@@ -1,7 +1,7 @@
 <div align="center">
  <img src="./logo.png" alt="Http Path Template Logo" width="96">
 
-# HTTP Path Template
+# Http Path Template
 
 [![crate.io](https://img.shields.io/crates/v/http_path_template.svg)](https://crates.io/crates/http_path_template)
 [![docs.rs](https://docs.rs/http_path_template/badge.svg)](https://docs.rs/http_path_template)


### PR DESCRIPTION
[Copilot speaking]

## Why

The generic numeric read API on `BytesView` (`get_num_le::<T>()`, `get_num_be::<T>()`, `get_num_ne::<T>()`) was bounded on `num_traits::FromBytes`. That trait's associated type is only required to be `NumBytes` — it does **not** guarantee POD layout, initialized padding, or all-bit-pattern validity.

This is unsound: a safe custom `FromBytes` implementation whose `Bytes` type contains a `bool` produced **Miri-confirmed UB** when reading byte `0x02` (an invalid `bool` bit pattern). `Vec<u8>` is likewise a legal associated type, and reading raw bytes into it would synthesize invalid pointer/capacity/length fields. The read path constructed arbitrary `T::Bytes` from raw bytes via `read_unaligned` / `MaybeUninit::assume_init`, so any such type triggered UB.

## What

De-generalize the numeric API entirely and drop the trait constraints:

- **Remove the `num-traits` dependency** — from the workspace `Cargo.toml`, the crate''s `Cargo.toml`, and the `allowed_external_types` list (`num_traits::ops::bytes::FromBytes` / `ToBytes`). One fewer external dependency.
- **Replace the generic accessors** with concrete, primitive-typed methods:
  - Read: `get_u16_le()` through `get_u128_le()`, signed equivalents, and `get_f32_*` / `get_f64_*`, in little-, big-, and native-endian variants.
  - Write: matching `put_u16_le(v)` through `put_f64_ne(v)`.
- Reads now go through a private generic helper `get_array::<N>() -> [u8; N]` and feed `<$t>::from_<endianness>_bytes(...)`. Since `[u8; N]` has no validity invariants, there is no way to construct an invalid value. Internal generics are kept only to avoid code repetition; the **public API is fully concrete**, and only built-in primitive numeric types are supported (which was the entire purpose of these helpers).

## Performance

Validated with Callgrind (WSL) and Criterion, before vs. after:

- Read fast path: **100 instructions** (parity with the previous generic API).
- Write path: **178 instructions** (unchanged).
- No wall-clock delta.

The zero-initialized `[u8; N]` read buffer is fully compiler-elided (the 4-byte load lands straight in a register; `copy_from_slice` overwrites the whole array, so the zero-init is dead code) — verified by disassembly and by an equivalent `MaybeUninit` variant measuring identically, so the safe `[u8; N]` form is kept. The cold buffered fallback (`get_array_buffered`) is marked `#[inline(never)]` so its callee-saved register spills (`r12`/`r13`) don''t inflate the hot read frame.

## Validation

- `just format`, `just readme`, `just spellcheck` — clean.
- 197 unit/integration tests, 19 Miri tests, clippy — all green.

Fixes AB#7622954