### PR TITLE
fix(bytesbuf): guard total capacity against overflow at growth sites

### DIFF
--- a/crates/bytesbuf/src/buf.rs
+++ b/crates/bytesbuf/src/buf.rs
@@ -135,8 +135,12 @@ pub struct BytesBuf {
 /// `available`. A bounds check on the grown component alone is insufficient: `len` can grow via
 /// appended shared memory while `available` holds separately reserved capacity, so only their sum
 /// is bounded by the invariant.
+#[track_caller]
 fn assert_capacity_within_bounds(len: usize, available: usize) {
-    assert!(len.checked_add(available).is_some(), "buffer capacity cannot exceed usize::MAX");
+    assert!(
+        len.checked_add(available).is_some(),
+        "buffer capacity cannot exceed usize::MAX (len={len}, available={available})"
+    );
 }
 
 impl BytesBuf {

--- a/crates/bytesbuf/src/buf.rs
+++ b/crates/bytesbuf/src/buf.rs
@@ -128,6 +128,17 @@ pub struct BytesBuf {
     available: usize,
 }
 
+/// Panics if `len + available` would exceed `usize::MAX`, i.e. would violate the buffer's
+/// `capacity() <= usize::MAX` type invariant.
+///
+/// The two capacity-growing sites (`reserve` and `append`) each grow only one of `len` or
+/// `available`. A bounds check on the grown component alone is insufficient: `len` can grow via
+/// appended shared memory while `available` holds separately reserved capacity, so only their sum
+/// is bounded by the invariant.
+fn assert_capacity_within_bounds(len: usize, available: usize) {
+    assert!(len.checked_add(available).is_some(), "buffer capacity cannot exceed usize::MAX");
+}
+
 impl BytesBuf {
     /// Creates an instance without any memory capacity.
     #[must_use]
@@ -246,10 +257,17 @@ impl BytesBuf {
         debug_assert!(additional_memory.capacity() >= bytes.get());
         debug_assert!(additional_memory.is_empty());
 
-        self.available = self
+        let new_available = self
             .available
             .checked_add(additional_memory.capacity())
             .expect("buffer capacity cannot exceed usize::MAX");
+
+        // Growing `available` must not push the total capacity (`len + available`) past `usize::MAX`.
+        // Checking `available` alone is insufficient because `len` can grow independently via
+        // appended shared memory (see `append`). This upholds the invariant relied on by `capacity()`.
+        assert_capacity_within_bounds(self.len, new_available);
+
+        self.available = new_available;
 
         // We put the new ones in front (existing content needs to stay at the end).
         self.span_builders_reversed.insert_many(0, additional_memory.span_builders_reversed);
@@ -287,7 +305,15 @@ impl BytesBuf {
 
         // We do this first so if we do panic, we have not performed any incomplete operations.
         // The freezing above is safe even if we panic here - freezing is an atomic operation.
-        self.len = self.len.checked_add(bytes_len).expect("buffer capacity cannot exceed usize::MAX");
+        let new_len = self.len.checked_add(bytes_len).expect("buffer capacity cannot exceed usize::MAX");
+
+        // Appended memory is shared (immutable) and may be aliased by other views, so the logical
+        // length can grow independently of physical address-space consumption. We must guard the
+        // total capacity (`len + available`), not just `len`, to uphold the invariant `capacity()`
+        // relies on.
+        assert_capacity_within_bounds(new_len, self.available);
+
+        self.len = new_len;
 
         // Any appended BytesView is frozen by definition, as contents of a BytesView are immutable.
         // This cannot wrap because we verified `len` is in-bounds and `frozen <= len` is a type invariant.
@@ -2564,6 +2590,26 @@ mod tests {
 
         // Buffer is unmodified.
         assert_eq!(buf.remaining_capacity(), capacity);
+    }
+
+    #[test]
+    fn capacity_bounds_check_accepts_maximum_total() {
+        // The largest representable total capacity is permitted; only exceeding it is rejected.
+        assert_capacity_within_bounds(usize::MAX, 0);
+        assert_capacity_within_bounds(0, usize::MAX);
+        assert_capacity_within_bounds(usize::MAX - 1, 1);
+        assert_capacity_within_bounds(usize::MAX / 2, usize::MAX / 2);
+    }
+
+    #[test]
+    fn capacity_bounds_check_rejects_len_plus_available_overflow() {
+        // Neither component overflows on its own, but their sum exceeds usize::MAX. This is the
+        // situation that arises when `len` grows via appended shared memory (in `append`) while
+        // `available` holds separately reserved capacity (in `extend_capacity_by_at_least`): each
+        // site guards only the component it grows, so only this combined check catches the overflow.
+        assert_panic!(assert_capacity_within_bounds(usize::MAX, 1));
+        assert_panic!(assert_capacity_within_bounds(usize::MAX - 4, 8));
+        assert_panic!(assert_capacity_within_bounds(usize::MAX / 2 + 1, usize::MAX / 2 + 1));
     }
 
     // Compile time test

--- a/crates/bytesbuf/src/buf.rs
+++ b/crates/bytesbuf/src/buf.rs
@@ -295,6 +295,17 @@ impl BytesBuf {
 
         let bytes_len = bytes.len();
 
+        // Validate capacity before performing any mutation (including the freeze below), so a
+        // rejected append leaves the buffer untouched. Freezing changes neither `len` nor
+        // `available`, so this check is equivalent whether run before or after it.
+        //
+        // Appended memory is shared (immutable) and may be aliased by other views, so the logical
+        // length can grow independently of physical address-space consumption. We must guard the
+        // total capacity (`len + available`), not just `len`, to uphold the invariant `capacity()`
+        // relies on.
+        let new_len = self.len.checked_add(bytes_len).expect("buffer capacity cannot exceed usize::MAX");
+        assert_capacity_within_bounds(new_len, self.available);
+
         // Only the first span builder may hold unfrozen data (the rest are for spare capacity).
         let total_unfrozen_bytes = NonZero::new(self.span_builders_reversed.last().map_or(0, SpanBuilder::len));
 
@@ -306,16 +317,6 @@ impl BytesBuf {
             // Debug build paranoia: nothing remains in the span builder, right?
             debug_assert_eq!(self.span_builders_reversed.last().map_or(0, SpanBuilder::len), 0);
         }
-
-        // We do this first so if we do panic, we have not performed any incomplete operations.
-        // The freezing above is safe even if we panic here - freezing is an atomic operation.
-        let new_len = self.len.checked_add(bytes_len).expect("buffer capacity cannot exceed usize::MAX");
-
-        // Appended memory is shared (immutable) and may be aliased by other views, so the logical
-        // length can grow independently of physical address-space consumption. We must guard the
-        // total capacity (`len + available`), not just `len`, to uphold the invariant `capacity()`
-        // relies on.
-        assert_capacity_within_bounds(new_len, self.available);
 
         self.len = new_len;
 

--- a/crates/bytesbuf/src/buf.rs
+++ b/crates/bytesbuf/src/buf.rs
@@ -128,13 +128,13 @@ pub struct BytesBuf {
     available: usize,
 }
 
-/// Panics if `len + available` would exceed `usize::MAX`, i.e. would violate the buffer's
-/// `capacity() <= usize::MAX` type invariant.
+/// Panics if the true (non-wrapping) sum `len + available` would overflow `usize`.
 ///
-/// The two capacity-growing sites (`reserve` and `append`) each grow only one of `len` or
+/// `capacity()` returns `len + available`, so that sum must fit in `usize` for `capacity()` not to
+/// wrap. The two capacity-growing sites (`reserve` and `append`) each grow only one of `len` or
 /// `available`. A bounds check on the grown component alone is insufficient: `len` can grow via
 /// appended shared memory while `available` holds separately reserved capacity, so only their sum
-/// is bounded by the invariant.
+/// is bounded.
 #[track_caller]
 fn assert_capacity_within_bounds(len: usize, available: usize) {
     assert!(

--- a/crates/bytesbuf/src/buf.rs
+++ b/crates/bytesbuf/src/buf.rs
@@ -472,7 +472,8 @@ impl BytesBuf {
         let frozen_len = self.frozen_spans.iter().map(|x| x.len() as usize).sum::<usize>();
         let unfrozen_len = self.span_builders_reversed.last().map_or(0, SpanBuilder::len) as usize;
 
-        // Will not overflow - `capacity <= usize::MAX` is a type invariant and obviously `len < capacity`.
+        // Will not overflow: `len` is a component of the total capacity `len + available`, which
+        // never overflows `usize` (enforced at the growth sites).
         frozen_len.wrapping_add(unfrozen_len)
     }
 
@@ -512,7 +513,8 @@ impl BytesBuf {
     /// ```
     #[must_use]
     pub fn capacity(&self) -> usize {
-        // Will not overflow - `capacity <= usize::MAX` is a type invariant.
+        // Will not overflow: `len + available` never overflows `usize` - the growth sites enforce
+        // this via `assert_capacity_within_bounds`.
         self.len().wrapping_add(self.remaining_capacity())
     }
 
@@ -656,8 +658,8 @@ impl BytesBuf {
             let span_len = span.len();
 
             if span_len as usize <= len {
-                // Will not wrap because a type invariant is `capacity <= usize::MAX`, so if
-                // capacity is in-bounds, the number of spans could not possibly be greater.
+                // Will not wrap: `len + available` never overflows `usize`, so the number of
+                // spans (each holding at least one byte) certainly cannot be a greater number.
                 detach_complete_frozen_spans = detach_complete_frozen_spans.wrapping_add(1);
 
                 len = len
@@ -1208,8 +1210,8 @@ struct ConsumeManifest {
 impl ConsumeManifest {
     const fn required_spans_capacity(&self) -> usize {
         if self.consume_partial_span_bytes != 0 {
-            // This will not wrap because a type invariant is `capacity <= usize::MAX`, so if
-            // capacity is already in-bounds, the count of spans certainly is not a greater number.
+            // This will not wrap: `len + available` never overflows `usize`, so the count of
+            // spans certainly cannot be a greater number.
             self.detach_complete_frozen_spans.wrapping_add(1)
         } else {
             self.detach_complete_frozen_spans
@@ -1331,8 +1333,8 @@ impl<'a> Iterator for BytesBufRemaining<'a> {
         let next_span_builder_index = self.next_span_builder_index?;
 
         self.next_span_builder_index = Some(
-            // Will not overflow because `capacity <= usize::MAX` is a type invariant,
-            // so the count of span builders certainly cannot be greater.
+            // Will not overflow: `len + available` never overflows `usize`, so the count of span
+            // builders certainly cannot be greater.
             next_span_builder_index.wrapping_add(1),
         );
         if self.next_span_builder_index == Some(self.buf.span_builders_reversed.len()) {
@@ -1345,8 +1347,8 @@ impl<'a> Iterator for BytesBufRemaining<'a> {
             .buf
             .span_builders_reversed
             .len()
-            // Will not overflow because `capacity <= usize::MAX` is a type invariant,
-            // so the count of span builders certainly cannot be greater.
+            // Will not overflow: `len + available` never overflows `usize`, so the count of span
+            // builders certainly cannot be greater.
             .wrapping_sub(next_span_builder_index + 1);
 
         let span_builder = self


### PR DESCRIPTION
[Copilot speaking]

## What

`BytesBuf`'s type invariant that total `capacity() == len + available` never exceeds `usize::MAX` was asserted (relied upon by `capacity()`'s `wrapping_add`) but not actually enforced. The two capacity-growing sites each guarded only the single component they grow:

- `extend_capacity_by_at_least` (the `reserve` path) checked only that `available` did not overflow.
- `append` (the `put_bytes` path) checked only that `len` did not overflow.

Appending an existing `BytesView` reuses shared, immutable memory that can be aliased by multiple views, so the logical `len` can grow independently of physical address-space consumption. As a result `len + available` could pass `usize::MAX` while neither component overflowed on its own, and `capacity()` would silently return a wrapped value, violating internal accounting assumptions. This is reachable on 32-bit targets, where the address space is small enough that shared-span aliasing plus reserved capacity can push the sum past `usize::MAX`.

## Fix

Both growth sites now validate the total `len + available` (not just the grown component) through a shared private `assert_capacity_within_bounds` helper, and do so before mutating any state, so a rejected grow leaves the buffer untouched. The `# Panics` docs on `reserve`/`put_bytes` already promised the total buffer capacity would be guarded, so this makes the code match the contract and makes `capacity()`'s invariant comment true.

## Testing

`capacity_bounds_check_*` tests exercise `assert_capacity_within_bounds` directly at `usize` boundaries (`usize::MAX`, `usize::MAX - 4` plus `8`, `usize::MAX/2 + 1` twice). The overflow regime is unreachable end-to-end on 64-bit (you cannot hold `2^64` bytes, even aliased), and forcing it by crafting `len`/`available` field values would construct an invalid `BytesBuf`, so the pure-function test is the honest way to lock in the overflow logic. The check-site wiring remains covered by the existing normal-path `append`/`reserve` tests plus review.

Verified locally: `cargo test -p bytesbuf`, `cargo clippy -p bytesbuf --all-targets`, `just format`, and `just spellcheck` all clean.
