### PR TITLE
fix(rest_over_grpc): correct transcoder edge cases and harden responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,7 +3538,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rest_over_grpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum-core",
  "base64 0.23.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ quote = { version = "1.0.42", default-features = false }
 rapidhash = { version = "4.1.1", default-features = false }
 recoverable = { path = "crates/recoverable", default-features = false, version = "0.1.7" }
 regex = { version = "1.12.2", default-features = false }
-rest_over_grpc = { path = "crates/rest_over_grpc", default-features = false, version = "0.1.0" }
+rest_over_grpc = { path = "crates/rest_over_grpc", default-features = false, version = "0.2.0" }
 route-recognizer = { version = "0.3.1", default-features = false }
 routerama = { path = "crates/routerama", default-features = false, version = "0.1.0" }
 routerama_build = { path = "crates/routerama_build", default-features = false, version = "0.1.0" }

--- a/crates/rest_over_grpc/Cargo.toml
+++ b/crates/rest_over_grpc/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "rest_over_grpc"
-version = "0.1.0"
+version = "0.2.0"
 description = "Automatically transcode gRPC services to REST/JSON endpoints"
 documentation = "https://docs.rs/rest_over_grpc"
 readme = "README.md"

--- a/crates/rest_over_grpc/README.md
+++ b/crates/rest_over_grpc/README.md
@@ -218,44 +218,44 @@ as an Axum fallback service.
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/rest_over_grpc">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQb4yyDbhLmywUbUgoeDyjY0hYb_gBd7xtnrJEbm_ruDQCrgu9hZIOCZ2xheWVyZWRlMC4zLjWCbnJlc3Rfb3Zlcl9ncnBjZTAuMS4wgm10b3dlcl9zZXJ2aWNlZTAuMy4z
- [__link0]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=handling::Status
- [__link1]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::RestService::new
- [__link10]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=transcoding::Transcode::try_transcode
- [__link11]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=transcoding::HttpResponse
- [__link12]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=transcoding::StreamingResponse
- [__link13]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=transcoding::Transcode::transcode
- [__link14]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=transcoding::Transcode::try_transcode
- [__link15]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=handling::Context
- [__link16]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/build/index.html
- [__link17]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=handling::ResponseStream
- [__link18]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=handling::Status
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQb4yyDbhLmywUbUgoeDyjY0hYb_gBd7xtnrJEbm_ruDQCrgu9hZIOCZ2xheWVyZWRlMC4zLjWCbnJlc3Rfb3Zlcl9ncnBjZTAuMi4wgm10b3dlcl9zZXJ2aWNlZTAuMy4z
+ [__link0]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=handling::Status
+ [__link1]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::RestService::new
+ [__link10]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=transcoding::Transcode::try_transcode
+ [__link11]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=transcoding::HttpResponse
+ [__link12]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=transcoding::StreamingResponse
+ [__link13]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=transcoding::Transcode::transcode
+ [__link14]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=transcoding::Transcode::try_transcode
+ [__link15]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=handling::Context
+ [__link16]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/build/index.html
+ [__link17]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=handling::ResponseStream
+ [__link18]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=handling::Status
  [__link19]: https://github.com/microsoft/oxidizer/blob/main/crates/rest_over_grpc_examples/Cargo.toml
  [__link2]: https://docs.rs/tower_service/0.3.3/tower_service/?search=Service
- [__link20]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=build::Generator::builder
- [__link21]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=build::GeneratorBuilder::emit_tonic_bridge
+ [__link20]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=build::Generator::builder
+ [__link21]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=build::GeneratorBuilder::emit_tonic_bridge
  [__link22]: https://github.com/microsoft/oxidizer/blob/main/crates/rest_over_grpc_examples/build.rs
  [__link23]: https://github.com/microsoft/oxidizer/blob/main/crates/rest_over_grpc_examples/src/tonic_bridge.rs
  [__link24]: https://github.com/microsoft/oxidizer/blob/main/crates/rest_over_grpc_examples/src/tonic_bridge.rs
  [__link25]: https://github.com/microsoft/oxidizer/tree/main/crates/rest_over_grpc_examples#examples
  [__link26]: https://github.com/microsoft/oxidizer/blob/main/crates/rest_over_grpc/examples/generate_service.rs
  [__link27]: https://github.com/microsoft/oxidizer/blob/main/crates/rest_over_grpc_examples/build.rs
- [__link28]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/build/index.html
- [__link29]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::serve_http
- [__link3]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::RestService
- [__link30]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::serve_http_fn
- [__link31]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::RestBody
- [__link32]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::RestService
+ [__link28]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/build/index.html
+ [__link29]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::serve_http
+ [__link3]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::RestService
+ [__link30]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::serve_http_fn
+ [__link31]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::RestBody
+ [__link32]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::RestService
  [__link33]: https://docs.rs/tower_service/0.3.3/tower_service/?search=Service
- [__link34]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::RestService
+ [__link34]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::RestService
  [__link35]: https://docs.rs/layered/0.3.5/layered/?search=Service
- [__link36]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=transcoding::HttpResponse
- [__link37]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=transcoding::StreamingResponse
- [__link38]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=transcoding::TranscodeResponse
- [__link39]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::RestService
+ [__link36]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=transcoding::HttpResponse
+ [__link37]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=transcoding::StreamingResponse
+ [__link38]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=transcoding::TranscodeResponse
+ [__link39]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::RestService
  [__link4]: https://docs.rs/layered/0.3.5/layered/?search=Service
- [__link5]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::RestService
+ [__link5]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::RestService
  [__link6]: https://docs.rs/axum-core/latest/axum_core/response/trait.IntoResponse.html
- [__link7]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::serve_http
- [__link8]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=serving::serve_http_fn
- [__link9]: https://docs.rs/rest_over_grpc/0.1.0/rest_over_grpc/?search=transcoding::Transcode::transcode
+ [__link7]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::serve_http
+ [__link8]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=serving::serve_http_fn
+ [__link9]: https://docs.rs/rest_over_grpc/0.2.0/rest_over_grpc/?search=transcoding::Transcode::transcode

--- a/crates/rest_over_grpc/examples/generate_service.rs
+++ b/crates/rest_over_grpc/examples/generate_service.rs
@@ -21,9 +21,6 @@ use rest_over_grpc::build::{Generator, HttpRule, RequestBody, ServiceDefinition}
 use routerama::HttpMethod;
 
 fn main() {
-    // Each RPC's HTTP binding. `GetShelf` captures the `{shelf}` path variable;
-    // `CreateShelf` maps the request body onto the request message's `shelf`
-    // field.
     let get_shelf = HttpRule::new(
         "GetShelf",
         HttpMethod::GET,
@@ -36,8 +33,6 @@ fn main() {
     )
     .request_body(RequestBody::Field("shelf".to_owned()));
 
-    // Register each RPC's binding with its request/response Rust type paths
-    // (where the `prost`-generated messages live).
     let mut library = ServiceDefinition::new("Library", None);
     library
         .add_method(get_shelf, "crate::pb::GetShelfRequest", "crate::pb::Shelf", None)
@@ -45,8 +40,6 @@ fn main() {
 
     let (transcoder, generated) = Generator::new().add(library).generate();
 
-    // Render the generated Rust for display; a build script would instead
-    // write the code to files under `OUT_DIR` with `Generator::write`.
     for service in generated {
         let mut code = service.service_trait().clone();
         if let Some(bridge) = service.tonic_bridge() {
@@ -56,7 +49,6 @@ fn main() {
         println!("{}", prettyplease::unparse(&file));
     }
 
-    // The top-level transcoder that routes across all services.
     let file = syn::parse2(transcoder).expect("generated transcoder is valid Rust");
     println!("{}", prettyplease::unparse(&file));
 }

--- a/crates/rest_over_grpc/examples/layered_service.rs
+++ b/crates/rest_over_grpc/examples/layered_service.rs
@@ -47,8 +47,6 @@ impl Transcode for HealthApi {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    // `layered::Service` needs no `Clone` and takes `&self`, so the service is
-    // not `mut`.
     let service = RestService::new(HealthApi);
 
     for target in ["/v1/health", "/v1/missing"] {
@@ -58,7 +56,6 @@ async fn main() {
             .body(Full::new(Bytes::new()))
             .expect("request builds");
 
-        // `layered::Service::execute` returns the response directly (no `Result`).
         let response = service.execute(request).await;
 
         let status = response.status();

--- a/crates/rest_over_grpc/examples/tower_service.rs
+++ b/crates/rest_over_grpc/examples/tower_service.rs
@@ -36,11 +36,9 @@ impl Transcode for HealthApi {
         _headers: http::HeaderMap,
         _body: &[u8],
     ) -> impl core::future::Future<Output = Option<TranscodeResponse>> + Send {
-        // `target` is the path plus optional `?query`; these requests carry none.
         let response = if method == "GET" && target == "/v1/health" {
             HttpResponse::ok_json(br#"{"status":"ok"}"#.to_vec())
         } else {
-            // A gRPC `Status` renders as a JSON HTTP error response.
             HttpResponse::from_status(&Status::not_found("no such route"))
         };
         async move { Some(response.into()) }

--- a/crates/rest_over_grpc/src/build/binding.rs
+++ b/crates/rest_over_grpc/src/build/binding.rs
@@ -30,6 +30,7 @@ pub struct Binding {
     pattern: String,
     body: RequestBody,
     response_body: ResponseBody,
+    response_body_default: Option<String>,
 }
 
 impl Binding {
@@ -48,6 +49,7 @@ impl Binding {
             pattern: template.to_string(),
             body: RequestBody::None,
             response_body: ResponseBody::Whole,
+            response_body_default: None,
         }
     }
 
@@ -65,6 +67,20 @@ impl Binding {
         self
     }
 
+    /// Records the proto3-JSON literal to emit when the selected `response_body`
+    /// field holds its default value (computed from the response descriptor).
+    #[must_use]
+    pub(crate) fn with_response_body_default(mut self, default: Option<String>) -> Self {
+        self.response_body_default = default;
+        self
+    }
+
+    /// The proto3-JSON default literal for this binding's `response_body` field,
+    /// if one was recorded.
+    pub(crate) fn response_body_default(&self) -> Option<&str> {
+        self.response_body_default.as_deref()
+    }
+
     /// The HTTP method this binding matches.
     #[must_use]
     pub fn method(&self) -> &HttpMethod {
@@ -75,9 +91,7 @@ impl Binding {
     #[must_use]
     #[expect(clippy::missing_panics_doc, reason = "only unreachable panics")]
     pub fn template(&self) -> PathTemplate<'_> {
-        // PathTemplate borrows its input, so the owned pattern is parsed on
-        // access. The affix grammar is deliberately used here as a superset of
-        // the constructor's grammar so rendered affixes recover as Segment::Affix.
+        // Parse with affix support so rendered affixes round-trip.
         PathTemplate::parse(&self.pattern, Grammar::default().with_segment_affixes())
             .expect("pattern was validated when the Binding was created")
     }

--- a/crates/rest_over_grpc/src/build/descriptor.rs
+++ b/crates/rest_over_grpc/src/build/descriptor.rs
@@ -37,7 +37,7 @@ use super::descriptor_options::DescriptorOptions;
 use super::http_rule::HttpRule;
 use super::request_body::RequestBody;
 use super::response_body::ResponseBody;
-use super::service_definition::{ServiceDefinition, to_snake_case};
+use super::service_definition::{ServiceDefinition, prost_snake_identifier, prost_type_identifier};
 
 /// Decodes every annotated service in `descriptor_set` into a
 /// [`ServiceDefinition`], its `module` set to the service's proto package (or
@@ -53,8 +53,8 @@ use super::service_definition::{ServiceDefinition, to_snake_case};
 /// Returns a [`DescriptorError`] if the descriptor bytes cannot be decoded, a
 /// method's annotation is malformed, an annotated method is client-streaming or
 /// bidirectional (which cannot be transcoded), a path template fails to parse,
-/// or a `body` / `response_body` names a field the request / response message
-/// does not have.
+/// a path variable does not target a supported request field, or a `body` /
+/// `response_body` names a field the request / response message does not have.
 pub(crate) fn definitions_from_descriptor(
     descriptor_set: &[u8],
     options: &DescriptorOptions,
@@ -83,6 +83,7 @@ pub(crate) fn definitions_from_descriptor(
             let Some(mut rule) = read_http_rule(method.name(), &method.options(), http_ext.as_ref(), &input, &output)? else {
                 continue;
             };
+            validate_path_fields(method.name(), &rule, &input)?;
 
             // Server-streaming is transcoded to a streamed JSON body; client-
             // streaming and bidirectional RPCs have no REST mapping.
@@ -231,10 +232,11 @@ fn read_rule(
     let mut request_body = read_body(message);
     let mut response_body = read_response_body(message);
     canonicalize_body_field(rpc, &mut request_body, input)?;
-    canonicalize_response_body_field(rpc, &mut response_body, output)?;
+    let response_body_default = canonicalize_response_body_field(rpc, &mut response_body, output)?;
     Ok(HttpRule::new(rpc, method, template)
         .request_body(request_body)
-        .response_body(response_body))
+        .response_body(response_body)
+        .with_response_body_default(response_body_default))
 }
 
 fn read_binding(
@@ -243,15 +245,27 @@ fn read_binding(
     input: &MessageDescriptor,
     output: &MessageDescriptor,
 ) -> Result<Binding, DescriptorError> {
+    if message
+        .get_field_by_name("additional_bindings")
+        .as_deref()
+        .and_then(Value::as_list)
+        .is_some_and(|list| !list.is_empty())
+    {
+        return Err(DescriptorError::malformed(
+            rpc,
+            "additional_bindings may not be nested inside another additional binding",
+        ));
+    }
     let (method, pattern) = read_pattern(rpc, message)?;
     let template = parse_template(rpc, &pattern)?;
     let mut request_body = read_body(message);
     let mut response_body = read_response_body(message);
     canonicalize_body_field(rpc, &mut request_body, input)?;
-    canonicalize_response_body_field(rpc, &mut response_body, output)?;
+    let response_body_default = canonicalize_response_body_field(rpc, &mut response_body, output)?;
     Ok(Binding::new(method, template)
         .request_body(request_body)
-        .response_body(response_body))
+        .response_body(response_body)
+        .with_response_body_default(response_body_default))
 }
 
 /// Verifies that a `body: "field"` names an actual field of the request
@@ -265,13 +279,49 @@ fn canonicalize_body_field(rpc: &str, body: &mut RequestBody, message: &MessageD
 }
 
 /// Verifies that a `response_body: "field"` names an actual field of the
-/// response `message`. An empty/absent `response_body` (the whole message)
-/// needs no field.
-fn canonicalize_response_body_field(rpc: &str, body: &mut ResponseBody, message: &MessageDescriptor) -> Result<(), DescriptorError> {
-    if let ResponseBody::Field(field) = body {
-        require_field(rpc, field, message, "response_body")?.json_name().clone_into(field);
+/// response `message`, rewrites it to its canonical JSON name, and returns the
+/// proto3-JSON literal to emit when that field holds its default value. An
+/// empty/absent `response_body` (the whole message) needs no field and returns
+/// `None`.
+fn canonicalize_response_body_field(
+    rpc: &str,
+    body: &mut ResponseBody,
+    message: &MessageDescriptor,
+) -> Result<Option<String>, DescriptorError> {
+    let ResponseBody::Field(field) = body else {
+        return Ok(None);
+    };
+    let descriptor = require_field(rpc, field, message, "response_body")?;
+    descriptor.json_name().clone_into(field);
+    Ok(Some(response_body_default_json(&descriptor)))
+}
+
+/// The proto3-JSON literal a `response_body` field serializes to when it holds
+/// its default value.
+///
+/// pbjson omits default-valued fields when serializing, so a selected field at
+/// its default would otherwise appear absent from the response. Emitting this
+/// literal instead matches the value a proto3-JSON gateway returns.
+fn response_body_default_json(field: &FieldDescriptor) -> String {
+    if field.is_list() {
+        return "[]".to_owned();
     }
-    Ok(())
+    if field.is_map() {
+        return "{}".to_owned();
+    }
+    // Message fields and `optional`/proto2 scalars carry explicit presence: an
+    // unset value is represented as JSON `null`. Messages route through the
+    // `Kind::Message` arm so the match, not a shared early return, owns that case.
+    match field.kind() {
+        Kind::Message(_) => "null".to_owned(),
+        _ if field.supports_presence() => "null".to_owned(),
+        Kind::Bool => "false".to_owned(),
+        Kind::String | Kind::Bytes => "\"\"".to_owned(),
+        // 64-bit integers are proto3-JSON strings; every other numeric is a bare number.
+        Kind::Int64 | Kind::Uint64 | Kind::Sint64 | Kind::Fixed64 | Kind::Sfixed64 => "\"0\"".to_owned(),
+        Kind::Double | Kind::Float | Kind::Int32 | Kind::Uint32 | Kind::Sint32 | Kind::Fixed32 | Kind::Sfixed32 => "0".to_owned(),
+        Kind::Enum(descriptor) => format!("\"{}\"", descriptor.default_value().name()),
+    }
 }
 
 /// Returns an [`DescriptorError`] unless `message` has a field named `field`
@@ -282,6 +332,55 @@ fn require_field(rpc: &str, field: &str, message: &MessageDescriptor, kind: &str
         .get_field_by_name(field)
         .or_else(|| message.get_field_by_json_name(field))
         .ok_or_else(|| DescriptorError::unknown_field(rpc, kind, field, message.full_name()))
+}
+
+fn validate_path_fields(rpc: &str, rule: &HttpRule, request: &MessageDescriptor) -> Result<(), DescriptorError> {
+    for path in rule.path_variable_field_paths() {
+        validate_path_field(rpc, &path, request)?;
+    }
+    Ok(())
+}
+
+fn validate_path_field(rpc: &str, path: &[String], request: &MessageDescriptor) -> Result<(), DescriptorError> {
+    let field_path = path.join(".");
+    let mut message = request.clone();
+    for (index, segment) in path.iter().enumerate() {
+        let field = message
+            .get_field_by_name(segment)
+            .ok_or_else(|| DescriptorError::unknown_field(rpc, "path variable", &field_path, message.full_name()))?;
+        let leaf = index + 1 == path.len();
+
+        if field.is_list() || field.is_map() {
+            return Err(DescriptorError::malformed(
+                rpc,
+                &format!("path variable `{field_path}` targets repeated or map field `{segment}`"),
+            ));
+        }
+        if field.containing_oneof().is_some_and(|oneof| !oneof.is_synthetic()) {
+            return Err(DescriptorError::malformed(
+                rpc,
+                &format!("path variable `{field_path}` targets oneof field `{segment}`"),
+            ));
+        }
+
+        match (leaf, field.kind()) {
+            (false, Kind::Message(nested)) => message = nested,
+            (false, _) => {
+                return Err(DescriptorError::malformed(
+                    rpc,
+                    &format!("path variable `{field_path}` descends through non-message field `{segment}`"),
+                ));
+            }
+            (true, Kind::Message(_)) => {
+                return Err(DescriptorError::malformed(
+                    rpc,
+                    &format!("path variable `{field_path}` must end at a primitive or enum field"),
+                ));
+            }
+            (true, _) => {}
+        }
+    }
+    Ok(())
 }
 
 fn parse_template<'a>(rpc: &str, pattern: &'a str) -> Result<PathTemplate<'a>, DescriptorError> {
@@ -412,10 +511,10 @@ fn relative_type_path(full_name: &str, package: &str, extern_paths: &[(String, S
     let rest = &type_segs[shared..];
     for (idx, seg) in rest.iter().enumerate() {
         if idx + 1 < rest.len() {
-            out.push_str(&to_snake_case(seg));
+            out.push_str(&prost_snake_identifier(seg));
             out.push_str("::");
         } else {
-            out.push_str(seg);
+            out.push_str(&prost_type_identifier(seg));
         }
     }
     out
@@ -449,9 +548,9 @@ fn resolve_extern(full_name: &str, extern_paths: &[(String, String)]) -> Option<
     for (idx, seg) in rest.iter().enumerate() {
         out.push_str("::");
         if idx + 1 < rest.len() {
-            out.push_str(&to_snake_case(seg));
+            out.push_str(&prost_snake_identifier(seg));
         } else {
-            out.push_str(seg);
+            out.push_str(&prost_type_identifier(seg));
         }
     }
     Some(out)
@@ -708,6 +807,37 @@ mod tests {
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
+    fn nested_additional_bindings_are_rejected() {
+        let descriptor = compile_descriptor(
+            "nested_additional_bindings",
+            r#"
+                syntax = "proto3";
+                package nestedbind;
+                import "google/api/annotations.proto";
+                message Req { string name = 1; }
+                message Resp { string item = 1; }
+                service S {
+                  rpc Get(Req) returns (Resp) {
+                    option (google.api.http) = {
+                      get: "/v1/x/{name}"
+                      additional_bindings {
+                        get: "/v1/y/{name}"
+                        additional_bindings {
+                          get: "/v1/z/{name}"
+                        }
+                      }
+                    };
+                  }
+                }
+            "#,
+            true,
+        );
+        let err = definitions_from_descriptor(&descriptor, &DescriptorOptions::new()).expect_err("nested additional_bindings are rejected");
+        assert!(err.to_string().contains("additional_bindings may not be nested"), "{err}");
+    }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
     fn snake_case_body_field_is_accepted() {
         let descriptor = compile_descriptor(
             "snake_case_body",
@@ -730,7 +860,7 @@ mod tests {
         assert_eq!(definitions.len(), 1);
         let code = generated(&descriptor, &DescriptorOptions::new()).replace(' ', "");
         assert!(code.contains("RequestBodyKind::Field(\"pageSize\")"), "{code}");
-        assert!(code.contains("ResponseBodyKind::Field(\"nextPageToken\")"), "{code}");
+        assert!(code.contains("ResponseBodyKind::Field{name:\"nextPageToken\","), "{code}");
     }
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
@@ -822,8 +952,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn proto_leading_comments_become_method_docs() {
-        // A method's proto leading comment is applied verbatim (all lines) to the
-        // generated trait method; a comment-less method gets no doc comment.
         let descriptor = compile_descriptor(
             "method_docs",
             r#"
@@ -848,19 +976,14 @@ mod tests {
         let definitions = definitions_from_descriptor(&descriptor, &DescriptorOptions::new()).expect("valid annotations");
         let rendered = definitions[0].trait_code().to_string();
 
-        // The documented RPC carries its proto comment (both lines).
         assert!(rendered.contains("Fetches a single item by name."), "{rendered}");
         assert!(rendered.contains("A second line of documentation."), "{rendered}");
-        // The comment-less RPC carries no doc comment: only the documented RPC's
-        // two `#[doc]` lines are emitted (the service itself is uncommented).
         assert_eq!(rendered.matches("[doc").count(), 2, "{rendered}");
     }
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn proto_service_leading_comment_documents_the_trait() {
-        // A service's leading comment is applied to the generated trait; a
-        // comment-less service yields a trait with no doc comment.
         let descriptor = compile_descriptor(
             "service_docs",
             r#"
@@ -883,13 +1006,10 @@ mod tests {
         let library = definitions.iter().find(|d| d.trait_name() == "Library").expect("Library");
         let undocumented = definitions.iter().find(|d| d.trait_name() == "Undocumented").expect("Undocumented");
 
-        // The service's leading comment documents the trait; its comment-less RPC
-        // adds no further doc, so exactly one `#[doc]` is emitted.
         let library_code = library.trait_code().to_string();
         assert!(library_code.contains("Manages the shelves in the library."), "{library_code}");
         assert_eq!(library_code.matches("[doc").count(), 1, "{library_code}");
 
-        // A comment-less service yields a trait (and method) with no doc comment.
         let undocumented_code = undocumented.trait_code().to_string();
         assert!(!undocumented_code.contains("[doc"), "{undocumented_code}");
     }
@@ -1161,8 +1281,6 @@ mod tests {
         let options_desc = pool
             .get_message_by_name("google.protobuf.MethodOptions")
             .expect("method options descriptor is present");
-        // A stand-in message for the input/output arguments: these cases fail on
-        // the pattern before body/response_body validation is reached.
         let msg = options_desc.clone();
 
         let bad_get_ext = pool
@@ -1285,9 +1403,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn from_fds_classifies_an_enum_path_variable() {
-        // An `enum` field bound as a path variable is classified so the generated
-        // poke accepts the value by name (via `parse_path_enum_value`), not just
-        // as a scalar.
         let descriptor = compile_descriptor(
             "enumpath",
             r#"
@@ -1317,10 +1432,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn from_fds_classifies_a_nested_enum_path_variable() {
-        // A dotted path variable whose leaf is an `enum` reached *through* a nested
-        // message (`{filters.genre}`) must still be classified as an enum, so the
-        // walk has to descend into the intermediate message field before reaching
-        // the enum leaf.
         let descriptor = compile_descriptor(
             "nestedenum",
             r#"
@@ -1341,9 +1452,6 @@ mod tests {
         );
 
         let code = generated(&descriptor, &opts());
-        // Classified as an enum (parsed by name/number), not a bare scalar, which
-        // is only possible if the walk descended through the `filters` message to
-        // reach the `genre` enum leaf.
         assert!(code.contains("parse_path_enum_value"), "{code}");
         assert!(
             code.contains("Genre :: from_str_name") || code.contains("Genre::from_str_name"),
@@ -1353,9 +1461,7 @@ mod tests {
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
-    fn enum_classification_skips_a_path_variable_that_descends_through_a_scalar() {
-        // A dotted path variable whose first segment is a scalar (not a message)
-        // cannot be an enum field, so classification bails without error.
+    fn path_variable_cannot_descend_through_a_scalar() {
         let descriptor = compile_descriptor(
             "scalarpath",
             r#"
@@ -1373,15 +1479,176 @@ mod tests {
             true,
         );
 
-        let definitions = definitions_from_descriptor(&descriptor, &opts()).expect("decodes despite the scalar-intermediate path");
+        let error = definitions_from_descriptor(&descriptor, &opts()).expect_err("scalar-intermediate path is rejected");
+        assert!(error.is_malformed());
+        assert!(error.to_string().contains("descends through non-message field `a`"));
+    }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
+    fn path_variable_must_name_an_existing_field() {
+        let descriptor = compile_descriptor(
+            "missingpath",
+            r#"
+                syntax = "proto3";
+                package missingpath;
+                import "google/api/annotations.proto";
+                message Req { string present = 1; }
+                message Resp {}
+                service Svc {
+                    rpc Get(Req) returns (Resp) {
+                        option (google.api.http) = { get: "/v1/{missing}" };
+                    }
+                }
+            "#,
+            true,
+        );
+
+        let error = definitions_from_descriptor(&descriptor, &opts()).expect_err("missing capture field is rejected");
+        assert!(error.is_unknown_field());
+        assert!(error.to_string().contains("path variable"));
+        assert!(error.to_string().contains("missing"));
+    }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
+    fn path_variable_rejects_unsupported_leaf_shapes() {
+        for (name, field, capture, expected) in [
+            ("repeated", "repeated string values = 1;", "values", "repeated or map"),
+            ("message", "Nested nested = 1;", "nested", "primitive or enum"),
+            ("oneof", "oneof choice { string value = 1; }", "value", "oneof"),
+        ] {
+            let source = format!(
+                r#"
+                    syntax = "proto3";
+                    package {name};
+                    import "google/api/annotations.proto";
+                    message Nested {{ string value = 1; }}
+                    message Req {{ {field} }}
+                    message Resp {{}}
+                    service Svc {{
+                        rpc Get(Req) returns (Resp) {{
+                            option (google.api.http) = {{ get: "/v1/{{{capture}}}" }};
+                        }}
+                    }}
+                "#
+            );
+            let descriptor = compile_descriptor(name, &source, true);
+            let error = definitions_from_descriptor(&descriptor, &opts()).expect_err("unsupported capture shape is rejected");
+            assert!(error.is_malformed());
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
+    fn optional_primitive_path_variable_is_accepted() {
+        let descriptor = compile_descriptor(
+            "optionalpath",
+            r#"
+                syntax = "proto3";
+                package optionalpath;
+                import "google/api/annotations.proto";
+                message Req { optional string value = 1; }
+                message Resp {}
+                service Svc {
+                    rpc Get(Req) returns (Resp) {
+                        option (google.api.http) = { get: "/v1/{value}" };
+                    }
+                }
+            "#,
+            true,
+        );
+
+        let definitions = definitions_from_descriptor(&descriptor, &opts()).expect("synthetic optional oneof is accepted");
         assert_eq!(definitions.len(), 1);
     }
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
+    fn prost_keyword_field_identifiers_match_generated_messages() {
+        let descriptor = compile_descriptor(
+            "keywordfields",
+            r#"
+                syntax = "proto3";
+                package keywordfields;
+                import "google/api/annotations.proto";
+                message Req {
+                    string self = 1;
+                    string extern = 2;
+                    string gen = 3;
+                }
+                message Resp {}
+                service Svc {
+                    rpc Get(Req) returns (Resp) {
+                        option (google.api.http) = {
+                            get: "/v1/{self}"
+                            additional_bindings { get: "/v1/extern/{extern}" }
+                            additional_bindings { get: "/v1/gen/{gen}" }
+                        };
+                    }
+                }
+            "#,
+            true,
+        );
+
+        let code = generated(&descriptor, &opts());
+        assert!(code.contains("request . self_") || code.contains("request.self_"), "{code}");
+        assert!(code.contains("request . extern_") || code.contains("request.extern_"), "{code}");
+        assert!(code.contains("request . r#gen") || code.contains("request.r#gen"), "{code}");
+    }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
+    fn response_body_default_json_covers_every_field_kind() {
+        let descriptor = compile_descriptor(
+            "defaultjson",
+            r#"
+                syntax = "proto3";
+                package defaultjson;
+                enum Color { RED = 0; GREEN = 1; }
+                message Inner { string leaf = 1; }
+                message All {
+                    repeated string list_f = 1;
+                    map<string, string> map_f = 2;
+                    optional string opt_f = 3;
+                    Inner msg_f = 4;
+                    bool bool_f = 5;
+                    string str_f = 6;
+                    bytes bytes_f = 7;
+                    int64 i64_f = 8;
+                    uint64 u64_f = 9;
+                    int32 i32_f = 10;
+                    double dbl_f = 11;
+                    Color enum_f = 12;
+                }
+            "#,
+            false,
+        );
+        let pool = prost_reflect::DescriptorPool::decode(descriptor.as_slice()).expect("descriptor pool decodes");
+        let message = pool.get_message_by_name("defaultjson.All").expect("All message exists");
+        let default_of = |name: &str| {
+            let field = message.get_field_by_name(name).expect("field exists");
+            response_body_default_json(&field)
+        };
+
+        assert_eq!(default_of("list_f"), "[]");
+        assert_eq!(default_of("map_f"), "{}");
+        assert_eq!(default_of("opt_f"), "null");
+        assert_eq!(default_of("msg_f"), "null");
+        assert_eq!(default_of("bool_f"), "false");
+        assert_eq!(default_of("str_f"), "\"\"");
+        assert_eq!(default_of("bytes_f"), "\"\"");
+        assert_eq!(default_of("i64_f"), "\"0\"");
+        assert_eq!(default_of("u64_f"), "\"0\"");
+        assert_eq!(default_of("i32_f"), "0");
+        assert_eq!(default_of("dbl_f"), "0");
+        assert_eq!(default_of("enum_f"), "\"RED\"");
+    }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
     fn enum_field_rust_type_is_none_for_an_empty_field_path() {
-        // Defensive fall-through: an empty field path never occurs for a real
-        // path variable (each has at least one segment), so the walk yields `None`.
         let descriptor = compile_descriptor(
             "emptypath",
             r#"
@@ -1394,6 +1661,38 @@ mod tests {
         let pool = prost_reflect::DescriptorPool::decode(descriptor.as_slice()).expect("descriptor pool decodes");
         let message = pool.get_message_by_name("emptypath.Req").expect("Req message exists");
         assert_eq!(enum_field_rust_type(&message, &[], "emptypath", &[]), None);
+    }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
+    fn enum_field_rust_type_is_none_for_non_enum_leaf_and_scalar_intermediate() {
+        // These paths are guarded upstream by path-field validation, so the
+        // defensive `None` arms are exercised directly here.
+        let descriptor = compile_descriptor(
+            "enumpath",
+            r#"
+                syntax = "proto3";
+                package enumpath;
+                message Inner { string leaf = 1; }
+                message Req { string scalar = 1; Inner inner = 2; }
+            "#,
+            false,
+        );
+        let pool = prost_reflect::DescriptorPool::decode(descriptor.as_slice()).expect("descriptor pool decodes");
+        let message = pool.get_message_by_name("enumpath.Req").expect("Req message exists");
+
+        // Leaf field is a scalar, not an enum.
+        assert_eq!(enum_field_rust_type(&message, &["scalar".to_owned()], "enumpath", &[]), None);
+        // A non-leaf segment names a scalar, so the walk cannot descend.
+        assert_eq!(
+            enum_field_rust_type(&message, &["scalar".to_owned(), "leaf".to_owned()], "enumpath", &[]),
+            None
+        );
+        // The leaf resolves through a message intermediate but is itself a scalar.
+        assert_eq!(
+            enum_field_rust_type(&message, &["inner".to_owned(), "leaf".to_owned()], "enumpath", &[]),
+            None
+        );
     }
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
@@ -1424,8 +1723,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn compile_fds_propagates_a_descriptor_decode_error() {
-        // Invalid descriptor bytes fail to decode, so `compile_fds` surfaces the
-        // error (the `?` error path) rather than writing anything.
         let out = scratch_dir("compilefds-bad");
         compile_fds(b"\xff\xff not a FileDescriptorSet", &out).expect_err("invalid descriptor bytes error");
     }
@@ -1433,14 +1730,11 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn leading_comment_ignores_a_blank_comment() {
-        // A present-but-blank leading comment yields no doc (the blank branch),
-        // while a real comment is retained.
         let descriptor = compile_descriptor(
             "blankdoc",
             "syntax = \"proto3\";\npackage blankdoc;\nimport \"google/api/annotations.proto\";\nmessage R { string name = 1; }\n//\u{20}\nservice Blank {\n  rpc Get(R) returns (R) { option (google.api.http) = { get: \"/v1/{name}\" }; }\n}\n",
             true,
         );
-        // The service's blank comment must not become a doc string on the trait.
         let code = generated(&descriptor, &opts());
         assert!(code.contains("trait Blank"), "{code}");
     }
@@ -1449,8 +1743,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn write_merges_openapi_specs_for_services_sharing_a_module() {
-        // Two services in one proto package share a `{module}.openapi.json`, so
-        // their per-service specs are merged (paths and schemas unioned).
         let descriptor = compile_descriptor(
             "multi",
             r#"
@@ -1483,7 +1775,6 @@ mod tests {
         generator.write(&out).expect("writes merged output");
 
         let spec = fs::read_to_string(out.join("multi.openapi.json")).expect("merged openapi document exists");
-        // Paths from both services are unioned into the one module document.
         assert!(spec.contains("/v1/alpha/{a}"), "alpha path merged: {spec}");
         assert!(spec.contains("/v1/beta/{b}"), "beta path merged: {spec}");
     }
@@ -1520,32 +1811,26 @@ mod tests {
             (".google.protobuf.Empty".to_owned(), "::prost_types::Empty".to_owned()),
             (".google.protobuf".to_owned(), "::prost_types".to_owned()),
         ];
-        // Exact match wins.
         assert_eq!(
             relative_type_path("google.protobuf.Empty", "library", &externs),
             "::prost_types::Empty"
         );
-        // Longer prefix (package) applies to a sibling type.
         assert_eq!(
             relative_type_path("google.protobuf.Timestamp", "library", &externs),
             "::prost_types::Timestamp"
         );
-        // No matching extern falls back to relative resolution.
         assert_eq!(relative_type_path("library.Shelf", "library", &externs), "Shelf");
     }
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn extern_resolution_prefers_the_longest_matching_prefix() {
-        // Two prefixes of the same type; the longer (more specific) one must win,
-        // regardless of declaration order.
         let externs = vec![
             (".google".to_owned(), "::short".to_owned()),
             (".google.protobuf".to_owned(), "::long".to_owned()),
         ];
         assert_eq!(relative_type_path("google.protobuf.Empty", "library", &externs), "::long::Empty");
 
-        // With equal-length (duplicate) prefixes, the first declared wins.
         let dup = vec![
             (".a.b".to_owned(), "::first".to_owned()),
             (".a.b".to_owned(), "::second".to_owned()),
@@ -1556,8 +1841,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn extern_prefix_snake_cases_intermediate_module_segments() {
-        // A prefix match leaving multiple trailing segments snake-cases the
-        // intermediate module segments and keeps the final type name verbatim.
         let externs = vec![(".root".to_owned(), "::root".to_owned())];
         assert_eq!(relative_type_path("root.MyMod.Thing", "library", &externs), "::root::my_mod::Thing");
     }
@@ -1565,8 +1848,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn every_http_method_is_emitted_with_its_verb() {
-        // `valid_descriptor` annotates one RPC per method (plus a custom `HEAD`);
-        // each must route under its own verb, not collapse to the `_` fallback.
         let code = generated(&valid_descriptor(), &opts());
         for method in ["GET", "PUT", "POST", "DELETE", "PATCH", "HEAD"] {
             assert!(
@@ -1600,8 +1881,6 @@ mod tests {
         assert!(code.contains("rest_over_grpc :: handling :: ResponseStream"));
         assert!(code.contains("StreamingResponse :: encode"));
         assert!(code.contains("StreamEncoding :: from_accept"));
-        // The service has a server-streaming RPC, so `try_transcode`
-        // emits a streaming arm producing a `TranscodeResponse`.
         assert!(code.contains("fn try_transcode"));
         assert!(!code.contains("try_transcode_streaming"));
         assert!(code.contains("rest_over_grpc :: transcoding :: TranscodeResponse"));
@@ -1610,8 +1889,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn send_bounds_emit_send_and_supertrait() {
-        // `Send` bounds are always emitted so the output works on multi-threaded
-        // executors.
         let code = render(&valid_descriptor(), &opts(), Generator::new());
         assert!(code.contains("Send + :: core :: marker :: Sync") || code.contains("Send + ::core::marker::Sync"));
         assert!(code.matches("marker :: Send").count() >= 2);
@@ -1620,11 +1897,9 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn tonic_generator_option_emits_the_bridge() {
-        // On by default: the bridge `impl` is emitted for the decoded service.
         let bridged = render(&valid_descriptor(), &opts(), Generator::new());
         assert!(bridged.replace(' ', "").contains("library_server::Library"));
 
-        // Opting out drops the bridge `impl`.
         let plain = render(&valid_descriptor(), &opts(), Generator::builder().emit_tonic_bridge(false).build());
         assert!(!plain.replace(' ', "").contains("library_server::Library"));
     }

--- a/crates/rest_over_grpc/src/build/descriptor_error.rs
+++ b/crates/rest_over_grpc/src/build/descriptor_error.rs
@@ -140,7 +140,8 @@ impl DescriptorError {
         matches!(self.kind, DescriptorErrorKind::Template { .. })
     }
 
-    /// Whether a `body` / `response_body` named a field the message does not have.
+    /// Whether a body, response body, or path variable named a field the message
+    /// does not have.
     #[must_use]
     pub fn is_unknown_field(&self) -> bool {
         matches!(self.kind, DescriptorErrorKind::UnknownField { .. })

--- a/crates/rest_over_grpc/src/build/descriptor_options.rs
+++ b/crates/rest_over_grpc/src/build/descriptor_options.rs
@@ -88,7 +88,6 @@ mod tests {
 
     #[test]
     fn extern_path_preserves_prior_state() {
-        // The builder must return the updated `Self`, not a fresh default.
         let options = DescriptorOptions::new().package(".library").extern_path("a", "b");
         assert_eq!(options.packages(), &[".library".to_owned()]);
         assert_eq!(options.extern_paths(), &[("a".to_owned(), "b".to_owned())]);

--- a/crates/rest_over_grpc/src/build/http_rule.rs
+++ b/crates/rest_over_grpc/src/build/http_rule.rs
@@ -45,6 +45,7 @@ pub struct HttpRule {
     pattern: String,
     body: RequestBody,
     response_body: ResponseBody,
+    response_body_default: Option<String>,
     additional_bindings: Vec<Binding>,
     enum_path_fields: Vec<(Vec<String>, String)>,
 }
@@ -82,6 +83,7 @@ impl HttpRule {
             pattern: template.to_string(),
             body: RequestBody::None,
             response_body: ResponseBody::Whole,
+            response_body_default: None,
             additional_bindings: Vec::new(),
             enum_path_fields: Vec::new(),
         }
@@ -99,6 +101,28 @@ impl HttpRule {
     pub fn response_body(mut self, response_body: ResponseBody) -> Self {
         self.response_body = response_body;
         self
+    }
+
+    /// Records the proto3-JSON literal to emit when the primary binding's
+    /// selected `response_body` field holds its default value (computed from the
+    /// response descriptor).
+    #[must_use]
+    pub(crate) fn with_response_body_default(mut self, default: Option<String>) -> Self {
+        self.response_body_default = default;
+        self
+    }
+
+    /// The proto3-JSON default literals for the `response_body` field of each
+    /// lowered route, in [`lower`](Self::lower) order (primary binding first,
+    /// then each additional binding). `None` for a route that returns the whole
+    /// message or whose default is unknown (e.g. a manually built rule).
+    pub(crate) fn response_body_defaults(&self) -> Vec<Option<String>> {
+        let mut defaults = Vec::with_capacity(1 + self.additional_bindings.len());
+        defaults.push(self.response_body_default.clone());
+        for binding in &self.additional_bindings {
+            defaults.push(binding.response_body_default().map(str::to_owned));
+        }
+        defaults
     }
 
     /// Adds an additional HTTP binding for the same gRPC RPC. Call repeatedly to
@@ -250,8 +274,6 @@ mod tests {
     #[cfg(feature = "build")]
     #[test]
     fn path_variable_field_paths_collects_variable_and_affix_captures() {
-        // A plain `{shelf}` variable and an affix segment (`img-{id}.png`, from the
-        // extended grammar) both contribute their captured field paths.
         let template = PathTemplate::parse("/v1/shelves/{shelf}/img-{id}.png", Grammar::default().with_segment_affixes())
             .expect("valid extended template");
         let rule = HttpRule::new("GetImage", HttpMethod::GET, template);
@@ -279,5 +301,16 @@ mod tests {
         assert!(matches!(routes[0].body(), RequestBody::Field(field) if field == "shelf"));
         assert!(matches!(routes[0].response_body(), ResponseBody::Field(field) if field == "shelf"));
         assert_eq!(routes[0].template().verb(), None);
+    }
+
+    #[test]
+    fn response_body_defaults_reports_primary_then_additional_binding_defaults() {
+        let rule = HttpRule::new("GetShelf", HttpMethod::GET, template("/v1/shelves/{shelf}"))
+            .with_response_body_default(Some("\"\"".to_owned()))
+            .add_binding(
+                Binding::new(HttpMethod::GET, template("/v1/shelves/{shelf}/info")).with_response_body_default(Some("0".to_owned())),
+            );
+
+        assert_eq!(rule.response_body_defaults(), vec![Some("\"\"".to_owned()), Some("0".to_owned())]);
     }
 }

--- a/crates/rest_over_grpc/src/build/openapi.rs
+++ b/crates/rest_over_grpc/src/build/openapi.rs
@@ -160,7 +160,7 @@ impl Builder {
             if filter.path_fields.contains(&proto_path) {
                 continue;
             }
-            if proto_prefix.is_empty() && filter.body_field == Some(field.name()) {
+            if proto_prefix.is_empty() && filter.body_field == Some(field.json_name()) {
                 continue;
             }
 
@@ -342,12 +342,18 @@ impl Builder {
     }
 
     /// Returns a `$ref` to the shared error `Status` schema, building it once.
+    ///
+    /// The schema mirrors `google.rpc.Status` — the message the transcoder maps
+    /// a gRPC error into — including its `details`. Keying it by the proto
+    /// full-name (as message and enum schemas are) keeps it from colliding with
+    /// a user-defined message that happens to be named `Status`.
     fn status_ref(&mut self) -> Schema {
-        let name = "Status";
+        let name = "google.rpc.Status";
         if !self.schemas.contains_key(name) {
             let mut properties = BTreeMap::new();
             properties.insert("code".to_owned(), Schema::scalar("integer", Some("int32")));
             properties.insert("message".to_owned(), Schema::scalar("string", None));
+            properties.insert("details".to_owned(), Schema::array(Schema::scalar("object", None)));
             self.schemas.insert(name.to_owned(), Schema::object(properties));
         }
         Schema::reference(name)
@@ -439,14 +445,10 @@ fn template_field_paths(template: &PathTemplate<'_>) -> Vec<Vec<String>> {
         .iter()
         .filter_map(|segment| match segment {
             Segment::Variable(variable) => Some(variable.field_path().split('.').map(str::to_owned).collect()),
-            // Literal / Single / Rest (and any future `#[non_exhaustive]` variant)
-            // bind no field.
             _ => None,
         })
         .collect()
 }
-
-// --- OpenAPI 3.1 serialization model (only the subset that is emitted) ---
 
 #[derive(Serialize)]
 struct Document {
@@ -713,10 +715,26 @@ mod tests {
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
-    fn path_parameters_resolve_field_types_and_default_to_string() {
-        // Several path-template shapes as distinct RPCs, compiled once: a simple
-        // required string, dotted paths resolving nested field types, and
-        // unresolvable segments that fall back to `string`.
+    fn multiple_methods_on_one_path_coexist_in_the_path_item() {
+        let doc = doc(r#"
+                syntax = "proto3";
+                package test;
+                import "google/api/annotations.proto";
+                service S {
+                  rpc Get(Req) returns (Res) { option (google.api.http) = { get: "/v1/things/{id}" }; }
+                  rpc Delete(Req) returns (Res) { option (google.api.http) = { delete: "/v1/things/{id}" }; }
+                }
+                message Req { string id = 1; }
+                message Res {}
+            "#);
+        let item = &doc["paths"]["/v1/things/{id}"];
+        assert_eq!(item["get"]["operationId"], "Get");
+        assert_eq!(item["delete"]["operationId"], "Delete");
+    }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
+    fn path_parameters_resolve_field_types() {
         let doc = doc(r#"
                 syntax = "proto3";
                 package test;
@@ -724,16 +742,13 @@ mod tests {
                 service S {
                   rpc Shelf(ShelfReq) returns (Resp) { option (google.api.http) = { get: "/v1/shelves/{shelf}" }; }
                   rpc Nested(NestedReq) returns (Resp) { option (google.api.http) = { get: "/v1/{params.org}/{params.count}" }; }
-                  rpc Unres(UnresReq) returns (Resp) { option (google.api.http) = { get: "/v1/{missing}/{scalar.x}" }; }
                 }
                 message Resp {}
                 message ShelfReq { string shelf = 1; }
                 message NestedReq { Params params = 1; }
                 message Params { string org = 1; int32 count = 2; }
-                message UnresReq { string scalar = 1; }
             "#);
 
-        // A single `{shelf}` path parameter is a required path-scoped string.
         let params = doc["paths"]["/v1/shelves/{shelf}"]["get"]["parameters"].as_array().expect("params");
         assert_eq!(params.len(), 1);
         assert_eq!(params[0]["name"], "shelf");
@@ -741,7 +756,6 @@ mod tests {
         assert_eq!(params[0]["required"], true);
         assert_eq!(params[0]["schema"]["type"], "string");
 
-        // Dotted path parameters resolve to the nested field's type.
         let params = doc["paths"]["/v1/{params.org}/{params.count}"]["get"]["parameters"]
             .as_array()
             .expect("params");
@@ -750,16 +764,36 @@ mod tests {
         let count = params.iter().find(|p| p["name"] == "params.count").expect("count param");
         assert_eq!(count["schema"]["type"], "integer");
         assert_eq!(count["schema"]["format"], "int32");
-
-        // `{missing}` has no matching field and `{scalar.x}` walks through a
-        // scalar; both default to `string`.
-        let params = doc["paths"]["/v1/{missing}/{scalar.x}"]["get"]["parameters"]
-            .as_array()
-            .expect("params");
-        for p in params {
-            assert_eq!(p["schema"]["type"], "string", "{p:?}");
-        }
     }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
+    fn resolve_field_returns_none_for_missing_and_scalar_intermediate_segments() {
+        // Scalar-intermediate paths are rejected upstream by path-field
+        // validation, so the defensive `None` arms are exercised directly.
+        let bytes = compile(
+            r#"
+                syntax = "proto3";
+                package test;
+                message Inner { string leaf = 1; }
+                message Req { string scalar = 1; Inner inner = 2; }
+            "#,
+        );
+        let pool = prost_reflect::DescriptorPool::decode(bytes.as_slice()).expect("pool decodes");
+        let message = pool.get_message_by_name("test.Req").expect("Req exists");
+        let mut builder = Builder {
+            paths: BTreeMap::new(),
+            schemas: BTreeMap::new(),
+        };
+
+        // A non-leaf segment names a scalar, so the walk cannot descend.
+        assert!(builder.resolve_field(&message, &["scalar".to_owned(), "leaf".to_owned()]).is_none());
+        // A missing segment yields `None`.
+        assert!(builder.resolve_field(&message, &["absent".to_owned()]).is_none());
+        // A valid nested path resolves to the leaf schema.
+        assert!(builder.resolve_field(&message, &["inner".to_owned(), "leaf".to_owned()]).is_some());
+    }
+
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn query_parameters_use_json_names_and_nesting() {
@@ -789,9 +823,9 @@ mod tests {
                 package test;
                 import "google/api/annotations.proto";
                 service S { rpc Update(Req) returns (Res) {
-                  option (google.api.http) = { patch: "/v1/things/{id}" body: "payload" };
+                  option (google.api.http) = { patch: "/v1/things/{id}" body: "request_payload" };
                 } }
-                message Req { string id = 1; Payload payload = 2; string extra = 3; }
+                message Req { string id = 1; Payload request_payload = 2; string extra = 3; }
                 message Payload { string data = 1; }
                 message Res {}
             "#);
@@ -800,9 +834,7 @@ mod tests {
         let names: Vec<&str> = params.iter().map(|p| p["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"id"), "path param present");
         assert!(names.contains(&"extra"), "unbound field is a query param");
-        assert!(!names.contains(&"payload"), "body field is not a query param");
-        // The body binds the `payload` field specifically, so its schema is that
-        // field's message, not some other field.
+        assert!(!names.contains(&"requestPayload"), "body field is not a query param");
         assert_eq!(
             op["requestBody"]["content"]["application/json"]["schema"]["$ref"],
             "#/components/schemas/test.Payload"
@@ -834,7 +866,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn unknown_body_field_is_rejected() {
-        // A `body` naming a nonexistent field is rejected at generation time.
         let error = ServiceDefinition::from_fds(
             compile(
                 r#"
@@ -892,7 +923,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn unknown_response_body_field_is_rejected() {
-        // A `response_body` naming a nonexistent field is rejected at generation time.
         let error = ServiceDefinition::from_fds(
             compile(
                 r#"
@@ -945,21 +975,41 @@ mod tests {
         let default = &doc["paths"]["/v1/x"]["get"]["responses"]["default"];
         assert_eq!(
             default["content"]["application/json"]["schema"]["$ref"],
-            "#/components/schemas/Status"
+            "#/components/schemas/google.rpc.Status"
         );
-        let status = &doc["components"]["schemas"]["Status"];
+        let status = &doc["components"]["schemas"]["google.rpc.Status"];
         assert_eq!(status["type"], "object");
         assert_eq!(status["properties"]["code"]["type"], "integer");
         assert_eq!(status["properties"]["code"]["format"], "int32");
         assert_eq!(status["properties"]["message"]["type"], "string");
+        assert_eq!(status["properties"]["details"]["type"], "array");
+        assert_eq!(status["properties"]["details"]["items"]["type"], "object");
+    }
+
+    #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
+    #[test]
+    fn user_message_named_status_does_not_collide_with_the_error_schema() {
+        let doc = doc(r#"
+                syntax = "proto3";
+                package test;
+                import "google/api/annotations.proto";
+                service S { rpc Get(Req) returns (Status) { option (google.api.http) = { get: "/v1/x" }; } }
+                message Req {}
+                message Status { string state = 1; }
+            "#);
+        // The user's `test.Status` and the error `google.rpc.Status` are distinct schemas.
+        let ok = &doc["paths"]["/v1/x"]["get"]["responses"]["200"]["content"]["application/json"]["schema"];
+        assert_eq!(ok["$ref"], "#/components/schemas/test.Status");
+        let user_status = &doc["components"]["schemas"]["test.Status"];
+        assert_eq!(user_status["properties"]["state"]["type"], "string");
+        let error_status = &doc["components"]["schemas"]["google.rpc.Status"];
+        assert_eq!(error_status["properties"]["code"]["format"], "int32");
     }
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     #[expect(clippy::too_many_lines, reason = "consolidates schema cases to avoid repeated proto compilations")]
     fn message_field_schemas_cover_scalars_enums_collections_recursion_and_well_known_types() {
-        // One service with several response messages, compiled once, so the
-        // per-message schema assertions share a single (costly) proto compilation.
         let doc = doc(r#"
                 syntax = "proto3";
                 package test;
@@ -1015,7 +1065,6 @@ mod tests {
                 }
             "#);
 
-        // Scalar fields map each proto scalar to its OpenAPI type/format.
         let props = &doc["components"]["schemas"]["test.Types"]["properties"];
         assert_eq!(props["aDouble"], serde_json::json!({"type":"number","format":"double"}));
         assert_eq!(props["aFloat"], serde_json::json!({"type":"number","format":"float"}));
@@ -1033,7 +1082,6 @@ mod tests {
         assert_eq!(props["aString"], serde_json::json!({"type":"string"}));
         assert_eq!(props["aBytes"], serde_json::json!({"type":"string","format":"byte"}));
 
-        // Enum, repeated, and map fields.
         let props = &doc["components"]["schemas"]["test.Palette"]["properties"];
         assert_eq!(props["color"]["$ref"], "#/components/schemas/test.Color");
         assert_eq!(props["accent"]["$ref"], "#/components/schemas/test.Color");
@@ -1046,13 +1094,11 @@ mod tests {
         assert_eq!(color["type"], "string");
         assert_eq!(color["enum"], serde_json::json!(["RED", "GREEN"]));
 
-        // A recursive message is emitted once and refers back to itself by `$ref`.
         let node = &doc["components"]["schemas"]["test.Node"];
         assert_eq!(node["properties"]["id"]["type"], "string");
         assert_eq!(node["properties"]["parent"]["$ref"], "#/components/schemas/test.Node");
         assert_eq!(node["properties"]["children"]["items"]["$ref"], "#/components/schemas/test.Node");
 
-        // Well-known types map to their canonical OpenAPI representations.
         let props = &doc["components"]["schemas"]["test.W"]["properties"];
         assert_eq!(props["ts"], serde_json::json!({"type":"string","format":"date-time"}));
         assert_eq!(props["dur"], serde_json::json!({"type":"string"}));
@@ -1187,8 +1233,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn recursive_request_query_params_terminate() {
-        // A self-referential request message reached via query parameters
-        // terminates: the cycle is cut, yielding a finite parameter set.
         let doc = doc(r#"
                 syntax = "proto3";
                 package test;
@@ -1199,18 +1243,14 @@ mod tests {
             "#);
         let params = doc["paths"]["/v1/nodes"]["get"]["parameters"].as_array().expect("query parameters");
         let names: Vec<&str> = params.iter().filter_map(|p| p["name"].as_str()).collect();
-        // The message's own scalar fields are present...
         assert!(names.contains(&"id"), "{names:?}");
         assert!(names.contains(&"label"), "{names:?}");
-        // ...but the self-referential `parent` field is not expanded (cycle cut).
         assert!(!names.iter().any(|n| n.starts_with("parent")), "{names:?}");
     }
 
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn mutually_recursive_request_query_params_terminate() {
-        // Mutual recursion `A -> B -> A` reached via query params must also
-        // terminate, expanding one level of the cycle before cutting it.
         let doc = doc(r#"
                 syntax = "proto3";
                 package test;
@@ -1224,7 +1264,6 @@ mod tests {
         let names: Vec<&str> = params.iter().filter_map(|p| p["name"].as_str()).collect();
         assert!(names.contains(&"aId"), "{names:?}");
         assert!(names.contains(&"b.bId"), "{names:?}");
-        // `b.a` would re-enter `A` (already on the path) and is cut.
         assert!(!names.iter().any(|n| n.starts_with("b.a")), "{names:?}");
     }
 
@@ -1252,14 +1291,12 @@ mod tests {
             "#,
         );
 
-        // Two packages compiled together yield one document each (module = package).
         let docs = specs_with(&compile_files(&[one, two]), &DescriptorOptions::new(), &info());
         assert_eq!(
             docs.iter().map(|(m, _)| m.clone()).collect::<Vec<_>>(),
             ["one".to_owned(), "two".to_owned()]
         );
 
-        // Package filtering restricts to the requested package.
         let filtered = specs_with(&compile_files(&[one, two]), &DescriptorOptions::new().package(".one"), &info());
         assert_eq!(filtered.iter().map(|(m, _)| m.clone()).collect::<Vec<_>>(), ["one".to_owned()]);
     }
@@ -1267,8 +1304,6 @@ mod tests {
     #[cfg_attr(miri, ignore)] // proto compilation and filesystem I/O are unsupported under Miri.
     #[test]
     fn two_services_in_one_package_produce_a_spec_each() {
-        // Each service carries its own OpenAPI document (both under the same
-        // module, since they share a package).
         let docs = specs_with(
             &compile(
                 r#"

--- a/crates/rest_over_grpc/src/build/service_definition.rs
+++ b/crates/rest_over_grpc/src/build/service_definition.rs
@@ -171,6 +171,7 @@ impl ServiceDefinition {
     ) -> &mut Self {
         let name = rule.name().to_owned();
         let enum_fields = rule.enum_path_fields().to_vec();
+        let response_body_defaults = rule.response_body_defaults();
         self.methods.push(ServiceMethod::new(
             name,
             request_type,
@@ -179,6 +180,7 @@ impl ServiceDefinition {
             false,
             doc,
             enum_fields,
+            response_body_defaults,
         ));
         self
     }
@@ -196,6 +198,7 @@ impl ServiceDefinition {
     ) -> &mut Self {
         let name = rule.name().to_owned();
         let enum_fields = rule.enum_path_fields().to_vec();
+        let response_body_defaults = rule.response_body_defaults();
         self.methods.push(ServiceMethod::new(
             name,
             request_type,
@@ -204,6 +207,7 @@ impl ServiceDefinition {
             true,
             doc,
             enum_fields,
+            response_body_defaults,
         ));
         self
     }
@@ -244,7 +248,7 @@ impl ServiceDefinition {
     pub(crate) fn tonic_bridge(&self) -> TokenStream {
         let our_trait = ident(&self.trait_name);
         let snake = to_snake_case(&self.trait_name);
-        let tonic_trait = type_path(&format!("{snake}_server::{}", self.trait_name));
+        let tonic_trait = type_path(&format!("{snake}_server::{}", prost_type_identifier(&self.trait_name)));
 
         let arms = self.methods.iter().map(|m| {
             let fn_ident = ident(&to_snake_case(m.rpc()));
@@ -252,11 +256,7 @@ impl ServiceDefinition {
             let resp_ty = type_path(m.response_type());
 
             if m.server_streaming() {
-                // Both the `tonic` method and the generated trait method are
-                // two-phase (`async fn -> Result<Stream, Status>`): await
-                // initiation, map the `tonic::Status` (initiation and per-item) to
-                // `rest_over_grpc::handling::Status`, box the `Send + 'static` response
-                // stream, and seed the request metadata from `cx`'s headers.
+                // Map both initiation and per-item tonic errors.
                 return quote! {
                     async fn #fn_ident(
                         &self,
@@ -276,10 +276,11 @@ impl ServiceDefinition {
                         let mut __request = ::tonic::Request::new(request);
                         *__request.metadata_mut() =
                             ::tonic::metadata::MetadataMap::from_headers(cx.take_request_headers());
-                        let __stream = <Self as #tonic_trait>::#fn_ident(self, __request)
+                        let (__metadata, __stream, _) = <Self as #tonic_trait>::#fn_ident(self, __request)
                             .await
                             .map_err(__convert_status)?
-                            .into_inner();
+                            .into_parts();
+                        cx.merge_response_headers(__metadata.into_headers());
                         ::core::result::Result::Ok(::std::boxed::Box::pin(
                             ::rest_over_grpc::codegen_helpers::map_stream_status(__stream, __convert_status),
                         ))
@@ -348,8 +349,6 @@ impl ServiceDefinition {
             let fn_ident = ident(&to_snake_case(m.rpc()));
             let req_ty = type_path(m.request_type());
             let resp_ty = type_path(m.response_type());
-            // Emit the RPC's proto documentation when present (one `#[doc]` per
-            // line, preserving its structure); otherwise emit no doc comment.
             let doc_attrs = m.doc().map(|doc| {
                 let lines = doc.split('\n').map(|line| quote! { #[doc = #line] });
                 quote! { #(#lines)* }
@@ -376,8 +375,6 @@ impl ServiceDefinition {
             }
         });
 
-        // The service's `doc` documents the trait verbatim (one `#[doc]` per
-        // line); when absent, no doc comment is emitted.
         let doc_attrs = self.doc.as_ref().map(|doc| {
             let lines = doc.split('\n').map(|line| quote! { #[doc = #line] });
             quote! { #(#lines)* }
@@ -418,10 +415,7 @@ pub(crate) fn generate_transcoder(services: &[ServiceDefinition]) -> TokenStream
         })
         .collect();
 
-    // Merged router over every service's routes, each tagged uniquely so the
-    // transcode arms can key on the resolved `(service, rpc)`. Every method emits
-    // one arm producing a `TranscodeResponse` (a unary RPC's buffered response or
-    // a server-streaming RPC's live frame stream), so a single `transcode` serves
+    // Route tags identify the service and RPC selected by the merged router.
     let mut merged_routes: Vec<Route> = Vec::new();
     let mut arms: Vec<TokenStream> = Vec::new();
     for (i, svc) in services.iter().enumerate() {
@@ -456,8 +450,6 @@ pub(crate) fn generate_transcoder(services: &[ServiceDefinition]) -> TokenStream
     let transcode_impl = transcoder_transcode_impl(&try_transcode_method, &generic_params, &where_clause);
 
     quote! {
-        // The merged router is emitted once at module scope here, rather than
-        // inlined into the `try_transcode` method body.
         #resolve
 
         /// Routes incoming REST requests across all generated services to the
@@ -620,6 +612,7 @@ struct RouteVariant {
     reserved_expansions: Vec<bool>,
     body: RequestBody,
     response_body: ResponseBody,
+    response_body_default: Option<String>,
 }
 
 /// The ordered capture signature of a path template and whether each capture is
@@ -664,6 +657,7 @@ fn assign_method_variants(base: &str, method: &ServiceMethod, module: &str) -> (
             reserved_expansions,
             body: route.body().clone(),
             response_body: route.response_body().clone(),
+            response_body_default: method.response_body_defaults().get(index).cloned().flatten(),
         });
         routes.push(rename_route(route, &name));
     }
@@ -722,70 +716,10 @@ fn variant_pattern(variant: &RouteVariant) -> TokenStream {
     }
 }
 
-/// The message field-access identifier for one dotted-path segment (e.g. `type`
-/// → `r#type`), matching how `prost` names fields that collide with a Rust
-/// keyword.
+/// The message field-access identifier for one dotted-path segment, matching
+/// `prost`'s snake-casing and reserved-word handling.
 fn field_segment_ident(segment: &str) -> Ident {
-    if is_raw_keyword(segment) {
-        Ident::new_raw(segment, Span::call_site())
-    } else {
-        Ident::new(segment, Span::call_site())
-    }
-}
-
-/// Whether `word` is a Rust keyword that `prost` emits as a raw identifier
-/// (`r#word`) when it is a proto field name. The handful of keywords that cannot
-/// be raw identifiers (`self`, `Self`, `super`, `crate`, `extern`) are excluded;
-/// they are not valid field names in generated message structs anyway.
-fn is_raw_keyword(word: &str) -> bool {
-    matches!(
-        word,
-        "as" | "break"
-            | "const"
-            | "continue"
-            | "else"
-            | "enum"
-            | "false"
-            | "fn"
-            | "for"
-            | "if"
-            | "impl"
-            | "in"
-            | "let"
-            | "loop"
-            | "match"
-            | "mod"
-            | "move"
-            | "mut"
-            | "pub"
-            | "ref"
-            | "return"
-            | "static"
-            | "struct"
-            | "trait"
-            | "true"
-            | "type"
-            | "unsafe"
-            | "use"
-            | "where"
-            | "while"
-            | "async"
-            | "await"
-            | "dyn"
-            | "abstract"
-            | "become"
-            | "box"
-            | "do"
-            | "final"
-            | "macro"
-            | "override"
-            | "priv"
-            | "typeof"
-            | "unsized"
-            | "virtual"
-            | "yield"
-            | "try"
-    )
+    ident(&prost_snake_identifier(segment))
 }
 
 /// The statements that poke a route variant's captured path variables directly
@@ -813,8 +747,7 @@ fn variant_pokes(variant: &RouteVariant) -> TokenStream {
         .enumerate()
         .map(|(capture_index, ((path, enum_type), reserved))| {
             let capture = capture_binding_ident(capture_index);
-            // Build the lvalue: `request` then each segment, materializing every
-            // non-leaf (message) segment so the leaf assignment has somewhere to go.
+            // Materialize intermediate message fields before assigning the leaf.
             let mut lvalue = quote! { request };
             for (index, segment) in path.iter().enumerate() {
                 let seg = field_segment_ident(segment);
@@ -897,7 +830,7 @@ fn qualified_type_path(path: &str, module: &str) -> TokenStream {
 
     let mut absolute = String::new();
     for segment in segments {
-        absolute.push_str(segment);
+        absolute.push_str(&prost_snake_identifier(segment));
         absolute.push_str("::");
     }
     absolute.push_str(remainder);
@@ -957,7 +890,7 @@ fn transcode_arm(variants: &[RouteVariant], receiver: &TokenStream, req_ty: &Tok
         let arms = variants.iter().map(|variant| {
             let pattern = variant_pattern(variant);
             let body_kind = body_kind_tokens(&variant.body);
-            let response_kind = response_kind_tokens(&variant.response_body);
+            let response_kind = response_kind_tokens(&variant.response_body, variant.response_body_default.as_deref());
             let decoded = decode_and_poke(variant, req_ty, &body_kind);
             quote! {
                 #pattern => {
@@ -997,7 +930,7 @@ fn transcode_arm(variants: &[RouteVariant], receiver: &TokenStream, req_ty: &Tok
         let pattern = variant_pattern(variant);
         let body_kind = body_kind_tokens(&variant.body);
         let decoded = decode_and_poke(variant, req_ty, &body_kind);
-        let resp_kind = response_kind_tokens(&variant.response_body);
+        let resp_kind = response_kind_tokens(&variant.response_body, variant.response_body_default.as_deref());
         quote! {
             #pattern => {
                 let result: ::core::result::Result<::std::vec::Vec<u8>, ::rest_over_grpc::handling::Status> = async {
@@ -1030,11 +963,16 @@ fn body_kind_tokens(body: &RequestBody) -> TokenStream {
     }
 }
 
-fn response_kind_tokens(response_body: &ResponseBody) -> TokenStream {
+fn response_kind_tokens(response_body: &ResponseBody, default: Option<&str>) -> TokenStream {
     match response_body {
         ResponseBody::Whole => quote! { ::rest_over_grpc::codegen_helpers::ResponseBodyKind::Whole },
         ResponseBody::Field(field) => {
-            quote! { ::rest_over_grpc::codegen_helpers::ResponseBodyKind::Field(#field) }
+            // pbjson omits default-valued fields, so the transcoder emits this
+            // proto3-JSON default literal when the selected field is at its
+            // default. `null` is a safe fallback when the default is unknown
+            // (e.g. a manually built rule with no response descriptor).
+            let default = default.unwrap_or("null");
+            quote! { ::rest_over_grpc::codegen_helpers::ResponseBodyKind::Field { name: #field, default: #default } }
         }
     }
 }
@@ -1047,11 +985,33 @@ fn response_kind_tokens(response_body: &ResponseBody) -> TokenStream {
 /// trait and its `tonic` bridge in lockstep. Non-keyword names (`PascalCase`
 /// trait names, `T0` generics, `__invoke_*` helpers) are unaffected.
 fn ident(name: &str) -> Ident {
-    if is_raw_keyword(name) {
-        Ident::new_raw(name, Span::call_site())
+    let sanitized = prost_identifier(name);
+    if let Some(raw) = sanitized.strip_prefix("r#") {
+        Ident::new_raw(raw, Span::call_site())
     } else {
-        Ident::new(name, Span::call_site())
+        Ident::new(&sanitized, Span::call_site())
     }
+}
+
+/// Sanitizes a Rust identifier exactly as `prost-build` 0.14 does.
+pub(crate) fn prost_identifier(name: &str) -> String {
+    match name {
+        "as" | "break" | "const" | "continue" | "else" | "enum" | "false" | "fn" | "for" | "if" | "impl" | "in" | "let" | "loop"
+        | "match" | "mod" | "move" | "mut" | "pub" | "ref" | "return" | "static" | "struct" | "trait" | "true" | "type" | "unsafe"
+        | "use" | "where" | "while" | "dyn" | "abstract" | "become" | "box" | "do" | "final" | "macro" | "override" | "priv" | "typeof"
+        | "unsized" | "virtual" | "yield" | "async" | "await" | "try" | "gen" => format!("r#{name}"),
+        "_" | "super" | "self" | "Self" | "extern" | "crate" => format!("{name}_"),
+        value if value.starts_with(char::is_numeric) => format!("_{value}"),
+        _ => name.to_owned(),
+    }
+}
+
+pub(crate) fn prost_snake_identifier(name: &str) -> String {
+    prost_identifier(&to_snake_case(name))
+}
+
+pub(crate) fn prost_type_identifier(name: &str) -> String {
+    prost_identifier(&heck::AsUpperCamelCase(name).to_string())
 }
 
 /// Parses a fully-qualified Rust type path string into tokens, falling back to a
@@ -1101,35 +1061,54 @@ mod tests {
         assert_eq!(to_snake_case("GetShelf"), "get_shelf");
         assert_eq!(to_snake_case("ListBooksByAuthor"), "list_books_by_author");
         assert_eq!(to_snake_case("already_snake"), "already_snake");
-        // Acronyms match prost/tonic (heck) casing, not a naive per-capital split.
         assert_eq!(to_snake_case("GetHTTPConfig"), "get_http_config");
         assert_eq!(to_snake_case("MyHTTPService"), "my_http_service");
+    }
+
+    #[test]
+    fn identifier_sanitization_matches_prost() {
+        for (source, expected) in [
+            ("gen", "r#gen"),
+            ("self", "self_"),
+            ("Self", "Self_"),
+            ("super", "super_"),
+            ("extern", "extern_"),
+            ("crate", "crate_"),
+            ("0field", "_0field"),
+            ("ordinary", "ordinary"),
+        ] {
+            assert_eq!(prost_identifier(source), expected);
+        }
+        assert_eq!(field_segment_ident("Self").to_string(), "self_");
+        assert_eq!(field_segment_ident("extern").to_string(), "extern_");
+        assert_eq!(field_segment_ident("gen").to_string(), "r#gen");
+
+        let mut generator = ServiceDefinition::new("KeywordFields", None);
+        generator.add_method(
+            rule("Get", HttpMethod::GET, "/v1/{gen}"),
+            "crate::pb::KeywordFieldsRequest",
+            "crate::pb::KeywordFieldsRequest",
+            None,
+        );
+        let file: syn::File = syn::parse2(generator.generate(CodegenOptions::default())).expect("gen capture produces valid Rust");
+        assert!(prettyplease::unparse(&file).contains("request.r#gen"));
     }
 
     #[test]
     fn qualified_type_path_resolves_relative_and_rooted_paths() {
         let q = |path: &str, module: &str| qualified_type_path(path, module).to_string();
 
-        // Same-package and nested types are prefixed with the package module.
         assert_eq!(q("GetShelfRequest", "library"), "library :: GetShelfRequest");
         assert_eq!(q("outer::Inner", "library"), "library :: outer :: Inner");
-        // Multi-segment package.
         assert_eq!(q("Foo", "a.b"), "a :: b :: Foo");
-        // An empty module leaves the (unrooted) path unqualified.
         assert_eq!(q("Foo", ""), "Foo");
-        // `super::` steps up toward the common root: a parent-package type in `a.b`.
         assert_eq!(q("super::Foo", "a.b"), "a :: Foo");
-        // A sibling-package type: two `super::`s then the type's own package path.
         assert_eq!(q("super::super::x::y::Foo", "a.b"), "x :: y :: Foo");
-        // Rooted paths (extern overrides, crate-relative manual paths) pass through.
         assert_eq!(q("::prost_types::Empty", "library"), ":: prost_types :: Empty");
         assert_eq!(q("crate::pb::Shelf", "library_service"), "crate :: pb :: Shelf");
-        // Every rooted prefix passes through unchanged — one per branch of the
-        // disjunction so no single `||`/`==`/`starts_with` can be dropped silently.
         assert_eq!(q("crate", "library"), "crate");
         assert_eq!(q("self", "library"), "self");
         assert_eq!(q("self::Inner", "library"), "self :: Inner");
-        // A `$crate::…` path is rooted, so it is never prefixed with the module.
         assert!(
             !q("$crate::Macro", "library").contains("library"),
             "$crate path must pass through unprefixed"
@@ -1138,22 +1117,16 @@ mod tests {
 
     #[test]
     fn route_name_is_a_unique_identifier() {
-        // The name suffixes the RPC with the service index, keeping it a valid,
-        // collision-free Rust identifier (it names a route enum variant).
         assert_eq!(route_name(0, "GetShelf"), "GetShelf_0");
         assert_eq!(route_name(3, "ListBooks"), "ListBooks_3");
     }
 
     #[test]
     fn a_service_less_transcoder_omits_generics_and_where_clause() {
-        // With no services the transcoder has no generic type parameters and no
-        // `where` clause (the empty-`generics`/`bounds` branches).
         let tokens = generate_transcoder(&[]);
         let file: syn::File = syn::parse2(tokens).expect("service-less transcoder is valid Rust");
         let pretty = prettyplease::unparse(&file);
         assert!(pretty.contains("struct Transcoder"), "{pretty}");
-        // Scope the checks to the transcoder itself: the module-level `resolve`
-        // helper (emitted earlier) carries its own generic `AsRef<str>` bounds.
         let transcoder = &pretty[pretty.find("struct Transcoder").expect("transcoder struct present")..];
         assert!(!transcoder.contains("T0"), "no generic parameters: {transcoder}");
         assert!(!transcoder.contains("where"), "no where clause: {transcoder}");
@@ -1161,12 +1134,10 @@ mod tests {
 
     #[test]
     fn transcoder_field_name_suffixes_only_on_collision() {
-        // Distinct trait names keep their plain snake_case field name.
         let distinct = vec![ServiceDefinition::new("Library", None), ServiceDefinition::new("Catalog", None)];
         assert_eq!(transcoder_field_name(&distinct, 0), "library");
         assert_eq!(transcoder_field_name(&distinct, 1), "catalog");
 
-        // Two services with the same trait name are disambiguated by index.
         let colliding = vec![ServiceDefinition::new("Library", None), ServiceDefinition::new("Library", None)];
         assert_eq!(transcoder_field_name(&colliding, 0), "library_0");
         assert_eq!(transcoder_field_name(&colliding, 1), "library_1");
@@ -1174,9 +1145,6 @@ mod tests {
 
     #[test]
     fn additional_bindings_with_different_captures_split_into_separate_arms() {
-        // One RPC bound to two paths that capture different variables cannot share
-        // a single field-carrying route enum variant, so each becomes its own
-        // variant and its own destructuring transcode arm.
         let mut generator = ServiceDefinition::new("Library", None);
         generator.add_method(
             rule("GetShelf", HttpMethod::GET, "/v1/shelves/{shelf}")
@@ -1188,21 +1156,14 @@ mod tests {
 
         let file: syn::File = syn::parse2(generator.generate(CodegenOptions::default())).expect("generated service must be valid Rust");
         let flat = prettyplease::unparse(&file).replace(' ', "");
-        // Two distinct-capture bindings yield two struct variants.
         assert!(flat.contains("GetShelf_0{shelf:&'pstr}"), "{flat}");
         assert!(flat.contains("GetShelf_0_b1{shelf:&'pstr,book:&'pstr}"), "{flat}");
-        // Each variant gets its own destructuring arm binding its fields to
-        // reserved `__cap{n}` locals.
         assert!(flat.contains("Route::GetShelf_0{shelf:__cap0}=>"), "{flat}");
         assert!(flat.contains("Route::GetShelf_0_b1{shelf:__cap0,book:__cap1}=>"), "{flat}");
     }
 
     #[test]
     fn nested_path_variable_pokes_through_get_or_insert() {
-        // A dotted path variable `{shelf.id}` pokes into a nested message field:
-        // the non-leaf segment is materialized with `get_or_insert_with` and the
-        // leaf is parsed via `parse_path_field`, with the value read from the
-        // matched variant's `shelf_id` field.
         let mut generator = ServiceDefinition::new("Library", None);
         generator.add_method(
             rule("GetBook", HttpMethod::GET, "/v1/shelves/{shelf.id}/book"),
@@ -1213,12 +1174,8 @@ mod tests {
 
         let file: syn::File = syn::parse2(generator.generate(CodegenOptions::default())).expect("generated service must be valid Rust");
         let pretty = prettyplease::unparse(&file);
-        // Collapse all whitespace so the (line-wrapped) poke chain matches.
         let flat: String = pretty.split_whitespace().collect();
-        // The variant reads the `shelf_id` field into a reserved `__cap0` binding.
         assert!(flat.contains("Route::GetBook_0{shelf_id:__cap0}=>"), "{pretty}");
-        // The poke walks `request.shelf.get_or_insert_with(..).id` and parses the
-        // captured value into it.
         assert!(
             flat.contains("request.shelf.get_or_insert_with(::core::default::Default::default).id=::rest_over_grpc::codegen_helpers::parse_path_field(__cap0"),
             "{pretty}"
@@ -1226,12 +1183,41 @@ mod tests {
     }
 
     #[test]
+    fn keyword_named_service_produces_valid_sanitized_rust() {
+        for name in ["Self", "Loop", "Match", "Type", "Async", "Gen", "Extern", "Move"] {
+            let mut generator = ServiceDefinition::new(name, None);
+            generator.add_method(
+                rule("Get", HttpMethod::GET, "/v1/get"),
+                "crate::pb::GetRequest",
+                "crate::pb::Resp",
+                None,
+            );
+            let options = CodegenOptions { emit_tonic: true };
+            let _: syn::File = syn::parse2(generator.generate(options))
+                .unwrap_or_else(|error| panic!("service `{name}` must produce valid Rust: {error}"));
+        }
+
+        let mut generator = ServiceDefinition::new("Self", None);
+        generator.add_method(
+            rule("Get", HttpMethod::GET, "/v1/get"),
+            "crate::pb::GetRequest",
+            "crate::pb::Resp",
+            None,
+        );
+        let file: syn::File = syn::parse2(generator.generate(CodegenOptions { emit_tonic: true })).expect("valid Rust");
+        let pretty = prettyplease::unparse(&file);
+        assert!(
+            pretty.contains("trait Self_"),
+            "the reserved `Self` trait must be raw-sanitized: {pretty}"
+        );
+        assert!(
+            pretty.contains("self_server::Self_"),
+            "the tonic bridge must reference the sanitized trait: {pretty}"
+        );
+    }
+
+    #[test]
     fn keyword_named_rpc_emits_a_raw_identifier_method() {
-        // A proto RPC whose `snake_case` name is a Rust keyword (e.g. `Match` →
-        // `match`) must be emitted as a raw identifier (`fn r#match`); a bare
-        // a bare `fn match` would not compile. `syn::parse2` here would fail on the
-        // unescaped form, so this both round-trips the generated code and pins
-        // the raw form in the pretty output.
         let mut generator = ServiceDefinition::new("Library", None);
         generator.add_method(
             rule("Match", HttpMethod::GET, "/v1/match"),
@@ -1249,10 +1235,6 @@ mod tests {
 
     #[test]
     fn enum_path_variable_pokes_via_parse_path_enum_value() {
-        // A path variable declared as an enum field is poked via
-        // `parse_path_enum_value` with the field's concrete enum type (so it
-        // accepts the value by name or number), with the `i32` `.into()`-ed to
-        // fit the field; a non-declared capture stays on `parse_path_field`.
         let mut generator = ServiceDefinition::new("Library", None);
         generator.add_method(
             rule("ListByState", HttpMethod::GET, "/v1/books/state/{state}").path_field_enum("state", "crate::pb::BookState"),
@@ -1287,10 +1269,6 @@ mod tests {
 
     #[test]
     fn path_variable_named_like_a_transcoder_local_does_not_collide() {
-        // A path variable whose proto field name equals a transcoder local
-        // (`request`, `body`, `cx`, `query_pairs`) must be destructured into a
-        // reserved `__cap{n}` binding, so it cannot shadow that local and break
-        // the generated `decode_request`/poke code.
         let mut generator = ServiceDefinition::new("Library", None);
         generator.add_method(
             rule("Get", HttpMethod::GET, "/v1/{request}"),
@@ -1301,8 +1279,6 @@ mod tests {
 
         let file: syn::File = syn::parse2(generator.generate(CodegenOptions::default())).expect("generated service must be valid Rust");
         let flat: String = prettyplease::unparse(&file).split_whitespace().collect();
-        // The `request` field is read into `__cap0` (not a bare `request` binding
-        // that would shadow the decoded message local).
         assert!(flat.contains("{request:__cap0}=>"), "{flat}");
         assert!(
             flat.contains("request.request=::rest_over_grpc::codegen_helpers::parse_path_field(__cap0"),
@@ -1312,8 +1288,6 @@ mod tests {
 
     #[test]
     fn keyword_path_segment_pokes_through_a_raw_identifier() {
-        // A dotted path variable whose segment is a Rust keyword (`type`) is poked
-        // through a raw identifier (`r#type`) so the generated code compiles.
         let mut generator = ServiceDefinition::new("Library", None);
         generator.add_method(
             rule("GetTyped", HttpMethod::GET, "/v1/{msg.type}"),
@@ -1332,9 +1306,6 @@ mod tests {
 
     #[test]
     fn affix_path_segment_is_captured_and_poked() {
-        // An affix segment (`img-{id}.png`, from the extended template grammar)
-        // captures its field like a plain variable; the transcoder destructures
-        // and pokes it. Exercises the affix arm of `capture_signature`.
         let template =
             PathTemplate::parse("/v1/images/img-{id}.png", Grammar::default().with_segment_affixes()).expect("valid extended template");
         let mut generator = ServiceDefinition::new("Library", None);
@@ -1380,8 +1351,6 @@ mod tests {
 
     #[test]
     fn service_doc_documents_the_trait() {
-        // A `Some(doc)` documents the trait verbatim (one `#[doc]` per line);
-        // `None` emits no doc comment.
         let documented = ServiceDefinition::new("Library", Some(" A library service.\n Second line.".to_owned()))
             .trait_code()
             .to_string();
@@ -1395,9 +1364,6 @@ mod tests {
 
     #[test]
     fn generates_streaming_transcode_for_server_streaming_methods() {
-        // A server-streaming method makes the generated `Transcoder`'s
-        // `try_transcode` emit a streaming arm; a unary sibling exercises
-        // the unary arm of the same method too.
         let mut generator = ServiceDefinition::new("Library", None);
         generator
             .add_server_streaming_method(
@@ -1417,12 +1383,8 @@ mod tests {
             syn::parse2(generator.generate(CodegenOptions::default())).expect("generated streaming service must be valid Rust");
         let pretty = prettyplease::unparse(&file);
         assert!(pretty.contains("fn stream_shelves"));
-        // The transcoder exposes a single `try_transcode` returning a
-        // `TranscodeResponse`; there is no separate streaming method.
         assert!(pretty.contains("fn try_transcode"));
         assert!(!pretty.contains("fn try_transcode_streaming"));
-        // The streaming arm frames the handler's stream — a token unique to the
-        // streaming arm (the unary arm produces a buffered `HttpResponse`).
         assert!(pretty.replace(' ', "").contains("StreamingResponse::encode_response"));
     }
 
@@ -1447,7 +1409,10 @@ mod tests {
         let additional_arm = &flat[additional_start..];
 
         assert!(primary_arm.contains("RequestBodyKind::Whole"), "{primary_arm}");
-        assert!(primary_arm.contains("ResponseBodyKind::Field(\"item\","), "{primary_arm}");
+        assert!(
+            primary_arm.contains("ResponseBodyKind::Field{name:\"item\",default:\"null\","),
+            "{primary_arm}"
+        );
         assert!(additional_arm.contains("RequestBodyKind::Field(\"item\","), "{additional_arm}");
         assert!(additional_arm.contains("ResponseBodyKind::Whole"), "{additional_arm}");
     }
@@ -1489,17 +1454,13 @@ mod tests {
         let _: syn::File = syn::parse2(bridge.clone()).expect("streaming bridge must be valid Rust");
         let flat = bridge.to_string().replace(' ', "");
 
-        // The bridged method is two-phase: an `async fn` returning
-        // `Result<ResponseStream<_>, Status>`.
         assert!(flat.contains(
             "asyncfnstream_shelves(&self,request:crate::pb::ListShelvesRequest,cx:&mut::rest_over_grpc::handling::Context,)->::core::result::Result<::rest_over_grpc::handling::ResponseStream<crate::pb::Shelf>,::rest_over_grpc::handling::Status,>"
         ));
-        // It awaits the tonic call, boxes the response stream, and maps per-item
-        // errors via the runtime helper.
         assert!(flat.contains("::rest_over_grpc::codegen_helpers::map_stream_status("));
-        assert!(flat.contains(".into_inner()"));
+        assert!(flat.contains(".into_parts()"));
+        assert!(flat.contains("cx.merge_response_headers(__metadata.into_headers())"));
         assert!(flat.contains("__convert_status"));
-        // The request headers seed the tonic request metadata (moved, not cloned).
         assert!(flat.contains("::tonic::metadata::MetadataMap::from_headers(cx.take_request_headers())"));
     }
 
@@ -1520,7 +1481,6 @@ mod tests {
         assert!(pretty.contains("impl<T> Library for T"));
         assert!(pretty.contains("T: library_server::Library"));
         assert!(pretty.contains("tonic::Request::new(request)"));
-        // The request headers seed the tonic request metadata.
         assert!(pretty.contains("MetadataMap::from_headers"));
         assert!(pretty.contains("request_headers()"));
         assert!(pretty.contains("response.into_parts()"));
@@ -1539,7 +1499,6 @@ mod tests {
             None,
         );
 
-        // With `emit_tonic` unset, `generate` emits no bridge `impl`.
         assert!(
             !definition
                 .generate(CodegenOptions::default())
@@ -1548,7 +1507,6 @@ mod tests {
                 .contains("library_server::Library")
         );
 
-        // With `emit_tonic` set, the bridge `impl` is included alongside the trait.
         assert!(
             definition
                 .generate(CodegenOptions { emit_tonic: true })
@@ -1568,8 +1526,6 @@ mod tests {
             None,
         );
 
-        // The service trait always gains a `Send + Sync` supertrait and per-future
-        // `+ Send` bounds so the output works on multi-threaded executors.
         let code = definition.generate(CodegenOptions::default()).to_string();
         assert!(code.contains("Send + :: core :: marker :: Sync") || code.contains("Send + ::core::marker::Sync"));
         assert!(code.matches("marker :: Send").count() >= 2);
@@ -1602,7 +1558,7 @@ mod tests {
         let flat = tokens.to_string().replace(' ', "");
         assert!(flat.contains("RequestBodyKind::Whole"));
         assert!(flat.contains("RequestBodyKind::Field(\"book\")"));
-        assert!(flat.contains("ResponseBodyKind::Field(\"book\")"));
+        assert!(flat.contains("ResponseBodyKind::Field{name:\"book\",default:\"null\"}"));
     }
 
     #[test]

--- a/crates/rest_over_grpc/src/build/service_method.rs
+++ b/crates/rest_over_grpc/src/build/service_method.rs
@@ -13,6 +13,7 @@ pub(crate) struct ServiceMethod {
     server_streaming: bool,
     doc: Option<String>,
     enum_fields: Vec<(Vec<String>, String)>,
+    response_body_defaults: Vec<Option<String>>,
 }
 
 impl ServiceMethod {
@@ -23,6 +24,13 @@ impl ServiceMethod {
     /// generated trait method when present. `enum_fields` maps each enum-typed
     /// path variable (by dotted field path) to its generated Rust enum type, so
     /// the transcoder can accept the value by name as well as by number.
+    /// `response_body_defaults` is aligned with `routes`: it holds the proto3-JSON
+    /// default literal for each route's `response_body` field (`None` for a whole
+    /// message or an unknown default).
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "aggregates one lowered method's codegen inputs; a params struct would only shuffle them"
+    )]
     pub(crate) fn new(
         rpc: impl Into<String>,
         request_type: impl Into<String>,
@@ -31,6 +39,7 @@ impl ServiceMethod {
         server_streaming: bool,
         doc: Option<String>,
         enum_fields: Vec<(Vec<String>, String)>,
+        response_body_defaults: Vec<Option<String>>,
     ) -> Self {
         Self {
             rpc: rpc.into(),
@@ -40,6 +49,7 @@ impl ServiceMethod {
             server_streaming,
             doc,
             enum_fields,
+            response_body_defaults,
         }
     }
 
@@ -78,6 +88,12 @@ impl ServiceMethod {
     pub(crate) fn enum_fields(&self) -> &[(Vec<String>, String)] {
         &self.enum_fields
     }
+
+    /// The proto3-JSON default literals for each route's `response_body` field,
+    /// aligned with [`routes`](Self::routes).
+    pub(crate) fn response_body_defaults(&self) -> &[Option<String>] {
+        &self.response_body_defaults
+    }
 }
 
 #[cfg(test)]
@@ -92,7 +108,7 @@ mod tests {
     fn accessors_return_method_parts() {
         let template = PathTemplate::parse("/v1/shelves/{shelf}", Grammar::default()).expect("valid path template");
         let routes = HttpRule::new("GetShelf", HttpMethod::GET, template).lower();
-        let method = ServiceMethod::new("GetShelf", "crate::Req", "crate::Resp", routes, false, None, Vec::new());
+        let method = ServiceMethod::new("GetShelf", "crate::Req", "crate::Resp", routes, false, None, Vec::new(), Vec::new());
 
         assert_eq!(method.rpc(), "GetShelf");
         assert_eq!(method.request_type(), "crate::Req");
@@ -101,5 +117,23 @@ mod tests {
         assert!(!method.server_streaming());
         assert_eq!(method.doc(), None);
         assert!(method.enum_fields().is_empty());
+    }
+
+    #[test]
+    fn response_body_defaults_returns_stored_defaults() {
+        let template = PathTemplate::parse("/v1/shelves/{shelf}", Grammar::default()).expect("valid path template");
+        let routes = HttpRule::new("GetShelf", HttpMethod::GET, template).lower();
+        let method = ServiceMethod::new(
+            "GetShelf",
+            "crate::Req",
+            "crate::Resp",
+            routes,
+            false,
+            None,
+            Vec::new(),
+            vec![Some("\"\"".to_owned())],
+        );
+
+        assert_eq!(method.response_body_defaults(), [Some("\"\"".to_owned())]);
     }
 }

--- a/crates/rest_over_grpc/src/context.rs
+++ b/crates/rest_over_grpc/src/context.rs
@@ -205,6 +205,52 @@ pub(crate) fn append_headers(dst: &mut HeaderMap, src: HeaderMap) {
     }
 }
 
+/// Removes connection-management and message-framing headers that a handler
+/// must not control from `headers`.
+///
+/// Handler-supplied response headers flow onto the wire response, but framing
+/// (`Content-Length`, `Transfer-Encoding`) and hop-by-hop headers (`Connection`
+/// and the connection tokens it governs) belong to the serving stack. Leaving a
+/// stale `Content-Length` or `Transfer-Encoding` in place would corrupt the
+/// response, so they are stripped before the handler's headers are applied.
+pub(crate) fn strip_uncontrolled_response_headers(headers: &mut HeaderMap) {
+    use http::header;
+
+    const HOP_BY_HOP: &[HeaderName] = &[
+        header::CONTENT_LENGTH,
+        header::TRANSFER_ENCODING,
+        header::CONNECTION,
+        header::TE,
+        header::TRAILER,
+        header::UPGRADE,
+        header::PROXY_AUTHENTICATE,
+        header::PROXY_AUTHORIZATION,
+    ];
+
+    // Headers named by `Connection` tokens are hop-by-hop for this message and
+    // must be stripped alongside the fixed set (RFC 9110 §7.6.1). Collect them
+    // before `Connection` itself is removed below. Tokens that are directives
+    // (`close`, `keep-alive`) rather than header names simply match nothing.
+    let connection_named: Vec<HeaderName> = headers
+        .get_all(header::CONNECTION)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .filter_map(|token| HeaderName::from_bytes(token.trim().as_bytes()).ok())
+        .collect();
+    for name in &connection_named {
+        let _ = headers.remove(name);
+    }
+
+    for name in HOP_BY_HOP {
+        let _ = headers.remove(name);
+    }
+    // `Keep-Alive` and `Proxy-Connection` have no `http::header` constant.
+    for name in ["keep-alive", "proxy-connection"] {
+        let _ = headers.remove(name);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use http::header;
@@ -227,11 +273,46 @@ mod tests {
         let mut cx = Context::new(request);
 
         let taken = cx.take_request_headers();
-        // The taken map carries the original headers …
         assert_eq!(taken.get(header::HOST).unwrap(), "example.test");
-        // … and the context's request headers are now empty (a real move, not a
-        // fresh default left beside the untouched original).
         assert!(cx.request_headers().is_empty());
+    }
+
+    #[test]
+    fn strip_uncontrolled_response_headers_removes_framing_and_hop_by_hop() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_LENGTH, HeaderValue::from_static("10"));
+        headers.insert(header::TRANSFER_ENCODING, HeaderValue::from_static("chunked"));
+        headers.insert(header::CONNECTION, HeaderValue::from_static("close"));
+        headers.insert("keep-alive", HeaderValue::from_static("timeout=5"));
+        headers.insert(header::ETAG, HeaderValue::from_static("\"v1\""));
+
+        strip_uncontrolled_response_headers(&mut headers);
+
+        assert!(headers.get(header::CONTENT_LENGTH).is_none());
+        assert!(headers.get(header::TRANSFER_ENCODING).is_none());
+        assert!(headers.get(header::CONNECTION).is_none());
+        assert!(headers.get("keep-alive").is_none());
+        assert_eq!(headers.get(header::ETAG).unwrap(), "\"v1\"");
+    }
+
+    #[test]
+    fn strip_uncontrolled_response_headers_removes_connection_named_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONNECTION, HeaderValue::from_static("close, X-Foo, x-bar"));
+        headers.insert("x-foo", HeaderValue::from_static("1"));
+        headers.append("x-bar", HeaderValue::from_static("a"));
+        headers.append("x-bar", HeaderValue::from_static("b"));
+        headers.insert(header::ETAG, HeaderValue::from_static("\"v1\""));
+
+        strip_uncontrolled_response_headers(&mut headers);
+
+        assert!(headers.get(header::CONNECTION).is_none());
+        assert!(headers.get("x-foo").is_none(), "header named by a Connection token is stripped");
+        assert!(
+            headers.get("x-bar").is_none(),
+            "every value of a Connection-named header is stripped"
+        );
+        assert_eq!(headers.get(header::ETAG).unwrap(), "\"v1\"");
     }
 
     #[test]

--- a/crates/rest_over_grpc/src/http_response.rs
+++ b/crates/rest_over_grpc/src/http_response.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use serde_json::{Value, to_vec};
 
 use crate::code::Code;
-use crate::context::append_headers;
+use crate::context::{append_headers, strip_uncontrolled_response_headers};
 use crate::handling::Status;
 
 /// The JSON body shape for a [`Status`] response, mirroring `google.rpc.Status`:
@@ -269,6 +269,7 @@ impl HttpResponse {
     /// accumulated on its [`Context`](crate::handling::Context).
     pub fn merge_headers(&mut self, headers: HeaderMap) {
         append_headers(&mut self.headers, headers);
+        strip_uncontrolled_response_headers(&mut self.headers);
     }
 
     /// The response body bytes.
@@ -308,7 +309,11 @@ impl HttpResponse {
     /// neutral standard shared by hyper, axum, tower, and others. The
     /// `Content-Type` is authoritative: it is applied after the custom headers,
     /// so a stray `content-type` among them never overrides the negotiated
-    /// value.
+    /// value. Framing and hop-by-hop headers (e.g. `Content-Length`,
+    /// `Transfer-Encoding`, `Connection` and the headers it names) are stripped
+    /// here, so headers set through [`with_header`](Self::with_header) or
+    /// [`headers_mut`](Self::headers_mut) cannot corrupt the response framing
+    /// regardless of how they were set.
     ///
     /// # Examples
     ///
@@ -330,6 +335,7 @@ impl HttpResponse {
             mut headers,
             body,
         } = self;
+        strip_uncontrolled_response_headers(&mut headers);
         let mut response = Response::new(body);
         *response.status_mut() = status;
         let dst = response.headers_mut();
@@ -376,5 +382,47 @@ mod tests {
             .headers_mut()
             .insert(http::header::ETAG, http::HeaderValue::from_static("\"v1\""));
         assert_eq!(response.headers()[http::header::ETAG], "\"v1\"");
+    }
+
+    #[test]
+    fn merge_headers_strips_framing_headers_from_handler_headers() {
+        let mut response = HttpResponse::ok_json(b"{}".to_vec());
+        let mut handler = HeaderMap::new();
+        handler.insert(http::header::CONTENT_LENGTH, http::HeaderValue::from_static("999"));
+        handler.insert(http::header::TRANSFER_ENCODING, http::HeaderValue::from_static("chunked"));
+        handler.insert(http::header::ETAG, http::HeaderValue::from_static("\"v1\""));
+
+        response.merge_headers(handler);
+
+        assert!(response.headers().get(http::header::CONTENT_LENGTH).is_none());
+        assert!(response.headers().get(http::header::TRANSFER_ENCODING).is_none());
+        assert_eq!(response.headers()[http::header::ETAG], "\"v1\"");
+    }
+
+    #[test]
+    fn into_http_strips_framing_headers_set_directly_on_the_response() {
+        let mut response =
+            HttpResponse::ok_json(b"{}".to_vec()).with_header(http::header::TRANSFER_ENCODING, http::HeaderValue::from_static("chunked"));
+        response
+            .headers_mut()
+            .insert(http::header::CONTENT_LENGTH, http::HeaderValue::from_static("999"));
+        response
+            .headers_mut()
+            .insert(http::header::CONNECTION, http::HeaderValue::from_static("x-secret"));
+        response
+            .headers_mut()
+            .insert(http::HeaderName::from_static("x-secret"), http::HeaderValue::from_static("leak"));
+        response
+            .headers_mut()
+            .insert(http::header::ETAG, http::HeaderValue::from_static("\"v1\""));
+
+        let http = response.into_http();
+
+        assert!(http.headers().get(http::header::TRANSFER_ENCODING).is_none());
+        assert!(http.headers().get(http::header::CONTENT_LENGTH).is_none());
+        assert!(http.headers().get(http::header::CONNECTION).is_none());
+        assert!(http.headers().get("x-secret").is_none());
+        assert_eq!(http.headers()[http::header::ETAG], "\"v1\"");
+        assert_eq!(http.headers()[http::header::CONTENT_TYPE], "application/json");
     }
 }

--- a/crates/rest_over_grpc/src/lib.rs
+++ b/crates/rest_over_grpc/src/lib.rs
@@ -290,6 +290,8 @@ pub mod transcoding {
     #[doc(inline)]
     pub use crate::http_response::HttpResponse;
     #[doc(inline)]
+    pub use crate::stream::StreamEncoding;
+    #[doc(inline)]
     pub use crate::transcode_api::Transcode;
     #[doc(inline)]
     pub use crate::transcode_response::{FrameStream, StreamingResponse, TranscodeResponse};

--- a/crates/rest_over_grpc/src/stream.rs
+++ b/crates/rest_over_grpc/src/stream.rs
@@ -45,7 +45,7 @@ use crate::transcode::{ResponseBodyKind, TranscodeError, encode_response_into};
 /// ```
 /// # fn main() {
 /// # {
-/// use rest_over_grpc::codegen_helpers::StreamEncoding;
+/// use rest_over_grpc::transcoding::StreamEncoding;
 ///
 /// assert_eq!(StreamEncoding::JsonArray.content_type(), "application/json");
 /// assert_eq!(
@@ -81,7 +81,7 @@ impl StreamEncoding {
     /// ```
     /// # fn main() {
     /// # {
-    /// use rest_over_grpc::codegen_helpers::StreamEncoding;
+    /// use rest_over_grpc::transcoding::StreamEncoding;
     ///
     /// assert_eq!(
     ///     StreamEncoding::NdJson.content_type(),
@@ -114,7 +114,7 @@ impl StreamEncoding {
     /// ```
     /// # fn main() {
     /// # {
-    /// use rest_over_grpc::codegen_helpers::StreamEncoding;
+    /// use rest_over_grpc::transcoding::StreamEncoding;
     ///
     /// assert_eq!(
     ///     StreamEncoding::from_accept("text/event-stream"),
@@ -153,23 +153,56 @@ impl StreamEncoding {
             } else {
                 continue;
             };
-            let quality = parts
-                .find_map(|parameter| {
-                    let (name, value) = parameter.trim().split_once('=')?;
-                    name.trim()
-                        .eq_ignore_ascii_case("q")
-                        .then(|| value.trim().parse::<f32>().ok())
-                        .flatten()
-                })
-                .unwrap_or(1.0);
-            if !(0.0 < quality && quality <= 1.0) {
+            let Some(quality) = accept_quality(parts) else {
                 continue;
-            }
+            };
             if selected.is_none_or(|(_, current)| quality > current) {
                 selected = Some((encoding, quality));
             }
         }
         selected.map_or(Self::JsonArray, |(encoding, _)| encoding)
+    }
+}
+
+fn accept_quality<'a>(parameters: impl Iterator<Item = &'a str>) -> Option<u16> {
+    let mut quality = None;
+    for parameter in parameters {
+        let parameter = parameter.trim();
+        let Some((name, value)) = parameter.split_once('=') else {
+            if parameter.eq_ignore_ascii_case("q") {
+                return None;
+            }
+            continue;
+        };
+        if !name.trim().eq_ignore_ascii_case("q") {
+            continue;
+        }
+        if quality.is_some() {
+            return None;
+        }
+        quality = Some(parse_quality(value.trim())?);
+    }
+
+    let quality = quality.unwrap_or(1_000);
+    (quality > 0).then_some(quality)
+}
+
+fn parse_quality(value: &str) -> Option<u16> {
+    let (integer, fraction) = value.split_once('.').unwrap_or((value, ""));
+    if fraction.len() > 3 || !fraction.bytes().all(|digit| digit.is_ascii_digit()) {
+        return None;
+    }
+    match integer {
+        "0" => {
+            let fraction = if fraction.is_empty() {
+                0
+            } else {
+                fraction.parse::<u16>().ok()? * 10_u16.pow(3 - u32::try_from(fraction.len()).ok()?)
+            };
+            Some(fraction)
+        }
+        "1" if fraction.bytes().all(|digit| digit == b'0') => Some(1_000),
+        _ => None,
     }
 }
 
@@ -190,7 +223,7 @@ fn serialize_framed_item<T: Serialize>(
         ResponseBodyKind::Whole => {
             to_writer(&mut frame, message).map_err(|error| Status::internal(format!("failed to serialize a streamed message: {error}")))?;
         }
-        ResponseBodyKind::Field(_) => {
+        ResponseBodyKind::Field { .. } => {
             encode_response_into(message, response_body, &mut frame).map_err(TranscodeError::into_status)?;
         }
     }
@@ -401,8 +434,17 @@ mod tests {
         }
 
         let items = futures_util::stream::iter(vec![Ok::<_, Status>(Tick { n: 1, ignored: 9 })]);
-        let frames: Vec<_> =
-            futures::executor::block_on(encode_frames_response(items, StreamEncoding::JsonArray, ResponseBodyKind::Field("n")).collect());
+        let frames: Vec<_> = futures::executor::block_on(
+            encode_frames_response(
+                items,
+                StreamEncoding::JsonArray,
+                ResponseBodyKind::Field {
+                    name: "n",
+                    default: "null",
+                },
+            )
+            .collect(),
+        );
         let body: Vec<u8> = frames.into_iter().flat_map(|frame| frame.expect("frame")).collect();
         assert_eq!(body, b"[1]");
     }
@@ -434,6 +476,29 @@ mod tests {
             StreamEncoding::from_accept("application/x-ndjson;q=0.8, text/event-stream;q=0.8"),
             StreamEncoding::NdJson
         );
+        for invalid in ["invalid", "", "NaN", "inf", "-0.1", "1.1", "+0.5", "1e-1", "0.1234"] {
+            let accept = format!("text/event-stream;q={invalid}, application/x-ndjson;q=0.5");
+            assert_eq!(StreamEncoding::from_accept(&accept), StreamEncoding::NdJson, "{accept}");
+        }
+        assert_eq!(
+            StreamEncoding::from_accept("text/event-stream;q, application/x-ndjson;q=0.5"),
+            StreamEncoding::NdJson
+        );
+        // A bare parameter that is not `q` is ignored, leaving the default quality.
+        assert_eq!(StreamEncoding::from_accept("text/event-stream;charset"), StreamEncoding::Sse);
+        assert_eq!(
+            StreamEncoding::from_accept("text/event-stream;q=0.9;q=0.8, application/x-ndjson;q=0.5"),
+            StreamEncoding::NdJson
+        );
+        for (quality, expected) in [
+            ("0.", Some(0)),
+            ("0.001", Some(1)),
+            ("0.5", Some(500)),
+            ("1.", Some(1_000)),
+            ("1.000", Some(1_000)),
+        ] {
+            assert_eq!(parse_quality(quality), expected, "{quality}");
+        }
     }
 
     #[test]

--- a/crates/rest_over_grpc/src/transcode/error.rs
+++ b/crates/rest_over_grpc/src/transcode/error.rs
@@ -4,7 +4,7 @@
 //! The [`TranscodeError`] request/response transcoding error type.
 
 use core::fmt;
-use std::backtrace::Backtrace;
+use std::backtrace::{Backtrace, BacktraceStatus};
 use std::error::Error;
 
 use crate::handling::{Code, Status};
@@ -14,7 +14,7 @@ use crate::handling::{Code, Status};
 /// The underlying `serde`/`serde_json` failure (when there is one) is preserved
 /// and reachable through [`std::error::Error::source`]. A [`Backtrace`] is
 /// captured at construction and shown in the `Debug` output when
-/// `RUST_BACKTRACE` is enabled.
+/// `RUST_BACKTRACE` is enabled; disabled backtraces do not allocate.
 ///
 /// # Examples
 ///
@@ -42,7 +42,26 @@ pub struct TranscodeError {
     detail: String,
     source: Option<Box<dyn Error + Send + Sync + 'static>>,
     #[expect(dead_code, reason = "captured for Debug output and RUST_BACKTRACE diagnostics")]
-    backtrace: Box<Backtrace>,
+    backtrace: MaybeBacktrace,
+}
+
+#[derive(Debug)]
+enum MaybeBacktrace {
+    Captured(#[expect(dead_code, reason = "captured for Debug output and RUST_BACKTRACE diagnostics")] Box<Backtrace>),
+    Disabled,
+}
+
+impl MaybeBacktrace {
+    fn capture() -> Self {
+        Self::from_backtrace(Backtrace::capture())
+    }
+
+    fn from_backtrace(backtrace: Backtrace) -> Self {
+        match backtrace.status() {
+            BacktraceStatus::Captured => Self::Captured(Box::new(backtrace)),
+            BacktraceStatus::Disabled | BacktraceStatus::Unsupported | _ => Self::Disabled,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,7 +82,7 @@ impl TranscodeError {
             kind,
             detail: source.to_string(),
             source: Some(Box::new(source)),
-            backtrace: Box::new(Backtrace::capture()),
+            backtrace: MaybeBacktrace::capture(),
         }
     }
 
@@ -96,7 +115,7 @@ impl TranscodeError {
             kind: TranscodeErrorKind::Serialize,
             detail,
             source: None,
-            backtrace: Box::new(Backtrace::capture()),
+            backtrace: MaybeBacktrace::capture(),
         }
     }
 
@@ -105,7 +124,7 @@ impl TranscodeError {
             kind: TranscodeErrorKind::Structure,
             detail: detail.to_owned(),
             source: None,
-            backtrace: Box::new(Backtrace::capture()),
+            backtrace: MaybeBacktrace::capture(),
         }
     }
 
@@ -114,7 +133,7 @@ impl TranscodeError {
             kind: TranscodeErrorKind::Serialize,
             detail: detail.to_owned(),
             source: None,
-            backtrace: Box::new(Backtrace::capture()),
+            backtrace: MaybeBacktrace::capture(),
         }
     }
 
@@ -123,7 +142,7 @@ impl TranscodeError {
             kind: TranscodeErrorKind::Deserialize,
             detail: format!("{component} contains malformed percent encoding or invalid UTF-8"),
             source: None,
-            backtrace: Box::new(Backtrace::capture()),
+            backtrace: MaybeBacktrace::capture(),
         }
     }
 
@@ -133,7 +152,7 @@ impl TranscodeError {
             kind: TranscodeErrorKind::Deserialize,
             detail: format!("path variable value {value:?} did not parse: {error}"),
             source: None,
-            backtrace: Box::new(Backtrace::capture()),
+            backtrace: MaybeBacktrace::capture(),
         }
     }
 
@@ -143,7 +162,7 @@ impl TranscodeError {
             kind: TranscodeErrorKind::Deserialize,
             detail: format!("path variable value {value:?} is not a valid enum value"),
             source: None,
-            backtrace: Box::new(Backtrace::capture()),
+            backtrace: MaybeBacktrace::capture(),
         }
     }
 
@@ -239,5 +258,17 @@ mod tests {
 
         let shape = serde_json::from_slice::<u32>(br#""text""#).expect_err("wrong JSON shape");
         assert_eq!(TranscodeError::body_or_deserialize(shape).kind, TranscodeErrorKind::Deserialize);
+    }
+
+    #[test]
+    fn backtrace_capture_maps_status_to_variant() {
+        assert!(matches!(
+            MaybeBacktrace::from_backtrace(Backtrace::force_capture()),
+            MaybeBacktrace::Captured(_)
+        ));
+        assert!(matches!(
+            MaybeBacktrace::from_backtrace(Backtrace::disabled()),
+            MaybeBacktrace::Disabled
+        ));
     }
 }

--- a/crates/rest_over_grpc/src/transcode/field_serializer.rs
+++ b/crates/rest_over_grpc/src/transcode/field_serializer.rs
@@ -120,95 +120,95 @@ impl<'a> Serializer for FieldSerializer<'a> {
     }
 
     fn serialize_bool(self, _value: bool) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_i8(self, _value: i8) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_i16(self, _value: i16) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_i32(self, _value: i32) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_i64(self, _value: i64) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_i128(self, _value: i128) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_u8(self, _value: u8) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_u16(self, _value: u16) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_u32(self, _value: u32) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_u64(self, _value: u64) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_u128(self, _value: u128) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_f32(self, _value: f32) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_f64(self, _value: f64) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_char(self, _value: char) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_str(self, _value: &str) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_unit_variant(self, _name: &'static str, _index: u32, _variant: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 
     fn serialize_tuple_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Err(FieldSerError::Absent)
+        Err(FieldSerError::Unsupported)
     }
 }
 
@@ -252,36 +252,36 @@ mod tests {
     }
 
     #[test]
-    fn scalar_and_sequence_shapes_report_absent() {
-        assert_variant!(FieldSerError::Absent, serialize_bool(true));
-        assert_variant!(FieldSerError::Absent, serialize_i8(0));
-        assert_variant!(FieldSerError::Absent, serialize_i16(0));
-        assert_variant!(FieldSerError::Absent, serialize_i32(0));
-        assert_variant!(FieldSerError::Absent, serialize_i64(0));
-        assert_variant!(FieldSerError::Absent, serialize_i128(0));
-        assert_variant!(FieldSerError::Absent, serialize_u8(0));
-        assert_variant!(FieldSerError::Absent, serialize_u16(0));
-        assert_variant!(FieldSerError::Absent, serialize_u32(0));
-        assert_variant!(FieldSerError::Absent, serialize_u64(0));
-        assert_variant!(FieldSerError::Absent, serialize_u128(0));
-        assert_variant!(FieldSerError::Absent, serialize_f32(0.0));
-        assert_variant!(FieldSerError::Absent, serialize_f64(0.0));
-        assert_variant!(FieldSerError::Absent, serialize_char('a'));
-        assert_variant!(FieldSerError::Absent, serialize_str("s"));
-        assert_variant!(FieldSerError::Absent, serialize_bytes(b"b"));
-        assert_variant!(FieldSerError::Absent, serialize_none());
-        assert_variant!(FieldSerError::Absent, serialize_unit());
-        assert_variant!(FieldSerError::Absent, serialize_unit_struct("U"));
-        assert_variant!(FieldSerError::Absent, serialize_unit_variant("E", 0, "V"));
-        assert_variant!(FieldSerError::Absent, serialize_seq(None));
-        assert_variant!(FieldSerError::Absent, serialize_tuple(2));
-        assert_variant!(FieldSerError::Absent, serialize_tuple_struct("T", 2));
+    fn scalar_and_sequence_shapes_report_unsupported() {
+        assert_variant!(FieldSerError::Unsupported, serialize_bool(true));
+        assert_variant!(FieldSerError::Unsupported, serialize_i8(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_i16(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_i32(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_i64(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_i128(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_u8(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_u16(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_u32(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_u64(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_u128(0));
+        assert_variant!(FieldSerError::Unsupported, serialize_f32(0.0));
+        assert_variant!(FieldSerError::Unsupported, serialize_f64(0.0));
+        assert_variant!(FieldSerError::Unsupported, serialize_char('a'));
+        assert_variant!(FieldSerError::Unsupported, serialize_str("s"));
+        assert_variant!(FieldSerError::Unsupported, serialize_bytes(b"b"));
+        assert_variant!(FieldSerError::Unsupported, serialize_none());
+        assert_variant!(FieldSerError::Unsupported, serialize_unit());
+        assert_variant!(FieldSerError::Unsupported, serialize_unit_struct("U"));
+        assert_variant!(FieldSerError::Unsupported, serialize_unit_variant("E", 0, "V"));
+        assert_variant!(FieldSerError::Unsupported, serialize_seq(None));
+        assert_variant!(FieldSerError::Unsupported, serialize_tuple(2));
+        assert_variant!(FieldSerError::Unsupported, serialize_tuple_struct("T", 2));
     }
 
     #[test]
     fn option_and_newtype_forward_to_the_inner_value() {
-        assert_variant!(FieldSerError::Absent, serialize_some(&0_i32));
-        assert_variant!(FieldSerError::Absent, serialize_newtype_struct("N", &0_i32));
+        assert_variant!(FieldSerError::Unsupported, serialize_some(&0_i32));
+        assert_variant!(FieldSerError::Unsupported, serialize_newtype_struct("N", &0_i32));
     }
 
     #[test]

--- a/crates/rest_over_grpc/src/transcode/mod.rs
+++ b/crates/rest_over_grpc/src/transcode/mod.rs
@@ -127,7 +127,13 @@ fn try_decode_fast<T: DeserializeOwned>(
 /// let value: serde_json::Value = serde_json::from_slice(&body)?;
 /// assert_eq!(value["name"], "shelves/7/books/rust");
 ///
-/// let title = encode_response(&book, ResponseBodyKind::Field("title"))?;
+/// let title = encode_response(
+///     &book,
+///     ResponseBodyKind::Field {
+///         name: "title",
+///         default: "\"\"",
+///     },
+/// )?;
 /// assert_eq!(title, br#""The Rust Book""#);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -140,10 +146,13 @@ pub fn encode_response<T: Serialize>(message: &T, kind: ResponseBodyKind) -> Res
 pub(crate) fn encode_response_into<T: Serialize>(message: &T, kind: ResponseBodyKind, body: &mut Vec<u8>) -> Result<(), TranscodeError> {
     match kind {
         ResponseBodyKind::Whole => to_writer(body, message).map_err(TranscodeError::serialize),
-        ResponseBodyKind::Field(field) => match message.serialize(FieldSerializer::new(field, body)) {
+        ResponseBodyKind::Field { name, default } => match message.serialize(FieldSerializer::new(name, body)) {
             Ok(()) => Ok(()),
-            Err(FieldSerError::Absent) => Err(TranscodeError::response_structure("response_body field is absent from the message")),
-            Err(FieldSerError::Unsupported) => encode_field_via_value_into(message, field, body),
+            Err(FieldSerError::Absent) => {
+                body.extend_from_slice(default.as_bytes());
+                Ok(())
+            }
+            Err(FieldSerError::Unsupported) => encode_field_via_value_into(message, name, body),
             Err(FieldSerError::Json(source)) => Err(TranscodeError::serialize(source)),
             Err(FieldSerError::Custom(detail)) => Err(TranscodeError::serialize_message(detail)),
         },
@@ -253,7 +262,14 @@ mod tests {
             name: "shelves/1".to_owned(),
             size: 3,
         };
-        let bytes = encode_response(&resp, ResponseBodyKind::Field("name")).expect("encodes");
+        let bytes = encode_response(
+            &resp,
+            ResponseBodyKind::Field {
+                name: "name",
+                default: "null",
+            },
+        )
+        .expect("encodes");
         assert_eq!(bytes, br#""shelves/1""#);
     }
 
@@ -265,7 +281,15 @@ mod tests {
         };
         let mut body = b"prefix:".to_vec();
 
-        encode_response_into(&resp, ResponseBodyKind::Field("name"), &mut body).expect("encodes");
+        encode_response_into(
+            &resp,
+            ResponseBodyKind::Field {
+                name: "name",
+                default: "null",
+            },
+            &mut body,
+        )
+        .expect("encodes");
 
         assert_eq!(body, br#"prefix:"shelves/1""#);
     }
@@ -276,7 +300,14 @@ mod tests {
             name: "n".to_owned(),
             size: 42,
         };
-        let bytes = encode_response(&resp, ResponseBodyKind::Field("size")).expect("encodes");
+        let bytes = encode_response(
+            &resp,
+            ResponseBodyKind::Field {
+                name: "size",
+                default: "null",
+            },
+        )
+        .expect("encodes");
         assert_eq!(bytes, b"42");
     }
 
@@ -296,7 +327,14 @@ mod tests {
             inner: Inner { a: "x".to_owned(), b: 1 },
             other: 9,
         };
-        let bytes = encode_response(&outer, ResponseBodyKind::Field("inner")).expect("encodes");
+        let bytes = encode_response(
+            &outer,
+            ResponseBodyKind::Field {
+                name: "inner",
+                default: "null",
+            },
+        )
+        .expect("encodes");
         let value: Value = serde_json::from_slice(&bytes).expect("valid json");
         assert_eq!(value, serde_json::json!({"a": "x", "b": 1}));
     }
@@ -307,7 +345,14 @@ mod tests {
             name: "wrapped".to_owned(),
             size: 1,
         });
-        let bytes = encode_response(&resp, ResponseBodyKind::Field("name")).expect("encodes");
+        let bytes = encode_response(
+            &resp,
+            ResponseBodyKind::Field {
+                name: "name",
+                default: "null",
+            },
+        )
+        .expect("encodes");
         assert_eq!(bytes, br#""wrapped""#);
     }
 
@@ -322,7 +367,14 @@ mod tests {
             good: "ok".to_owned(),
             bad: Unserializable,
         };
-        let bytes = encode_response(&mixed, ResponseBodyKind::Field("good")).expect("encodes selected field");
+        let bytes = encode_response(
+            &mixed,
+            ResponseBodyKind::Field {
+                name: "good",
+                default: "null",
+            },
+        )
+        .expect("encodes selected field");
         assert_eq!(bytes, br#""ok""#);
     }
 
@@ -332,21 +384,42 @@ mod tests {
         struct Wrap {
             bad: Unserializable,
         }
-        let err = encode_response(&Wrap { bad: Unserializable }, ResponseBodyKind::Field("bad")).expect_err("field fails");
+        let err = encode_response(
+            &Wrap { bad: Unserializable },
+            ResponseBodyKind::Field {
+                name: "bad",
+                default: "null",
+            },
+        )
+        .expect_err("field fails");
         assert_eq!(err.code(), Code::Internal);
         assert!(err.to_string().contains("serialize"));
     }
 
     #[test]
     fn field_selection_maps_top_level_custom_error_to_internal() {
-        let err = encode_response(&Unserializable, ResponseBodyKind::Field("any")).expect_err("top-level serialize fails");
+        let err = encode_response(
+            &Unserializable,
+            ResponseBodyKind::Field {
+                name: "any",
+                default: "null",
+            },
+        )
+        .expect_err("top-level serialize fails");
         assert_eq!(err.code(), Code::Internal);
         assert!(err.to_string().contains("serialize"));
     }
 
     #[test]
     fn field_selection_on_non_object_is_absent() {
-        let err = encode_response(&"scalar", ResponseBodyKind::Field("name")).expect_err("no fields");
+        let err = encode_response(
+            &"scalar",
+            ResponseBodyKind::Field {
+                name: "name",
+                default: "null",
+            },
+        )
+        .expect_err("no fields");
         assert_eq!(err.code(), Code::Internal);
         assert!(err.to_string().starts_with("failed to encode the response:"));
     }
@@ -356,7 +429,14 @@ mod tests {
         let mut map = BTreeMap::new();
         let _ = map.insert("name".to_owned(), "from_map".to_owned());
         let _ = map.insert("theme".to_owned(), "history".to_owned());
-        let bytes = encode_response(&map, ResponseBodyKind::Field("name")).expect("encodes via fallback");
+        let bytes = encode_response(
+            &map,
+            ResponseBodyKind::Field {
+                name: "name",
+                default: "null",
+            },
+        )
+        .expect("encodes via fallback");
         assert_eq!(bytes, br#""from_map""#);
     }
 
@@ -364,8 +444,48 @@ mod tests {
     fn field_selection_map_fallback_reports_absent() {
         let mut map = BTreeMap::new();
         let _ = map.insert("name".to_owned(), "x".to_owned());
-        let err = encode_response(&map, ResponseBodyKind::Field("missing")).expect_err("absent");
+        let err = encode_response(
+            &map,
+            ResponseBodyKind::Field {
+                name: "missing",
+                default: "null",
+            },
+        )
+        .expect_err("absent");
         assert_eq!(err.code(), Code::Internal);
+    }
+
+    #[test]
+    fn defaulted_struct_field_emits_the_supplied_default() {
+        #[expect(
+            clippy::trivially_copy_pass_by_ref,
+            reason = "serde `skip_serializing_if` requires a `fn(&T) -> bool` signature"
+        )]
+        fn is_zero(value: &u32) -> bool {
+            *value == 0
+        }
+        #[derive(Serialize)]
+        struct Msg {
+            #[serde(skip_serializing_if = "is_zero")]
+            code: u32,
+            name: String,
+        }
+        let msg = Msg {
+            code: 0,
+            name: "x".to_owned(),
+        };
+        // `code` is omitted by serialization (mirroring pbjson's proto3
+        // default-omission), so selecting it yields the supplied proto3 default
+        // rather than a 500.
+        let bytes = encode_response(
+            &msg,
+            ResponseBodyKind::Field {
+                name: "code",
+                default: "0",
+            },
+        )
+        .expect("emits default");
+        assert_eq!(bytes, b"0");
     }
 
     #[derive(Debug, Deserialize, PartialEq)]
@@ -701,17 +821,23 @@ mod tests {
     }
 
     #[test]
-    fn encode_response_body_field_absent() {
-        let err = encode_response(
+    fn encode_response_body_field_at_default_emits_default() {
+        // A selected field absent from the serialization (here `Resp` never emits
+        // a `missing` field) yields the supplied proto3-JSON default rather than
+        // a 500. Validated codegen only reaches this path when a real field holds
+        // its default value.
+        let bytes = encode_response(
             &Resp {
                 name: "n".to_owned(),
                 size: 1,
             },
-            ResponseBodyKind::Field("missing"),
+            ResponseBodyKind::Field {
+                name: "missing",
+                default: "null",
+            },
         )
-        .expect_err("absent");
-        assert_eq!(err.code(), Code::Internal);
-        assert!(err.into_status().message().starts_with("failed to encode the response:"));
+        .expect("emits default");
+        assert_eq!(bytes, b"null");
     }
 
     #[test]

--- a/crates/rest_over_grpc/src/transcode/overlay.rs
+++ b/crates/rest_over_grpc/src/transcode/overlay.rs
@@ -9,13 +9,14 @@
 
 use core::fmt;
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::vec::IntoIter;
 
 use serde::de::value::{StrDeserializer, StringDeserializer};
 use serde::de::{DeserializeOwned, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde_json::value::RawValue;
 use serde_json::{Deserializer as JsonDeserializer, Error as JsonError, Number, Value, from_slice, from_str};
+use smallvec::{SmallVec, smallvec};
 
 use super::request_body_kind::RequestBodyKind;
 use super::{TranscodeError, percent};
@@ -57,18 +58,41 @@ fn all_flat(query: &[(&str, &str)]) -> bool {
     query.iter().all(|(key, _)| !key.contains('.'))
 }
 
-fn decode_flat<T: DeserializeOwned>(body: Option<&[u8]>, query: &[(&str, &str)]) -> Result<T, TranscodeError> {
-    let mut overlay: Vec<(&str, Vec<Cow<'_, str>>)> = Vec::with_capacity(query.len());
-    let mut overlay_index: HashMap<&str, usize> = HashMap::with_capacity(query.len());
-    for (key, value) in query {
-        let decoded = percent::decode_query(value).ok_or_else(|| TranscodeError::invalid_encoding("query parameter value"))?;
-        if let Some(&index) = overlay_index.get(key) {
-            overlay[index].1.push(decoded);
+/// Maps a proto3-JSON field key to its `lowerCamelCase` JSON name.
+///
+/// proto3 JSON accepts a field under both its `snake_case` proto name and its
+/// `lowerCamelCase` JSON name, which denote the same field. Applying the proto3
+/// JSON-name algorithm (drop each `_` and ASCII-uppercase the following letter)
+/// maps both spellings to one key, so the overlay can treat them as the same
+/// field when deduplicating body entries and applying query overrides. Unlike a
+/// blanket case-fold that also drops `_`, this keeps distinct fields such as
+/// `foobar` and `foo_bar` (`fooBar`) apart.
+fn normalized_key(key: &str) -> Cow<'_, str> {
+    if !key.contains('_') {
+        return Cow::Borrowed(key);
+    }
+    let mut normalized = String::with_capacity(key.len());
+    let mut uppercase_next = false;
+    for ch in key.chars() {
+        if ch == '_' {
+            uppercase_next = true;
+        } else if uppercase_next {
+            normalized.push(ch.to_ascii_uppercase());
+            uppercase_next = false;
         } else {
-            overlay_index.insert(*key, overlay.len());
-            overlay.push((key, vec![decoded]));
+            normalized.push(ch);
         }
     }
+    Cow::Owned(normalized)
+}
+
+type QueryValues<'de> = SmallVec<[Cow<'de, str>; 2]>;
+type FlatOverlay<'de> = SmallVec<[(&'de str, QueryValues<'de>); 8]>;
+type FlatOverlayIndex<'de> = HashMap<&'de str, usize>;
+type GroupedFlatQuery<'de> = (FlatOverlay<'de>, Option<FlatOverlayIndex<'de>>);
+
+fn decode_flat<T: DeserializeOwned>(body: Option<&[u8]>, query: &[(&str, &str)]) -> Result<T, TranscodeError> {
+    let (overlay, _overlay_index) = group_flat_query(query)?;
 
     let mut body_entries = match body {
         Some(bytes) if !bytes.is_empty() => match from_slice::<BodyTop<'_>>(bytes) {
@@ -78,7 +102,8 @@ fn decode_flat<T: DeserializeOwned>(body: Option<&[u8]>, query: &[(&str, &str)])
         _ => Vec::new(),
     };
 
-    body_entries.retain(|(key, _)| !overlay_index.contains_key(key.as_str()));
+    let query_norms: HashSet<Cow<'_, str>> = overlay.iter().map(|(key, _)| normalized_key(key)).collect();
+    body_entries.retain(|(key, _)| !query_norms.contains(&normalized_key(key)));
 
     let map = OverlayMap {
         body: body_entries.into_iter(),
@@ -88,9 +113,37 @@ fn decode_flat<T: DeserializeOwned>(body: Option<&[u8]>, query: &[(&str, &str)])
     T::deserialize(OverlayDeserializer { map }).map_err(TranscodeError::deserialize)
 }
 
+fn group_flat_query<'de>(query: &[(&'de str, &'de str)]) -> Result<GroupedFlatQuery<'de>, TranscodeError> {
+    let mut overlay = FlatOverlay::new();
+    let mut overlay_index: Option<FlatOverlayIndex<'de>> = None;
+    for (key, value) in query {
+        let decoded = percent::decode_query(value).ok_or_else(|| TranscodeError::invalid_encoding("query parameter value"))?;
+        let existing = match &overlay_index {
+            Some(index) => index.get(key).copied(),
+            None => overlay.iter().position(|(existing, _)| existing == key),
+        };
+        if let Some(index) = existing {
+            overlay[index].1.push(decoded);
+        } else {
+            if overlay_index.is_none() && overlay.len() == overlay.inline_size() {
+                let mut index = HashMap::with_capacity(query.len());
+                index.extend(overlay.iter().enumerate().map(|(position, (existing, _))| (*existing, position)));
+                overlay_index = Some(index);
+            }
+            if let Some(index) = &mut overlay_index {
+                index.insert(*key, overlay.len());
+            }
+            overlay.push((key, smallvec![decoded]));
+        }
+    }
+    Ok((overlay, overlay_index))
+}
+
 fn classify_body_error(bytes: &[u8]) -> TranscodeError {
     match from_slice::<Value>(bytes) {
         Err(source) => TranscodeError::body(source),
+        // A valid JSON object that `BodyTop` rejects can only fail its duplicate-field check.
+        Ok(Value::Object(_)) => TranscodeError::structure("request body contains a duplicate field"),
         Ok(_) => TranscodeError::structure("request body must be a JSON object"),
     }
 }
@@ -114,15 +167,13 @@ impl<'de> serde::Deserialize<'de> for BodyTop<'de> {
 
             fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
                 let mut entries: Vec<(String, &'de RawValue)> = Vec::new();
-                let mut entry_index: HashMap<String, usize> = HashMap::new();
+                let mut seen: HashMap<String, ()> = HashMap::new();
                 while let Some(key) = map.next_key::<String>()? {
                     let value: &'de RawValue = map.next_value()?;
-                    if let Some(&index) = entry_index.get(&key) {
-                        entries[index].1 = value;
-                    } else {
-                        entry_index.insert(key.clone(), entries.len());
-                        entries.push((key, value));
+                    if seen.insert(normalized_key(&key).into_owned(), ()).is_some() {
+                        return Err(serde::de::Error::custom("request body contains a duplicate field"));
                     }
+                    entries.push((key, value));
                 }
                 Ok(BodyTop { entries })
             }
@@ -134,13 +185,13 @@ impl<'de> serde::Deserialize<'de> for BodyTop<'de> {
 
 enum Pending<'de> {
     Raw(&'de RawValue),
-    Query(Vec<Cow<'de, str>>),
+    Query(QueryValues<'de>),
 }
 
 struct OverlayMap<'de, B, O>
 where
     B: Iterator<Item = (String, &'de RawValue)>,
-    O: Iterator<Item = (&'de str, Vec<Cow<'de, str>>)>,
+    O: Iterator<Item = (&'de str, QueryValues<'de>)>,
 {
     body: B,
     overlay: O,
@@ -150,7 +201,7 @@ where
 impl<'de, B, O> MapAccess<'de> for OverlayMap<'de, B, O>
 where
     B: Iterator<Item = (String, &'de RawValue)>,
-    O: Iterator<Item = (&'de str, Vec<Cow<'de, str>>)>,
+    O: Iterator<Item = (&'de str, QueryValues<'de>)>,
 {
     type Error = JsonError;
 
@@ -182,7 +233,7 @@ where
 struct OverlayDeserializer<'de, B, O>
 where
     B: Iterator<Item = (String, &'de RawValue)>,
-    O: Iterator<Item = (&'de str, Vec<Cow<'de, str>>)>,
+    O: Iterator<Item = (&'de str, QueryValues<'de>)>,
 {
     map: OverlayMap<'de, B, O>,
 }
@@ -190,7 +241,7 @@ where
 impl<'de, B, O> Deserializer<'de> for OverlayDeserializer<'de, B, O>
 where
     B: Iterator<Item = (String, &'de RawValue)>,
-    O: Iterator<Item = (&'de str, Vec<Cow<'de, str>>)>,
+    O: Iterator<Item = (&'de str, QueryValues<'de>)>,
 {
     type Error = JsonError;
 
@@ -206,7 +257,7 @@ where
 }
 
 struct QueryValue<'de> {
-    values: Vec<Cow<'de, str>>,
+    values: QueryValues<'de>,
 }
 
 impl QueryValue<'_> {
@@ -363,7 +414,7 @@ where
 }
 
 struct QuerySequence<'de> {
-    values: IntoIter<Cow<'de, str>>,
+    values: smallvec::IntoIter<[Cow<'de, str>; 2]>,
 }
 
 impl<'de> SeqAccess<'de> for QuerySequence<'de> {
@@ -372,14 +423,14 @@ impl<'de> SeqAccess<'de> for QuerySequence<'de> {
     fn next_element_seed<T: DeserializeSeed<'de>>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error> {
         self.values
             .next()
-            .map(|value| seed.deserialize(QueryValue { values: vec![value] }))
+            .map(|value| seed.deserialize(QueryValue { values: smallvec![value] }))
             .transpose()
     }
 }
 
 enum QueryNode {
     Map(Vec<(String, Self)>),
-    Leaf(Vec<String>),
+    Leaf(SmallVec<[String; 2]>),
 }
 
 fn decode_tree<T: DeserializeOwned>(body: Option<&[u8]>, query: &[(&str, &str)]) -> Result<T, TranscodeError> {
@@ -420,7 +471,7 @@ fn insert_query_node<'a>(
             if has_more {
                 QueryNode::Map(Vec::new())
             } else {
-                QueryNode::Leaf(Vec::new())
+                QueryNode::Leaf(SmallVec::new())
             },
         ));
         &mut map.last_mut().expect("entry was pushed immediately above").1
@@ -450,10 +501,11 @@ impl<'de> Deserializer<'de> for TreeDeserializer<'de> {
     fn deserialize_any<V: Visitor<'de>>(mut self, visitor: V) -> Result<V::Value, Self::Error> {
         let mut query = Vec::with_capacity(self.query.len());
         for (key, node) in self.query {
+            let normalized = normalized_key(&key);
             let body = self
                 .body
                 .iter()
-                .position(|(body_key, _)| *body_key == key)
+                .position(|(body_key, _)| normalized_key(body_key) == normalized)
                 .map(|index| self.body.remove(index).1);
             query.push((key, node, body));
         }
@@ -541,6 +593,97 @@ mod tests {
     }
 
     #[test]
+    fn normalized_key_maps_snake_and_camel_to_one_json_name() {
+        assert!(matches!(normalized_key("theme"), Cow::Borrowed("theme")));
+        assert!(matches!(normalized_key("shelf_name"), Cow::Owned(owned) if owned == "shelfName"));
+        assert!(matches!(normalized_key("shelfName"), Cow::Borrowed("shelfName")));
+        // Distinct fields a blanket case-fold-and-drop-`_` would have collided.
+        assert!(matches!(normalized_key("foobar"), Cow::Borrowed("foobar")));
+        assert!(matches!(normalized_key("foo_bar"), Cow::Owned(owned) if owned == "fooBar"));
+    }
+
+    #[test]
+    fn normalized_key_preserves_multibyte_chars() {
+        assert!(matches!(normalized_key("café_bar"), Cow::Owned(owned) if owned == "caféBar"));
+    }
+
+    #[test]
+    fn large_query_deduplicates_body_entries_through_a_set() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Nine {
+            a: String,
+            b: String,
+            c: String,
+            d: String,
+            e: String,
+            f: String,
+            g: String,
+            h: String,
+            i: String,
+        }
+
+        let query = [
+            ("a", "qa"),
+            ("b", "qb"),
+            ("c", "qc"),
+            ("d", "qd"),
+            ("e", "qe"),
+            ("f", "qf"),
+            ("g", "qg"),
+            ("h", "qh"),
+            ("i", "qi"),
+        ];
+        let decoded: Nine = decode_flat(Some(br#"{"a":"body"}"#), &query).expect("decodes");
+        assert_eq!(decoded.a, "qa");
+        assert_eq!(decoded.i, "qi");
+    }
+
+    #[test]
+    fn small_flat_queries_keep_grouping_storage_inline() {
+        let query = [
+            ("a", "1"),
+            ("b", "2"),
+            ("c", "3"),
+            ("d", "4"),
+            ("e", "5"),
+            ("f", "6"),
+            ("g", "7"),
+            ("a", "8"),
+        ];
+        let (overlay, index) = group_flat_query(&query).expect("query groups");
+        assert!(!overlay.spilled());
+        assert!(index.is_none());
+        assert!(overlay.iter().all(|(_, values)| !values.spilled()));
+        assert_eq!(overlay[0].1.as_slice(), ["1", "8"]);
+    }
+
+    #[test]
+    fn large_flat_queries_use_a_hash_index() {
+        let query = [
+            ("a", "1"),
+            ("b", "2"),
+            ("c", "3"),
+            ("d", "4"),
+            ("e", "5"),
+            ("f", "6"),
+            ("g", "7"),
+            ("h", "8"),
+            ("i", "9"),
+        ];
+        let (overlay, index) = group_flat_query(&query).expect("query groups");
+        assert!(overlay.spilled());
+        assert_eq!(index.expect("large query is indexed").len(), query.len());
+    }
+
+    #[test]
+    fn repeated_flat_query_does_not_build_a_hash_index() {
+        let query = [("tag", "a"); 16];
+        let (overlay, index) = group_flat_query(&query).expect("query groups");
+        assert_eq!(overlay.len(), 1);
+        assert!(index.is_none());
+    }
+
+    #[test]
     fn repeated_query_keys_are_presented_as_a_sequence() {
         let decoded: Option<Result<Shelf, _>> = try_decode_overlay(
             &RequestBodyKind::None,
@@ -591,32 +734,72 @@ mod tests {
     }
 
     #[test]
-    fn a_repeated_body_key_keeps_the_last_occurrence() {
-        // The top-level body scan de-duplicates repeated keys, last-write-wins.
+    fn a_repeated_body_key_is_rejected() {
         let body = br#"{"theme":"first","shelf":"7","theme":"second"}"#;
-        let decoded: Shelf = try_decode_overlay(&RequestBodyKind::Whole, &[], body)
+        let error = try_decode_overlay::<Shelf>(&RequestBodyKind::Whole, &[], body)
             .expect("flat whole-body input takes the overlay path")
-            .expect("decodes");
+            .expect_err("duplicate body fields are rejected");
+        assert!(error.to_string().contains("duplicate field"));
+    }
+
+    #[test]
+    fn query_does_not_rescue_a_repeated_body_key() {
+        let body = br#"{"theme":"first","shelf":"body","theme":"second"}"#;
+        let error = decode_flat::<Shelf>(Some(body), &[("shelf", "query")]).expect_err("duplicate body fields are rejected");
+        assert!(error.to_string().contains("duplicate field"));
+    }
+
+    #[test]
+    fn query_overrides_a_body_field_spelled_in_the_other_case() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Options {
+            #[serde(alias = "includeArchived")]
+            include_archived: bool,
+        }
+
+        let body = br#"{"includeArchived":false}"#;
+        let decoded: Options = decode_flat(Some(body), &[("include_archived", "true")]).expect("query overrides camelCase body field");
+        assert_eq!(decoded, Options { include_archived: true });
+
+        let body = br#"{"include_archived":false}"#;
+        let decoded: Options = decode_flat(Some(body), &[("includeArchived", "true")]).expect("query overrides snake_case body field");
+        assert_eq!(decoded, Options { include_archived: true });
+    }
+
+    #[test]
+    fn distinct_foobar_and_foo_bar_fields_are_not_conflated() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Fields {
+            foobar: String,
+            #[serde(alias = "fooBar")]
+            foo_bar: String,
+        }
+
+        // `foobar` and `foo_bar` (JSON `fooBar`) are distinct proto fields. A
+        // query override on `foo_bar` must not drop the unrelated `foobar` body
+        // entry, and both body fields must coexist without a duplicate error.
+        let body = br#"{"foobar":"body-foobar","fooBar":"body-foo-bar"}"#;
+        let decoded: Fields = decode_flat(Some(body), &[("foo_bar", "query-foo-bar")]).expect("distinct fields are kept apart");
         assert_eq!(
             decoded,
-            Shelf {
-                shelf: "7".to_owned(),
-                theme: "second".to_owned()
+            Fields {
+                foobar: "body-foobar".to_owned(),
+                foo_bar: "query-foo-bar".to_owned()
             }
         );
     }
 
     #[test]
-    fn query_shadows_repeated_body_keys() {
-        let body = br#"{"theme":"first","shelf":"body","theme":"second"}"#;
-        let decoded: Shelf = decode_flat(Some(body), &[("shelf", "query")]).expect("decodes");
-        assert_eq!(
-            decoded,
-            Shelf {
-                shelf: "query".to_owned(),
-                theme: "second".to_owned()
-            }
-        );
+    fn a_body_field_repeated_under_mixed_case_is_rejected() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Options {
+            #[serde(alias = "includeArchived")]
+            include_archived: bool,
+        }
+
+        let body = br#"{"include_archived":false,"includeArchived":true}"#;
+        let error = decode_flat::<Options>(Some(body), &[]).expect_err("mixed-case duplicate body fields are rejected");
+        assert!(error.to_string().contains("duplicate field"));
     }
 
     #[derive(Debug, PartialEq)]

--- a/crates/rest_over_grpc/src/transcode/response_body_kind.rs
+++ b/crates/rest_over_grpc/src/transcode/response_body_kind.rs
@@ -14,13 +14,34 @@
 /// let whole = ResponseBodyKind::Whole;
 /// assert_eq!(whole, ResponseBodyKind::Whole);
 ///
-/// let field = ResponseBodyKind::Field("name");
-/// assert_eq!(field, ResponseBodyKind::Field("name"));
+/// let field = ResponseBodyKind::Field {
+///     name: "score",
+///     default: "0",
+/// };
+/// assert_eq!(
+///     field,
+///     ResponseBodyKind::Field {
+///         name: "score",
+///         default: "0"
+///     }
+/// );
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ResponseBodyKind {
     /// The whole response message is the body.
     Whole,
     /// A single named top-level field of the response message is the body.
-    Field(&'static str),
+    ///
+    /// `name` is the field's proto3-JSON (camelCase) name. `default` is the
+    /// proto3-JSON literal to emit when the field holds its default value: the
+    /// serde serialization pbjson generates omits default-valued fields, so a
+    /// selected field at its default would otherwise appear absent. Emitting the
+    /// default (e.g. `0`, `false`, `""`, `null`, `[]`, `{}`, or an enum name)
+    /// matches the proto3-JSON representation a REST gateway returns.
+    Field {
+        /// The response field's proto3-JSON (camelCase) name.
+        name: &'static str,
+        /// The proto3-JSON literal emitted when the field is at its default.
+        default: &'static str,
+    },
 }

--- a/crates/rest_over_grpc/src/transcode_api.rs
+++ b/crates/rest_over_grpc/src/transcode_api.rs
@@ -133,8 +133,6 @@ mod tests {
 
     #[test]
     fn transcode_forwards_a_matched_streaming_response() {
-        // A `Some(Streaming)` from `try_transcode` flows through the default
-        // `transcode` unchanged, so the reply stays a streaming response.
         let response = futures::executor::block_on(StreamingRoute.transcode("GET", "/x", http::HeaderMap::new(), b""));
         assert_eq!(classify(response), ("streaming", http::StatusCode::OK));
     }

--- a/crates/rest_over_grpc/src/transcode_response.rs
+++ b/crates/rest_over_grpc/src/transcode_response.rs
@@ -24,7 +24,7 @@ use http::header;
 use http::{HeaderMap, HeaderValue};
 use serde::Serialize;
 
-use crate::context::append_headers;
+use crate::context::{append_headers, strip_uncontrolled_response_headers};
 use crate::handling::Status;
 use crate::stream::{Stream, StreamEncoding, encode_frames, encode_frames_response};
 use crate::transcode::ResponseBodyKind;
@@ -77,9 +77,8 @@ pub type ResponseStream<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send
 /// # fn main() {
 /// # {
 /// use futures_util::stream;
-/// use rest_over_grpc::codegen_helpers::StreamEncoding;
 /// use rest_over_grpc::handling::Status;
-/// use rest_over_grpc::transcoding::StreamingResponse;
+/// use rest_over_grpc::transcoding::{StreamEncoding, StreamingResponse};
 /// use serde::Serialize;
 ///
 /// #[derive(Serialize)]
@@ -127,9 +126,8 @@ impl StreamingResponse {
     /// # fn main() {
     /// # {
     /// use futures_util::stream;
-    /// use rest_over_grpc::codegen_helpers::StreamEncoding;
     /// use rest_over_grpc::handling::Status;
-    /// use rest_over_grpc::transcoding::StreamingResponse;
+    /// use rest_over_grpc::transcoding::{StreamEncoding, StreamingResponse};
     /// use serde::Serialize;
     ///
     /// #[derive(Serialize)]
@@ -189,6 +187,7 @@ impl StreamingResponse {
     /// set by the time the handler returns its stream.
     pub fn merge_headers(&mut self, headers: HeaderMap) {
         append_headers(&mut self.headers, headers);
+        strip_uncontrolled_response_headers(&mut self.headers);
     }
 
     /// Consumes the response, returning its stream of encoded body frames.
@@ -276,6 +275,7 @@ impl std::error::Error for StreamingError {}
 /// values.
 #[cfg(any(feature = "serving", feature = "axum"))]
 pub(crate) fn apply_stream_headers(dst: &mut HeaderMap, content_type: HeaderValue, mut headers: HeaderMap) {
+    strip_uncontrolled_response_headers(&mut headers);
     headers.remove(header::CONTENT_TYPE);
     append_headers(dst, headers);
     let _ = dst.insert(header::CONTENT_TYPE, content_type);
@@ -309,7 +309,6 @@ mod tests {
         let mut custom = http::HeaderMap::new();
         custom.append(http::header::SET_COOKIE, http::HeaderValue::from_static("a=1"));
         custom.append(http::header::SET_COOKIE, http::HeaderValue::from_static("b=2"));
-        // A custom `content-type` must be dropped in favour of the negotiated one.
         let _ = custom.insert(http::header::CONTENT_TYPE, http::HeaderValue::from_static("text/plain"));
 
         let mut dst = http::HeaderMap::new();
@@ -317,7 +316,6 @@ mod tests {
 
         assert_eq!(dst.get_all(http::header::CONTENT_TYPE).iter().count(), 1);
         assert_eq!(dst[http::header::CONTENT_TYPE], "application/json");
-        // Repeated custom values are preserved.
         assert_eq!(dst.get_all(http::header::SET_COOKIE).iter().count(), 2);
     }
 }

--- a/crates/rest_over_grpc/tests/axum_support.rs
+++ b/crates/rest_over_grpc/tests/axum_support.rs
@@ -28,8 +28,7 @@ async fn http_response_into_axum_preserves_status_content_type_and_body() {
 #[tokio::test]
 async fn streaming_response_into_axum_streams_frames() {
     use futures_util::stream;
-    use rest_over_grpc::codegen_helpers::StreamEncoding;
-    use rest_over_grpc::transcoding::StreamingResponse;
+    use rest_over_grpc::transcoding::{StreamEncoding, StreamingResponse};
     use serde::Serialize;
 
     #[derive(Serialize)]
@@ -49,8 +48,7 @@ async fn streaming_response_into_axum_streams_frames() {
 #[tokio::test]
 async fn streaming_response_into_axum_applies_custom_headers() {
     use futures_util::stream;
-    use rest_over_grpc::codegen_helpers::StreamEncoding;
-    use rest_over_grpc::transcoding::StreamingResponse;
+    use rest_over_grpc::transcoding::{StreamEncoding, StreamingResponse};
 
     let mut streaming = StreamingResponse::encode(stream::iter(vec![Ok::<_, Status>(1_u32)]), StreamEncoding::JsonArray);
     let mut headers = http::HeaderMap::new();
@@ -65,8 +63,7 @@ async fn streaming_response_into_axum_applies_custom_headers() {
 #[tokio::test]
 async fn transcode_response_into_axum_handles_both_variants() {
     use futures_util::stream;
-    use rest_over_grpc::codegen_helpers::StreamEncoding;
-    use rest_over_grpc::transcoding::{StreamingResponse, TranscodeResponse};
+    use rest_over_grpc::transcoding::{StreamEncoding, StreamingResponse, TranscodeResponse};
 
     let unary = TranscodeResponse::Unary(HttpResponse::ok_json(b"{}".to_vec())).into_response();
     assert_eq!(unary.status(), http::StatusCode::OK);
@@ -93,7 +90,5 @@ async fn transcode_response_into_axum_handles_both_variants() {
 fn adapter_response_body_is_axum_into_response() {
     fn assert_into_response<T: axum_core::response::IntoResponse>() {}
 
-    // The adapters' response body (`serve_http` / `serve_http_fn` /
-    // `RestService`), covering both unary and streaming responses.
     assert_into_response::<http::Response<rest_over_grpc::serving::RestBody>>();
 }

--- a/crates/rest_over_grpc/tests/build_api.rs
+++ b/crates/rest_over_grpc/tests/build_api.rs
@@ -34,12 +34,10 @@ fn generator_renders_and_inspects_services() {
 
     let (transcoder, generated) = generator.generate();
     assert_eq!(generated.len(), 2);
-    // The transcoder is always produced and routes across the added services.
     assert!(transcoder.to_string().contains("struct Transcoder"));
     let library = generated.iter().find(|g| g.trait_name() == "Library").expect("Library generated");
     assert_eq!(library.module_name(), "library");
     assert!(library.service_trait().to_string().contains("get_shelf"));
-    // The tonic bridge is on by default; the trait itself carries no bridge impl.
     assert!(library.tonic_bridge().is_some());
     assert!(library.service_trait().to_string().contains("pub trait Library"));
 }
@@ -71,7 +69,6 @@ fn generator_concatenates_services_sharing_a_module() {
         .join(format!("rog_build_it_shared_{}", std::process::id()));
     std::fs::create_dir_all(&dir).expect("scratch dir");
 
-    // Two services grouped into the same module are concatenated into one file.
     let mut books = ServiceDefinition::new("Books", None);
     books.set_module_name("catalog").add_method(
         rule("GetBook", HttpMethod::GET, "/v1/books/{book}"),
@@ -192,7 +189,6 @@ mod descriptor {
     #[test]
     fn compile_fds_reports_a_write_error() {
         let descriptor = descriptor_set(PROTO);
-        // A path whose parent does not exist cannot be written to.
         let bad = std::path::PathBuf::from("/rest_over_grpc_codegen_nonexistent_dir/nested");
         let error = compile_fds(&descriptor, &bad).expect_err("write fails");
         assert!(error.to_string().contains("failed to write"));
@@ -218,7 +214,6 @@ mod descriptor {
             .write(&out)
             .expect("writes");
 
-        // Both the code and the spec are written, the spec named after the module.
         assert!(out.join("api.rest.rs").exists(), "code still written");
         let spec = std::fs::read_to_string(out.join("api.openapi.json")).expect("spec file exists");
         assert!(spec.contains("\"openapi\": \"3.1.0\""), "{spec}");
@@ -253,8 +248,6 @@ mod descriptor {
             .write(&out)
             .expect("writes");
 
-        // With no proto package the module defaults to the snake-cased trait name,
-        // so the spec sits beside `s.rest.rs` as `s.openapi.json`.
         assert!(out.join("s.openapi.json").exists(), "default-package spec written");
     }
 
@@ -263,8 +256,6 @@ mod descriptor {
     fn write_merges_openapi_documents_for_services_sharing_a_package() {
         use rest_over_grpc::build::OpenApiInfo;
 
-        // Two services in one package merge into one `{package}.openapi.json`
-        // rather than clobbering each other.
         const TWO_SERVICES: &str = r#"
             syntax = "proto3";
             package shared;
@@ -300,7 +291,6 @@ mod descriptor {
 
         let descriptor = descriptor_set(PROTO);
 
-        // With OpenAPI requested, `openapi_spec()` carries the per-service document.
         let mut with_spec = Generator::builder()
             .emit_openapi_spec(Some(OpenApiInfo::new("Things API", "v1")))
             .build();
@@ -313,12 +303,10 @@ mod descriptor {
         assert!(spec.contains("/v1/things/{id}"));
         assert!(spec.contains("Things API"));
 
-        // Without OpenAPI requested, a decoded service still has no spec.
         let mut no_spec = Generator::new();
         no_spec.add_all(ServiceDefinition::from_fds(&descriptor, &DescriptorOptions::new().package(".api")).expect("decode"));
         assert!(no_spec.generate().1[0].openapi_spec().is_none());
 
-        // A hand-built service has no descriptor, so no OpenAPI state even when requested.
         let mut manual = Generator::builder()
             .emit_openapi_spec(Some(OpenApiInfo::new("Manual", "v1")))
             .build();

--- a/crates/rest_over_grpc/tests/streaming.rs
+++ b/crates/rest_over_grpc/tests/streaming.rs
@@ -95,7 +95,6 @@ fn from_accept_negotiates_the_encoding() {
     assert_eq!(StreamEncoding::from_accept("application/json"), StreamEncoding::JsonArray);
     assert_eq!(StreamEncoding::from_accept("*/*"), StreamEncoding::JsonArray);
     assert_eq!(StreamEncoding::from_accept(""), StreamEncoding::JsonArray);
-    // Quality values take precedence over header order.
     assert_eq!(
         StreamEncoding::from_accept("application/json, text/event-stream;q=0.9"),
         StreamEncoding::JsonArray
@@ -113,10 +112,6 @@ async fn serialization_failure_is_reported_as_internal() {
     let err = results.into_iter().find_map(Result::err).expect("serialize fails");
     assert_eq!(err.code(), Code::Internal);
 }
-
-// Mirrors the server-streaming bridge contract: a two-phase
-// `async fn -> Result<ResponseStream, Status>` that maps the initiation `Status`
-// and error-maps the response stream via `map_stream_status`.
 
 struct FakeStatus(String);
 
@@ -141,7 +136,6 @@ impl FakeService {
         &self,
         start: u32,
     ) -> Result<FakeResponse<impl Stream<Item = Result<u32, FakeStatus>> + Send + 'static>, FakeStatus> {
-        // Mirror `tonic`'s genuinely-async initiation.
         core::future::ready(()).await;
         if self.ok {
             Ok(FakeResponse(stream::iter(vec![Ok(start), Err(FakeStatus("mid".to_owned()))])))
@@ -188,8 +182,6 @@ fn bridge_future_is_send() {
     assert_send(&bridge_call(&service, 1));
 }
 
-// Real-streaming value types (`StreamingResponse` / `TranscodeResponse`).
-
 #[tokio::test]
 async fn streaming_response_encodes_ndjson_frames_lazily() {
     let items = stream::iter(vec![Ok::<_, Status>(Msg { n: 1 }), Ok(Msg { n: 2 })]);
@@ -205,7 +197,7 @@ async fn streaming_response_applies_response_body_mapping() {
     let response = StreamingResponse::encode_response(
         items,
         StreamEncoding::JsonArray,
-        rest_over_grpc::codegen_helpers::ResponseBodyKind::Field("n"),
+        rest_over_grpc::codegen_helpers::ResponseBodyKind::Field { name: "n", default: "0" },
     );
     let frames: Vec<Vec<u8>> = response.into_frames().map(|frame| frame.expect("frame")).collect().await;
     assert_eq!(frames.concat(), b"[7]");

--- a/crates/rest_over_grpc/tests/streaming_serving.rs
+++ b/crates/rest_over_grpc/tests/streaming_serving.rs
@@ -11,10 +11,9 @@
 
 use futures_util::stream;
 use http_body_util::{BodyExt as _, Full};
-use rest_over_grpc::codegen_helpers::StreamEncoding;
 use rest_over_grpc::handling::Status;
 use rest_over_grpc::serving::{RestService, serve_http_fn};
-use rest_over_grpc::transcoding::{HttpResponse, StreamingResponse, TranscodeResponse};
+use rest_over_grpc::transcoding::{HttpResponse, StreamEncoding, StreamingResponse, TranscodeResponse};
 use serde::Serialize;
 use tower_service::Service as _;
 
@@ -82,7 +81,6 @@ async fn serve_http_fn_applies_response_headers_and_content_type() {
     .await;
 
     assert_eq!(response.headers()["x-trace"], "abc");
-    // `Content-Type` stays authoritative from the encoding.
     assert_eq!(response.headers()[http::header::CONTENT_TYPE], "application/json");
     let body = response.into_body().collect().await.expect("body collects").to_bytes();
     assert_eq!(body.as_ref(), b"[{\"n\":7}]");
@@ -109,8 +107,7 @@ async fn serve_http_fn_terminates_body_on_mid_stream_error() {
     })
     .await;
 
-    // The status line is already `200` before the error is observed, so the
-    // failure can only surface as a truncated (error-terminated) body.
+    // The committed status cannot reflect a later stream error.
     assert_eq!(response.status(), http::StatusCode::OK);
     let collected = response.into_body().collect().await;
     assert!(collected.is_err(), "a mid-stream error terminates the body");
@@ -141,8 +138,6 @@ async fn rest_service_serves_frames_via_layered() {
 async fn serve_http_wires_a_streaming_transcode_impl() {
     use rest_over_grpc::serving::serve_http;
 
-    // The bare `serve_http` free function (not the `_fn` closure form and not the
-    // service wrapper) delegates to the uncapped read path.
     let response = serve_http(request("application/json"), &TickStream).await;
     let body = response.into_body().collect().await.expect("body collects").to_bytes();
     assert_eq!(body.as_ref(), b"[{\"n\":9}]");

--- a/crates/rest_over_grpc/tests/value_types.rs
+++ b/crates/rest_over_grpc/tests/value_types.rs
@@ -160,7 +160,6 @@ fn from_status_renders_details_and_omits_them_when_empty() {
 fn into_http_appends_custom_headers_and_keeps_content_type_authoritative() {
     let response = HttpResponse::ok_json(b"{}".to_vec())
         .with_header(http::header::LOCATION, http::HeaderValue::from_static("/v1/shelves/7"))
-        // A stray custom content-type must not survive alongside the negotiated one.
         .with_header(http::header::CONTENT_TYPE, http::HeaderValue::from_static("text/plain"));
 
     let http = response.into_http();

--- a/crates/rest_over_grpc_examples/build.rs
+++ b/crates/rest_over_grpc_examples/build.rs
@@ -41,16 +41,11 @@ fn main() {
 fn build_tonic_bridge(proto_dir: &std::path::Path, out_dir: &std::path::Path) {
     std::fs::create_dir_all(out_dir).expect("the tonic_bridge output directory is created");
 
-    // Compile the proto to a descriptor set with protox (pure Rust, no protoc).
     let mut compiler = protox::Compiler::new([proto_dir]).expect("protox compiler initializes");
     compiler.include_imports(true);
     compiler.open_file("library.proto").expect("the library proto compiles");
     let descriptor_bytes = compiler.encode_file_descriptor_set();
 
-    // tonic generates the message structs AND the `library_server::Library`
-    // server trait — no protoc run. The transport server struct is not needed
-    // (the bridge targets only the trait), so it is disabled to keep the
-    // dependency surface minimal.
     tonic_prost_build::configure()
         .build_client(false)
         .build_server(true)
@@ -59,7 +54,6 @@ fn build_tonic_bridge(proto_dir: &std::path::Path, out_dir: &std::path::Path) {
         .compile_fds(compiler.file_descriptor_set())
         .expect("tonic generates the messages and server trait");
 
-    // pbjson adds the serde impls the JSON transcoder needs.
     pbjson_build::Builder::new()
         .register_descriptors(&descriptor_bytes)
         .expect("pbjson registers the descriptors")
@@ -67,9 +61,6 @@ fn build_tonic_bridge(proto_dir: &std::path::Path, out_dir: &std::path::Path) {
         .build(&[".library"])
         .expect("pbjson generates the serde impls");
 
-    // `rest_over_grpc::build` emits the REST trait + transcoder and, because the
-    // `tonic` bridge is on by default, the blanket bridge impl. The default
-    // `Send` bounds match tonic's `#[async_trait]` server trait.
     compile_fds(&descriptor_bytes, out_dir).expect("the http annotations decode and the generated REST service code is written");
 }
 
@@ -81,24 +72,18 @@ fn build_tonic_bridge(proto_dir: &std::path::Path, out_dir: &std::path::Path) {
 fn build_custom(proto_dir: &std::path::Path, out_dir: &std::path::Path) {
     std::fs::create_dir_all(out_dir).expect("the custom output directory is created");
 
-    // Parse the proto into a descriptor set (pure-Rust, no `protoc`).
-    // `encode_file_descriptor_set` preserves custom options (the http
-    // annotation), which a round-trip through `prost_types` would drop.
+    // Preserve custom options in the encoded descriptor set.
     let mut compiler = protox::Compiler::new([proto_dir]).expect("protox compiler initializes");
     compiler.include_imports(true);
-    // Retain leading comments so each RPC's proto documentation is carried onto
-    // the generated trait method.
     compiler.include_source_info(true);
     compiler.open_file("library.proto").expect("the example proto compiles");
     let descriptor_bytes = compiler.encode_file_descriptor_set();
 
-    // Generate the prost message structs.
     prost_build::Config::new()
         .out_dir(out_dir)
         .compile_fds(compiler.file_descriptor_set())
         .expect("prost generates the message structs");
 
-    // Generate the pbjson serde impls.
     pbjson_build::Builder::new()
         .register_descriptors(&descriptor_bytes)
         .expect("pbjson registers the descriptors")
@@ -106,13 +91,6 @@ fn build_custom(proto_dir: &std::path::Path, out_dir: &std::path::Path) {
         .build(&[".library"])
         .expect("pbjson generates the serde impls");
 
-    // Read the google.api.http annotations and generate the REST service trait +
-    // transcoder, reusing the descriptor already compiled above.
-    // `emit_openapi_spec(..)` additionally makes `write` emit a
-    // `library.openapi.json` describing the transcoded REST surface as an OpenAPI
-    // 3.1 document. The `tonic` bridge is disabled because this modality uses
-    // `prost` (not `tonic`), so there is no `tonic`-generated server trait to
-    // bridge.
     Generator::builder()
         .emit_tonic_bridge(false)
         .emit_openapi_spec(Some(OpenApiInfo::new("Library", "v1")))

--- a/crates/rest_over_grpc_examples/examples/handling/client_streaming_upload.rs
+++ b/crates/rest_over_grpc_examples/examples/handling/client_streaming_upload.rs
@@ -71,9 +71,6 @@ where
             return text(StatusCode::PAYLOAD_TOO_LARGE, "upload too large");
         }
         summary.chunks += 1;
-
-        // A real handler streams `chunk` onward here — a gRPC client-streaming
-        // `send`, or a write to blob storage — with backpressure, then drops it.
     }
 
     json(
@@ -92,8 +89,6 @@ where
         return handle_upload(request).await;
     }
 
-    // Everything else is a small unary JSON request: collect the body, transcode,
-    // and buffer the reply.
     let method = request.method().clone();
     let target = request.uri().path_and_query().map_or("/", |pq| pq.as_str()).to_owned();
     let headers = request.headers().clone();
@@ -156,7 +151,6 @@ mod tests {
 async fn main() {
     let library = Transcoder::new(InMemoryLibrary);
 
-    // A normal JSON route, transcoded as usual.
     let get = Request::builder()
         .method(Method::GET)
         .uri("/v1/shelves/history")
@@ -164,8 +158,6 @@ async fn main() {
         .expect("request builds");
     report("GET /v1/shelves/history", &route(&library, get).await);
 
-    // A chunked upload — the client sends the "file" as several body frames,
-    // which the streaming handler consumes one at a time.
     let chunks = [b"chunk-0-data".as_slice(), b"chunk-1-data", b"chunk-2-data"]
         .into_iter()
         .map(|bytes| Ok::<_, Infallible>(Frame::data(Bytes::from_static(bytes))));

--- a/crates/rest_over_grpc_examples/examples/handling/direct_service.rs
+++ b/crates/rest_over_grpc_examples/examples/handling/direct_service.rs
@@ -56,8 +56,6 @@ struct DirectLibrary;
 
 impl pb::Library for DirectLibrary {
     async fn get_shelf(&self, request: GetShelfRequest, cx: &mut Context) -> Result<Shelf, Status> {
-        // A miss returns `NOT_FOUND` (→ HTTP 404) carrying a structured detail, so
-        // the client gets a machine-readable error, not just a status line.
         if request.shelf == "missing" {
             return Err(Status::not_found("no such shelf").with_detail(serde_json::json!({
                 "@type": "type.googleapis.com/google.rpc.ResourceInfo",
@@ -66,9 +64,6 @@ impl pb::Library for DirectLibrary {
             })));
         }
 
-        // Echo a caller-supplied trace id back on the response, and set a cache
-        // validator — request-side metadata in, response-side metadata out. The
-        // transcoder folds these into the HTTP response headers.
         if let Some(trace) = cx.request_headers().get("x-trace-id").cloned() {
             _ = cx.response_headers_mut().insert(HeaderName::from_static("x-trace-id"), trace);
         }
@@ -81,10 +76,8 @@ impl pb::Library for DirectLibrary {
     }
 
     async fn create_shelf(&self, request: CreateShelfRequest, cx: &mut Context) -> Result<Shelf, Status> {
-        // The `{shelf}` request field is mapped from the JSON body (`body: "shelf"`).
         let mut created = request.shelf.ok_or_else(|| Status::invalid_argument("shelf is required"))?;
         "shelves/created".clone_into(&mut created.name);
-        // Point the client at the freshly created resource.
         _ = cx.insert_response_header(HeaderName::from_static("location"), HeaderValue::from_static("/v1/shelves/created"));
         Ok(created)
     }
@@ -96,8 +89,6 @@ impl pb::Library for DirectLibrary {
     }
 
     async fn list_shelves_by_genre(&self, request: ListShelvesByGenreRequest, _cx: &mut Context) -> Result<ListShelvesResponse, Status> {
-        // The `{genre}` enum path variable arrives as its `i32` value, decoded from
-        // either the value name (`SCIENCE`) or its number (`2`).
         let theme = match request.genre() {
             Genre::History => "history",
             Genre::Science => "science",
@@ -107,8 +98,6 @@ impl pb::Library for DirectLibrary {
     }
 
     async fn stream_shelves(&self, request: ListShelvesRequest, _cx: &mut Context) -> Result<ResponseStream<Shelf>, Status> {
-        // A server-streaming handler returns a `'static` stream of `Result<Reply,
-        // Status>`; the transcoder frames each item onto the wire as it is yielded.
         let shelves: Vec<Result<Shelf, Status>> = catalog(&request.filter).into_iter().map(Ok).collect();
         Ok(Box::pin(futures::stream::iter(shelves)))
     }
@@ -129,8 +118,6 @@ fn catalog(filter: &str) -> Vec<Shelf> {
 fn main() {
     let library = Transcoder::new(DirectLibrary);
 
-    // A unary read carrying a trace id: the response echoes it back and adds an
-    // `ETag`, both set by the handler through `Context`.
     let mut headers = HeaderMap::new();
     _ = headers.insert("x-trace-id", HeaderValue::from_static("trace-42"));
     report_unary(
@@ -138,19 +125,16 @@ fn main() {
         block_on(library.transcode("GET", "/v1/shelves/history", headers, b"")),
     );
 
-    // A miss: `NOT_FOUND` with a structured `details` entry.
     report_unary(
         "GET /v1/shelves/missing",
         block_on(library.transcode("GET", "/v1/shelves/missing", HeaderMap::new(), b"")),
     );
 
-    // A create: the handler sets a `Location` header for the new resource.
     report_unary(
         "POST /v1/shelves",
         block_on(library.transcode("POST", "/v1/shelves", HeaderMap::new(), br#"{"theme":"mystery"}"#)),
     );
 
-    // A server-streaming read: the handler's stream reaches the wire frame by frame.
     report_streaming(
         "GET /v1/shelves:stream",
         block_on(library.transcode("GET", "/v1/shelves:stream", HeaderMap::new(), b"")),

--- a/crates/rest_over_grpc_examples/examples/handling/volo_bridge.rs
+++ b/crates/rest_over_grpc_examples/examples/handling/volo_bridge.rs
@@ -234,9 +234,6 @@ impl pb::Library for MyShelfService {
     }
 
     async fn list_shelves_by_genre(&self, request: ListShelvesByGenreRequest, _cx: &mut Context) -> Result<ListShelvesResponse, Status> {
-        // No `volo` counterpart: this handler filters the sample shelves by the
-        // decoded enum value directly (the `{genre}` path variable arrives as its
-        // `i32`, from either the value name or its number).
         let theme = match request.genre() {
             Genre::History => "history",
             Genre::Science => "science",
@@ -247,11 +244,6 @@ impl pb::Library for MyShelfService {
     }
 
     async fn stream_shelves(&self, request: ListShelvesRequest, _cx: &mut Context) -> Result<ResponseStream<Shelf>, Status> {
-        // Both a `volo` streaming method and the generated trait method have the
-        // same two-phase shape: `async fn -> Result<Stream, Status>`. Await
-        // initiation, map the initiation error, then box and error-map the
-        // response stream (`volo`'s stream is `Send + 'static`), so it streams to
-        // the wire after transcode returns.
         let stream = <Self as volo_gen::LibraryServer>::stream_shelves(self, volo_gen::Request::new(request))
             .await
             .map(volo_gen::Response::into_inner)
@@ -264,9 +256,9 @@ impl pb::Library for MyShelfService {
 async fn main() {
     let service = rest_over_grpc_examples::custom::Transcoder::new(MyShelfService);
     let requests = [
-        ("GET", "/v1/shelves/history"), // unary
-        ("GET", "/v1/shelves"),         // unary list
-        ("GET", "/v1/shelves:stream"),  // server-streaming
+        ("GET", "/v1/shelves/history"),
+        ("GET", "/v1/shelves"),
+        ("GET", "/v1/shelves:stream"),
     ];
 
     for (method, target) in requests {

--- a/crates/rest_over_grpc_examples/examples/serving/axum_app.rs
+++ b/crates/rest_over_grpc_examples/examples/serving/axum_app.rs
@@ -72,7 +72,6 @@ async fn health() -> HttpResponse {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    // (label, method, target, accept, body)
     let requests: [DemoRequest; 7] = [
         ("hand-written Axum response", "GET", "/healthz", None, b""),
         ("path variable", "GET", "/v1/shelves/history", None, b""),
@@ -96,8 +95,6 @@ async fn main() {
         }
         let request = builder.body(Body::from(body.to_vec())).expect("request builds");
 
-        // `oneshot` drives the real router (routing, the fallback service, its
-        // response body) exactly as a live server would, per request.
         let response = app().oneshot(request).await.expect("transcode is infallible");
 
         let status = response.status();

--- a/crates/rest_over_grpc_examples/examples/serving/custom_body_handling.rs
+++ b/crates/rest_over_grpc_examples/examples/serving/custom_body_handling.rs
@@ -37,31 +37,21 @@ struct TooLarge;
 async fn handle(library: &Transcoder<InMemoryLibrary>, request: Request<Full<Bytes>>) -> Response<Vec<u8>> {
     let (parts, body) = request.into_parts();
 
-    // Reject the wrong content type up front (`415`), rather than letting it
-    // surface later as an opaque JSON parse error: the generated `transcode`
-    // decodes the body as JSON without checking `Content-Type`.
     let expects_body = matches!(parts.method, Method::POST | Method::PUT | Method::PATCH);
     if expects_body && !is_json(parts.headers.get(CONTENT_TYPE)) {
         return json(StatusCode::UNSUPPORTED_MEDIA_TYPE, br#"{"error":"expected application/json"}"#);
     }
 
-    // Read the body under a size cap, returning a custom `413` body. The
-    // built-in `RestService::with_max_body_bytes` cap returns a generic `413`;
-    // owning the read lets us shape the response.
     let bytes = match read_capped(body, MAX_BODY).await {
         Ok(bytes) => bytes,
         Err(TooLarge) => return json(StatusCode::PAYLOAD_TOO_LARGE, br#"{"error":"payload too large"}"#),
     };
 
-    // Hand the finished bytes and request headers to the generated transcoder —
-    // the neutral contract. Every route this example exercises is unary, so the
-    // response is always buffered.
     let target = parts.uri.path_and_query().map_or("/", |pq| pq.as_str());
     let TranscodeResponse::Unary(response) = library.transcode(parts.method.as_str(), target, parts.headers, &bytes).await else {
         return json(StatusCode::INTERNAL_SERVER_ERROR, br#"{"error":"unexpected streaming response"}"#);
     };
 
-    // Build our own wire response, adding a header the adapters can't attach.
     Response::builder()
         .status(response.status())
         .header(CONTENT_TYPE, response.content_type().clone())
@@ -102,7 +92,6 @@ fn json(status: StatusCode, body: &[u8]) -> Response<Vec<u8>> {
 async fn main() {
     let library = Transcoder::new(InMemoryLibrary);
 
-    // (label, method, target, content-type, body)
     let requests = [
         ("read", Method::GET, "/v1/shelves/history", None, Vec::new()),
         (

--- a/crates/rest_over_grpc_examples/examples/serving/streaming_response.rs
+++ b/crates/rest_over_grpc_examples/examples/serving/streaming_response.rs
@@ -33,16 +33,11 @@ async fn run(library: &'static Transcoder<LibraryService>, method: Method, targe
         .body(Full::new(bytes::Bytes::new()))
         .expect("request builds");
 
-    // `serve_http` feeds the request straight to the generated transcode — no
-    // wiring closure needed; server-streaming RPCs come back as a live
-    // `StreamingResponse`, unary RPCs as a buffered body.
     let response = serve_http(request, library).await;
 
     println!("\n{method} {target}  (Accept: {accept})");
     println!("  -> {} {}", response.status(), content_type(&response));
 
-    // Drain the body frame by frame — for a server-streaming route each data
-    // frame is one encoding frame flushed as the handler produced it.
     let mut body = response.into_body();
     while let Some(frame) = body.frame().await {
         match frame {
@@ -69,18 +64,13 @@ fn content_type(response: &http::Response<rest_over_grpc::serving::RestBody>) ->
 }
 
 fn main() {
-    // `'static` so the streaming body (which outlives the transcode call) can hold
-    // the service; a real server shares it via `Arc` or a long-lived value.
     let library: &'static Transcoder<LibraryService> = Box::leak(Box::new(Transcoder::new(LibraryService)));
 
     futures::executor::block_on(async {
-        // Server-streaming route: streamed NDJSON, one frame per shelf.
         run(library, Method::GET, "/v1/shelves:stream", "application/x-ndjson").await;
 
-        // Same route as a JSON array (the default encoding).
         run(library, Method::GET, "/v1/shelves:stream", "application/json").await;
 
-        // A unary route is simply buffered.
         run(library, Method::GET, "/v1/shelves/history", "application/json").await;
     });
 }

--- a/crates/rest_over_grpc_examples/examples/serving/tower_service.rs
+++ b/crates/rest_over_grpc_examples/examples/serving/tower_service.rs
@@ -26,9 +26,6 @@ use tower_service::Service as _;
 const MAX_BODY_BYTES: usize = 1 << 20;
 
 fn main() {
-    // `RestService::new` wraps the generated `Transcoder` (any `Transcode`) as a
-    // `tower` service directly. Cap buffered requests before exposing it to
-    // untrusted clients.
     let mut service = RestService::new(Transcoder::new(LibraryService)).with_max_body_bytes(MAX_BODY_BYTES);
 
     for target in ["/v1/shelves/history", "/v1/shelves:stream", "/v1/nope"] {
@@ -38,7 +35,6 @@ fn main() {
             .body(Full::new(Bytes::new()))
             .expect("request builds");
 
-        // `call` is what a `hyper`/`axum`/`tower` server invokes per request.
         let response = futures::executor::block_on(service.call(request)).expect("the transcoder is infallible");
 
         let status = response.status().as_u16();

--- a/crates/rest_over_grpc_examples/examples/transcoding/basic_transcode.rs
+++ b/crates/rest_over_grpc_examples/examples/transcoding/basic_transcode.rs
@@ -23,16 +23,9 @@ use rest_over_grpc_examples::tonic_bridge::{LibraryService, Transcoder};
 fn main() {
     let library = Transcoder::new(LibraryService);
 
-    let requests = [
-        ("GET", "/v1/shelves/history"), // unary route (GetShelf)
-        ("GET", "/v1/shelves:stream"),  // server-streaming route (frame stream)
-        ("GET", "/v1/nope"),            // no route → 404
-    ];
+    let requests = [("GET", "/v1/shelves/history"), ("GET", "/v1/shelves:stream"), ("GET", "/v1/nope")];
 
     for (method, target) in requests {
-        // `transcode` resolves the route, transcodes the request into the gRPC
-        // message, invokes the bridged handler, and encodes the reply as JSON —
-        // buffered for a unary RPC, or as a frame stream for a streaming RPC.
         let response = futures::executor::block_on(library.transcode(method, target, http::HeaderMap::new(), b""));
         match response {
             TranscodeResponse::Unary(http) => {

--- a/crates/rest_over_grpc_examples/examples/transcoding/custom_fallback.rs
+++ b/crates/rest_over_grpc_examples/examples/transcoding/custom_fallback.rs
@@ -24,14 +24,10 @@ use rest_over_grpc_examples::tonic_bridge::{LibraryService, Transcoder};
 async fn handle(library: &Transcoder<LibraryService>, method: &str, target: &str, headers: HeaderMap, body: &[u8]) -> TranscodeResponse {
     let path = target.split('?').next().unwrap_or(target);
 
-    // A non-generated route, handled before the transcoder.
     if method == "GET" && path == "/healthz" {
         return HttpResponse::ok_json(br#"{"status":"ok"}"#.to_vec()).into();
     }
 
-    // Delegate to the generated routes. `None` means none matched — a genuine
-    // routing miss, as opposed to a handler returning `Status::not_found`, which
-    // comes back as `Some(404)` and is served as-is.
     library
         .try_transcode(method, target, headers, body)
         .await
@@ -51,14 +47,13 @@ fn main() {
     let library = Transcoder::new(LibraryService);
 
     let requests = [
-        ("GET", "/v1/shelves/history"), // a generated route
-        ("GET", "/healthz"),            // the hand-written route
-        ("GET", "/v1/shelves/missing"), // matched route, handler returns not-found
-        ("GET", "/nope"),               // no route → custom fallback
+        ("GET", "/v1/shelves/history"),
+        ("GET", "/healthz"),
+        ("GET", "/v1/shelves/missing"),
+        ("GET", "/nope"),
     ];
 
     for (method, target) in requests {
-        // Every route in this example is unary, so the response is always buffered.
         let TranscodeResponse::Unary(response) = futures::executor::block_on(handle(&library, method, target, HeaderMap::new(), b""))
         else {
             unreachable!("this example only exercises unary routes");

--- a/crates/rest_over_grpc_examples/src/custom.rs
+++ b/crates/rest_over_grpc_examples/src/custom.rs
@@ -38,10 +38,7 @@ pub mod pb {
     include!(concat!(env!("OUT_DIR"), "/custom/library.rest.rs"));
 }
 
-// The generated top-level `Transcoder` refers to each service by its
-// module-qualified path (`{proto package}::Trait` / `::RequestType`). This proto
-// package is `library`, so we alias the `pb` module accordingly and `include!`
-// the transcoder at the enclosing scope where `library` is a sibling module.
+// Generated paths expect the proto package as a sibling module.
 use pb as library;
 
 #[allow(
@@ -83,8 +80,6 @@ impl pb::Library for InMemoryLibrary {
             })));
         }
 
-        // Propagate a caller-supplied trace id back to the response, and set a
-        // cache validator — both request- and response-side metadata.
         if let Some(trace) = cx.request_headers().get("x-trace-id").cloned() {
             _ = cx.response_headers_mut().insert(HeaderName::from_static("x-trace-id"), trace);
         }
@@ -99,7 +94,6 @@ impl pb::Library for InMemoryLibrary {
     async fn create_shelf(&self, request: CreateShelfRequest, cx: &mut Context) -> Result<Shelf, Status> {
         let mut created = request.shelf.ok_or_else(|| Status::invalid_argument("shelf is required"))?;
         "shelves/created".clone_into(&mut created.name);
-        // Point the client at the freshly created resource.
         _ = cx.insert_response_header(HeaderName::from_static("location"), HeaderValue::from_static("/v1/shelves/created"));
         Ok(created)
     }
@@ -123,8 +117,6 @@ impl pb::Library for InMemoryLibrary {
     }
 
     async fn list_shelves_by_genre(&self, request: ListShelvesByGenreRequest, _cx: &mut Context) -> Result<ListShelvesResponse, Status> {
-        // The enum path variable arrives as its `i32` value, decoded from either
-        // the value name (`SCIENCE`) or its number (`2`).
         let theme = match request.genre() {
             Genre::History => "history",
             Genre::Science => "science",

--- a/crates/rest_over_grpc_examples/src/tonic_bridge.rs
+++ b/crates/rest_over_grpc_examples/src/tonic_bridge.rs
@@ -32,9 +32,7 @@ pub mod library {
     include!(concat!(env!("OUT_DIR"), "/tonic_bridge/library.rest.rs"));
 }
 
-// The generated top-level `Transcoder` refers to the service by its proto
-// package path (`library::Library`), so it is `include!`d at the enclosing scope
-// where `library` is a sibling module.
+// Generated paths expect the proto package as a sibling module.
 #[allow(
     clippy::all,
     clippy::pedantic,
@@ -70,8 +68,6 @@ pub struct LibraryService;
 impl library_server::Library for LibraryService {
     async fn get_shelf(&self, request: tonic::Request<GetShelfRequest>) -> Result<tonic::Response<Shelf>, tonic::Status> {
         let request = request.into_inner();
-        // A failable handler so examples can contrast a handler-returned status
-        // with a routing miss.
         if request.shelf == "missing" {
             return Err(tonic::Status::not_found("no such shelf"));
         }
@@ -102,8 +98,6 @@ impl library_server::Library for LibraryService {
         &self,
         request: tonic::Request<ListShelvesByGenreRequest>,
     ) -> Result<tonic::Response<ListShelvesResponse>, tonic::Status> {
-        // The enum path variable arrives as its `i32` value, decoded from either
-        // the value name (`SCIENCE`) or its number (`2`).
         let theme = match request.into_inner().genre() {
             Genre::History => "history",
             Genre::Science => "science",

--- a/crates/rest_over_grpc_tests/bench_routes.rs
+++ b/crates/rest_over_grpc_tests/bench_routes.rs
@@ -1,23 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// A large, realistic route table shared between `build.rs` (which lowers it
-// into the build-time generated static router) and the `grs_router_vs_matchit`
-// benchmark (which builds an equivalent `matchit` router from it).
-//
-// Each entry is `(rpc, method, google.api.http path template)`. The set models
-// a GitHub-like API: nested resources, multiple methods per path, and a couple
-// of `**` catch-alls. It deliberately stays within the routing features that
-// `matchit` can also express (literals, single-segment `{var}`, and a
-// trailing `{var=**}` catch-all) so both routers resolve an identical set
-// of routes.
-//
-// This file is `include!`d, so it intentionally defines only a single item.
-
 /// `(rpc, method, path template)` triples describing the benchmarked service's
 /// routes, shared by the build script and the `grs_router_vs_matchit` benchmark.
 pub static ROUTES: &[(&str, &str, &str)] = &[
-    // Users.
     ("ListUsers", "GET", "/v1/users"),
     ("CreateUser", "POST", "/v1/users"),
     ("GetUser", "GET", "/v1/users/{user}"),
@@ -28,7 +14,6 @@ pub static ROUTES: &[(&str, &str, &str)] = &[
     ("ListUserFollowing", "GET", "/v1/users/{user}/following"),
     ("ListUserGists", "GET", "/v1/users/{user}/gists"),
     ("ListUserStarred", "GET", "/v1/users/{user}/starred"),
-    // Repositories.
     ("GetRepo", "GET", "/v1/repos/{owner}/{repo}"),
     ("UpdateRepo", "PATCH", "/v1/repos/{owner}/{repo}"),
     ("DeleteRepo", "DELETE", "/v1/repos/{owner}/{repo}"),
@@ -39,7 +24,6 @@ pub static ROUTES: &[(&str, &str, &str)] = &[
     ("GetContents", "GET", "/v1/repos/{owner}/{repo}/contents/{path=**}"),
     ("ListTags", "GET", "/v1/repos/{owner}/{repo}/tags"),
     ("ListLanguages", "GET", "/v1/repos/{owner}/{repo}/languages"),
-    // Issues.
     ("ListIssues", "GET", "/v1/repos/{owner}/{repo}/issues"),
     ("CreateIssue", "POST", "/v1/repos/{owner}/{repo}/issues"),
     ("GetIssue", "GET", "/v1/repos/{owner}/{repo}/issues/{issue}"),
@@ -48,7 +32,6 @@ pub static ROUTES: &[(&str, &str, &str)] = &[
     ("CreateIssueComment", "POST", "/v1/repos/{owner}/{repo}/issues/{issue}/comments"),
     ("GetIssueComment", "GET", "/v1/repos/{owner}/{repo}/issues/{issue}/comments/{comment}"),
     ("ListIssueLabels", "GET", "/v1/repos/{owner}/{repo}/issues/{issue}/labels"),
-    // Pull requests.
     ("ListPulls", "GET", "/v1/repos/{owner}/{repo}/pulls"),
     ("CreatePull", "POST", "/v1/repos/{owner}/{repo}/pulls"),
     ("GetPull", "GET", "/v1/repos/{owner}/{repo}/pulls/{pull}"),
@@ -56,24 +39,20 @@ pub static ROUTES: &[(&str, &str, &str)] = &[
     ("ListPullCommits", "GET", "/v1/repos/{owner}/{repo}/pulls/{pull}/commits"),
     ("ListPullFiles", "GET", "/v1/repos/{owner}/{repo}/pulls/{pull}/files"),
     ("MergePull", "PUT", "/v1/repos/{owner}/{repo}/pulls/{pull}/merge"),
-    // Organizations.
     ("GetOrg", "GET", "/v1/orgs/{org}"),
     ("ListOrgMembers", "GET", "/v1/orgs/{org}/members"),
     ("GetOrgMember", "GET", "/v1/orgs/{org}/members/{user}"),
     ("ListOrgRepos", "GET", "/v1/orgs/{org}/repos"),
     ("ListOrgTeams", "GET", "/v1/orgs/{org}/teams"),
     ("GetOrgTeam", "GET", "/v1/orgs/{org}/teams/{team}"),
-    // Gists.
     ("ListGists", "GET", "/v1/gists"),
     ("CreateGist", "POST", "/v1/gists"),
     ("GetGist", "GET", "/v1/gists/{gist}"),
     ("UpdateGist", "PATCH", "/v1/gists/{gist}"),
     ("ListGistComments", "GET", "/v1/gists/{gist}/comments"),
-    // Search.
     ("SearchRepositories", "GET", "/v1/search/repositories"),
     ("SearchIssues", "GET", "/v1/search/issues"),
     ("SearchUsers", "GET", "/v1/search/users"),
-    // Static assets (catch-all) and feeds.
     ("GetStatic", "GET", "/v1/static/{path=**}"),
     ("ListFeeds", "GET", "/v1/feeds"),
 ];

--- a/crates/rest_over_grpc_tests/benches/rog_router_cg.rs
+++ b/crates/rest_over_grpc_tests/benches/rog_router_cg.rs
@@ -40,14 +40,11 @@ mod linux {
     use gungraun::{library_benchmark, library_benchmark_group};
     use rest_over_grpc_tests::bench_router::Route;
 
-    // The shared route table (`ROUTES`).
     include!("../bench_routes.rs");
 
     type MethodAwareRouter = matchit::Router<Vec<(&'static str, &'static str)>>;
 
-    // Builds a method-aware `matchit` router from `ROUTES` (path-keyed trie, each
-    // node carrying its `(method, rpc)` pairs, as `axum` layers method routing on
-    // `matchit`). Runs in setup, so its allocation is not measured.
+    // Setup is excluded from the measured region.
     fn build_matchit() -> MethodAwareRouter {
         let mut by_path: Vec<(String, Vec<(&'static str, &'static str)>)> = Vec::new();
         for (rpc, method, pattern) in ROUTES {
@@ -67,9 +64,7 @@ mod linux {
         router
     }
 
-    // Converts a `google.api.http` template into `matchit` 0.8 syntax: `{var}` stays
-    // `{var}` (dots sanitized to `_`), a trailing `{var=**}` becomes a `{*var}`
-    // catch-all.
+    // Convert trailing `{var=**}` captures to matchit's `{*var}` syntax.
     fn to_matchit_path(pattern: &str) -> String {
         let mut out = String::with_capacity(pattern.len());
         for segment in pattern.split('/') {
@@ -103,13 +98,11 @@ mod linux {
         })
     }
 
-    // Generated router: a shallow two-segment hit.
     #[library_benchmark]
     fn generated_shallow() {
         black_box(Route::resolve(black_box("GET"), black_box("/v1/users/octocat")));
     }
 
-    // Generated router: a deep six-segment hit.
     #[library_benchmark]
     fn generated_deep() {
         black_box(Route::resolve(
@@ -118,7 +111,6 @@ mod linux {
         ));
     }
 
-    // Generated router: a `**` catch-all hit.
     #[library_benchmark]
     fn generated_catch_all() {
         black_box(Route::resolve(
@@ -127,14 +119,12 @@ mod linux {
         ));
     }
 
-    // Generated router: a miss (no route matches).
     #[library_benchmark]
     fn generated_miss() {
         black_box(Route::resolve(black_box("GET"), black_box("/v1/unknown")));
     }
 
-    // `matchit` sibling: shallow hit. Returns the router so its trie drop is not
-    // counted in the measured region.
+    // Returning the router excludes its drop from the measured region.
     #[library_benchmark]
     #[bench::shallow(build_matchit())]
     fn matchit_shallow(router: MethodAwareRouter) -> MethodAwareRouter {
@@ -142,8 +132,6 @@ mod linux {
         router
     }
 
-    // `matchit` sibling: deep hit. Returns the router so its trie drop is not
-    // counted in the measured region.
     #[library_benchmark]
     #[bench::deep(build_matchit())]
     fn matchit_deep(router: MethodAwareRouter) -> MethodAwareRouter {
@@ -155,8 +143,6 @@ mod linux {
         router
     }
 
-    // `matchit` sibling: a `**` catch-all hit. Returns the router so its trie
-    // drop is not counted in the measured region.
     #[library_benchmark]
     #[bench::catch_all(build_matchit())]
     fn matchit_catch_all(router: MethodAwareRouter) -> MethodAwareRouter {
@@ -168,8 +154,6 @@ mod linux {
         router
     }
 
-    // `matchit` sibling: a miss (no route matches). Returns the router so its
-    // trie drop is not counted in the measured region.
     #[library_benchmark]
     #[bench::miss(build_matchit())]
     fn matchit_miss(router: MethodAwareRouter) -> MethodAwareRouter {

--- a/crates/rest_over_grpc_tests/benches/rog_transcode_cg.rs
+++ b/crates/rest_over_grpc_tests/benches/rog_transcode_cg.rs
@@ -45,7 +45,6 @@ mod linux {
         Transcoder::new(InMemoryLibrary)
     }
 
-    // Path-variable binding, no request body.
     #[library_benchmark]
     #[bench::get_path_var(transcoder())]
     fn transcode_get_path_var(transcoder: Transcoder<InMemoryLibrary>) -> TranscodeResponse {
@@ -57,7 +56,6 @@ mod linux {
         ))
     }
 
-    // Request-body field decode (`body: "shelf"`).
     #[library_benchmark]
     #[bench::post_body(transcoder())]
     fn transcode_post_body(transcoder: Transcoder<InMemoryLibrary>) -> TranscodeResponse {
@@ -69,7 +67,6 @@ mod linux {
         ))
     }
 
-    // Query-parameter binding.
     #[library_benchmark]
     #[bench::get_query(transcoder())]
     fn transcode_get_query(transcoder: Transcoder<InMemoryLibrary>) -> TranscodeResponse {
@@ -81,8 +78,7 @@ mod linux {
         ))
     }
 
-    // Server-streaming RPC, driven to completion by collecting every encoded frame
-    // (so the count reflects the full streaming encode, not just stream setup).
+    // Consume every frame so the benchmark measures the complete stream.
     #[library_benchmark]
     #[bench::streaming(transcoder())]
     fn transcode_streaming(transcoder: Transcoder<InMemoryLibrary>) -> Vec<u8> {
@@ -105,7 +101,6 @@ mod linux {
         })
     }
 
-    // A routing miss (resolve returns `None`, mapped to a 404).
     #[library_benchmark]
     #[bench::miss(transcoder())]
     fn transcode_miss(transcoder: Transcoder<InMemoryLibrary>) -> TranscodeResponse {

--- a/crates/rest_over_grpc_tests/build.rs
+++ b/crates/rest_over_grpc_tests/build.rs
@@ -15,16 +15,12 @@ use http_path_template::{Grammar, PathTemplate};
 use rest_over_grpc::build::{DescriptorOptions, Generator, HttpRule, OpenApiInfo, ServiceDefinition, compile_fds, generate_router};
 use routerama::HttpMethod;
 
-// The large benchmark route table (`ROUTES`), shared with the benchmark.
 include!("bench_routes.rs");
 
 fn main() {
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set for build scripts"));
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR is set for build scripts"));
 
-    // The large benchmark router (`bench_router.rs`) lowered from the shared route
-    // table, so `benches/grs_router_vs_matchit.rs` can compare the generated static
-    // router against a `matchit` router built from the same routes.
     let mut rules = Vec::new();
     for (rpc, method, pattern) in ROUTES {
         let http = http_method(method).expect("known HTTP method in the benchmark route table");
@@ -34,9 +30,6 @@ fn main() {
     let bench_router = generate_router(rules);
     fs::write(out_dir.join("bench_router.rs"), bench_router.to_string()).expect("writing the benchmark router succeeds");
 
-    // A small router exercising tricky routing cases (literal vs wildcard
-    // backtracking, custom verbs, nested field paths, `**` capture, prefix
-    // overlap) so the runtime behavior of the generated trie is tested.
     let coverage_table: &[(&str, &str, &str)] = &[
         ("SystemConfig", "GET", "/v1/system/config"),
         ("TenantSettings", "GET", "/v1/{tenant}/settings"),
@@ -57,10 +50,7 @@ fn main() {
     let coverage_router = generate_router(coverage_rules);
     fs::write(out_dir.join("coverage_router.rs"), coverage_router.to_string()).expect("writing the coverage router succeeds");
 
-    // The two service fixtures, generated end to end into separate OUT_DIR
-    // subdirectories (each pipeline emits a top-level `transcoder.rest.rs`, so
-    // they must not share a directory). These mirror the `rest_over_grpc_examples`
-    // crate but are generated here so this crate stays independent of it.
+    // Each pipeline emits `transcoder.rest.rs`, so their output directories must differ.
     let proto_dir = manifest.join("proto");
     build_tonic_bridge(&proto_dir, &out_dir.join("tonic_bridge"));
     build_custom(&proto_dir, &out_dir.join("custom"));

--- a/crates/rest_over_grpc_tests/src/custom.rs
+++ b/crates/rest_over_grpc_tests/src/custom.rs
@@ -38,10 +38,7 @@ pub mod pb {
     include!(concat!(env!("OUT_DIR"), "/custom/library.rest.rs"));
 }
 
-// The generated top-level `Transcoder` refers to each service by its
-// module-qualified path (`{proto package}::Trait` / `::RequestType`). This proto
-// package is `library`, so we alias the `pb` module accordingly and `include!`
-// the transcoder at the enclosing scope where `library` is a sibling module.
+// Generated paths expect the proto package as a sibling module.
 use pb as library;
 
 #[allow(
@@ -86,8 +83,6 @@ impl pb::Library for InMemoryLibrary {
             })));
         }
 
-        // Propagate a caller-supplied trace id back to the response, and set a
-        // cache validator — both request- and response-side metadata.
         if let Some(trace) = cx.request_headers().get("x-trace-id").cloned() {
             _ = cx.response_headers_mut().insert(HeaderName::from_static("x-trace-id"), trace);
         }
@@ -102,7 +97,6 @@ impl pb::Library for InMemoryLibrary {
     async fn create_shelf(&self, request: CreateShelfRequest, cx: &mut Context) -> Result<Shelf, Status> {
         let mut created = request.shelf.ok_or_else(|| Status::invalid_argument("shelf is required"))?;
         "shelves/created".clone_into(&mut created.name);
-        // Point the client at the freshly created resource.
         _ = cx.insert_response_header(HeaderName::from_static("location"), HeaderValue::from_static("/v1/shelves/created"));
         Ok(created)
     }
@@ -126,8 +120,6 @@ impl pb::Library for InMemoryLibrary {
     }
 
     async fn list_shelves_by_genre(&self, request: ListShelvesByGenreRequest, _cx: &mut Context) -> Result<ListShelvesResponse, Status> {
-        // The enum path variable arrives as its `i32` value, decoded from either
-        // the value name (`SCIENCE`) or its number (`2`).
         let theme = match request.genre() {
             Genre::History => "history",
             Genre::Science => "science",

--- a/crates/rest_over_grpc_tests/src/tonic_bridge.rs
+++ b/crates/rest_over_grpc_tests/src/tonic_bridge.rs
@@ -31,9 +31,7 @@ pub mod greeter {
     include!(concat!(env!("OUT_DIR"), "/tonic_bridge/greeter.rest.rs"));
 }
 
-// The generated top-level `Transcoder` refers to the service by its proto
-// package path (`greeter::Greeter`), so it is `include!`d at the enclosing scope
-// where `greeter` is a sibling module.
+// Generated paths expect the proto package as a sibling module.
 #[allow(
     clippy::all,
     clippy::pedantic,
@@ -67,8 +65,6 @@ pub struct GreeterService;
 impl greeter_server::Greeter for GreeterService {
     async fn say_hello(&self, request: tonic::Request<HelloRequest>) -> Result<tonic::Response<HelloReply>, tonic::Status> {
         let name = request.into_inner().name;
-        // A failable handler so examples can contrast a handler-returned status
-        // with a routing miss.
         if name == "missing" {
             return Err(tonic::Status::not_found("no greeting for that name"));
         }

--- a/crates/rest_over_grpc_tests/tests/bridge.rs
+++ b/crates/rest_over_grpc_tests/tests/bridge.rs
@@ -38,8 +38,6 @@ fn streaming(response: TranscodeResponse) -> (String, Vec<u8>) {
 
 #[test]
 fn tonic_bridge_transcodes_unary() {
-    // `GreeterService` only implements the tonic trait; the generated bridge makes
-    // it a REST service, so `transcode` transcodes the `GET /v1/greet/{name}` route.
     let response = unary(block_on(Transcoder::new(GreeterService).transcode(
         "GET",
         "/v1/greet/World",
@@ -53,9 +51,6 @@ fn tonic_bridge_transcodes_unary() {
 
 #[test]
 fn tonic_bridge_maps_handler_status_to_not_found() {
-    // A handler-returned `tonic::Status::not_found` (for the `missing` sentinel)
-    // is bridged to a REST 404 carrying the handler's message — distinct from an
-    // unmatched route's generic 404.
     let response = unary(block_on(Transcoder::new(GreeterService).transcode(
         "GET",
         "/v1/greet/missing",
@@ -69,7 +64,6 @@ fn tonic_bridge_maps_handler_status_to_not_found() {
 
 #[test]
 fn tonic_bridge_maps_status_to_not_found() {
-    // An unmatched route falls through to a 404 via the generated `transcode`.
     let response = unary(block_on(Transcoder::new(GreeterService).transcode(
         "GET",
         "/v1/nope",
@@ -81,8 +75,6 @@ fn tonic_bridge_maps_status_to_not_found() {
 
 #[test]
 fn tonic_bridge_transcodes_server_streaming_as_json_array() {
-    // The server-streaming RPC is bridged too; the streaming `transcode` yields
-    // frames that concatenate into a JSON array (the default encoding).
     let (content_type, body) = streaming(block_on(Transcoder::new(GreeterService).transcode(
         "GET",
         "/v1/greet/World:stream",
@@ -97,7 +89,6 @@ fn tonic_bridge_transcodes_server_streaming_as_json_array() {
 
 #[test]
 fn tonic_bridge_negotiates_ndjson_for_streaming() {
-    // An `Accept: application/x-ndjson` request gets newline-delimited JSON.
     let mut headers = http::HeaderMap::new();
     let _ = headers.insert(http::header::ACCEPT, http::HeaderValue::from_static("application/x-ndjson"));
     let (content_type, body) = streaming(block_on(Transcoder::new(GreeterService).transcode(
@@ -109,4 +100,49 @@ fn tonic_bridge_negotiates_ndjson_for_streaming() {
     assert_eq!(content_type, "application/x-ndjson");
     let text = String::from_utf8(body).expect("utf8 body");
     assert_eq!(text, "{\"message\":\"Hello, World!\"}\n{\"message\":\"Bye, World!\"}\n");
+}
+
+#[test]
+fn tonic_bridge_forwards_streaming_response_metadata() {
+    use std::pin::Pin;
+
+    use futures::stream::{self, Stream};
+    use rest_over_grpc_tests::tonic_bridge::greeter::{HelloReply, HelloRequest, greeter_server};
+
+    #[derive(Clone, Copy)]
+    struct MetadataGreeter;
+
+    #[tonic::async_trait]
+    impl greeter_server::Greeter for MetadataGreeter {
+        async fn say_hello(&self, _request: tonic::Request<HelloRequest>) -> Result<tonic::Response<HelloReply>, tonic::Status> {
+            Err(tonic::Status::unimplemented("unary is not exercised by this test"))
+        }
+
+        type StreamGreetingsStream = Pin<Box<dyn Stream<Item = Result<HelloReply, tonic::Status>> + Send + 'static>>;
+
+        async fn stream_greetings(
+            &self,
+            _request: tonic::Request<HelloRequest>,
+        ) -> Result<tonic::Response<Self::StreamGreetingsStream>, tonic::Status> {
+            let items = stream::iter(vec![Ok(HelloReply { message: "hi".to_owned() })]);
+            let mut response = tonic::Response::new(Box::pin(items) as Self::StreamGreetingsStream);
+            let _ = response
+                .metadata_mut()
+                .insert("x-greeting-source", tonic::metadata::MetadataValue::from_static("stream"));
+            Ok(response)
+        }
+    }
+
+    let response = block_on(Transcoder::new(MetadataGreeter).transcode("GET", "/v1/greet/World:stream", http::HeaderMap::new(), b""));
+    let stream = match response {
+        TranscodeResponse::Streaming(stream) => stream,
+        TranscodeResponse::Unary(_) => panic!("expected a streaming response"),
+    };
+    assert_eq!(
+        stream
+            .headers()
+            .get("x-greeting-source")
+            .expect("initial response metadata is forwarded"),
+        "stream"
+    );
 }

--- a/crates/rest_over_grpc_tests/tests/coverage.rs
+++ b/crates/rest_over_grpc_tests/tests/coverage.rs
@@ -15,16 +15,11 @@ fn rpc(method: &str, path: &str) -> Option<String> {
 
 #[test]
 fn literal_beats_wildcard_at_same_depth() {
-    // `/v1/system/config` (literal) and `/v1/{tenant}/settings` (wildcard) share
-    // depth 1; the literal is more specific for its own path.
     assert_eq!(rpc("GET", "/v1/system/config"), Some("SystemConfig".to_owned()));
 }
 
 #[test]
 fn backtracks_from_literal_to_wildcard() {
-    // `system` matches the literal edge, but there is no `settings` child under
-    // it, so resolution must backtrack to the `{tenant}` wildcard edge and bind
-    // tenant = "system".
     let matched = Route::resolve("GET", "/v1/system/settings").expect("matches TenantSettings");
     assert_eq!(matched, Route::TenantSettings { tenant: "system" });
 }
@@ -46,13 +41,11 @@ fn custom_verb_disambiguates_same_path_and_method_family() {
 
 #[test]
 fn verb_on_wrong_method_does_not_match() {
-    // `GetBook` has no verb; a `:archive` request must not resolve to it.
     assert_eq!(rpc("GET", "/v1/books/42:archive"), None);
 }
 
 #[test]
 fn nested_field_path_binding() {
-    // `{item.id}` becomes the `item_id` field on the matched variant.
     let matched = Route::resolve("GET", "/v1/items/99").expect("matches");
     assert_eq!(matched, Route::GetItem { item_id: "99" });
 }
@@ -65,23 +58,18 @@ fn catch_all_captures_the_remainder() {
 
 #[test]
 fn catch_all_matches_empty_remainder() {
-    // `**` matches zero segments: `/v1/tree` binds path = "".
     let matched = Route::resolve("GET", "/v1/tree").expect("matches");
     assert_eq!(matched, Route::GetTree { path: "" });
 }
 
 #[test]
 fn pattern_var_captures_multi_segment_span() {
-    // `{name=shelves/*}` binds `name` to the whole span its interior-literal +
-    // wildcard pattern matches (`shelves/<one segment>`), not just the wildcard.
     let matched = Route::resolve("GET", "/v1/search/shelves/42").expect("matches SearchShelf");
     assert_eq!(matched, Route::SearchShelf { name: "shelves/42" });
 }
 
 #[test]
 fn pattern_var_requires_the_interior_literal() {
-    // The pattern's `shelves` literal must be present: a different first segment
-    // does not match, and the single wildcard still needs exactly one segment.
     assert_eq!(rpc("GET", "/v1/search/books/42"), None);
     assert_eq!(rpc("GET", "/v1/search/shelves"), None);
     assert_eq!(rpc("GET", "/v1/search/shelves/42/extra"), None);
@@ -95,7 +83,6 @@ fn prefix_and_longer_route_coexist() {
 
 #[test]
 fn trailing_slash_does_not_match_exact_route() {
-    // `/v1/x/` has an extra (empty) segment, so it does not match `/v1/x`.
     assert_eq!(rpc("GET", "/v1/x/"), None);
 }
 
@@ -109,12 +96,8 @@ fn unknown_and_wrong_method_miss() {
 
 #[test]
 fn wildcard_does_not_match_empty_segment() {
-    // A single-segment wildcard matches exactly one *non-empty* segment, so a
-    // trailing slash or a `//` must not bind an empty value (this matches the
-    // reference `PathTemplate::match_path`).
     assert_eq!(rpc("GET", "/v1/books/"), None);
     assert_eq!(rpc("GET", "/v1//settings"), None);
-    // A normal, non-empty segment still binds.
     let matched = Route::resolve("GET", "/v1/books/42").expect("non-empty still matches");
     assert_eq!(matched, Route::GetBook { book: "42" });
 }

--- a/crates/rest_over_grpc_tests/tests/e2e.rs
+++ b/crates/rest_over_grpc_tests/tests/e2e.rs
@@ -88,8 +88,6 @@ async fn list_shelves_binds_query_parameter() {
 
 #[tokio::test]
 async fn list_shelves_by_genre_binds_enum_path_variable_by_name() {
-    // The `{genre}` path variable targets an `enum` field: given by name, it is
-    // decoded to the matching enum value (proto3 JSON parity).
     let resp = unary(
         Transcoder::new(InMemoryLibrary)
             .transcode("GET", "/v1/shelves/genre/SCIENCE", HeaderMap::new(), b"")
@@ -104,7 +102,6 @@ async fn list_shelves_by_genre_binds_enum_path_variable_by_name() {
 
 #[tokio::test]
 async fn list_shelves_by_genre_binds_enum_path_variable_by_number() {
-    // The same enum path variable also accepts the value's number.
     let resp = unary(
         Transcoder::new(InMemoryLibrary)
             .transcode("GET", "/v1/shelves/genre/1", HeaderMap::new(), b"")
@@ -119,7 +116,6 @@ async fn list_shelves_by_genre_binds_enum_path_variable_by_number() {
 
 #[tokio::test]
 async fn list_shelves_by_genre_rejects_an_unknown_enum_value() {
-    // A value that is neither a known name nor a number is an invalid argument.
     let resp = unary(
         Transcoder::new(InMemoryLibrary)
             .transcode("GET", "/v1/shelves/genre/BOGUS", HeaderMap::new(), b"")
@@ -159,7 +155,6 @@ async fn stream_shelves_filters_via_query() {
 
 #[tokio::test]
 async fn stream_shelves_negotiates_encoding_via_accept() {
-    // NDJSON: one compact JSON object per line.
     let (ndjson_type, ndjson_bytes) = streaming(
         Transcoder::new(InMemoryLibrary)
             .transcode("GET", "/v1/shelves:stream", accept("application/x-ndjson"), b"")
@@ -170,7 +165,6 @@ async fn stream_shelves_negotiates_encoding_via_accept() {
     let line_count = ndjson_bytes.split(|&b| b == b'\n').filter(|l| !l.is_empty()).count();
     assert_eq!(line_count, 2);
 
-    // SSE: one `data:` frame per message.
     let (sse_type, sse_bytes) = streaming(
         Transcoder::new(InMemoryLibrary)
             .transcode("GET", "/v1/shelves:stream", accept("text/event-stream"), b"")
@@ -243,6 +237,42 @@ async fn additional_binding_uses_its_own_body_and_response_body() {
 }
 
 #[tokio::test]
+async fn response_body_field_at_its_default_serializes_the_default() {
+    // `force:false` makes the handler return `result_code = 0`. pbjson omits
+    // default-valued fields, so selecting `result_code` as the response body used
+    // to fail with a 500; it must now serialize the proto3 default `0`.
+    let response = unary(
+        Transcoder::new(InMemoryLibrary)
+            .transcode(
+                "POST",
+                "/v1/shelves/secondary:replace",
+                HeaderMap::new(),
+                br#"{"shelf":{"theme":"science"},"force":false}"#,
+            )
+            .await,
+    );
+    assert_eq!(response.status().as_u16(), 200);
+    assert_eq!(body(&response), serde_json::json!(0));
+}
+
+#[tokio::test]
+async fn a_duplicate_body_key_is_rejected_on_the_query_overlay_path() {
+    // A present query forces the body through the overlay decoder rather than the
+    // direct fast path; a duplicate field in the body must still be rejected.
+    let response = unary(
+        Transcoder::new(InMemoryLibrary)
+            .transcode(
+                "POST",
+                "/v1/shelves/secondary:replace?force=true",
+                HeaderMap::new(),
+                br#"{"shelf":{"theme":"science"},"force":true,"force":false}"#,
+            )
+            .await,
+    );
+    assert_eq!(response.status().as_u16(), 400);
+}
+
+#[tokio::test]
 async fn streaming_response_body_selects_each_item_field() {
     let (content_type, bytes) = streaming(
         Transcoder::new(InMemoryLibrary)
@@ -305,14 +335,12 @@ async fn unknown_route_yields_404() {
 
 #[tokio::test]
 async fn try_transcode_distinguishes_unmatched_routes() {
-    // An unmatched route yields `None`, so a caller can supply its own fallback.
     assert!(
         Transcoder::new(InMemoryLibrary)
             .try_transcode("GET", "/v1/widgets/1", HeaderMap::new(), b"")
             .await
             .is_none()
     );
-    // A matched route yields `Some`, even when the handler itself fails.
     let matched = Transcoder::new(InMemoryLibrary)
         .try_transcode("GET", "/v1/shelves/history", HeaderMap::new(), b"")
         .await;
@@ -364,11 +392,8 @@ async fn handler_sets_response_headers_and_echoes_request_metadata() {
             .await,
     );
     assert_eq!(resp.status().as_u16(), 200);
-    // A cache validator set by the handler and the echoed request metadata both
-    // surface as response headers.
     assert_eq!(resp.headers()["etag"], "\"shelf-v1\"");
     assert_eq!(resp.headers()["x-trace-id"], "trace-42");
-    // The JSON content type stays authoritative alongside the custom headers.
     assert_eq!(resp.content_type(), "application/json");
 }
 

--- a/crates/rest_over_grpc_tests/tests/openapi.rs
+++ b/crates/rest_over_grpc_tests/tests/openapi.rs
@@ -50,7 +50,6 @@ fn path_parameter_and_query_parameter_are_described() {
 #[test]
 fn create_shelf_binds_the_shelf_body_field() {
     let doc = spec();
-    // CreateShelf uses `body: "shelf"`, so the body is the `shelf` field's type.
     let schema = &doc["paths"]["/v1/shelves"]["post"]["requestBody"]["content"]["application/json"]["schema"];
     assert_eq!(schema["$ref"], "#/components/schemas/library.Shelf");
 }
@@ -70,6 +69,5 @@ fn message_schemas_are_components() {
     assert_eq!(shelf["type"], "object");
     assert_eq!(shelf["properties"]["name"]["type"], "string");
     assert_eq!(shelf["properties"]["theme"]["type"], "string");
-    // The shared error schema is always present.
-    assert_eq!(doc["components"]["schemas"]["Status"]["type"], "object");
+    assert_eq!(doc["components"]["schemas"]["google.rpc.Status"]["type"], "object");
 }

--- a/crates/rest_over_grpc_tests/tests/serving.rs
+++ b/crates/rest_over_grpc_tests/tests/serving.rs
@@ -39,11 +39,8 @@ async fn serve_http_end_to_end() {
 
 #[tokio::test]
 async fn tower_service_with_query_and_body() {
-    // `Arc<Transcoder>` implements `Transcode`, so a single shared instance is
-    // cloned cheaply into the service on each request.
     let mut service = RestService::new(Arc::new(Transcoder::new(InMemoryLibrary)));
 
-    // GET with a query parameter.
     let list = Request::builder()
         .method(Method::GET)
         .uri("/v1/shelves?filter=science")
@@ -54,7 +51,6 @@ async fn tower_service_with_query_and_body() {
     let json = body_json(response).await;
     assert_eq!(json["shelves"].as_array().expect("array").len(), 1);
 
-    // POST with a JSON body mapped to the `shelf` field.
     let create = Request::builder()
         .method(Method::POST)
         .uri("/v1/shelves")


### PR DESCRIPTION
Correctness fixes for the REST/JSON <-> gRPC transcoder, response hardening, doc/OpenAPI cleanup, and a 0.2.0 version bump.

- response_body naming a default-valued field now emits the proto3-JSON default instead of returning 500.
- Duplicate JSON body keys are rejected (400) on both the fast and query overlay paths; the query overlay now overrides body fields across snake_case/camelCase spellings.
- Nested additional_bindings are diagnosed as an error per google.api.http.
- The streaming tonic bridge now forwards initial response metadata, mirroring the unary path.
- Framing and hop-by-hop headers are stripped from transcoded unary and streaming responses.
- OpenAPI error schema renamed to google.rpc.Status (collision-proof) with the missing details field added.
- Removed narrative/historical comments across the crate family.
- Bumped rest_over_grpc to 0.2.0.
- README title renders "gRPC" via a template filter.