### PR TITLE
docs(tick): clarify auto_advance_timers behavior

### DIFF
--- a/crates/tick/src/clock_control.rs
+++ b/crates/tick/src/clock_control.rs
@@ -266,14 +266,50 @@ impl ClockControl {
         self
     }
 
-    /// Configures whether the `ClockControl` should automatically advance to fire upcoming timers.
+    /// Configures whether the clock automatically advances to fire pending timers.
     ///
-    /// When enabled, the clock will automatically advance to the next scheduled timer whenever
-    /// the current time is accessed, firing timers in sequence.
+    /// When enabled, the clock fast-forwards on its own to fire timers, so timer-based futures
+    /// such as [`Delay`](crate::Delay) complete without any manual clock advancement and without
+    /// waiting for real time to elapse. This is the simplest way to keep time-dependent tests both
+    /// deterministic and fast: awaiting a delay resolves right away in wall-clock terms.
+    ///
+    /// The clock advances both when a timer is scheduled and when the current time is read, jumping
+    /// forward to a timer's deadline before firing it. Simulated time is still consumed, so
+    /// elapsed-time measurements (for example via a [`Stopwatch`](crate::Stopwatch)) reflect each
+    /// delay's configured duration. A delay with no finite deadline
+    /// ([`Duration::MAX`](std::time::Duration::MAX)) never completes.
+    ///
+    /// # Timers do not run concurrently
+    ///
+    /// Timers are fired eagerly, one at a time, as they are scheduled; this option does not
+    /// simulate multiple timers running side by side. Do not rely on concurrent delays completing
+    /// in duration order — a shorter delay scheduled after a longer one may still complete after
+    /// it. When the relative ordering of concurrent timers matters, drive the clock explicitly with
+    /// [`Self::advance`] instead.
     ///
     /// > **Note**: When [`Self::auto_advance_limit`] is set, the maximum total auto-advance
     /// > duration is respected. Once the limit is reached, no further timers will be fired
     /// > automatically.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    ///
+    /// use tick::ClockControl;
+    ///
+    /// # async fn auto_advance_timers_example() {
+    /// let clock = ClockControl::new().auto_advance_timers(true).to_clock();
+    ///
+    /// let stopwatch = clock.stopwatch();
+    ///
+    /// // Resolves right away in real time — no manual `advance` call is needed.
+    /// clock.delay(Duration::from_secs(30)).await;
+    ///
+    /// // Simulated time still elapses by the delay's duration.
+    /// assert_eq!(stopwatch.elapsed(), Duration::from_secs(30));
+    /// # }
+    /// ```
     #[must_use]
     pub fn auto_advance_timers(self, enabled: bool) -> Self {
         self.with_state(|v| v.auto_advance_timers = enabled);


### PR DESCRIPTION
[Copilot speaking]

## Summary

Improves the API documentation for `ClockControl::auto_advance_timers()` in the `tick` crate. Docs-only change — no behavior is modified.

## Background

A peer reported that `auto_advance_timers` was "unusable" because it fires each timer during registration, collapsing multi-timer completion order to registration order rather than delay order. Investigation confirmed the mechanism but concluded this is **by design, not a bug**: `tick` makes no documented promise that concurrent timers complete in duration order, and `Delay` explicitly disclaims precision. The real gap was that the documentation did not make the eager, one-at-a-time firing behavior clear, and it under-described when advancement is triggered.

## Changes

- Headline now states that timer-based futures such as `Delay` complete without manual advancement or real waiting.
- Corrects the trigger description: the clock advances **both** when a timer is scheduled **and** when the current time is read (the previous doc only mentioned the latter).
- Clarifies that simulated time is still consumed, so elapsed-time measurements reflect each delay's configured duration.
- Notes that a `Duration::MAX` delay never completes.
- Adds a **"Timers do not run concurrently"** caveat: timers fire eagerly, one at a time; do not rely on concurrent delays completing in duration order; use `ClockControl::advance` when relative ordering matters.
- Adds an example mirroring the existing hidden-`# async fn` doctest pattern used by `auto_advance_limit`.

## Validation

- `cargo test -p tick --doc --all-features` — 55 doctests pass (including the new example).
- `just spellcheck` — clean.
- `cargo doc -p tick --all-features --no-deps` with `-D rustdoc::broken_intra_doc_links` — clean.
