### PR TITLE
fix(releasing): handle proc-macro packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,12 +207,18 @@ jobs:
       - name: Check Spelling
         run: just spellcheck
 
-  # Runs cargo-semver-checks against each crate's PREVIOUS VERSION-BUMP COMMIT in
-  # git history (the most recent commit on the base branch that changed the
-  # crate's `[package] version`, passed as --baseline-rev), scoped to the crates
-  # whose `version =` is bumped in this PR (the "publishing set"). The baseline
-  # rustdoc is rebuilt from that commit's source, so no registry access is needed
-  # and the check behaves identically for OSS and enterprise/offline consumers.
+  # Runs cargo-semver-checks against each ordinary library crate's PREVIOUS
+  # VERSION-BUMP COMMIT in git history (the most recent commit on the base branch
+  # that changed the crate's `[package] version`, passed as --baseline-rev),
+  # scoped to the crates whose `version =` is bumped in this PR (the "publishing
+  # set"). Proc-macro-only targets are detected from cargo metadata before tool
+  # invocation and reported as requiring manual SemVer review because
+  # cargo-semver-checks cannot inspect their macro contract. A breaking
+  # proc-macro increment marks its direct published consumer for manual review;
+  # propagation continues one edge at a time only through breaking consumer
+  # increments. The baseline rustdoc for ordinary libraries is rebuilt from that
+  # commit's source, so no registry access is needed and the check behaves
+  # identically for OSS and enterprise/offline consumers.
   # The version-increment VERDICT is informational: an under-incremented crate is
   # reported (status=fail) but never fails the build. The check must, however,
   # actually run — an operational failure (script/tooling error, or a failure to
@@ -243,16 +249,18 @@ jobs:
           rust-toolchain: RUST_LATEST
           cargo-tools: CARGO_SEMVER_CHECKS_VERSION
 
-      # Compute the publishing set (version-bumped published crates), run
-      # cargo-semver-checks per crate against its previous version-bump commit in
-      # git history (--baseline-rev, no registry), and render a Markdown report
+      # Compute the publishing set (version-bumped published crates), report
+      # proc-macro-only crates and breaking-chain consumers as requiring manual
+      # review, run cargo-semver-checks for ordinary libraries against their
+      # previous version-bump commit in git history (--baseline-rev, no
+      # registry), and render a Markdown report
       # (scripts/ci/semver-report.ps1 — reuses the release library's version-diff
       # / next-version helpers). Sets outputs:
       #   publishing = true|false        (any crate version bumped)
       #   status     = pass|warn|fail    (fail = a crate is under-incremented for
-      #                                   its API changes; warn = a baseline could
-      #                                   not be determined so a check is
-      #                                   incomplete; pass = all sufficient)
+      #                                   its API changes; warn = manual proc-macro
+      #                                   review is required or a baseline could
+      #                                   not be determined; pass = all sufficient)
       # The version-increment verdict is informational (an under-increment sets
       # status=fail, but the script still exits 0). This step is intentionally
       # NOT continue-on-error: an operational failure here (git/tooling error)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -274,10 +274,13 @@ change:
 - Every proc-macro-only package in the release set is shown in the
   standard interactive package dialog, even when it was supplied via
   `-Packages` or was cascade-added without changes in its own folder.
-- The dialog uses the same renderer, choices, and decision handling as
-  every other package. Proc-macro detection only bypasses the unsupported
-  automated check and records that the standard decision was made
-  manually.
+- The tool asks the same questions for every package. For a proc macro, it
+  skips the unsupported automated check and records the answer as a manual
+  review.
+- For a proc macro that is not yet in the plan, choosing **No material
+  changes** completes the review. The package is not released unless
+  another package needs it. If that happens later in the same run, the
+  proc macro gets a patch release without another prompt.
 - Use **View diff**, then either keep the currently planned change type
   or select breaking / non-breaking / patch. For a targeted package, a
   new selection replaces the provisional `-Packages` change type. For a
@@ -288,15 +291,13 @@ change:
   re-released at least as `patch`, and its own public API is still
   analysed by `cargo-semver-checks`. A manually chosen proc-macro
   severity is never copied to dependents.
-- When the reviewed proc-macro release is breaking, its direct published
-  consumers receive an additional mandatory manual-review dialog. Their
-  provisional level remains `max(patch, cargo-semver-checks result)`.
-  A final increment that is non-breaking under that package's SemVer
-  rules stops manual propagation there. A breaking increment advances
-  the same review to that package's direct published consumers. This
-  repeats one dependency edge at a time, while all other transitive
-  dependents stay on the normal cascade path. For `0.0.x` packages,
-  every increment is breaking and therefore advances review.
+- If the proc-macro release is breaking, the tool asks the maintainer to
+  review each published crate that directly depends on it.
+- If one of those crates is also breaking, the tool then reviews that
+  crate's direct dependents. Otherwise, the extra review stops there.
+  Each crate keeps its own result; the proc macro's result is never copied
+  to another crate. For `0.0.x` packages, every release is breaking, so
+  the review continues to the next set of direct dependents.
 
 The CI SemVer report follows the same target detection. It skips the
 unsupported invocation, emits a `warn` row saying manual proc-macro

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -274,6 +274,10 @@ change:
 - Every proc-macro-only package in the release set is shown in the
   standard interactive package dialog, even when it was supplied via
   `-Packages` or was cascade-added without changes in its own folder.
+- The dialog uses the same renderer, choices, and decision handling as
+  every other package. Proc-macro detection only bypasses the unsupported
+  automated check and records that the standard decision was made
+  manually.
 - Use **View diff**, then either keep the currently planned change type
   or select breaking / non-breaking / patch. For a targeted package, a
   new selection replaces the provisional `-Packages` change type. For a
@@ -322,7 +326,7 @@ cargo test -p templated_uri
 ```
 
 The `patch` token is the provisional plan entry, not an automated
-compatibility verdict. In the mandatory proc-macro dialog, view the diff
+compatibility verdict. In the standard package dialog, view the diff
 and choose the actual change type before allowing the release to proceed.
 If that choice is breaking, the planner next requires review of
 `templated_uri`, its direct published consumer; keep or elevate

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -203,9 +203,9 @@ Examples:
 
 After parsing the tokens, the planner walks the workspace dependency
 graph forward from every user-source release and adds each transitive
-published dependent as a cascade-source release. The change type for
-every release in the plan — both the directly-requested (user-source)
-crates and the cascade-pulled dependents — is derived by running
+published dependent as a cascade-source release. For ordinary library
+packages, the required change type — both for directly-requested
+(user-source) packages and cascade-pulled dependents — is derived by running
 [`cargo semver-checks`](https://crates.io/crates/cargo-semver-checks)
 against each crate's **previous version-bump commit in git history** —
 the most recent commit that changed the crate's `[package] version`,
@@ -255,6 +255,79 @@ Cascade dependents are floored at `patch` (they must re-release to pick
 up the new dependency version even when their own public API is
 unchanged), then raised to whatever their own `cargo semver-checks`
 result requires.
+
+#### Proc-macro-only packages require manual SemVer review
+
+`cargo semver-checks` deliberately supports ordinary library targets,
+not proc-macro-only targets. For a package whose `cargo metadata`
+targets contain `proc-macro` but no ordinary `lib` target, the tool exits
+with "no crates with library targets selected". This is expected: its
+rustdoc-based analysis cannot validate the procedural macro contract,
+including exported macro names, accepted input syntax, diagnostics, or
+generated output.
+
+The release tooling detects this target shape from the workspace
+metadata **before invoking `cargo semver-checks`**. It does not reinterpret
+the unsupported-tool error as success and does not guess a breaking
+change:
+
+- Every proc-macro-only package in the release set is shown in the
+  standard interactive package dialog, even when it was supplied via
+  `-Packages` or was cascade-added without changes in its own folder.
+- Use **View diff**, then either keep the currently planned change type
+  or select breaking / non-breaking / patch. For a targeted package, a
+  new selection replaces the provisional `-Packages` change type. For a
+  cascade-added package, it replaces the mechanical `patch` floor.
+- The final release plan labels the package as manually classified and
+  states that `cargo-semver-checks` was not run for it.
+- Ordinary library dependents keep their normal behavior: each is
+  re-released at least as `patch`, and its own public API is still
+  analysed by `cargo-semver-checks`. A manually chosen proc-macro
+  severity is never copied to dependents.
+- When the reviewed proc-macro release is breaking, its direct published
+  consumers receive an additional mandatory manual-review dialog. Their
+  provisional level remains `max(patch, cargo-semver-checks result)`.
+  A final increment that is non-breaking under that package's SemVer
+  rules stops manual propagation there. A breaking increment advances
+  the same review to that package's direct published consumers. This
+  repeats one dependency edge at a time, while all other transitive
+  dependents stay on the normal cascade path. For `0.0.x` packages,
+  every increment is breaking and therefore advances review.
+
+The CI SemVer report follows the same target detection. It skips the
+unsupported invocation, emits a `warn` row saying manual proc-macro
+review is required, and does **not** claim that the version increment was
+automatically verified. For a breaking proc-macro increment, CI marks
+the direct published consumer for manual review while retaining that
+consumer's ordinary `cargo-semver-checks` result. It continues only
+through consumers whose own version increment is breaking. If a required
+direct consumer is absent from the publishing set, the report calls out
+the incomplete review chain. If CI cannot determine a reviewed package's
+baseline, it conservatively continues the warning to the next edge rather
+than treating the unknown result as non-breaking.
+
+Build and test validation are separate from SemVer validation. The
+release driver runs `cargo check --workspace` after applying the plan,
+and normal CI exercises the workspace tests. Those checks can catch
+compilation failures and tested behavioral regressions, but passing them
+does not prove compatibility for exported macro names, all accepted
+inputs, diagnostics, or generated code. Review those aspects explicitly.
+
+For example, to validate the main consumer and release
+`templated_uri_macros`, run:
+
+```powershell
+cargo test -p templated_uri
+./scripts/release-packages.ps1 -Packages 'templated_uri_macros@patch'
+```
+
+The `patch` token is the provisional plan entry, not an automated
+compatibility verdict. In the mandatory proc-macro dialog, view the diff
+and choose the actual change type before allowing the release to proceed.
+If that choice is breaking, the planner next requires review of
+`templated_uri`, its direct published consumer; keep or elevate
+`templated_uri` based on whether its public contract exposes the macro
+change.
 
 **Baseline semantics.** The baseline is the crate's previous
 version-bump commit — the most recent commit (before the change under
@@ -387,6 +460,12 @@ The user-review queue therefore contains two categories of finding:
      publishable packages with no on-disk changes; the "View diff" option
      is relabelled `View diff (no changes in this package)` so the empty
      state is obvious before you open the editor.
+   - For every proc-macro-only package in the release set, show the same
+     menu as a mandatory manual SemVer review. This includes targeted
+     packages and unchanged proc-macro dependents added by cascade.
+     A breaking result then surfaces direct published consumers one edge
+     at a time; propagation stops at the first consumer reviewed below
+     breaking.
    - After review, apply all version-number increments, changelog
      updates, README regeneration, `Cargo.toml` rewrites, and workspace
      `[workspace.dependencies]` updates in one shot.

--- a/scripts/ci/semver-report.ps1
+++ b/scripts/ci/semver-report.ps1
@@ -5,10 +5,9 @@
 
 <#
 .SYNOPSIS
-    Runs cargo-semver-checks for each crate a PR is publishing and renders a
-    rich, per-crate Markdown report comparing the on-disk version increment
-    against the minimum increment the crate's API changes require versus the
-    crate's previous version-bump commit in git history.
+    Reports SemVer validation for each crate a PR is publishing, using
+    cargo-semver-checks for ordinary libraries and explicit manual-review
+    warnings for proc-macro-only crates.
 
 .DESCRIPTION
     For every crate whose `[package] version` differs from the PR base ref (the
@@ -18,20 +17,30 @@
       2. locates the crate's PREVIOUS version-bump commit — the most recent commit
          reachable from -BaseRef (so this PR's own bump, which lives only on the PR
          head, is excluded) that changed the crate's `[package] version` line,
-      3. runs `cargo semver-checks --package <crate> --baseline-rev <sha>` so the
+      3. detects proc-macro-only crates from `cargo metadata`; those require
+         explicit manual SemVer review because cargo-semver-checks has no
+         supported API surface for them,
+      4. for ordinary library crates, runs
+         `cargo semver-checks --package <crate> --baseline-rev <sha>` so the
          comparison source is the crate's own source at that commit (the baseline
          rustdoc is rebuilt from git — no registry access, works OSS + enterprise),
-      4. parses the required change type from the output, and
-      5. computes the *minimum* version the increment should reach given the
-         detected API changes.
+      5. parses the required change type from the output, and
+      6. computes the *minimum* version the increment should reach given the
+         detected API changes,
+      7. when a manually reviewed proc-macro-chain release has a breaking
+         increment, marks its direct published consumers for manual review while
+         preserving their automated result, and repeats only through consumers
+         whose own increment is breaking.
 
     It writes a Markdown report to -ReportPath containing:
       - a summary status line (🛑 when at least one crate is under-incremented,
-        ⚠️ when the only problem is a baseline that could not be determined,
+        ⚠️ when manual proc-macro review is required or a baseline could not
+        be determined,
         ✅ when every publishing crate is sufficiently incremented),
       - a table: Crate | Baseline | Baseline commit | This PR | Minimum required | Status,
-      - collapsible per-crate detail for under-incremented crates and for
-        crates whose baseline could not be determined, and
+      - collapsible per-crate detail for under-incremented crates, proc-macro
+        manual reviews, missing direct consumers, and crates whose baseline
+        could not be determined, and
       - a link to the triggering Actions run.
 
     Two GitHub Actions step outputs are written to -GitHubOutput:
@@ -39,10 +48,11 @@
       status     = 'pass' | 'warn' | 'fail'
                      fail = at least one crate is under-incremented;
                      warn = no crate is under-incremented but at least one
-                            baseline could not be determined (check incomplete);
+                            proc-macro needs manual review or a baseline could
+                            not be determined (check incomplete);
                      pass = every crate is sufficiently incremented.
-      A failed/unknown baseline is NEVER reported as 'fail' on its own — 'fail'
-      is reserved for genuine under-increments per this contract.
+      A failed/unknown baseline or manual-review requirement is NEVER reported
+      as 'fail' on its own — 'fail' is reserved for genuine under-increments.
 
     The report is informational: callers keep the job non-failing.
 
@@ -102,9 +112,10 @@ if ($changedFolders.Count -eq 0) {
 }
 
 # --- 2. Run cargo-semver-checks per crate and gather results. -----------------
-# A row per crate: cargo name, on-disk (this-PR) version, git-history baseline,
-# the parsed required change type, the computed minimum version, and the raw
-# tool detail (for under-incremented crates).
+# A row per crate: cargo name/folder, on-disk (this-PR) version, git-history
+# baseline, the parsed required change type, whether the actual increment is
+# breaking, the computed minimum version, manual-review provenance, and raw tool
+# detail.
 $rows = New-Object System.Collections.Generic.List[object]
 
 Push-Location $RepoRoot
@@ -124,7 +135,12 @@ try {
             $bump = Get-PreviousVersionBumpCommit -RepoRoot $RepoRoot -BaseRef $BaseRef -PackageFolder $folder
         } catch {
             Write-Host "cargo semver-checks: $cargoName (on-disk v$onDisk) — baseline lookup FAILED: $($_.Exception.Message)"
+            $detail = "Baseline lookup failed — could not locate the crate's previous version-bump commit in git history. The semver comparison was skipped for this crate; verify the version increment manually.`n`n$($_.Exception.Message)"
+            if ($pkg.IsProcMacroOnly) {
+                $detail += "`n`nThis is also a proc-macro-only crate, so its procedural macro contract requires manual review. Because CI cannot determine whether its increment is breaking, direct published consumers are conservatively included in the manual review chain."
+            }
             $rows.Add([pscustomobject]@{
+                Folder      = $folder
                 Crate       = $cargoName
                 Baseline    = '⚠️ unknown'
                 BaselineSha = ''
@@ -132,7 +148,38 @@ try {
                 Required    = '?'
                 Sufficient  = $false
                 ChangeType  = 'unknown'
-                Detail      = "Baseline lookup failed — could not locate the crate's previous version-bump commit in git history. The semver comparison was skipped for this crate; verify the version increment manually.`n`n$($_.Exception.Message)"
+                ReleaseIsBreaking           = $null
+                RequiresManualSemverReview  = [bool]$pkg.IsProcMacroOnly
+                ManualSemverReviewSources   = @()
+                Detail      = $detail
+            })
+            continue
+        }
+
+        if ($pkg.IsProcMacroOnly) {
+            $baselineVersion = if ($null -eq $bump) { 'new crate' } else { $bump.Version }
+            $baselineSha = if ($null -eq $bump) { '' } else { $bump.Sha }
+            $releaseIsBreaking = if ($null -eq $bump) {
+                $false
+            } else {
+                $releaseChangeType = Get-ChangeTypeFromVersions -oldVersion $baselineVersion -newVersion $onDisk
+                Test-IsBreakingChange -oldVersion $baselineVersion -ChangeType $releaseChangeType
+            }
+
+            Write-Host "cargo semver-checks: $cargoName — proc-macro-only target; manual SemVer review required."
+            $rows.Add([pscustomobject]@{
+                Folder      = $folder
+                Crate       = $cargoName
+                Baseline    = $baselineVersion
+                BaselineSha = $baselineSha
+                OnDisk      = $onDisk
+                Required    = '?'
+                Sufficient  = $null
+                ChangeType  = 'manual'
+                ReleaseIsBreaking          = $releaseIsBreaking
+                RequiresManualSemverReview = $true
+                ManualSemverReviewSources  = @()
+                Detail      = "``$cargoName`` is a proc-macro-only crate. cargo-semver-checks intentionally skips proc-macro targets because they have no supported library API surface. Review exported macro names, accepted input syntax, diagnostics, and generated output manually; build and test results do not establish public API SemVer compatibility."
             })
             continue
         }
@@ -143,6 +190,7 @@ try {
             # baseline to compare against, so nothing to enforce.
             Write-Host "cargo semver-checks: $cargoName (on-disk v$onDisk) — no prior version-bump commit, skipping."
             $rows.Add([pscustomobject]@{
+                Folder      = $folder
                 Crate       = $cargoName
                 Baseline    = 'new crate'
                 BaselineSha = ''
@@ -150,6 +198,9 @@ try {
                 Required    = $onDisk
                 Sufficient  = $true
                 ChangeType  = 'none'
+                ReleaseIsBreaking          = $false
+                RequiresManualSemverReview = $false
+                ManualSemverReviewSources  = @()
                 Detail      = ''
             })
             continue
@@ -158,6 +209,9 @@ try {
         $baselineVersion = $bump.Version
         $baselineSha     = $bump.Sha
         $shortSha        = if ($baselineSha.Length -ge 7) { $baselineSha.Substring(0, 7) } else { $baselineSha }
+
+        $releaseChangeType = Get-ChangeTypeFromVersions -oldVersion $baselineVersion -newVersion $onDisk
+        $releaseIsBreaking = Test-IsBreakingChange -oldVersion $baselineVersion -ChangeType $releaseChangeType
 
         Write-Host "cargo semver-checks: $cargoName (on-disk v$onDisk) vs v$baselineVersion @ $shortSha..."
         $PSNativeCommandUseErrorActionPreference = $false
@@ -171,6 +225,7 @@ try {
         } catch {
             Write-Host "cargo semver-checks: $cargoName — analysis FAILED: $($_.Exception.Message)"
             $rows.Add([pscustomobject]@{
+                Folder      = $folder
                 Crate       = $cargoName
                 Baseline    = "⚠️ $baselineVersion"
                 BaselineSha = $baselineSha
@@ -178,6 +233,9 @@ try {
                 Required    = '?'
                 Sufficient  = $false
                 ChangeType  = 'unknown'
+                ReleaseIsBreaking          = $releaseIsBreaking
+                RequiresManualSemverReview = $false
+                ManualSemverReviewSources  = @()
                 Detail      = "cargo semver-checks could not be evaluated against ``$baselineSha`` (v$baselineVersion). The version increment was NOT verified — check it manually.`n`n$($_.Exception.Message)"
             })
             continue
@@ -206,6 +264,7 @@ try {
         $detail = $detail.Trim()
 
         $rows.Add([pscustomobject]@{
+            Folder      = $folder
             Crate       = $cargoName
             Baseline    = $baselineVersion
             BaselineSha = $baselineSha
@@ -213,6 +272,9 @@ try {
             Required    = $required
             Sufficient  = $sufficient
             ChangeType  = $changeType
+            ReleaseIsBreaking          = $releaseIsBreaking
+            RequiresManualSemverReview = $false
+            ManualSemverReviewSources  = @()
             Detail      = $detail
         })
     }
@@ -220,13 +282,82 @@ try {
     Pop-Location
 }
 
-# --- 3. Render the Markdown report. -------------------------------------------
-$underBumped = @($rows | Where-Object { -not $_.Sufficient })
+# --- 3. Propagate manual review one breaking edge at a time. ------------------
+$rowByFolder = @{}
+foreach ($row in $rows) { $rowByFolder[$row.Folder] = $row }
+
+$reviewQueue = [System.Collections.Generic.Queue[string]]::new()
+# A known non-breaking increment stops propagation. A known breaking increment
+# continues it. Unknown is conservative: CI cannot prove that the chain may stop,
+# so it continues the warning to the next direct published consumer.
+foreach ($row in $rows | Where-Object {
+    $_.RequiresManualSemverReview -and $false -ne $_.ReleaseIsBreaking
+}) {
+    $reviewQueue.Enqueue($row.Folder)
+}
+$expandedReviewSources = [System.Collections.Generic.HashSet[string]]::new()
+$missingManualReviews = New-Object 'System.Collections.Generic.List[object]'
+$missingReviewKeys = [System.Collections.Generic.HashSet[string]]::new()
+
+while ($reviewQueue.Count -gt 0) {
+    $sourceFolder = $reviewQueue.Dequeue()
+    if (-not $expandedReviewSources.Add($sourceFolder)) { continue }
+    $sourceRow = $rowByFolder[$sourceFolder]
+    if ($null -eq $sourceRow) { continue }
+
+    $sourcePkg = $byFolder[$sourceFolder]
+    $sourceCargoName = $sourcePkg.Name.Replace('-', '_')
+    $directDependents = Get-DirectPublishedDependentsFromBaseline `
+        -Baseline $packages `
+        -TargetCargoName $sourceCargoName
+
+    foreach ($dependentFolder in $directDependents) {
+        if (-not $rowByFolder.ContainsKey($dependentFolder)) {
+            $missingKey = "$sourceFolder->$dependentFolder"
+            if ($missingReviewKeys.Add($missingKey)) {
+                $missingManualReviews.Add([pscustomobject]@{
+                    SourceFolder    = $sourceFolder
+                    SourceCrate     = $sourceRow.Crate
+                    DependentFolder = $dependentFolder
+                    DependentCrate  = $byFolder[$dependentFolder].Name
+                })
+            }
+            continue
+        }
+
+        $dependentRow = $rowByFolder[$dependentFolder]
+        $dependentRow.RequiresManualSemverReview = $true
+        $dependentRow.ManualSemverReviewSources = @(
+            @($dependentRow.ManualSemverReviewSources) + $sourceRow.Crate |
+                Sort-Object -Unique
+        )
+
+        if ($false -ne $dependentRow.ReleaseIsBreaking) {
+            $reviewQueue.Enqueue($dependentFolder)
+        }
+    }
+}
+
+foreach ($row in $rows | Where-Object { @($_.ManualSemverReviewSources).Count -gt 0 }) {
+    $sources = @($row.ManualSemverReviewSources) -join ', '
+    $manualDetail = "Manual review is also required because direct dependency release(s) ``$sources`` were manually reviewed as breaking in the proc-macro compatibility chain. cargo-semver-checks still ran for this ordinary library when possible, but cannot prove whether the procedural macro contract is re-exported or otherwise exposed. If this crate's release is breaking, review continues to its direct published consumers; otherwise propagation stops here."
+    if ([string]::IsNullOrWhiteSpace([string]$row.Detail)) {
+        $row.Detail = $manualDetail
+    } else {
+        $row.Detail = "$($row.Detail)`n`n$manualDetail"
+    }
+}
+
+# --- 4. Render the Markdown report. -------------------------------------------
 $unknownRows = @($rows | Where-Object { $_.ChangeType -eq 'unknown' })
-$realUnder   = @($underBumped | Where-Object { $_.ChangeType -ne 'unknown' })
+$manualRows  = @($rows | Where-Object { $_.RequiresManualSemverReview })
+$realUnder   = @($rows | Where-Object {
+    $_.ChangeType -notin @('unknown', 'manual') -and -not $_.Sufficient
+})
 $hasReal      = $realUnder.Count -gt 0
 $hasUnknown   = $unknownRows.Count -gt 0
-$anyProblem   = $underBumped.Count -gt 0
+$hasManual    = $manualRows.Count -gt 0 -or $missingManualReviews.Count -gt 0
+$anyProblem   = $hasReal -or $hasUnknown -or $hasManual
 
 $bt = [char]0x60   # backtick, kept in a variable to avoid PowerShell escaping.
 $sb = New-Object System.Text.StringBuilder
@@ -239,12 +370,24 @@ if ($hasReal) {
         [void]$sb.AppendLine()
         [void]$sb.AppendLine("⚠️ The baseline (previous version-bump commit) could not be determined for **$($unknownRows.Count)** other crate(s); their version increment was **not** verified — check them manually.")
     }
+    if ($hasManual) {
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine("⚠️ **$($manualRows.Count)** publishing crate(s) require manual proc-macro compatibility review. Ordinary libraries retain their cargo-semver-checks result; review propagation advances only across a breaking release.")
+    }
 } elseif ($hasUnknown) {
     # No crate is under-incremented; the only problem is an unresolved baseline.
     # This is a warning (the check is incomplete), NOT an under-increment failure.
     [void]$sb.AppendLine('## ⚠️ Semver baseline could not be determined')
     [void]$sb.AppendLine()
     [void]$sb.AppendLine("${bt}cargo semver-checks${bt} could not determine the previous version-bump commit for **$($unknownRows.Count)** of $($rows.Count) crate(s), so their version increment was **not** verified. No crate was found to be under-incremented; check the crate(s) below manually.")
+    if ($hasManual) {
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine("Additionally, **$($manualRows.Count)** publishing crate(s) require manual proc-macro compatibility review.")
+    }
+} elseif ($hasManual) {
+    [void]$sb.AppendLine('## ⚠️ Manual proc-macro SemVer review required')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("${bt}cargo semver-checks${bt} intentionally does not analyse proc-macro-only targets. **$($manualRows.Count) of $($rows.Count)** publishing crate(s) require manual review either for their own procedural macro contract or because they directly consume a manually reviewed breaking release. Ordinary libraries retain their automated result, and review advances to the next dependency edge only when the current release is breaking.")
 } else {
     [void]$sb.AppendLine('## ✅ Version increments look sufficient')
     [void]$sb.AppendLine()
@@ -262,15 +405,26 @@ if (-not [string]::IsNullOrEmpty($RunUrl)) {
 [void]$sb.AppendLine('| Crate | Baseline | Baseline commit | This PR | Minimum required | Status |')
 [void]$sb.AppendLine('|---|---|---|---|---|---|')
 foreach ($r in $rows) {
-    if ($r.ChangeType -eq 'unknown') {
+    $requiresPropagatedReview = @($r.ManualSemverReviewSources).Count -gt 0
+    if ($r.ChangeType -eq 'unknown' -and $r.RequiresManualSemverReview) {
+        $status = '⚠️ baseline unknown; manual proc-macro chain review required'
+        $req    = '—'
+    } elseif ($r.ChangeType -eq 'unknown') {
         $status = '⚠️ baseline unknown — not verified'
         $req    = '—'
+    } elseif ($r.ChangeType -eq 'manual') {
+        $status = '⚠️ manual proc-macro review required'
+        $req    = '—'
+    } elseif (-not $r.Sufficient) {
+        $status = "🛑 increase to at least ${bt}$($r.Required)${bt}"
+        if ($requiresPropagatedReview) { $status += '; manual chain review required' }
+        $req    = "**$($r.Required)**"
+    } elseif ($requiresPropagatedReview) {
+        $status = '⚠️ automated check ok; manual proc-macro chain review required'
+        $req    = $r.Required
     } elseif ($r.Sufficient) {
         $status = '✅ ok'
         $req    = $r.Required
-    } else {
-        $status = "🛑 increase to at least ${bt}$($r.Required)${bt}"
-        $req    = "**$($r.Required)**"
     }
 
     # The resolved commit semver-checks compared against (--baseline-rev), shown
@@ -292,9 +446,22 @@ foreach ($r in $rows) {
 
 $fence = "$bt$bt$bt"
 if ($anyProblem) {
-    foreach ($r in $underBumped) {
-        $icon    = if ($r.ChangeType -eq 'unknown') { '⚠️' } else { '🛑' }
-        $summary = if ($r.ChangeType -eq 'unknown') { 'baseline lookup detail' } else { 'cargo semver-checks detail' }
+    foreach ($r in $rows | Where-Object {
+        $_.RequiresManualSemverReview -or
+        $_.ChangeType -in @('unknown', 'manual') -or
+        -not $_.Sufficient
+    }) {
+        $isRealUnder = $r.ChangeType -notin @('unknown', 'manual') -and -not $r.Sufficient
+        $icon = if ($isRealUnder) { '🛑' } else { '⚠️' }
+        $summary = if (@($r.ManualSemverReviewSources).Count -gt 0) {
+            'manual proc-macro propagation review detail'
+        } else {
+            switch ($r.ChangeType) {
+                'unknown' { 'baseline lookup detail' }
+                'manual'  { 'manual proc-macro review detail' }
+                default   { 'cargo semver-checks detail' }
+            }
+        }
         [void]$sb.AppendLine("<details><summary>$icon <code>$($r.Crate)</code> — $summary</summary>")
         [void]$sb.AppendLine()
         [void]$sb.AppendLine($fence)
@@ -303,10 +470,25 @@ if ($anyProblem) {
         [void]$sb.AppendLine('</details>')
         [void]$sb.AppendLine()
     }
+    foreach ($missing in $missingManualReviews) {
+        [void]$sb.AppendLine("<details><summary>⚠️ <code>$($missing.DependentCrate)</code> — missing direct-consumer review</summary>")
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine($fence)
+        [void]$sb.AppendLine("``$($missing.SourceCrate)`` has a breaking release in the manual proc-macro compatibility chain, but direct published consumer ``$($missing.DependentCrate)`` is not in this PR's publishing set. Run the release planner so the consumer receives its patch cascade floor, cargo-semver-checks analysis, and mandatory manual review.")
+        [void]$sb.AppendLine($fence)
+        [void]$sb.AppendLine('</details>')
+        [void]$sb.AppendLine()
+    }
     if ($hasReal) {
         [void]$sb.AppendLine('> If these breaking changes are intentional, increase each crate to at least its **Minimum required** version. This check is **informational and does not block the merge**.')
-    } else {
+    } elseif ($hasUnknown) {
         [void]$sb.AppendLine('> The baseline could not be determined for the crate(s) above, so their version increments were not verified. This check is **informational and does not block the merge**.')
+    } else {
+        [void]$sb.AppendLine('> Proc-macro API compatibility must be reviewed manually; successful builds and tests do not establish SemVer compatibility. This check is **informational and does not block the merge**.')
+    }
+    if ($missingManualReviews.Count -gt 0) {
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('> At least one direct published consumer that requires review is absent from the publishing set. Re-run the release planner before merging.')
     }
 } else {
     [void]$sb.AppendLine('> This check is informational and does not block the merge.')
@@ -319,5 +501,5 @@ if (-not [string]::IsNullOrEmpty($RunUrl)) {
 
 Set-Content -Path $ReportPath -Value $sb.ToString() -Encoding utf8
 Write-Host "Report written to $ReportPath"
-$status = if ($hasReal) { 'fail' } elseif ($hasUnknown) { 'warn' } else { 'pass' }
+$status = if ($hasReal) { 'fail' } elseif ($hasUnknown -or $hasManual) { 'warn' } else { 'pass' }
 Write-Outputs -publishing 'true' -status $status

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -606,7 +606,6 @@ function Get-ManualSemverReviewFindings {
             RequiresManualSemverReview = $true
             ManualSemverReviewKind      = 'proc-macro'
             ManualSemverReviewSources   = @()
-            PlannedChangeType           = $entry.EffectiveChangeType
         }
     }
 
@@ -663,7 +662,6 @@ function Get-ManualSemverReviewFindings {
                 RequiresManualSemverReview = $true
                 ManualSemverReviewKind      = 'proc-macro-dependent'
                 ManualSemverReviewSources   = @($sourceEntry.Name)
-                PlannedChangeType           = $dependentEntry.EffectiveChangeType
             }
         }
     }
@@ -1259,25 +1257,12 @@ function Format-PackageMenu {
     }
     $hasChanges = $changeCount -gt 0
 
-    $requiresManualSemverReview = $false
-    if ($null -ne $Finding.PSObject.Properties['RequiresManualSemverReview']) {
-        $requiresManualSemverReview = [bool]$Finding.RequiresManualSemverReview
+    $inReleaseSet = $false
+    if ($null -ne $Finding.PSObject.Properties['InReleaseSet']) {
+        $inReleaseSet = [bool]$Finding.InReleaseSet
     }
 
-    $manualReviewKind = ''
-    if ($null -ne $Finding.PSObject.Properties['ManualSemverReviewKind']) {
-        $manualReviewKind = [string]$Finding.ManualSemverReviewKind
-    }
-    $manualReviewSources = @()
-    if ($null -ne $Finding.PSObject.Properties['ManualSemverReviewSources']) {
-        $manualReviewSources = @($Finding.ManualSemverReviewSources)
-    }
-
-    $headerLine = if ($requiresManualSemverReview -and $manualReviewKind -eq 'proc-macro-dependent') {
-        "Manual SemVer review required for package affected by a breaking proc-macro review chain: $folder$queueSuffix"
-    } elseif ($requiresManualSemverReview) {
-        "Manual SemVer review required for proc-macro-only package: $folder$queueSuffix"
-    } elseif ($hasChanges) {
+    $headerLine = if ($hasChanges) {
         "Detected package with unreleased modifications: $folder$queueSuffix"
     } else {
         "Reviewing package (no detected changes): $folder$queueSuffix"
@@ -1287,16 +1272,6 @@ function Format-PackageMenu {
     $sb = [System.Text.StringBuilder]::new()
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine($headerLine)
-    if ($requiresManualSemverReview -and $manualReviewKind -eq 'proc-macro-dependent') {
-        $sourceLabel = if ($manualReviewSources.Count -eq 1) { 'dependency' } else { 'dependencies' }
-        [void]$sb.AppendLine("  Direct $sourceLabel with a manually reviewed breaking release: $($manualReviewSources -join ', ')")
-        [void]$sb.AppendLine('  cargo-semver-checks still classifies this library, but cannot prove whether the procedural macro contract is re-exported or otherwise exposed.')
-        [void]$sb.AppendLine('  Review the diff and public contract manually. A breaking result continues review to direct published consumers; any weaker result stops propagation here.')
-    } elseif ($requiresManualSemverReview) {
-        [void]$sb.AppendLine('  cargo-semver-checks cannot inspect procedural macro names, accepted inputs, or generated output.')
-        [void]$sb.AppendLine('  Review the diff and choose the appropriate change type manually.')
-        [void]$sb.AppendLine('  A breaking result continues manual review to direct published consumers; any weaker result leaves them on the normal cascade path.')
-    }
     # Show direct in-workspace dependents (packages that import this one
     # directly) as a comma-separated list. We deliberately omit transitive
     # dependents and full chains: in a workspace with hundreds of packages
@@ -1323,13 +1298,8 @@ function Format-PackageMenu {
     }
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine("  1. $viewDiffLabel")
-    if ($requiresManualSemverReview -and $Finding.InReleaseSet) {
-        $plannedChangeType = if ([string]::IsNullOrWhiteSpace([string]$Finding.PlannedChangeType)) {
-            'current'
-        } else {
-            [string]$Finding.PlannedChangeType
-        }
-        [void]$sb.AppendLine("  2. Keep the planned $plannedChangeType release after manual review")
+    if ($inReleaseSet) {
+        [void]$sb.AppendLine('  2. Keep the currently planned release level')
     } else {
         [void]$sb.AppendLine('  2. No material changes - release only if required by cascade logic')
     }
@@ -1856,25 +1826,20 @@ function Invoke-PlanReview {
             $next      = $queue[0]
             $remaining = $queue.Count - 1
             $decision  = Get-PackageReleaseDecision -Finding $next -RemainingCount $remaining -RepoRoot $RepoRoot
+            $isManualSemverReview = [bool]$next.RequiresManualSemverReview
+            if ($isManualSemverReview) {
+                # Proc-macro status affects why this decision is required and
+                # how review propagates, not the menu or decision semantics.
+                [void]$reviewedManualSemver.Add($next.Folder)
+            }
 
             if ($decision.Action -eq 'ignore') {
-                if ($next.RequiresManualSemverReview) {
-                    [void]$reviewedManualSemver.Add($next.Folder)
-                    if ($next.InReleaseSet) {
-                        $plannedLevel = $resolvedHash[$next.Folder].EffectiveChangeType
-                        if ($next.ManualSemverReviewKind -eq 'proc-macro-dependent') {
-                            Write-Host "  Keeping '$($next.Folder)' at its manually reviewed $plannedLevel level after the breaking proc-macro dependency review." -ForegroundColor DarkGray
-                        } else {
-                            Write-Host "  Keeping '$($next.Folder)' at its manually reviewed $plannedLevel level; cargo-semver-checks was not run for this proc-macro-only package." -ForegroundColor DarkGray
-                        }
-                    } else {
-                        Write-Host "  Skipping '$($next.Folder)' after manual proc-macro review; cascade may still pull it into the release plan on a later iteration." -ForegroundColor DarkGray
-                        [void]$declined.Add($next.Folder)
+                if ($next.InReleaseSet) {
+                    $plannedLevel = $resolvedHash[$next.Folder].EffectiveChangeType
+                    Write-Host "  Keeping '$($next.Folder)' at its currently planned $plannedLevel release level." -ForegroundColor DarkGray
+                    if (-not $isManualSemverReview) {
+                        [void]$reviewedCascadeAsIs.Add($next.Folder)
                     }
-                } elseif ($next.InReleaseSet) {
-                    $cascadeLevel = $resolvedHash[$next.Folder].EffectiveChangeType
-                    Write-Host "  Keeping '$($next.Folder)' at its cascade-applied $cascadeLevel level; reviewer should confirm no further elevation is needed." -ForegroundColor DarkGray
-                    [void]$reviewedCascadeAsIs.Add($next.Folder)
                 } else {
                     Write-Host "  Skipping '$($next.Folder)'; cascade may still pull it into the release plan on a later iteration." -ForegroundColor DarkGray
                     [void]$declined.Add($next.Folder)
@@ -1887,10 +1852,9 @@ function Invoke-PlanReview {
             # change-spec vocabulary ('breaking'/'nonbreaking'/'patch').
             #
             # For both new and elevation cases we craft the parsed-token object
-            # directly rather than going through Parse-ReleaseTokens. Ordinary
-            # re-surfaced findings are cascade-source entries. A mandatory
-            # proc-macro review can also re-surface a user-source entry; that
-            # path replaces its provisional token below to avoid a duplicate.
+            # directly rather than going through Parse-ReleaseTokens. A finding
+            # can also re-surface a user-source entry; replace its provisional
+            # token below instead of adding a duplicate.
             $changeSpec = switch ($decision.Action) {
                 'breaking'     { 'breaking' }
                 'non-breaking' { 'nonbreaking' }
@@ -1905,35 +1869,28 @@ function Invoke-PlanReview {
                 RawToken               = $newToken
             }
 
-            if ($next.RequiresManualSemverReview) {
-                [void]$reviewedManualSemver.Add($next.Folder)
-                $existingEntry = $resolvedHash[$next.Folder]
-                if ($null -ne $existingEntry -and $existingEntry.Source -eq 'user') {
-                    # The package was already a user-source token (targeted mode).
-                    # Replace that provisional decision with the one made after
-                    # viewing the manual SemVer review dialog instead of appending a
-                    # duplicate token that Resolve-ReleaseSet would reject.
-                    $folderNorm = $next.Folder.Replace('-', '_')
-                    $cargoNorm  = $existingEntry.Name.Replace('-', '_')
-                    $tokenIndex = -1
-                    for ($i = 0; $i -lt $userTokens.Count; $i++) {
-                        $tokenNorm = $userTokens[$i].Name.Replace('-', '_')
-                        if ($tokenNorm -eq $folderNorm -or $tokenNorm -eq $cargoNorm) {
-                            $tokenIndex = $i
-                            break
-                        }
+            $existingEntry = $resolvedHash[$next.Folder]
+            if ($null -ne $existingEntry -and $existingEntry.Source -eq 'user') {
+                # The package was already a user-source token (targeted mode).
+                # Replace that provisional decision instead of appending a
+                # duplicate token that Resolve-ReleaseSet would reject.
+                $folderNorm = $next.Folder.Replace('-', '_')
+                $cargoNorm  = $existingEntry.Name.Replace('-', '_')
+                $tokenIndex = -1
+                for ($i = 0; $i -lt $userTokens.Count; $i++) {
+                    $tokenNorm = $userTokens[$i].Name.Replace('-', '_')
+                    if ($tokenNorm -eq $folderNorm -or $tokenNorm -eq $cargoNorm) {
+                        $tokenIndex = $i
+                        break
                     }
-                    if ($tokenIndex -lt 0) {
-                        throw "Internal error: could not locate the user token for manually reviewed package '$($next.Folder)'."
-                    }
-                    $userTokens[$tokenIndex] = $newTokenEntry
-                } else {
-                    $userTokens.Add($newTokenEntry)
                 }
-                continue
+                if ($tokenIndex -lt 0) {
+                    throw "Internal error: could not locate the user token for reviewed package '$($next.Folder)'."
+                }
+                $userTokens[$tokenIndex] = $newTokenEntry
+            } else {
+                $userTokens.Add($newTokenEntry)
             }
-
-            $userTokens.Add($newTokenEntry)
         }
 
         Write-Warning "Plan review reached its runaway-cap of $runawayCap iterations; aborting further prompts. This is a defence-in-depth safety net — the state-signature check above should have caught any logic loop earlier; if you see this, please report."

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -339,6 +339,8 @@ function Update-EntryForRequiredChangeType {
 #     Source                    = 'user'|'cascade'
 #     AutoUpgraded              = $true|$false   # user-source entry strengthened by cascade
 #     PinHonoredAgainstCascade  = $true|$false   # -Force kept an explicit pin below cascade-required version
+#     IsProcMacroOnly           = $true|$false   # cargo metadata target classification
+#     RequiresManualSemverReview = $true|$false  # proc-macro API cannot be checked automatically
 #     CascadeReasons            = [List<{Target,Breaking}>]                  # one per (target → dep) edge
 #     RawToken                  = '<original token>'|$null                   # null for cascade-source
 #   }
@@ -361,26 +363,30 @@ function Update-EntryForRequiredChangeType {
 #          set PinHonoredAgainstCascade=$true); otherwise honour the pin and
 #          bump only the change-type tag.
 #        - or create a new cascade-source entry.
+#      Ordinary library dependents use their own cargo-semver-checks result,
+#      floored at patch. Proc-macro-only dependents use a provisional patch floor
+#      and are explicitly classified in the interactive review.
 #      Cascade reasons are recorded per (target → dep) edge with dedup by
 #      target name (re-encountering an edge for an already-strengthened target
 #      overwrites the prior reason in place).
 #
 # Note: cascade is one-level. The set of dependents reachable from a user
-# target is the transitive published dependents BFS; each dependent's
-# cascade-applied change type is derived from cargo-semver-checks analysing the
-# dependent's OWN current working-tree public API vs its previous version-bump
-# commit
-# (floored at 'patch' — it must re-release to pick up the new dependency
-# version even when its own API is unchanged). This replaces the former
-# allowed_external_types exposure heuristic.
+# target is the transitive published dependents BFS. For an ordinary library,
+# the dependent's cascade-applied change type is derived from cargo-semver-checks
+# analysing its OWN current working-tree public API vs its previous version-bump
+# commit, floored at patch because it must re-release to pick up the dependency
+# version. A proc-macro-only dependent starts at that mechanical patch floor and
+# is then classified by the user in the standard review dialog. This replaces
+# the former allowed_external_types exposure heuristic.
 function Resolve-ReleaseSet {
     param(
         [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$ParsedTokens,
         [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$WorkspaceBaseline,
         # Classifier scriptblock: (folder, cargoName) -> 'breaking'|'non-breaking'|
-        # 'patch'|'none'. Decides each crate's minimum change type from its real
-        # API diff (cargo-semver-checks) vs its previous version-bump commit. Production
-        # passes $script:DefaultSemverClassifier (which calls
+        # 'patch'|'none' for ordinary libraries. Decides each crate's minimum
+        # change type from its real API diff (cargo-semver-checks) vs its previous
+        # version-bump commit. Proc-macro-only packages bypass it and enter manual
+        # review. Production passes $script:DefaultSemverClassifier (which calls
         # Get-CrateRequiredChangeType); the default here is a no-op ('none') so
         # callers that only exercise version/pin/BFS math need not supply one.
         [Parameter(Mandatory = $false)][scriptblock]$GetRequiredChangeType = { param($folder, $cargoName) 'none' },
@@ -443,6 +449,8 @@ function Resolve-ReleaseSet {
             Source                   = 'user'
             AutoUpgraded             = $false
             PinHonoredAgainstCascade = $false
+            IsProcMacroOnly          = [bool]$pkg.IsProcMacroOnly
+            RequiresManualSemverReview = [bool]$pkg.IsProcMacroOnly
             CascadeReasons           = New-Object 'System.Collections.Generic.List[object]'
             RawToken                 = $req.RawToken
         }
@@ -463,14 +471,21 @@ function Resolve-ReleaseSet {
         foreach ($depFolder in $reachable) {
             $depPkg  = $baselineByFolder[$depFolder]
 
-            # The dependent's change type is decided by cargo-semver-checks
-            # analysing ITS OWN current working-tree API (which already reflects
-            # the target's in-progress changes, including re-exported types) vs
-            # its previous version-bump commit — floored at 'patch' because it must be
-            # re-released to pick up the new dependency version even when its own
-            # public API is unchanged. This replaces the old
-            # allowed_external_types exposure heuristic.
-            $dependentChangeType = Get-StrongerChangeType 'patch' (& $GetRequiredChangeType $depPkg.Folder $depPkg.Name)
+            # Ordinary library dependents are classified from their own API diff
+            # and floored at patch because they must re-release to pick up the new
+            # dependency version. cargo-semver-checks deliberately has no
+            # proc-macro-only API surface, so those dependents keep the mechanical
+            # patch floor until the interactive manual-review queue asks the user
+            # to inspect their diff and choose the final change type.
+            if ($depPkg.IsProcMacroOnly) {
+                $dependentChangeType = 'patch'
+            } else {
+                $classifiedChangeType = & $GetRequiredChangeType $depPkg.Folder $depPkg.Name
+                if ($classifiedChangeType -eq 'manual') {
+                    throw "Internal error: '$($depPkg.Name)' requires manual SemVer review but cargo metadata did not classify it as proc-macro-only."
+                }
+                $dependentChangeType = Get-StrongerChangeType 'patch' $classifiedChangeType
+            }
 
             $depBreakingForReason = Test-IsBreakingChange -oldVersion $depPkg.Version -ChangeType $dependentChangeType
             $cascadeReason = [pscustomobject]@{
@@ -512,6 +527,8 @@ function Resolve-ReleaseSet {
                     Source                   = 'cascade'
                     AutoUpgraded             = $false
                     PinHonoredAgainstCascade = $false
+                    IsProcMacroOnly          = [bool]$depPkg.IsProcMacroOnly
+                    RequiresManualSemverReview = [bool]$depPkg.IsProcMacroOnly
                     CascadeReasons           = New-Object 'System.Collections.Generic.List[object]'
                     RawToken                 = $null
                 }
@@ -529,13 +546,163 @@ function Resolve-ReleaseSet {
     # when the real API diff demands a stronger change type.
     foreach ($folder in $userFolders) {
         $entry    = $resolved[$folder]
+        if ($entry.IsProcMacroOnly) { continue }
         $required = & $GetRequiredChangeType $entry.Folder $entry.Name
+        if ($required -eq 'manual') {
+            throw "Internal error: '$($entry.Name)' requires manual SemVer review but cargo metadata did not classify it as proc-macro-only."
+        }
         if ([string]::IsNullOrEmpty($required) -or $required -eq 'none') { continue }
         Update-EntryForRequiredChangeType -Entry $entry -RequiredChangeType $required `
             -RequirementLabel 'cargo-semver-checks' -RequirementDetail "the crate's own public API changes" -Force:$Force
     }
 
     return @($resolved.Values)
+}
+
+# Builds the mandatory manual-review queue for:
+#   * every proc-macro-only package already present in the release set, and
+#   * direct published consumers of a manually reviewed breaking entry.
+#
+# The second category advances one dependency edge at a time. A consumer is not
+# allowed to propagate the review farther until its own standard dialog has
+# completed and its final planned increment is breaking. Keeping or selecting a
+# non-breaking/patch level stops the review chain at that package. All transitive
+# published dependents are still present in the normal cascade release set and
+# retain their cargo-semver-checks classification.
+function Get-ManualSemverReviewFindings {
+    param(
+        [Parameter(Mandatory = $true)][hashtable]$ResolvedReleaseSet,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$WorkspaceBaseline,
+        [Parameter(Mandatory = $false)][hashtable]$ModifiedSnapshot,
+        [Parameter(Mandatory = $false)][AllowEmptyCollection()][System.Collections.Generic.HashSet[string]]$ReviewedManualSemver
+    )
+
+    $byFolder = @{}
+    foreach ($pkg in $WorkspaceBaseline) { $byFolder[$pkg.Folder] = $pkg }
+
+    if ($null -eq $ReviewedManualSemver) {
+        $ReviewedManualSemver = [System.Collections.Generic.HashSet[string]]::new()
+    }
+
+    $findingsByFolder = [ordered]@{}
+    foreach ($entry in @($ResolvedReleaseSet.Values | Sort-Object -Property Folder)) {
+        if (-not $entry.IsProcMacroOnly) { continue }
+        $pkg = $byFolder[$entry.Folder]
+        if ($null -eq $pkg) { continue }
+
+        $changedFileCount = 0
+        if ($null -ne $ModifiedSnapshot -and $ModifiedSnapshot.ContainsKey($entry.Folder)) {
+            $changedFileCount = $ModifiedSnapshot[$entry.Folder]
+        }
+
+        $findingsByFolder[$entry.Folder] = [pscustomobject]@{
+            Folder                     = $entry.Folder
+            PackageName                = $entry.Name
+            CurrentVersion             = $entry.CurrentVersion
+            InReleaseSet               = $true
+            ChangedFileCount           = $changedFileCount
+            DependencyChains           = @()
+            WorkspaceDependencyChains  = Get-InWorkspaceDependencyChains -Packages $WorkspaceBaseline -TargetFolder $entry.Folder
+            RequiresManualSemverReview = $true
+            ManualSemverReviewKind      = 'proc-macro'
+            ManualSemverReviewSources   = @()
+            PlannedChangeType           = $entry.EffectiveChangeType
+        }
+    }
+
+    foreach ($sourceFolder in @($ReviewedManualSemver | Sort-Object)) {
+        if (-not $ResolvedReleaseSet.ContainsKey($sourceFolder)) { continue }
+        $sourceEntry = $ResolvedReleaseSet[$sourceFolder]
+        # -Force can intentionally keep an explicit version pin below the
+        # required severity while upgrading only EffectiveChangeType for cascade
+        # bookkeeping. Manual review propagation follows the version that will
+        # actually be written, matching CI, not that stronger internal tag.
+        $plannedChangeType = Get-ChangeTypeFromVersions `
+            -oldVersion $sourceEntry.CurrentVersion `
+            -newVersion $sourceEntry.EffectiveTargetVersion
+        if (-not (Test-IsBreakingChange -oldVersion $sourceEntry.CurrentVersion -ChangeType $plannedChangeType)) {
+            continue
+        }
+
+        $sourcePkg = $byFolder[$sourceFolder]
+        if ($null -eq $sourcePkg) { continue }
+        $sourceCargoName = $sourcePkg.Name.Replace('-', '_')
+
+        $directDependents = Get-DirectPublishedDependentsFromBaseline `
+            -Baseline $WorkspaceBaseline `
+            -TargetCargoName $sourceCargoName
+
+        foreach ($dependentFolder in $directDependents) {
+            if (-not $ResolvedReleaseSet.ContainsKey($dependentFolder)) {
+                throw "Internal error: direct published dependent '$dependentFolder' of manually reviewed breaking package '$sourceFolder' is missing from the resolved release set."
+            }
+
+            if ($findingsByFolder.Contains($dependentFolder)) {
+                $existingSources = @($findingsByFolder[$dependentFolder].ManualSemverReviewSources)
+                $findingsByFolder[$dependentFolder].ManualSemverReviewSources = @(
+                    $existingSources + $sourceEntry.Name | Sort-Object -Unique
+                )
+                continue
+            }
+
+            $dependentEntry = $ResolvedReleaseSet[$dependentFolder]
+            $dependentPkg = $byFolder[$dependentFolder]
+            $changedFileCount = 0
+            if ($null -ne $ModifiedSnapshot -and $ModifiedSnapshot.ContainsKey($dependentFolder)) {
+                $changedFileCount = $ModifiedSnapshot[$dependentFolder]
+            }
+
+            $findingsByFolder[$dependentFolder] = [pscustomobject]@{
+                Folder                     = $dependentEntry.Folder
+                PackageName                = $dependentEntry.Name
+                CurrentVersion             = $dependentEntry.CurrentVersion
+                InReleaseSet               = $true
+                ChangedFileCount           = $changedFileCount
+                DependencyChains           = @()
+                WorkspaceDependencyChains  = Get-InWorkspaceDependencyChains -Packages $WorkspaceBaseline -TargetFolder $dependentFolder
+                RequiresManualSemverReview = $true
+                ManualSemverReviewKind      = 'proc-macro-dependent'
+                ManualSemverReviewSources   = @($sourceEntry.Name)
+                PlannedChangeType           = $dependentEntry.EffectiveChangeType
+            }
+        }
+    }
+
+    return @($findingsByFolder.Values)
+}
+
+# Persists completed manual-review provenance on final resolved entries so the
+# release-plan display records both proc-macro classification and every
+# downstream review performed because a direct dependency remained breaking.
+function Set-ManualSemverReviewAnnotations {
+    param(
+        [Parameter(Mandatory = $true)][hashtable]$ResolvedReleaseSet,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$WorkspaceBaseline,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][System.Collections.Generic.HashSet[string]]$ReviewedManualSemver,
+        [Parameter(Mandatory = $false)][hashtable]$ModifiedSnapshot
+    )
+
+    $findings = Get-ManualSemverReviewFindings `
+        -ResolvedReleaseSet $ResolvedReleaseSet `
+        -WorkspaceBaseline $WorkspaceBaseline `
+        -ModifiedSnapshot $ModifiedSnapshot `
+        -ReviewedManualSemver $ReviewedManualSemver
+    $findingByFolder = @{}
+    foreach ($finding in $findings) { $findingByFolder[$finding.Folder] = $finding }
+
+    foreach ($entry in $ResolvedReleaseSet.Values) {
+        $completed = $ReviewedManualSemver.Contains($entry.Folder)
+        $kind = $null
+        $sources = @()
+        if ($completed -and $findingByFolder.ContainsKey($entry.Folder)) {
+            $kind = $findingByFolder[$entry.Folder].ManualSemverReviewKind
+            $sources = @($findingByFolder[$entry.Folder].ManualSemverReviewSources)
+        }
+
+        $entry | Add-Member -NotePropertyName ManualSemverReviewCompleted -NotePropertyValue $completed -Force
+        $entry | Add-Member -NotePropertyName ManualSemverReviewKind -NotePropertyValue $kind -Force
+        $entry | Add-Member -NotePropertyName ManualSemverReviewSources -NotePropertyValue $sources -Force
+    }
 }
 
 # Repo root for the default classifier, set by Invoke-ReleasePackagesMain before
@@ -1092,7 +1259,25 @@ function Format-PackageMenu {
     }
     $hasChanges = $changeCount -gt 0
 
-    $headerLine = if ($hasChanges) {
+    $requiresManualSemverReview = $false
+    if ($null -ne $Finding.PSObject.Properties['RequiresManualSemverReview']) {
+        $requiresManualSemverReview = [bool]$Finding.RequiresManualSemverReview
+    }
+
+    $manualReviewKind = ''
+    if ($null -ne $Finding.PSObject.Properties['ManualSemverReviewKind']) {
+        $manualReviewKind = [string]$Finding.ManualSemverReviewKind
+    }
+    $manualReviewSources = @()
+    if ($null -ne $Finding.PSObject.Properties['ManualSemverReviewSources']) {
+        $manualReviewSources = @($Finding.ManualSemverReviewSources)
+    }
+
+    $headerLine = if ($requiresManualSemverReview -and $manualReviewKind -eq 'proc-macro-dependent') {
+        "Manual SemVer review required for package affected by a breaking proc-macro review chain: $folder$queueSuffix"
+    } elseif ($requiresManualSemverReview) {
+        "Manual SemVer review required for proc-macro-only package: $folder$queueSuffix"
+    } elseif ($hasChanges) {
         "Detected package with unreleased modifications: $folder$queueSuffix"
     } else {
         "Reviewing package (no detected changes): $folder$queueSuffix"
@@ -1102,6 +1287,16 @@ function Format-PackageMenu {
     $sb = [System.Text.StringBuilder]::new()
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine($headerLine)
+    if ($requiresManualSemverReview -and $manualReviewKind -eq 'proc-macro-dependent') {
+        $sourceLabel = if ($manualReviewSources.Count -eq 1) { 'dependency' } else { 'dependencies' }
+        [void]$sb.AppendLine("  Direct $sourceLabel with a manually reviewed breaking release: $($manualReviewSources -join ', ')")
+        [void]$sb.AppendLine('  cargo-semver-checks still classifies this library, but cannot prove whether the procedural macro contract is re-exported or otherwise exposed.')
+        [void]$sb.AppendLine('  Review the diff and public contract manually. A breaking result continues review to direct published consumers; any weaker result stops propagation here.')
+    } elseif ($requiresManualSemverReview) {
+        [void]$sb.AppendLine('  cargo-semver-checks cannot inspect procedural macro names, accepted inputs, or generated output.')
+        [void]$sb.AppendLine('  Review the diff and choose the appropriate change type manually.')
+        [void]$sb.AppendLine('  A breaking result continues manual review to direct published consumers; any weaker result leaves them on the normal cascade path.')
+    }
     # Show direct in-workspace dependents (packages that import this one
     # directly) as a comma-separated list. We deliberately omit transitive
     # dependents and full chains: in a workspace with hundreds of packages
@@ -1128,7 +1323,16 @@ function Format-PackageMenu {
     }
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine("  1. $viewDiffLabel")
-    [void]$sb.AppendLine('  2. No material changes - release only if required by cascade logic')
+    if ($requiresManualSemverReview -and $Finding.InReleaseSet) {
+        $plannedChangeType = if ([string]::IsNullOrWhiteSpace([string]$Finding.PlannedChangeType)) {
+            'current'
+        } else {
+            [string]$Finding.PlannedChangeType
+        }
+        [void]$sb.AppendLine("  2. Keep the planned $plannedChangeType release after manual review")
+    } else {
+        [void]$sb.AppendLine('  2. No material changes - release only if required by cascade logic')
+    }
     [void]$sb.AppendLine("  3. Release as breaking change $($changeTypeHints['breaking'])")
     if (-not $hideNonBreaking) {
         [void]$sb.AppendLine("  4. Release as non-breaking change $($changeTypeHints['non-breaking'])")
@@ -1463,7 +1667,9 @@ function Invoke-WorkspaceCheck {
 # state (a working list of parse-tokens, a $declined hashset of NON-release-set
 # folders the user said "no" to, and a $reviewedCascadeAsIs hashset of
 # release-set cascade-source folders the user explicitly said "this cascade
-# change type is fine, don't elevate"). On each loop:
+# change type is fine, don't elevate"). A separate $reviewedManualSemver set
+# records proc-macro-only packages whose standard decision dialog has completed.
+# On each loop:
 #
 #   1. Re-resolve the release set from the current $userTokens via
 #      Resolve-ReleaseSet (cheap — operates on the immutable workspace
@@ -1498,13 +1704,14 @@ function Invoke-WorkspaceCheck {
 #
 # Returns: hashtable (folder -> resolved entry) representing the final plan.
 #
-# Termination: each iteration must change state (adds to $userTokens via
-# accept, OR to $declined / $reviewedCascadeAsIs via ignore). Verified by a
-# state-signature comparison at the top of each iteration — if two consecutive
-# iterations produce the same signature we throw a "no progress" diagnostic
-# rather than infinite-loop. A soft runaway cap (10 * published-package count)
-# bounds total prompts as a defence-in-depth safety net; the real bound is
-# one prompt per published package (the first time it surfaces).
+# Termination: each iteration must change state (adds to or updates $userTokens
+# via accept, OR adds to $declined / $reviewedCascadeAsIs /
+# $reviewedManualSemver via ignore). Verified by a state-signature comparison at
+# the top of each iteration — if two consecutive iterations produce the same
+# signature we throw a "no progress" diagnostic rather than infinite-loop. A
+# soft runaway cap (10 * published-package count) bounds total prompts as a
+# defence-in-depth safety net; the real bound is one prompt per published
+# package (the first time it surfaces).
 function Invoke-PlanReview {
     param(
         [Parameter(Mandatory = $true)][string]$RepoRoot,
@@ -1531,6 +1738,11 @@ function Invoke-PlanReview {
     # applied level, don't elevate". Entries are never removed: the decision
     # stands even if cascade strengthens the level on a later iteration.
     $reviewedCascadeAsIs = [System.Collections.Generic.HashSet[string]]::new()
+    # Proc-macro-only packages cannot be classified by cargo-semver-checks.
+    # Every such package that enters the plan is shown in the standard review
+    # dialog exactly once, including user-source entries and unchanged thin
+    # proc-macro crates pulled in by an implementation-crate release.
+    $reviewedManualSemver = [System.Collections.Generic.HashSet[string]]::new()
 
     # Runaway cap is a defence-in-depth safety net; the real termination
     # guarantee comes from the state-signature progress check below. Each
@@ -1551,10 +1763,11 @@ function Invoke-PlanReview {
     try {
         for ($iter = 0; $iter -lt $runawayCap; $iter++) {
             # State signature: every iteration must mutate at least one of
-            # {userTokens, declined, reviewedCascadeAsIs}. The current control
-            # flow guarantees this — accept appends to userTokens; ignore adds
-            # to declined or reviewedCascadeAsIs; the switch's default arm
-            # throws on any unrecognised action; an empty queue early-returns.
+            # {userTokens, declined, reviewedCascadeAsIs, reviewedManualSemver}.
+            # The current control flow guarantees this — accept appends to or
+            # updates userTokens; ignore adds to one of the review sets; the
+            # switch's default arm throws on any unrecognised action; an empty
+            # queue early-returns.
             # The signature check is therefore unreachable in normal
             # operation, but kept as defense-in-depth so a future change that
             # introduces a state-leak path (e.g. a new `continue`-without-
@@ -1563,7 +1776,8 @@ function Invoke-PlanReview {
             $tokenSig    = (@($userTokens.ToArray()) | ForEach-Object { $_.RawToken }) -join '|'
             $declinedSig = (@($declined) | Sort-Object) -join ','
             $reviewedSig = (@($reviewedCascadeAsIs) | Sort-Object) -join ','
-            $signature   = "tokens=[$tokenSig];declined=[$declinedSig];reviewed=[$reviewedSig]"
+            $manualSig   = (@($reviewedManualSemver) | Sort-Object) -join ','
+            $signature   = "tokens=[$tokenSig];declined=[$declinedSig];reviewed=[$reviewedSig];manual=[$manualSig]"
             if ($iter -gt 0 -and $signature -eq $previousSignature) {
                 throw "Plan review made no progress on iteration $iter (state signature unchanged). This indicates a logic bug; please report. Signature: $signature"
             }
@@ -1585,30 +1799,57 @@ function Invoke-PlanReview {
 
             # Handoff: a previously-declined or previously-reviewed-as-is folder
             # may now have a different cascade story (cascade pulled it into the
-            # release set, or strengthened its level). Decisions are final, so we
-            # do NOT re-prompt — the user's earlier "ignore" stands and the
-            # cascade-applied level is silently accepted. Show-ReleasePlan's
-            # output records the cascade reasons for transparency.
+            # release set, or strengthened its level). Ordinary decisions are
+            # final, but they cannot suppress a later mandatory proc-macro-chain
+            # review. Show-ReleasePlan records the cascade reasons.
 
             Write-Host ''
             Write-Host '🔍 Analyzing packages for unreleased modifications...' -ForegroundColor Cyan
 
             if ($Mode -eq 'all-changed') {
-                $allFindings = @(Get-UnreleasedModifiedDependencies -RepoRoot $RepoRoot -ResolvedReleaseSet $resolvedHash -ModifiedSnapshot $ModifiedSnapshot -IncludeAllModifiedAsRoots)
+                $modifiedFindings = @(Get-UnreleasedModifiedDependencies -RepoRoot $RepoRoot -ResolvedReleaseSet $resolvedHash -ModifiedSnapshot $ModifiedSnapshot -IncludeAllModifiedAsRoots)
             } else {
-                $allFindings = @(Get-UnreleasedModifiedDependencies -RepoRoot $RepoRoot -ResolvedReleaseSet $resolvedHash -ModifiedSnapshot $ModifiedSnapshot)
+                $modifiedFindings = @(Get-UnreleasedModifiedDependencies -RepoRoot $RepoRoot -ResolvedReleaseSet $resolvedHash -ModifiedSnapshot $ModifiedSnapshot)
+            }
+
+            # Manual SemVer findings take precedence over ordinary
+            # modification/elevation findings for the same folder. The queue
+            # includes unchanged proc-macro release-set members and advances to
+            # direct published consumers one breaking reviewed edge at a time.
+            $findingsByFolder = [ordered]@{}
+            $manualFindings = @(Get-ManualSemverReviewFindings `
+                -ResolvedReleaseSet $resolvedHash `
+                -WorkspaceBaseline $WorkspaceBaseline `
+                -ModifiedSnapshot $ModifiedSnapshot `
+                -ReviewedManualSemver $reviewedManualSemver)
+            foreach ($finding in @($manualFindings) + @($modifiedFindings)) {
+                if (-not $findingsByFolder.Contains($finding.Folder)) {
+                    $findingsByFolder[$finding.Folder] = $finding
+                }
             }
 
             $queue = @(
-                $allFindings | Where-Object {
-                    -not $declined.Contains($_.Folder) -and
-                    -not $reviewedCascadeAsIs.Contains($_.Folder)
+                $findingsByFolder.Values | Where-Object {
+                    if ($_.RequiresManualSemverReview) {
+                        # A prior ordinary "skip" or "keep cascade level"
+                        # decision did not evaluate the opaque proc-macro
+                        # contract. Only a completed manual SemVer review may
+                        # suppress this mandatory finding.
+                        return -not $reviewedManualSemver.Contains($_.Folder)
+                    }
+                    return -not $declined.Contains($_.Folder) -and
+                        -not $reviewedCascadeAsIs.Contains($_.Folder)
                 }
             )
 
             if ($queue.Count -eq 0) {
                 Write-Host ''
                 Write-Host '✅ No further unreleased modifications detected; release plan finalised.' -ForegroundColor Green
+                Set-ManualSemverReviewAnnotations `
+                    -ResolvedReleaseSet $resolvedHash `
+                    -WorkspaceBaseline $WorkspaceBaseline `
+                    -ReviewedManualSemver $reviewedManualSemver `
+                    -ModifiedSnapshot $ModifiedSnapshot
                 return $resolvedHash
             }
 
@@ -1617,7 +1858,20 @@ function Invoke-PlanReview {
             $decision  = Get-PackageReleaseDecision -Finding $next -RemainingCount $remaining -RepoRoot $RepoRoot
 
             if ($decision.Action -eq 'ignore') {
-                if ($next.InReleaseSet) {
+                if ($next.RequiresManualSemverReview) {
+                    [void]$reviewedManualSemver.Add($next.Folder)
+                    if ($next.InReleaseSet) {
+                        $plannedLevel = $resolvedHash[$next.Folder].EffectiveChangeType
+                        if ($next.ManualSemverReviewKind -eq 'proc-macro-dependent') {
+                            Write-Host "  Keeping '$($next.Folder)' at its manually reviewed $plannedLevel level after the breaking proc-macro dependency review." -ForegroundColor DarkGray
+                        } else {
+                            Write-Host "  Keeping '$($next.Folder)' at its manually reviewed $plannedLevel level; cargo-semver-checks was not run for this proc-macro-only package." -ForegroundColor DarkGray
+                        }
+                    } else {
+                        Write-Host "  Skipping '$($next.Folder)' after manual proc-macro review; cascade may still pull it into the release plan on a later iteration." -ForegroundColor DarkGray
+                        [void]$declined.Add($next.Folder)
+                    }
+                } elseif ($next.InReleaseSet) {
                     $cascadeLevel = $resolvedHash[$next.Folder].EffectiveChangeType
                     Write-Host "  Keeping '$($next.Folder)' at its cascade-applied $cascadeLevel level; reviewer should confirm no further elevation is needed." -ForegroundColor DarkGray
                     [void]$reviewedCascadeAsIs.Add($next.Folder)
@@ -1633,11 +1887,10 @@ function Invoke-PlanReview {
             # change-spec vocabulary ('breaking'/'nonbreaking'/'patch').
             #
             # For both new and elevation cases we craft the parsed-token object
-            # directly rather than going through Parse-ReleaseTokens. That's
-            # safe because Resolve-ReleaseSet's duplicate-folder check only
-            # fires against other user-source tokens — and the only re-surfaced
-            # findings are cascade-source entries (user-source members are never
-            # re-surfaced, per Get-UnreleasedModifiedDependencies's predicate).
+            # directly rather than going through Parse-ReleaseTokens. Ordinary
+            # re-surfaced findings are cascade-source entries. A mandatory
+            # proc-macro review can also re-surface a user-source entry; that
+            # path replaces its provisional token below to avoid a duplicate.
             $changeSpec = switch ($decision.Action) {
                 'breaking'     { 'breaking' }
                 'non-breaking' { 'nonbreaking' }
@@ -1645,12 +1898,42 @@ function Invoke-PlanReview {
                 default        { throw "Internal error: Get-PackageReleaseDecision returned unexpected action '$($decision.Action)'." }
             }
             $newToken = "$($next.Folder)@$changeSpec"
-            $userTokens.Add(([pscustomobject]@{
+            $newTokenEntry = [pscustomobject]@{
                 Name                   = $next.Folder
                 RequestedChangeType    = $decision.Action
                 RequestedTargetVersion = $null
                 RawToken               = $newToken
-            }))
+            }
+
+            if ($next.RequiresManualSemverReview) {
+                [void]$reviewedManualSemver.Add($next.Folder)
+                $existingEntry = $resolvedHash[$next.Folder]
+                if ($null -ne $existingEntry -and $existingEntry.Source -eq 'user') {
+                    # The package was already a user-source token (targeted mode).
+                    # Replace that provisional decision with the one made after
+                    # viewing the manual SemVer review dialog instead of appending a
+                    # duplicate token that Resolve-ReleaseSet would reject.
+                    $folderNorm = $next.Folder.Replace('-', '_')
+                    $cargoNorm  = $existingEntry.Name.Replace('-', '_')
+                    $tokenIndex = -1
+                    for ($i = 0; $i -lt $userTokens.Count; $i++) {
+                        $tokenNorm = $userTokens[$i].Name.Replace('-', '_')
+                        if ($tokenNorm -eq $folderNorm -or $tokenNorm -eq $cargoNorm) {
+                            $tokenIndex = $i
+                            break
+                        }
+                    }
+                    if ($tokenIndex -lt 0) {
+                        throw "Internal error: could not locate the user token for manually reviewed package '$($next.Folder)'."
+                    }
+                    $userTokens[$tokenIndex] = $newTokenEntry
+                } else {
+                    $userTokens.Add($newTokenEntry)
+                }
+                continue
+            }
+
+            $userTokens.Add($newTokenEntry)
         }
 
         Write-Warning "Plan review reached its runaway-cap of $runawayCap iterations; aborting further prompts. This is a defence-in-depth safety net — the state-signature check above should have caught any logic loop earlier; if you see this, please report."
@@ -1665,6 +1948,11 @@ function Invoke-PlanReview {
             $resolvedHash = @{}
             foreach ($e in $resolvedArr) { $resolvedHash[$e.Folder] = $e }
         }
+        Set-ManualSemverReviewAnnotations `
+            -ResolvedReleaseSet $resolvedHash `
+            -WorkspaceBaseline $WorkspaceBaseline `
+            -ReviewedManualSemver $reviewedManualSemver `
+            -ModifiedSnapshot $ModifiedSnapshot
         return $resolvedHash
     } finally {
         foreach ($p in $script:TempPackageDiffPaths) {
@@ -1910,6 +2198,12 @@ function Show-ReleasePlan {
         }
         $color = if ($entry.PinHonoredAgainstCascade) { 'Yellow' } else { 'Green' }
         Write-Host "  • $($entry.Folder): $($entry.CurrentVersion) -> $($entry.EffectiveTargetVersion)   [$tag]" -ForegroundColor $color
+        if ($entry.IsProcMacroOnly) {
+            Write-Host '      SemVer classification: manual proc-macro review (cargo-semver-checks not run)' -ForegroundColor Yellow
+        } elseif ($entry.ManualSemverReviewCompleted) {
+            $sources = @($entry.ManualSemverReviewSources) -join ', '
+            Write-Host "      SemVer classification: cargo-semver-checks plus manual review of breaking proc-macro dependency chain ($sources)" -ForegroundColor Yellow
+        }
         if ($null -ne $entry.CascadeReasons -and $entry.CascadeReasons.Count -gt 0) {
             $names = ($entry.CascadeReasons | ForEach-Object { $_.Target } | Sort-Object -Unique) -join ', '
             $reasonLabel = if ($entry.PinHonoredAgainstCascade) { 'cascade required upgrade from' } else { 'strengthened by cascade from' }
@@ -1919,6 +2213,12 @@ function Show-ReleasePlan {
 
     foreach ($entry in $cascadeEntries) {
         Write-Host "  • $($entry.Folder): $($entry.CurrentVersion) -> $($entry.EffectiveTargetVersion)   [cascade ($($entry.EffectiveChangeType))]" -ForegroundColor DarkCyan
+        if ($entry.IsProcMacroOnly) {
+            Write-Host '      SemVer classification: manual proc-macro review (cargo-semver-checks not run)' -ForegroundColor Yellow
+        } elseif ($entry.ManualSemverReviewCompleted) {
+            $sources = @($entry.ManualSemverReviewSources) -join ', '
+            Write-Host "      SemVer classification: cargo-semver-checks plus manual review of breaking proc-macro dependency chain ($sources)" -ForegroundColor Yellow
+        }
         $names = ($entry.CascadeReasons | ForEach-Object { $_.Target } | Sort-Object -Unique) -join ', '
         Write-Host "      cascaded from: $names" -ForegroundColor DarkGray
     }

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -1299,9 +1299,9 @@ function Format-PackageMenu {
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine("  1. $viewDiffLabel")
     if ($inReleaseSet) {
-        [void]$sb.AppendLine('  2. Keep the currently planned release level')
+        [void]$sb.AppendLine('  2. Keep the release level already in the plan')
     } else {
-        [void]$sb.AppendLine('  2. No material changes - release only if required by cascade logic')
+        [void]$sb.AppendLine('  2. No material changes - release only if another package requires it')
     }
     [void]$sb.AppendLine("  3. Release as breaking change $($changeTypeHints['breaking'])")
     if (-not $hideNonBreaking) {
@@ -1803,8 +1803,9 @@ function Invoke-PlanReview {
                     if ($_.RequiresManualSemverReview) {
                         # A prior ordinary "skip" or "keep cascade level"
                         # decision did not evaluate the opaque proc-macro
-                        # contract. Only a completed manual SemVer review may
-                        # suppress this mandatory finding.
+                        # contract. Only a completed manual review may suppress
+                        # this finding. Choosing "No material changes" in the
+                        # manual dialog counts as a completed review.
                         return -not $reviewedManualSemver.Contains($_.Folder)
                     }
                     return -not $declined.Contains($_.Folder) -and
@@ -1828,8 +1829,9 @@ function Invoke-PlanReview {
             $decision  = Get-PackageReleaseDecision -Finding $next -RemainingCount $remaining -RepoRoot $RepoRoot
             $isManualSemverReview = [bool]$next.RequiresManualSemverReview
             if ($isManualSemverReview) {
-                # Proc-macro status affects why this decision is required and
-                # how review propagates, not the menu or decision semantics.
+                # Every answer completes the manual review. "No material
+                # changes" means no release now, but a later cascade may still
+                # add the package at the patch floor without asking again.
                 [void]$reviewedManualSemver.Add($next.Folder)
             }
 

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -530,7 +530,10 @@ function Reset-ReleaseScriptCaches {
 # Memoised, mockable classifier: returns the minimum change type a crate's
 # current working-tree public API requires versus its previous version-bump
 # commit ('breaking' / 'non-breaking' / 'patch' / 'none' when there is no prior
-# bump to compare against), by running cargo-semver-checks once per crate.
+# bump to compare against). Ordinary library crates are classified by running
+# cargo-semver-checks once per crate. Proc-macro-only crates have no supported
+# cargo-semver-checks API surface, so they return the explicit 'manual' result
+# before the tool is invoked; the interactive planner owns that decision.
 # Resolve-ReleaseSet is invoked many times during the interactive review loop, so
 # results are cached per cargo name for the run. Test suites Mock this function to
 # supply deterministic verdicts without invoking the real tool (see the scenario
@@ -548,6 +551,15 @@ function Get-CrateRequiredChangeType {
         return $script:CrateSemverVerdictCache[$CargoName]
     }
 
+    $workspacePackage = Get-WorkspacePackages -repoRoot $RepoRoot |
+        Where-Object { $_.Folder -eq $Folder -or $_.Name -eq $CargoName } |
+        Select-Object -First 1
+    if ($null -ne $workspacePackage -and $workspacePackage.IsProcMacroOnly) {
+        Write-Host "cargo semver-checks: '$CargoName' is proc-macro-only; manual SemVer review is required." -ForegroundColor Yellow
+        $script:CrateSemverVerdictCache[$CargoName] = 'manual'
+        return 'manual'
+    }
+
     Write-Host "🔎 cargo semver-checks: analysing '$CargoName' against its previous version-bump commit..." -ForegroundColor Cyan
     $result = Invoke-CrateSemverCheck -PackageName $CargoName -PackageFolder $Folder -RepoRoot $RepoRoot
     $script:CrateSemverVerdictCache[$CargoName] = $result
@@ -559,6 +571,8 @@ function Get-CrateRequiredChangeType {
 #   Folder                - folder name under crates/ (used as the script's PackageName argument)
 #   Published             - $true if the package is published to crates.io
 #   Deps                  - array of normalized dependency names (kind 'normal' or 'build', not 'dev')
+#   HasLibraryTarget      - $true when cargo metadata reports a regular 'lib' target
+#   IsProcMacroOnly       - $true when the package has a 'proc-macro' target and no regular 'lib' target
 function Get-WorkspacePackages {
     param([string]$repoRoot)
 
@@ -579,12 +593,17 @@ function Get-WorkspacePackages {
             }
         }
 
+        $targetKinds = @($package.targets | ForEach-Object { @($_.kind) } | Sort-Object -Unique)
+        $hasLibraryTarget = $targetKinds -contains 'lib'
+
         $packages += [pscustomobject]@{
             Name                 = $package.name
             Folder               = Split-Path $manifestDir -Leaf
             Version              = $package.version
             Published            = -not ($null -ne $package.publish -and $package.publish.Count -eq 0)
             Deps                 = $deps
+            HasLibraryTarget     = $hasLibraryTarget
+            IsProcMacroOnly      = (-not $hasLibraryTarget) -and ($targetKinds -contains 'proc-macro')
         }
     }
 
@@ -715,6 +734,28 @@ function Get-AllTransitiveDependents {
     }
 
     return $dependents
+}
+
+# Returns the published workspace packages that directly depend on a cargo
+# package in an already-captured metadata snapshot. This deliberately follows
+# exactly one dependency edge; callers can advance a review frontier only after
+# classifying that edge's consumer.
+function Get-DirectPublishedDependentsFromBaseline {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Baseline,
+        [Parameter(Mandatory = $true)][string]$TargetCargoName
+    )
+
+    return @(
+        $Baseline |
+            Where-Object {
+                $_.Published -and
+                $_.Name.Replace('-', '_') -ne $TargetCargoName -and
+                $_.Deps -contains $TargetCargoName
+            } |
+            Sort-Object -Property Folder |
+            ForEach-Object { $_.Folder }
+    )
 }
 
 # --- FILE-CHANGE ANALYSIS ---
@@ -1222,12 +1263,13 @@ function Get-UnreleasedModifiedDependencies {
                     $isInReleaseSet = $null -ne $depEntry
                     if (-not $findings.Contains($depFolder)) {
                         $findings[$depFolder] = [pscustomobject]@{
-                            Folder           = $depFolder
-                            PackageName      = $depPackage.Name
-                            CurrentVersion   = $depPackage.Version
-                            InReleaseSet     = $isInReleaseSet
-                            ChangedFileCount = $modifiedMap[$depFolder]
-                            DependencyChains = @(, $depChain)
+                            Folder                     = $depFolder
+                            PackageName                = $depPackage.Name
+                            CurrentVersion             = $depPackage.Version
+                            InReleaseSet               = $isInReleaseSet
+                            ChangedFileCount           = $modifiedMap[$depFolder]
+                            DependencyChains           = @(, $depChain)
+                            RequiresManualSemverReview = [bool]$depPackage.IsProcMacroOnly
                         }
                     }
                     else {
@@ -1272,12 +1314,13 @@ function Get-UnreleasedModifiedDependencies {
         if (-not (& $shouldSurface $folder)) { continue }
         $pkg = $byFolder[$folder]
         $findings[$folder] = [pscustomobject]@{
-            Folder           = $folder
-            PackageName      = $pkg.Name
-            CurrentVersion   = $pkg.Version
-            InReleaseSet     = $ResolvedReleaseSet.ContainsKey($folder)
-            ChangedFileCount = $modifiedMap[$folder]
-            DependencyChains = @()
+            Folder                     = $folder
+            PackageName                = $pkg.Name
+            CurrentVersion             = $pkg.Version
+            InReleaseSet               = $ResolvedReleaseSet.ContainsKey($folder)
+            ChangedFileCount           = $modifiedMap[$folder]
+            DependencyChains           = @()
+            RequiresManualSemverReview = [bool]$pkg.IsProcMacroOnly
         }
     }
 

--- a/scripts/release-packages.ps1
+++ b/scripts/release-packages.ps1
@@ -55,18 +55,33 @@
 
     Cargo's 0.x.y SemVer rules are honored throughout: for `0.x.y` packages a
     Breaking change becomes `0.(x+1).0`, NonBreaking and Patch both map to
-    incrementing `y`. Every release in the plan is classified by running
-    `cargo semver-checks` against each crate's previous version-bump commit in
-    git history (the most recent commit that changed the crate's `[package]
-    version`, with the baseline rustdoc rebuilt from source via `--baseline-rev`,
-    so no registry access is required and it works in OSS and enterprise/offline
-    environments alike): a dependent whose own public API is unaffected by the
-    release cascades as a `patch` (it still re-releases to pick up the new
-    dependency version), while a dependent whose API actually changes (e.g. because
-    it re-exports a changed type) cascades at the severity `cargo semver-checks`
-    reports. Dev-only dependents are skipped — they automatically pick up the
-    new workspace version. cargo-semver-checks is a hard dependency (install
-    the version pinned in constants.env); there is no heuristic fallback.
+    incrementing `y`. Every ordinary library release in the plan is classified
+    by running `cargo semver-checks` against the crate's previous version-bump
+    commit in git history (the most recent commit that changed the crate's
+    `[package] version`, with the baseline rustdoc rebuilt from source via
+    `--baseline-rev`, so no registry access is required and it works in OSS and
+    enterprise/offline environments alike): a dependent whose own public API is
+    unaffected by the release cascades as a `patch` (it still re-releases to pick
+    up the new dependency version), while a dependent whose API actually changes
+    (e.g. because it re-exports a changed type) cascades at the severity
+    `cargo semver-checks` reports. Dev-only dependents are skipped — they
+    automatically pick up the new workspace version.
+
+    Proc-macro-only packages are detected from `cargo metadata` before
+    cargo-semver-checks runs. The tool cannot inspect procedural macro names,
+    accepted inputs, diagnostics, or generated output, so every proc-macro-only
+    package in the release set is shown in the standard diff + release-decision
+    dialog for explicit manual classification. This includes targeted packages
+    and unchanged proc-macro dependents added by cascade. Build/test success is
+    separate validation and does not prove procedural macro API compatibility.
+    A breaking manual result triggers the same mandatory review for direct
+    published consumers. Their provisional level remains the stronger of the
+    patch cascade floor and their own cargo-semver-checks result; the proc-macro
+    severity is not copied. Review advances another edge only when that
+    consumer's final result is breaking, and stops on any weaker result.
+
+    cargo-semver-checks remains a hard dependency for ordinary library packages
+    (install the version pinned in constants.env); there is no heuristic fallback.
 
     User-provided change types may be automatically upgraded by this analysis
     if the crate's real API diff requires a stronger change type (e.g. a

--- a/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
+++ b/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
@@ -187,6 +187,11 @@ function Write-PackageCargoToml {
         $entries = ($Package.AllowedExternalTypes | ForEach-Object { "`"$_`"" }) -join ', '
         $lines += "allowed_external_types = [$entries]"
     }
+    if ($Package.ContainsKey('ProcMacro') -and $Package.ProcMacro) {
+        $lines += ''
+        $lines += '[lib]'
+        $lines += 'proc-macro = true'
+    }
 
     $allDeps = @()
     if ($null -ne $Package.Deps) { $allDeps = @($Package.Deps) }

--- a/scripts/tests/Pester/integration/SemverReport.Tests.ps1
+++ b/scripts/tests/Pester/integration/SemverReport.Tests.ps1
@@ -1,0 +1,131 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\_common\TestHelpers.ps1')
+    . (Join-Path $PSScriptRoot '..\_common\New-SyntheticWorkspace.ps1')
+}
+
+Describe 'CI SemVer report proc-macro handling' {
+    It 'reports explicit manual review without invoking the unsupported proc-macro analysis path' {
+        $spec = @{
+            Packages = @(
+                @{ Name = 'consumer'; Version = '1.0.0'; Deps = @(@{ Name = 'macros' }) }
+                @{ Name = 'macros'; Version = '0.2.0'; ProcMacro = $true }
+            )
+        }
+        $workspace = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'semver-proc-macro')
+        $workspace.SetVersion('macros', '0.2.1')
+
+        $reportPath = Join-Path $TestDrive 'semver-report.md'
+        $outputPath = Join-Path $TestDrive 'github-output.txt'
+        $reportScript = Join-Path (Get-OxiRepoRoot) 'scripts\ci\semver-report.ps1'
+
+        & $reportScript `
+            -BaseRef HEAD `
+            -ReportPath $reportPath `
+            -RepoRoot $workspace.Path `
+            -GitHubOutput $outputPath 6> $null
+
+        $outputs = Get-Content -Path $outputPath -Raw
+        $report = Get-Content -Path $reportPath -Raw
+
+        $outputs | Should -Match '(?m)^publishing=true\r?$'
+        $outputs | Should -Match '(?m)^status=warn\r?$'
+        $report | Should -Match 'Manual proc-macro SemVer review required'
+        $report | Should -Match 'manual proc-macro review required'
+        $report | Should -Match 'intentionally does not analyse proc-macro-only targets'
+        $report | Should -Not -Match 'no crates with library targets selected'
+        $report | Should -Not -Match 'baseline unknown'
+        $report | Should -Not -Match 'missing direct-consumer review'
+    }
+
+    It 'reports a direct published consumer omitted after a breaking proc-macro release' {
+        $spec = @{
+            Packages = @(
+                @{ Name = 'consumer'; Version = '1.0.0'; Deps = @(@{ Name = 'macros' }) }
+                @{ Name = 'macros'; Version = '1.0.0'; ProcMacro = $true }
+            )
+        }
+        $workspace = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'semver-breaking-proc-macro')
+        $workspace.SetVersion('macros', '2.0.0')
+
+        $reportPath = Join-Path $TestDrive 'breaking-semver-report.md'
+        $outputPath = Join-Path $TestDrive 'breaking-github-output.txt'
+        $reportScript = Join-Path (Get-OxiRepoRoot) 'scripts\ci\semver-report.ps1'
+
+        & $reportScript `
+            -BaseRef HEAD `
+            -ReportPath $reportPath `
+            -RepoRoot $workspace.Path `
+            -GitHubOutput $outputPath 6> $null
+
+        $outputs = Get-Content -Path $outputPath -Raw
+        $report = Get-Content -Path $reportPath -Raw
+
+        $outputs | Should -Match '(?m)^status=warn\r?$'
+        $report | Should -Match '<code>consumer</code> — missing direct-consumer review'
+        $report | Should -Match 'direct published consumer `consumer` is not in this PR''s publishing set'
+        $report | Should -Match 'Re-run the release planner before merging'
+    }
+
+    It 'continues CI review propagation through a breaking proc-macro facade' {
+        $spec = @{
+            Packages = @(
+                @{ Name = 'consumer'; Version = '1.0.0'; Deps = @(@{ Name = 'facade_macros' }) }
+                @{ Name = 'facade_macros'; Version = '1.0.0'; ProcMacro = $true; Deps = @(@{ Name = 'root_macros' }) }
+                @{ Name = 'root_macros'; Version = '1.0.0'; ProcMacro = $true }
+            )
+        }
+        $workspace = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'semver-recursive-proc-macro')
+        $workspace.SetVersion('root_macros', '2.0.0')
+        $workspace.SetVersion('facade_macros', '2.0.0')
+
+        $reportPath = Join-Path $TestDrive 'recursive-semver-report.md'
+        $outputPath = Join-Path $TestDrive 'recursive-github-output.txt'
+        $reportScript = Join-Path (Get-OxiRepoRoot) 'scripts\ci\semver-report.ps1'
+
+        & $reportScript `
+            -BaseRef HEAD `
+            -ReportPath $reportPath `
+            -RepoRoot $workspace.Path `
+            -GitHubOutput $outputPath 6> $null
+
+        $outputs = Get-Content -Path $outputPath -Raw
+        $report = Get-Content -Path $reportPath -Raw
+
+        $outputs | Should -Match '(?m)^status=warn\r?$'
+        $report | Should -Match '<code>consumer</code> — missing direct-consumer review'
+        $report | Should -Match '`facade_macros` has a breaking release'
+        $report | Should -Match '`root_macros`'
+        $report | Should -Not -Match 'no crates with library targets selected'
+    }
+
+    It 'conservatively continues proc-macro review when the baseline is unknown' {
+        $spec = @{
+            Packages = @(
+                @{ Name = 'consumer'; Version = '1.0.0'; Deps = @(@{ Name = 'macros' }) }
+                @{ Name = 'macros'; Version = '1.0.0'; ProcMacro = $true }
+            )
+        }
+        $workspace = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'semver-unknown-proc-macro')
+
+        $reportPath = Join-Path $TestDrive 'unknown-semver-report.md'
+        $outputPath = Join-Path $TestDrive 'unknown-github-output.txt'
+        $reportScript = Join-Path (Get-OxiRepoRoot) 'scripts\ci\semver-report.ps1'
+
+        & $reportScript `
+            -BaseRef refs/heads/missing-semver-test-ref `
+            -ReportPath $reportPath `
+            -RepoRoot $workspace.Path `
+            -GitHubOutput $outputPath 6> $null
+
+        $outputs = Get-Content -Path $outputPath -Raw
+        $report = Get-Content -Path $reportPath -Raw
+
+        $outputs | Should -Match '(?m)^status=warn\r?$'
+        $report | Should -Match '\| `consumer` .*baseline unknown; manual proc-macro chain review required'
+        $report | Should -Match 'CI cannot determine whether its increment is breaking'
+        $report | Should -Match 'direct dependency release\(s\) `macros`'
+    }
+}

--- a/scripts/tests/Pester/scenarios/S25-proc-macro-user-review.scenario.psd1
+++ b/scripts/tests/Pester/scenarios/S25-proc-macro-user-review.scenario.psd1
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+@{
+    Name        = 'S25-proc-macro-user-review'
+    Description = 'A breaking user-selected proc macro triggers manual review of its direct published consumer. Keeping that consumer at patch stops review propagation, while the next-level dependent retains normal cascade classification.'
+
+    Workspace = @{
+        Spec = @{
+            Packages = @(
+                @{ Name = 'downstream'; Version = '1.0.0'; Deps = @(@{ Name = 'consumer' }) }
+                @{ Name = 'consumer'; Version = '1.0.0'; Deps = @(@{ Name = 'macros' }) }
+                @{ Name = 'macros'; Version = '1.0.0'; ProcMacro = $true }
+            )
+        }
+    }
+
+    History = @()
+
+    Run = @{
+        Packages = @('macros@patch')
+        Answers = @(
+            @{ Match = "Choose option for 'macros'"; Reply = '1' }
+            @{ Match = "Choose option for 'macros'"; Reply = '3' }
+            @{ Match = "Choose option for 'consumer'"; Reply = '2' }
+        )
+    }
+
+    Expect = @{
+        Released = @(
+            @{ Package = 'macros'; To = '2.0.0' }
+            @{ Package = 'consumer'; To = '1.0.1' }
+            @{ Package = 'downstream'; To = '1.0.1' }
+        )
+        PromptsRaised = @(
+            "Choose option for 'macros'"
+            "Choose option for 'macros'"
+            "Choose option for 'consumer'"
+        )
+        UnconsumedAnswers = @()
+    }
+}

--- a/scripts/tests/Pester/scenarios/S26-proc-macro-cascade-review.scenario.psd1
+++ b/scripts/tests/Pester/scenarios/S26-proc-macro-cascade-review.scenario.psd1
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+@{
+    Name        = 'S26-proc-macro-cascade-review'
+    Description = 'A proc-macro-only dependent pulled into the release set by an implementation-crate release is manually reviewed even when its own package folder is unchanged. Selecting a non-breaking release replaces the mechanical patch floor and does not trigger downstream manual review.'
+
+    Workspace = @{
+        Spec = @{
+            Packages = @(
+                @{ Name = 'consumer'; Version = '1.0.0'; Deps = @(@{ Name = 'macros' }) }
+                @{ Name = 'macros'; Version = '1.0.0'; ProcMacro = $true; Deps = @(@{ Name = 'implementation' }) }
+                @{ Name = 'implementation'; Version = '1.0.0' }
+            )
+        }
+    }
+
+    History = @()
+
+    Run = @{
+        Packages = @('implementation@patch')
+        Answers = @(
+            @{ Match = "Choose option for 'macros'"; Reply = '4' }
+        )
+    }
+
+    Expect = @{
+        Released = @(
+            @{ Package = 'implementation'; To = '1.0.1' }
+            @{ Package = 'macros'; To = '1.1.0' }
+            @{ Package = 'consumer'; To = '1.0.1' }
+        )
+        PromptsRaised = @(
+            "Choose option for 'macros'"
+        )
+        UnconsumedAnswers = @()
+    }
+}

--- a/scripts/tests/Pester/scenarios/S27-proc-macro-recursive-review.scenario.psd1
+++ b/scripts/tests/Pester/scenarios/S27-proc-macro-recursive-review.scenario.psd1
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+@{
+    Name        = 'S27-proc-macro-recursive-review'
+    Description = 'Manual review advances one published dependency edge at a time: a breaking proc macro surfaces its facade, and a breaking facade then surfaces its direct consumer.'
+
+    Workspace = @{
+        Spec = @{
+            Packages = @(
+                @{ Name = 'app'; Version = '1.0.0'; Deps = @(@{ Name = 'facade' }) }
+                @{ Name = 'facade'; Version = '1.0.0'; Deps = @(@{ Name = 'macros' }) }
+                @{ Name = 'macros'; Version = '1.0.0'; ProcMacro = $true }
+            )
+        }
+    }
+
+    History = @()
+
+    Run = @{
+        Packages = @('macros@patch')
+        Answers = @(
+            @{ Match = "Choose option for 'macros'"; Reply = '3' }
+            @{ Match = "Choose option for 'facade'"; Reply = '3' }
+            @{ Match = "Choose option for 'app'"; Reply = '2' }
+        )
+    }
+
+    Expect = @{
+        Released = @(
+            @{ Package = 'macros'; To = '2.0.0' }
+            @{ Package = 'facade'; To = '2.0.0' }
+            @{ Package = 'app'; To = '1.0.1' }
+        )
+        PromptsRaised = @(
+            "Choose option for 'macros'"
+            "Choose option for 'facade'"
+            "Choose option for 'app'"
+        )
+        UnconsumedAnswers = @()
+    }
+}

--- a/scripts/tests/Pester/scenarios/S28-proc-macro-no-material-then-cascade.scenario.psd1
+++ b/scripts/tests/Pester/scenarios/S28-proc-macro-no-material-then-cascade.scenario.psd1
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+@{
+    Name        = 'S28-proc-macro-no-material-then-cascade'
+    Description = 'Choosing no material changes completes proc-macro review. If a later decision pulls that proc macro into the release plan, it gets the patch floor without a second prompt.'
+
+    Workspace = @{
+        Spec = @{
+            Packages = @(
+                @{ Name = 'seed'; Version = '1.0.0'; Deps = @(@{ Name = 'macros' }) }
+                @{ Name = 'macros'; Version = '1.0.0'; ProcMacro = $true; Deps = @(@{ Name = 'implementation' }) }
+                @{ Name = 'implementation'; Version = '1.0.0' }
+            )
+        }
+    }
+
+    History = @(
+        @{ Op = 'ModifySource'; Package = 'seed' }
+        @{ Op = 'ModifySource'; Package = 'macros' }
+        @{ Op = 'ModifySource'; Package = 'implementation' }
+        @{ Op = 'AddCommit'; Message = 'package edits' }
+    )
+
+    Run = @{
+        Packages = @('seed@patch')
+        Answers = @(
+            @{ Match = "Choose option for 'macros'"; Reply = '2' }
+            @{ Match = "Choose option for 'implementation'"; Reply = '5' }
+        )
+    }
+
+    Expect = @{
+        Released = @(
+            @{ Package = 'seed'; To = '1.0.1' }
+            @{ Package = 'macros'; To = '1.0.1' }
+            @{ Package = 'implementation'; To = '1.0.1' }
+        )
+        PromptsRaised = @(
+            "Choose option for 'macros'"
+            "Choose option for 'implementation'"
+        )
+        UnconsumedAnswers = @()
+    }
+}

--- a/scripts/tests/Pester/unit/release-crate/PromptFlow.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-crate/PromptFlow.Tests.ps1
@@ -82,6 +82,44 @@ Describe 'Format-PackageMenu' {
         $out | Should -Match 'Detected package with unreleased modifications: ohno'
     }
 
+    Context 'manual proc-macro SemVer review' {
+        It 'explains the unsupported automated check and offers the standard decision choices' {
+            $finding = NewFinding -Folder 'macros' -CurrentVersion '1.2.3'
+            $finding | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
+            $finding | Add-Member -NotePropertyName RequiresManualSemverReview -NotePropertyValue $true
+            $finding | Add-Member -NotePropertyName ManualSemverReviewKind -NotePropertyValue 'proc-macro'
+            $finding | Add-Member -NotePropertyName ManualSemverReviewSources -NotePropertyValue @()
+            $finding | Add-Member -NotePropertyName PlannedChangeType -NotePropertyValue 'patch'
+
+            $out = Format-PackageMenu -Finding $finding -RemainingCount 0
+
+            $out | Should -Match 'Manual SemVer review required for proc-macro-only package: macros'
+            $out | Should -Match 'cargo-semver-checks cannot inspect procedural macro names'
+            $out | Should -Match 'Review the diff and choose the appropriate change type manually'
+            $out | Should -Match '2\. Keep the planned patch release after manual review'
+            $out | Should -Match '3\. Release as breaking change'
+            $out | Should -Match '4\. Release as non-breaking change'
+            $out | Should -Match '5\. Release as patch'
+        }
+
+        It 'explains one-hop propagation for an ordinary dependent of a reviewed breaking package' {
+            $finding = NewFinding -Folder 'facade' -CurrentVersion '1.2.3'
+            $finding | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
+            $finding | Add-Member -NotePropertyName RequiresManualSemverReview -NotePropertyValue $true
+            $finding | Add-Member -NotePropertyName ManualSemverReviewKind -NotePropertyValue 'proc-macro-dependent'
+            $finding | Add-Member -NotePropertyName ManualSemverReviewSources -NotePropertyValue @('macros')
+            $finding | Add-Member -NotePropertyName PlannedChangeType -NotePropertyValue 'patch'
+
+            $out = Format-PackageMenu -Finding $finding -RemainingCount 0
+
+            $out | Should -Match 'package affected by a breaking proc-macro review chain: facade'
+            $out | Should -Match 'Direct dependency with a manually reviewed breaking release: macros'
+            $out | Should -Match 'cargo-semver-checks still classifies this library'
+            $out | Should -Match 'breaking result continues review to direct published consumers'
+            $out | Should -Match 'weaker result stops propagation here'
+        }
+    }
+
     Context 'no-changes (-All-mode) finding' {
 
         # When the planner surfaces a package via -All mode there may be no
@@ -1081,6 +1119,119 @@ Describe 'Invoke-PlanReview -Mode all-changed' {
         Should -Invoke -CommandName Get-UnreleasedModifiedDependencies -Times 1 -Exactly -ParameterFilter {
             -not $IncludeAllModifiedAsRoots
         }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-PlanReview mandatory proc-macro review precedence
+# ---------------------------------------------------------------------------
+
+Describe 'Invoke-PlanReview mandatory proc-macro review precedence' {
+    It 're-prompts a previously declined consumer when a breaking proc macro later enters the plan' {
+        Mock -CommandName Write-Host -MockWith { } -ModuleName $null
+
+        $baseline = @(
+            [pscustomobject]@{
+                Name = 'seed'; Folder = 'seed'; Version = '1.0.0'
+                Published = $true; Deps = @(); IsProcMacroOnly = $false
+            }
+            [pscustomobject]@{
+                Name = 'z_macros'; Folder = 'z_macros'; Version = '1.0.0'
+                Published = $true; Deps = @(); IsProcMacroOnly = $true
+            }
+            [pscustomobject]@{
+                Name = 'a_consumer'; Folder = 'a_consumer'; Version = '1.0.0'
+                Published = $true; Deps = @('z_macros'); IsProcMacroOnly = $false
+            }
+        )
+        Mock -CommandName Get-WorkspacePackages -MockWith { $baseline }
+
+        Mock -CommandName Resolve-ReleaseSet -MockWith {
+            $entries = New-Object 'System.Collections.Generic.List[object]'
+            $entries.Add([pscustomobject]@{
+                Folder = 'seed'; Name = 'seed'; CurrentVersion = '1.0.0'
+                EffectiveChangeType = 'patch'; EffectiveTargetVersion = '1.0.1'
+                Source = 'user'; AutoUpgraded = $false
+                PinHonoredAgainstCascade = $false; IsProcMacroOnly = $false
+                RequiresManualSemverReview = $false
+                CascadeReasons = New-Object 'System.Collections.Generic.List[object]'
+                RawToken = 'seed@patch'
+            })
+
+            if (@($ParsedTokens.Name) -contains 'z_macros') {
+                $entries.Add([pscustomobject]@{
+                    Folder = 'z_macros'; Name = 'z_macros'; CurrentVersion = '1.0.0'
+                    EffectiveChangeType = 'breaking'; EffectiveTargetVersion = '2.0.0'
+                    Source = 'user'; AutoUpgraded = $false
+                    PinHonoredAgainstCascade = $false; IsProcMacroOnly = $true
+                    RequiresManualSemverReview = $true
+                    CascadeReasons = New-Object 'System.Collections.Generic.List[object]'
+                    RawToken = 'z_macros@breaking'
+                })
+                $consumerReasons = New-Object 'System.Collections.Generic.List[object]'
+                $consumerReasons.Add([pscustomobject]@{ Target = 'z_macros'; Breaking = $false })
+                $entries.Add([pscustomobject]@{
+                    Folder = 'a_consumer'; Name = 'a_consumer'; CurrentVersion = '1.0.0'
+                    EffectiveChangeType = 'patch'; EffectiveTargetVersion = '1.0.1'
+                    Source = 'cascade'; AutoUpgraded = $false
+                    PinHonoredAgainstCascade = $false; IsProcMacroOnly = $false
+                    RequiresManualSemverReview = $false
+                    CascadeReasons = $consumerReasons; RawToken = $null
+                })
+            }
+            $entries
+        }
+
+        # Both findings exist from the beginning. The ordinary consumer is
+        # deliberately first and is declined before the proc macro is accepted.
+        Mock -CommandName Get-UnreleasedModifiedDependencies -MockWith {
+            [pscustomobject]@{
+                Folder = 'a_consumer'; PackageName = 'a_consumer'
+                CurrentVersion = '1.0.0'; InReleaseSet = $false
+                ChangedFileCount = 1; DependencyChains = @()
+                WorkspaceDependencyChains = @()
+                RequiresManualSemverReview = $false
+            }
+            [pscustomobject]@{
+                Folder = 'z_macros'; PackageName = 'z_macros'
+                CurrentVersion = '1.0.0'; InReleaseSet = $false
+                ChangedFileCount = 1; DependencyChains = @()
+                WorkspaceDependencyChains = @()
+                RequiresManualSemverReview = $true
+                ManualSemverReviewKind = 'proc-macro'
+                ManualSemverReviewSources = @()
+                PlannedChangeType = 'patch'
+            }
+        }
+
+        $script:MandatoryReviewPromptFolders = New-Object 'System.Collections.Generic.List[string]'
+        Mock -CommandName Get-PackageReleaseDecision -MockWith {
+            $script:MandatoryReviewPromptFolders.Add($Finding.Folder)
+            switch ($script:MandatoryReviewPromptFolders.Count) {
+                1 { return @{ Action = 'ignore' } }
+                2 { return @{ Action = 'breaking' } }
+                3 { return @{ Action = 'ignore' } }
+                default { throw "Unexpected review prompt for '$($Finding.Folder)'." }
+            }
+        }
+
+        $initialToken = [pscustomobject]@{
+            Name = 'seed'; RequestedChangeType = 'patch'
+            RequestedTargetVersion = $null; RawToken = 'seed@patch'
+        }
+
+        $plan = Invoke-PlanReview `
+            -RepoRoot $TestDrive `
+            -ParsedTokens @($initialToken) `
+            -WorkspaceBaseline $baseline
+
+        $script:MandatoryReviewPromptFolders.ToArray() | Should -Be @(
+            'a_consumer',
+            'z_macros',
+            'a_consumer'
+        )
+        $plan['a_consumer'].ManualSemverReviewCompleted | Should -BeTrue
+        $plan['a_consumer'].ManualSemverReviewSources | Should -Be @('z_macros')
     }
 }
 

--- a/scripts/tests/Pester/unit/release-crate/PromptFlow.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-crate/PromptFlow.Tests.ps1
@@ -83,40 +83,39 @@ Describe 'Format-PackageMenu' {
     }
 
     Context 'manual proc-macro SemVer review' {
-        It 'explains the unsupported automated check and offers the standard decision choices' {
+        It 'renders the same menu as an ordinary package already in the release plan' {
+            $ordinary = NewFinding -Folder 'macros' -CurrentVersion '1.2.3'
+            $ordinary | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
+
             $finding = NewFinding -Folder 'macros' -CurrentVersion '1.2.3'
             $finding | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
             $finding | Add-Member -NotePropertyName RequiresManualSemverReview -NotePropertyValue $true
             $finding | Add-Member -NotePropertyName ManualSemverReviewKind -NotePropertyValue 'proc-macro'
             $finding | Add-Member -NotePropertyName ManualSemverReviewSources -NotePropertyValue @()
-            $finding | Add-Member -NotePropertyName PlannedChangeType -NotePropertyValue 'patch'
 
             $out = Format-PackageMenu -Finding $finding -RemainingCount 0
 
-            $out | Should -Match 'Manual SemVer review required for proc-macro-only package: macros'
-            $out | Should -Match 'cargo-semver-checks cannot inspect procedural macro names'
-            $out | Should -Match 'Review the diff and choose the appropriate change type manually'
-            $out | Should -Match '2\. Keep the planned patch release after manual review'
-            $out | Should -Match '3\. Release as breaking change'
-            $out | Should -Match '4\. Release as non-breaking change'
-            $out | Should -Match '5\. Release as patch'
+            $out | Should -Be (Format-PackageMenu -Finding $ordinary -RemainingCount 0)
+            $out | Should -Match 'Detected package with unreleased modifications: macros'
+            $out | Should -Match '2\. Keep the currently planned release level'
+            $out | Should -Not -Match 'Manual SemVer|cargo-semver-checks|proc-macro'
         }
 
-        It 'explains one-hop propagation for an ordinary dependent of a reviewed breaking package' {
+        It 'renders the same menu for a mandatory downstream review as for an ordinary package' {
+            $ordinary = NewFinding -Folder 'facade' -CurrentVersion '1.2.3'
+            $ordinary | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
+
             $finding = NewFinding -Folder 'facade' -CurrentVersion '1.2.3'
             $finding | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
             $finding | Add-Member -NotePropertyName RequiresManualSemverReview -NotePropertyValue $true
             $finding | Add-Member -NotePropertyName ManualSemverReviewKind -NotePropertyValue 'proc-macro-dependent'
             $finding | Add-Member -NotePropertyName ManualSemverReviewSources -NotePropertyValue @('macros')
-            $finding | Add-Member -NotePropertyName PlannedChangeType -NotePropertyValue 'patch'
 
             $out = Format-PackageMenu -Finding $finding -RemainingCount 0
 
-            $out | Should -Match 'package affected by a breaking proc-macro review chain: facade'
-            $out | Should -Match 'Direct dependency with a manually reviewed breaking release: macros'
-            $out | Should -Match 'cargo-semver-checks still classifies this library'
-            $out | Should -Match 'breaking result continues review to direct published consumers'
-            $out | Should -Match 'weaker result stops propagation here'
+            $out | Should -Be (Format-PackageMenu -Finding $ordinary -RemainingCount 0)
+            $out | Should -Match 'Detected package with unreleased modifications: facade'
+            $out | Should -Not -Match 'Manual SemVer|cargo-semver-checks|proc-macro'
         }
     }
 
@@ -970,7 +969,7 @@ Describe 'Invoke-PlanReview iteration-cap behaviour' {
                     CurrentVersion         = '1.0.0'
                     EffectiveChangeType    = 'non-breaking'
                     EffectiveTargetVersion = '1.1.0'
-                    Source                 = 'user'
+                    Source                 = if ($t.Name -eq 'p1') { 'user' } else { 'cascade' }
                     AutoUpgraded           = $false
                     CascadeReasons         = New-Object 'System.Collections.Generic.List[object]'
                     RawToken               = $t.RawToken
@@ -1200,7 +1199,6 @@ Describe 'Invoke-PlanReview mandatory proc-macro review precedence' {
                 RequiresManualSemverReview = $true
                 ManualSemverReviewKind = 'proc-macro'
                 ManualSemverReviewSources = @()
-                PlannedChangeType = 'patch'
             }
         }
 

--- a/scripts/tests/Pester/unit/release-crate/PromptFlow.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-crate/PromptFlow.Tests.ps1
@@ -97,7 +97,7 @@ Describe 'Format-PackageMenu' {
 
             $out | Should -Be (Format-PackageMenu -Finding $ordinary -RemainingCount 0)
             $out | Should -Match 'Detected package with unreleased modifications: macros'
-            $out | Should -Match '2\. Keep the currently planned release level'
+            $out | Should -Match '2\. Keep the release level already in the plan'
             $out | Should -Not -Match 'Manual SemVer|cargo-semver-checks|proc-macro'
         }
 
@@ -250,7 +250,7 @@ Describe 'Format-PackageMenu' {
         $lines = $out -split "`r?`n" | Where-Object { $_ -match '^\s*\d\. ' }
         $lines.Count | Should -Be 5
         $lines[0] | Should -Match '^\s*1\. View diff$'
-        $lines[1] | Should -Match '^\s*2\. No material changes - release only if required by cascade logic$'
+        $lines[1] | Should -Match '^\s*2\. No material changes - release only if another package requires it$'
         # Options 3-5 now carry a concrete version transition; precise transition asserted in dedicated tests below.
         $lines[2] | Should -Match '^\s*3\. Release as breaking change \(.+\)$'
         $lines[3] | Should -Match '^\s*4\. Release as non-breaking change \(.+\)$'
@@ -1230,6 +1230,80 @@ Describe 'Invoke-PlanReview mandatory proc-macro review precedence' {
         )
         $plan['a_consumer'].ManualSemverReviewCompleted | Should -BeTrue
         $plan['a_consumer'].ManualSemverReviewSources | Should -Be @('z_macros')
+    }
+
+    It 'keeps an out-of-plan no-material decision when cascade later adds the proc macro' {
+        Mock -CommandName Write-Host -MockWith { } -ModuleName $null
+
+        $baseline = @(
+            [pscustomobject]@{
+                Name = 'seed'; Folder = 'seed'; Version = '1.0.0'
+                Published = $true; Deps = @('macros'); IsProcMacroOnly = $false
+            }
+            [pscustomobject]@{
+                Name = 'macros'; Folder = 'macros'; Version = '1.0.0'
+                Published = $true; Deps = @('implementation'); IsProcMacroOnly = $true
+            }
+            [pscustomobject]@{
+                Name = 'implementation'; Folder = 'implementation'; Version = '1.0.0'
+                Published = $true; Deps = @(); IsProcMacroOnly = $false
+            }
+        )
+        Mock -CommandName Get-WorkspacePackages -MockWith { $baseline }
+
+        Mock -CommandName Get-UnreleasedModifiedDependencies -MockWith {
+            [pscustomobject]@{
+                Folder = 'macros'; PackageName = 'macros'
+                CurrentVersion = '1.0.0'
+                InReleaseSet = $ResolvedReleaseSet.ContainsKey('macros')
+                ChangedFileCount = 1; DependencyChains = @()
+                WorkspaceDependencyChains = @()
+                RequiresManualSemverReview = $true
+                ManualSemverReviewKind = 'proc-macro'
+                ManualSemverReviewSources = @()
+            }
+            if (-not $ResolvedReleaseSet.ContainsKey('implementation')) {
+                [pscustomobject]@{
+                    Folder = 'implementation'; PackageName = 'implementation'
+                    CurrentVersion = '1.0.0'; InReleaseSet = $false
+                    ChangedFileCount = 1; DependencyChains = @()
+                    WorkspaceDependencyChains = @()
+                    RequiresManualSemverReview = $false
+                }
+            }
+        }
+
+        $script:NoMaterialPromptStates = New-Object 'System.Collections.Generic.List[object]'
+        Mock -CommandName Get-PackageReleaseDecision -MockWith {
+            $script:NoMaterialPromptStates.Add([pscustomobject]@{
+                Folder = $Finding.Folder
+                InReleaseSet = [bool]$Finding.InReleaseSet
+            })
+            switch ($Finding.Folder) {
+                'macros' { return @{ Action = 'ignore' } }
+                'implementation' { return @{ Action = 'patch' } }
+                default { throw "Unexpected review prompt for '$($Finding.Folder)'." }
+            }
+        }
+
+        $initialToken = [pscustomobject]@{
+            Name = 'seed'; RequestedChangeType = 'patch'
+            RequestedTargetVersion = $null; RawToken = 'seed@patch'
+        }
+
+        $plan = Invoke-PlanReview `
+            -RepoRoot $TestDrive `
+            -ParsedTokens @($initialToken) `
+            -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType { param($folder, $cargoName) 'none' }
+
+        $script:NoMaterialPromptStates.Count | Should -Be 2
+        $script:NoMaterialPromptStates[0].Folder | Should -Be 'macros'
+        $script:NoMaterialPromptStates[0].InReleaseSet | Should -BeFalse
+        $script:NoMaterialPromptStates[1].Folder | Should -Be 'implementation'
+        $plan['macros'].Source | Should -Be 'cascade'
+        $plan['macros'].EffectiveChangeType | Should -Be 'patch'
+        $plan['macros'].ManualSemverReviewCompleted | Should -BeTrue
     }
 }
 

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -14,7 +14,8 @@ BeforeAll {
             [string]   $Name = $null,
             [string]   $Version = '0.1.0',
             [string[]] $Deps = @(),
-            [bool]     $Published = $true
+            [bool]     $Published = $true,
+            [bool]     $IsProcMacroOnly = $false
         )
         if ([string]::IsNullOrEmpty($Name)) { $Name = $Folder }
         return [pscustomobject]@{
@@ -23,6 +24,7 @@ BeforeAll {
             Version   = $Version
             Published = $Published
             Deps      = $Deps
+            IsProcMacroOnly = $IsProcMacroOnly
         }
     }
 
@@ -93,6 +95,22 @@ Describe 'Get-TransitivePublishedDependentsFromBaseline' {
     }
 }
 
+Describe 'Get-DirectPublishedDependentsFromBaseline' {
+    It 'returns only immediate published consumers' {
+        # a -> b -> c; private also directly consumes a but is not published.
+        $baseline = @(
+            (New-BaselinePackage -Folder 'a')
+            (New-BaselinePackage -Folder 'b' -Deps @('a'))
+            (New-BaselinePackage -Folder 'c' -Deps @('b'))
+            (New-BaselinePackage -Folder 'private' -Deps @('a') -Published $false)
+        )
+
+        $result = Get-DirectPublishedDependentsFromBaseline -Baseline $baseline -TargetCargoName 'a'
+
+        $result | Should -Be @('b')
+    }
+}
+
 Describe 'Resolve-ReleaseSet' {
     Context 'single user-source entry without dependents' {
         It 'returns a single user-source entry with the right effective state (0.x non-breaking -> 0.y.(z+1))' {
@@ -125,6 +143,155 @@ Describe 'Resolve-ReleaseSet' {
             $parsed = Parse-ReleaseTokens -Tokens @('pkg@breaking')
             $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline
             $resolved[0].EffectiveTargetVersion | Should -Be '2.0.0'
+        }
+
+        It 'marks a user-selected proc-macro-only package for manual review without invoking the classifier' {
+            $baseline = @(
+                (New-BaselinePackage -Folder 'macros' -Version '1.0.0' -IsProcMacroOnly $true)
+            )
+            $classifier = {
+                throw 'The automated classifier must not run for proc-macro-only packages.'
+            }
+            $parsed = Parse-ReleaseTokens -Tokens @('macros@patch')
+
+            $resolved = Resolve-ReleaseSet `
+                -ParsedTokens $parsed `
+                -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType $classifier
+
+            $resolved[0].EffectiveChangeType | Should -Be 'patch'
+            $resolved[0].RequiresManualSemverReview | Should -BeTrue
+            $resolved[0].IsProcMacroOnly | Should -BeTrue
+        }
+    }
+
+    Describe 'Get-ManualSemverReviewFindings: breaking review propagation' {
+        BeforeAll {
+            function script:New-ProcMacroReviewBaseline {
+                return @(
+                    (New-BaselinePackage -Folder 'macros' -Name 'macros' -Version '1.0.0' -IsProcMacroOnly $true)
+                    (New-BaselinePackage -Folder 'facade' -Name 'facade' -Version '1.0.0' -Deps @('macros'))
+                    (New-BaselinePackage -Folder 'app' -Name 'app' -Version '1.0.0' -Deps @('facade'))
+                )
+            }
+
+            function script:Resolve-ToHash {
+                param(
+                    [object[]]$Baseline,
+                    [string[]]$Tokens
+                )
+                $parsed = Parse-ReleaseTokens -Tokens $Tokens
+                $entries = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $Baseline
+                $result = @{}
+                foreach ($entry in $entries) { $result[$entry.Folder] = $entry }
+                return $result
+            }
+        }
+
+        It 'does not advance beyond an unreviewed proc macro' {
+            $baseline = New-ProcMacroReviewBaseline
+            $resolved = Resolve-ToHash -Baseline $baseline -Tokens @('macros@breaking')
+            $reviewed = [System.Collections.Generic.HashSet[string]]::new()
+
+            $findings = @(Get-ManualSemverReviewFindings `
+                -ResolvedReleaseSet $resolved `
+                -WorkspaceBaseline $baseline `
+                -ReviewedManualSemver $reviewed)
+
+            $findings.Folder | Should -Be @('macros')
+        }
+
+        It 'surfaces only the direct consumer after the proc macro is reviewed as breaking' {
+            $baseline = New-ProcMacroReviewBaseline
+            $resolved = Resolve-ToHash -Baseline $baseline -Tokens @('macros@breaking')
+            $reviewed = [System.Collections.Generic.HashSet[string]]::new()
+            [void]$reviewed.Add('macros')
+
+            $findings = @(Get-ManualSemverReviewFindings `
+                -ResolvedReleaseSet $resolved `
+                -WorkspaceBaseline $baseline `
+                -ReviewedManualSemver $reviewed)
+            $facade = $findings | Where-Object { $_.Folder -eq 'facade' }
+
+            $facade | Should -Not -BeNullOrEmpty
+            $facade.ManualSemverReviewKind | Should -Be 'proc-macro-dependent'
+            $facade.ManualSemverReviewSources | Should -Be @('macros')
+            $findings.Folder | Should -Not -Contain 'app'
+        }
+
+        It 'stops when the reviewed proc macro is non-breaking' {
+            $baseline = New-ProcMacroReviewBaseline
+            $resolved = Resolve-ToHash -Baseline $baseline -Tokens @('macros@patch')
+            $reviewed = [System.Collections.Generic.HashSet[string]]::new()
+            [void]$reviewed.Add('macros')
+
+            $findings = @(Get-ManualSemverReviewFindings `
+                -ResolvedReleaseSet $resolved `
+                -WorkspaceBaseline $baseline `
+                -ReviewedManualSemver $reviewed)
+
+            $findings.Folder | Should -Be @('macros')
+        }
+
+        It 'advances to the next hop only after the direct consumer is reviewed as breaking' {
+            $baseline = New-ProcMacroReviewBaseline
+            $resolved = Resolve-ToHash -Baseline $baseline -Tokens @('macros@breaking', 'facade@breaking')
+            $reviewed = [System.Collections.Generic.HashSet[string]]::new()
+            [void]$reviewed.Add('macros')
+            [void]$reviewed.Add('facade')
+
+            $findings = @(Get-ManualSemverReviewFindings `
+                -ResolvedReleaseSet $resolved `
+                -WorkspaceBaseline $baseline `
+                -ReviewedManualSemver $reviewed)
+            $app = $findings | Where-Object { $_.Folder -eq 'app' }
+
+            $app | Should -Not -BeNullOrEmpty
+            $app.ManualSemverReviewSources | Should -Be @('facade')
+        }
+
+        It 'does not advance when the direct consumer is reviewed below breaking' {
+            $baseline = New-ProcMacroReviewBaseline
+            $resolved = Resolve-ToHash -Baseline $baseline -Tokens @('macros@breaking', 'facade@patch')
+            $reviewed = [System.Collections.Generic.HashSet[string]]::new()
+            [void]$reviewed.Add('macros')
+            [void]$reviewed.Add('facade')
+
+            $findings = @(Get-ManualSemverReviewFindings `
+                -ResolvedReleaseSet $resolved `
+                -WorkspaceBaseline $baseline `
+                -ReviewedManualSemver $reviewed)
+
+            $findings.Folder | Should -Not -Contain 'app'
+        }
+
+        It 'follows the actual forced pin instead of a stronger internal severity tag' {
+            $baseline = New-ProcMacroReviewBaseline
+            $parsed = Parse-ReleaseTokens -Tokens @('macros@breaking', 'facade@1.1.0')
+            $classifier = New-StubClassifier @{ facade = 'breaking' }
+            $entries = Resolve-ReleaseSet `
+                -ParsedTokens $parsed `
+                -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType $classifier `
+                -Force
+            $resolved = @{}
+            foreach ($entry in $entries) { $resolved[$entry.Folder] = $entry }
+            $reviewed = [System.Collections.Generic.HashSet[string]]::new()
+            [void]$reviewed.Add('macros')
+            [void]$reviewed.Add('facade')
+
+            # -Force retains the non-breaking 1.1.0 pin while the internal tag stays
+            # breaking so cascade bookkeeping remains conservative.
+            $resolved['facade'].EffectiveChangeType | Should -Be 'breaking'
+            $resolved['facade'].EffectiveTargetVersion | Should -Be '1.1.0'
+
+            $findings = @(Get-ManualSemverReviewFindings `
+                -ResolvedReleaseSet $resolved `
+                -WorkspaceBaseline $baseline `
+                -ReviewedManualSemver $reviewed)
+
+            $findings.Folder | Should -Contain 'facade'
+            $findings.Folder | Should -Not -Contain 'app'
         }
     }
 
@@ -272,6 +439,38 @@ Describe 'Resolve-ReleaseSet' {
             foreach ($e in $resolved) { $byFolder[$e.Folder] = $e }
             $byFolder['b'].EffectiveChangeType | Should -Be 'non-breaking'
             $byFolder['c'].EffectiveChangeType | Should -Be 'patch'
+        }
+
+        It 'adds a proc-macro-only cascade dependent at the mechanical patch floor for manual review' {
+            # consumer -> macros -> implementation. Releasing implementation
+            # pulls in both dependents. The proc-macro itself cannot be
+            # cargo-semver-checked, while the ordinary consumer still can.
+            $baseline = @(
+                (New-BaselinePackage -Folder 'implementation' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'macros' -Version '1.0.0' -Deps @('implementation') -IsProcMacroOnly $true)
+                (New-BaselinePackage -Folder 'consumer' -Version '1.0.0' -Deps @('macros'))
+            )
+            $calls = [System.Collections.Generic.List[string]]::new()
+            $classifier = {
+                param([string]$Folder, [string]$CargoName)
+                $calls.Add($Folder)
+                return 'none'
+            }.GetNewClosure()
+            $parsed = Parse-ReleaseTokens -Tokens @('implementation@patch')
+
+            $resolved = Resolve-ReleaseSet `
+                -ParsedTokens $parsed `
+                -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType $classifier
+            $byFolder = @{}
+            foreach ($entry in $resolved) { $byFolder[$entry.Folder] = $entry }
+
+            $byFolder['macros'].Source | Should -Be 'cascade'
+            $byFolder['macros'].EffectiveChangeType | Should -Be 'patch'
+            $byFolder['macros'].RequiresManualSemverReview | Should -BeTrue
+            $calls | Should -Not -Contain 'macros'
+            $calls | Should -Contain 'implementation'
+            $calls | Should -Contain 'consumer'
         }
     }
 

--- a/scripts/tests/Pester/unit/releasing/GitFs.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/GitFs.Tests.ps1
@@ -401,6 +401,61 @@ Describe 'Get-WorkspacePackages' {
     }
 }
 
+Describe 'Get-WorkspacePackages: proc-macro target classification' {
+    BeforeAll {
+        Reset-ReleaseScriptCaches
+        $spec = @{
+            Packages = @(
+                @{ Name = 'macros'; Version = '0.2.0'; ProcMacro = $true }
+                @{ Name = 'library'; Version = '1.0.0' }
+            )
+        }
+        $script:ProcMacroWorkspace = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'proc-macro-targets')
+    }
+
+    It 'identifies a proc-macro-only package from cargo metadata' {
+        $packages = Get-WorkspacePackages -repoRoot $script:ProcMacroWorkspace.Path
+        $macros = $packages | Where-Object { $_.Name -eq 'macros' }
+
+        $macros.IsProcMacroOnly | Should -BeTrue
+        $macros.HasLibraryTarget | Should -BeFalse
+    }
+
+    It 'preserves ordinary library classification' {
+        $packages = Get-WorkspacePackages -repoRoot $script:ProcMacroWorkspace.Path
+        $library = $packages | Where-Object { $_.Name -eq 'library' }
+
+        $library.IsProcMacroOnly | Should -BeFalse
+        $library.HasLibraryTarget | Should -BeTrue
+    }
+
+    It 'returns manual without invoking cargo-semver-checks for a proc-macro-only package' {
+        Reset-ReleaseScriptCaches
+        Mock -CommandName Invoke-CrateSemverCheck -MockWith {
+            throw 'Invoke-CrateSemverCheck must not run for proc-macro-only packages.'
+        }
+
+        Get-CrateRequiredChangeType `
+            -Folder 'macros' `
+            -CargoName 'macros' `
+            -RepoRoot $script:ProcMacroWorkspace.Path | Should -Be 'manual'
+
+        Should -Invoke -CommandName Invoke-CrateSemverCheck -Times 0 -Exactly
+    }
+
+    It 'continues invoking cargo-semver-checks for an ordinary library package' {
+        Reset-ReleaseScriptCaches
+        Mock -CommandName Invoke-CrateSemverCheck -MockWith { 'patch' }
+
+        Get-CrateRequiredChangeType `
+            -Folder 'library' `
+            -CargoName 'library' `
+            -RepoRoot $script:ProcMacroWorkspace.Path | Should -Be 'patch'
+
+        Should -Invoke -CommandName Invoke-CrateSemverCheck -Times 1 -Exactly
+    }
+}
+
 Describe 'Get-AllTransitiveDependents' {
     BeforeAll {
         Reset-ReleaseScriptCaches


### PR DESCRIPTION
## Summary

- detect proc-macro-only packages from Cargo metadata before invoking `cargo-semver-checks`, then use the standard package review prompt and decision path for explicit manual classification
- when a proc-macro release is marked breaking, require manual review of crates that directly depend on it
- continue that review to the next layer only when a reviewed dependent is also marked breaking; each crate keeps its own classification
- treat **No material changes** as a completed review: an out-of-plan proc macro is released only if later cascade requires it, at the normal patch floor and without a second prompt
- align CI SemVer reporting, workflow guidance, release documentation, and focused Pester coverage without changing ordinary-library analysis

The supported release command is:

```powershell
./scripts/release-packages.ps1 -Packages 'templated_uri_macros@patch'
```

The provisional `patch` entry is replaced or retained by the standard interactive review decision.

## Validation

- 230 focused Pester tests passed, including all 28 release scenarios
- reproduced direct and cascade release-planner paths and the CI SemVer report path
- package-scoped formatting completed for all 45 workspace packages
- `just readme` completed
- final read-only changeset review found no high-confidence defects

`just spellcheck` could not run locally because the pinned `cargo-spellcheck` build requires `libclang`, which is unavailable on this Windows host; CI provisions that dependency.