### PR TITLE
feat!: support no_std in bytesbuf and thread_aware

### DIFF
--- a/crates/anyspawn/Cargo.toml
+++ b/crates/anyspawn/Cargo.toml
@@ -34,7 +34,7 @@ tokio = ["dep:tokio"]
 
 [dependencies]
 futures-channel = { workspace = true, features = ["alloc"] }
-thread_aware = { workspace = true, features = ["derive"] }
+thread_aware = { workspace = true, features = ["derive", "std"] }
 tokio = { workspace = true, features = ["rt"], optional = true }
 
 [dev-dependencies]

--- a/crates/bytesbuf/Cargo.toml
+++ b/crates/bytesbuf/Cargo.toml
@@ -32,24 +32,27 @@ allowed_external_types = [
 all-features = true
 
 [features]
-default = []
+default = ["std"]
+# Enables the global memory pool, standard I/O adapters, and metrics. Disable for `#![no_std]`
+# environments; the crate still requires `alloc`.
+std = ["dep:nm", "dep:plurality", "thread_aware/std", "bytes?/std"]
 # Interoperability with the `bytes` crate.
 bytes-compat = ["dep:bytes"]
-test-util = []
+test-util = ["std"]
 
 [dependencies]
-bytes = { workspace = true, features = ["std"], optional = true }
-new_zealand = { workspace = true }
-nm = { workspace = true }
-plurality = { workspace = true }
+bytes = { workspace = true, optional = true }
+nm = { workspace = true, optional = true }
+plurality = { workspace = true, optional = true }
 smallvec = { workspace = true, features = ["const_new", "union"] }
-thread_aware = { workspace = true, features = ["derive"] }
+thread_aware = { workspace = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 alloc_tracker = { workspace = true }
 bytes = { workspace = true, features = ["std"] }
 criterion = { workspace = true }
 mutants = { workspace = true }
+new_zealand = { workspace = true }
 static_assertions = { workspace = true }
 testing_aids = { path = "../testing_aids" }
 
@@ -75,6 +78,7 @@ required-features = ["test-util"]
 [[bench]]
 name = "global_pool"
 harness = false
+required-features = ["std"]
 
 [[bench]]
 name = "view"
@@ -94,6 +98,7 @@ required-features = ["test-util"]
 [[bench]]
 name = "global_pool_cg"
 harness = false
+required-features = ["std"]
 
 [[example]]
 name = "bb_has_memory_forwarding"

--- a/crates/bytesbuf/README.md
+++ b/crates/bytesbuf/README.md
@@ -15,6 +15,15 @@
 
 Types for creating and manipulating byte sequences.
 
+## Crate features
+
+* The **`std` Cargo feature** *(enabled by default)* enables the global memory pool, standard I/O
+  adapters, and metrics. Disable it for `#![no_std]` environments; the crate still requires
+  `alloc` and pointer-width atomics.
+* **`bytes-compat`** enables interoperability with the `bytes` crate and is available with or
+  without `std`.
+* **`test-util`** enables memory providers intended for tests and implies `std`.
+
 <img src="https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/bytesbuf/docs/diagrams/Introduction.png" alt="Diagram showing byte sequences inside BytesView and BytesBuf" />
 
 Types in this crate enable you to operate on logical sequences of bytes stored in memory,
@@ -44,7 +53,8 @@ There are many helper methods on this type for easily consuming bytes from the v
 * [`get_byte()`][__link4] reads a single byte.
 * [`copy_to_slice()`][__link5] copies bytes into a provided slice.
 * [`copy_to_uninit_slice()`][__link6] copies bytes into a provided uninitialized slice.
-* [`BytesView`][__link7] implements [`std::io::Read`][__link8] and [`std::io::BufRead`][__link9] directly, since
+* With the `std` feature, [`BytesView`][__link7] implements [`std::io::Read`][__link8] and [`std::io::BufRead`][__link9]
+  directly, since
   it is already a buffered byte sequence.
 
 ```rust
@@ -129,9 +139,12 @@ from the following list:
    instance of a shared [`GlobalPool`][__link20]. In a typical web application, the global memory pool
    is a service exposed by the application framework. In a different context (e.g. example
    or test code with no framework), you can create your own instance via [`GlobalPool::new()`][__link21].
+   In a `no_std` environment, applications that already own a specialized memory provider can
+   integrate it by implementing [`Memory`][__link22]. The crate does not provide a general-purpose
+   allocator-backed provider without `std`.
 
 Once you have a memory provider, you can reserve memory from it by calling
-[`Memory::reserve()`][__link22] on it. This returns a [`BytesBuf`][__link23] with at least the requested
+[`Memory::reserve()`][__link23] on it. This returns a [`BytesBuf`][__link24] with at least the requested
 number of bytes of memory capacity.
 
 ```rust
@@ -142,19 +155,19 @@ let memory = connection.memory();
 let mut buf = memory.reserve(100);
 ```
 
-Now that you have the memory capacity in a [`BytesBuf`][__link24], you can fill the memory
-capacity with bytes of data. Creating byte sequences in a [`BytesBuf`][__link25] is an
+Now that you have the memory capacity in a [`BytesBuf`][__link25], you can fill the memory
+capacity with bytes of data. Creating byte sequences in a [`BytesBuf`][__link26] is an
 append-only process - you can only add data to the end of the buffered sequence.
 
-There are many helper methods on [`BytesBuf`][__link26] for easily appending bytes to the buffer:
+There are many helper methods on [`BytesBuf`][__link27] for easily appending bytes to the buffer:
 
-* [`put_u64_le()`][__link27] and the sibling `put_<type>_<endianness>()` methods append numbers of a
+* [`put_u64_le()`][__link28] and the sibling `put_<type>_<endianness>()` methods append numbers of a
   specific primitive type (`u16`/`i16` through `u128`/`i128`, plus `f32`/`f64`) in little-,
   big-, or native-endian byte order.
-* [`put_slice()`][__link28] appends a slice of bytes.
-* [`put_byte()`][__link29] appends a single byte.
-* [`put_byte_repeated()`][__link30] appends multiple repetitions of a byte.
-* [`put_bytes()`][__link31] appends an existing [`BytesView`][__link32].
+* [`put_slice()`][__link29] appends a slice of bytes.
+* [`put_byte()`][__link30] appends a single byte.
+* [`put_byte_repeated()`][__link31] appends multiple repetitions of a byte.
+* [`put_bytes()`][__link32] appends an existing [`BytesView`][__link33].
 
 ```rust
 use bytesbuf::mem::Memory;
@@ -171,18 +184,18 @@ buf.put_slice(*b"Hello, world!");
 If the helper methods are not sufficient, you can write contents directly into mutable byte slices
 using the fundamental methods that underpin the convenience methods:
 
-* [`first_unfilled_slice()`][__link33] returns a mutable slice of uninitialized bytes from the beginning of the
+* [`first_unfilled_slice()`][__link34] returns a mutable slice of uninitialized bytes from the beginning of the
   buffer’s remaining capacity. The length of this slice is determined by the memory layout
   of the buffer and it may not contain all the capacity that has been reserved.
-* [`advance()`][__link34] declares that a number of bytes at the beginning of [`first_unfilled_slice()`][__link35]
+* [`advance()`][__link35] declares that a number of bytes at the beginning of [`first_unfilled_slice()`][__link36]
   have been initialized with data and are no longer unused. This will mark these bytes as valid for
-  consumption and advance [`first_unfilled_slice()`][__link36] to the next slice of unused memory capacity
+  consumption and advance [`first_unfilled_slice()`][__link37] to the next slice of unused memory capacity
   if the current slice has been completely filled.
 
 See `examples/bb_slice_by_slice_write.rs` for an example of how to use these methods.
 
-If you do not know exactly how much memory you need in advance, you can extend the [`BytesBuf`][__link37]
-capacity on demand by calling [`BytesBuf::reserve`][__link38]. You can use [`remaining_capacity()`][__link39]
+If you do not know exactly how much memory you need in advance, you can extend the [`BytesBuf`][__link38]
+capacity on demand by calling [`BytesBuf::reserve`][__link39]. You can use [`remaining_capacity()`][__link40]
 to identify how much unused memory capacity is available.
 
 ```rust
@@ -202,8 +215,8 @@ assert!(buf.capacity() >= 100 + 80);
 assert!(buf.remaining_capacity() >= 80);
 ```
 
-When you have written your byte sequence into the memory capacity of the [`BytesBuf`][__link40], you can consume
-the data in the buffer as a [`BytesView`][__link41].
+When you have written your byte sequence into the memory capacity of the [`BytesBuf`][__link41], you can consume
+the data in the buffer as a [`BytesView`][__link42].
 
 ```rust
 use bytesbuf::mem::Memory;
@@ -219,7 +232,7 @@ buf.put_slice(*b"Hello, world!");
 let message = buf.consume_all();
 ```
 
-This can be done piece by piece, and you can continue writing to the [`BytesBuf`][__link42]
+This can be done piece by piece, and you can continue writing to the [`BytesBuf`][__link43]
 after consuming some already written bytes.
 
 ```rust
@@ -240,8 +253,8 @@ buf.put_slice(*b"Hello, world!");
 let final_contents = buf.consume_all();
 ```
 
-If you already have a [`BytesView`][__link43] that you want to write into a [`BytesBuf`][__link44], call
-[`BytesBuf::put_bytes`][__link45]. This is a highly efficient zero-copy operation
+If you already have a [`BytesView`][__link44] that you want to write into a [`BytesBuf`][__link45], call
+[`BytesBuf::put_bytes`][__link46]. This is a highly efficient zero-copy operation
 that reuses the memory capacity of the view you are appending.
 
 ```rust
@@ -265,27 +278,27 @@ to mix and match memory from different providers, though this may disable some o
 ## Implementing Types that Produce or Consume Byte Sequences
 
 If you are implementing a type that produces or consumes byte sequences, you should
-implement the [`HasMemory`][__link46] trait to make it possible for the caller to use optimally
+implement the [`HasMemory`][__link47] trait to make it possible for the caller to use optimally
 configured memory when creating the byte sequences or buffers to use with your type.
 
 Even if the implementation of your type today is not capable of taking advantage of
 optimizations that depend on the memory configuration, it may be capable of doing so
 in the future or may, today or in the future, pass the data to another type that
-implements [`HasMemory`][__link47], which can take advantage of memory optimizations.
+implements [`HasMemory`][__link48], which can take advantage of memory optimizations.
 Therefore, it is best to implement this trait on all types that consume byte sequences
-via [`BytesView`][__link48] or produce byte sequences via [`BytesBuf`][__link49].
+via [`BytesView`][__link49] or produce byte sequences via [`BytesBuf`][__link50].
 
-The recommended implementation strategy for [`HasMemory`][__link50] is as follows:
+The recommended implementation strategy for [`HasMemory`][__link51] is as follows:
 
-* If your type always passes a [`BytesView`][__link51] or [`BytesBuf`][__link52] to another type that
-  implements [`HasMemory`][__link53], simply forward the memory provider from the other type.
+* If your type always passes a [`BytesView`][__link52] or [`BytesBuf`][__link53] to another type that
+  implements [`HasMemory`][__link54], simply forward the memory provider from the other type.
 * If your type can take advantage of optimizations enabled by specific memory configurations,
   (e.g. because it uses operating system APIs that unlock better performance when the memory
   is appropriately configured), return a memory provider that performs the necessary
   configuration.
-* If your type neither passes anything to another type that implements [`HasMemory`][__link54]
+* If your type neither passes anything to another type that implements [`HasMemory`][__link55]
   nor can take advantage of optimizations enabled by specific memory configurations, obtain
-  an instance of [`GlobalPool`][__link55] as a dependency and return it as the memory provider.
+  an instance of [`GlobalPool`][__link56] as a dependency and return it as the memory provider.
 
 Example of forwarding the memory provider (see `examples/bb_has_memory_forwarding.rs`
 for full code):
@@ -394,16 +407,16 @@ checked for compatibility.
 
 ## Compatibility with the `bytes` Crate
 
-The popular [`Bytes`][__link56] type from the `bytes` crate is often used in the Rust ecosystem to
+The popular [`Bytes`][__link57] type from the `bytes` crate is often used in the Rust ecosystem to
 represent simple byte buffers of consecutive bytes. For compatibility with this commonly used
-type, this crate offers conversion methods to translate between [`BytesView`][__link57] and [`Bytes`][__link58]
+type, this crate offers conversion methods to translate between [`BytesView`][__link58] and [`Bytes`][__link59]
 when the `bytes-compat` Cargo feature is enabled:
 
-* `BytesView::to_bytes()` converts a [`BytesView`][__link59] into a [`Bytes`][__link60] instance. This
+* `BytesView::to_bytes()` converts a [`BytesView`][__link60] into a [`Bytes`][__link61] instance. This
   is not always zero-copy because a byte sequence is not guaranteed to be consecutive in memory.
   You are discouraged from using this method in any performance-relevant logic path.
-* `BytesView::from(Bytes)` or `let s: BytesView = bytes.into()` converts a [`Bytes`][__link61] instance
-  into a [`BytesView`][__link62]. This is an efficient zero-copy operation that reuses the memory of the
+* `BytesView::from(Bytes)` or `let s: BytesView = bytes.into()` converts a [`Bytes`][__link62] instance
+  into a [`BytesView`][__link63]. This is an efficient zero-copy operation that reuses the memory of the
   `Bytes` instance.
 
 ## Static Data
@@ -420,7 +433,7 @@ Optimal processing of static data requires satisfying multiple requirements:
 * We want to use memory that is optimally configured for the context in which the data is
   consumed (e.g. network connection, file, etc).
 
-The standard pattern here is to use [`OnceLock`][__link63] to lazily initialize a [`BytesView`][__link64] from
+The standard pattern here is to use [`OnceLock`][__link64] to lazily initialize a [`BytesView`][__link65] from
 the static data on first use, using memory from a memory provider that is optimal for the
 intended usage.
 
@@ -474,7 +487,7 @@ See the `mem::testing` module for details (requires `test-util` Cargo feature).
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/bytesbuf">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbvoc1LZxTdZ0bwD6tOCnz9mMbRK42K6IkEecbA1i1D0CL4_hhZIGCaGJ5dGVzYnVmZTAuNy4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbfyF05lgqtFgbrQha6QGqA3AbwqFDXpFbd_wbL166axa7WHZhZIGCaGJ5dGVzYnVmZTAuNy4w
  [__link0]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
  [__link1]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
  [__link10]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
@@ -490,53 +503,54 @@ This crate was developed as part of <a href="https://github.com/microsoft/oxidiz
  [__link2]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
  [__link20]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::GlobalPool
  [__link21]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::GlobalPool::new
- [__link22]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::Memory::reserve
- [__link23]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
+ [__link22]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::Memory
+ [__link23]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::Memory::reserve
  [__link24]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
  [__link25]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
  [__link26]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
- [__link27]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_u64_le
- [__link28]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_slice
- [__link29]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_byte
+ [__link27]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
+ [__link28]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_u64_le
+ [__link29]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_slice
  [__link3]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView::get_u64_le
- [__link30]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_byte_repeated
- [__link31]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_bytes
- [__link32]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
- [__link33]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::first_unfilled_slice
- [__link34]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::advance
- [__link35]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::first_unfilled_slice
+ [__link30]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_byte
+ [__link31]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_byte_repeated
+ [__link32]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_bytes
+ [__link33]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
+ [__link34]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::first_unfilled_slice
+ [__link35]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::advance
  [__link36]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::first_unfilled_slice
- [__link37]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
- [__link38]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::reserve
- [__link39]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::remaining_capacity
+ [__link37]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::first_unfilled_slice
+ [__link38]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
+ [__link39]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::reserve
  [__link4]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView::get_byte
- [__link40]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
- [__link41]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
- [__link42]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
- [__link43]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
- [__link44]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
- [__link45]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_bytes
- [__link46]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::HasMemory
+ [__link40]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::remaining_capacity
+ [__link41]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
+ [__link42]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
+ [__link43]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
+ [__link44]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
+ [__link45]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
+ [__link46]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf::put_bytes
  [__link47]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::HasMemory
- [__link48]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
- [__link49]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
+ [__link48]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::HasMemory
+ [__link49]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
  [__link5]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView::copy_to_slice
- [__link50]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::HasMemory
- [__link51]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
- [__link52]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
- [__link53]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::HasMemory
+ [__link50]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
+ [__link51]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::HasMemory
+ [__link52]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
+ [__link53]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesBuf
  [__link54]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::HasMemory
- [__link55]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::GlobalPool
- [__link56]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
- [__link57]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
- [__link58]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
- [__link59]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
+ [__link55]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::HasMemory
+ [__link56]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=mem::GlobalPool
+ [__link57]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
+ [__link58]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
+ [__link59]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
  [__link6]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView::copy_to_uninit_slice
- [__link60]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
+ [__link60]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
  [__link61]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
- [__link62]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
- [__link63]: https://doc.rust-lang.org/stable/std/?search=sync::OnceLock
- [__link64]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
+ [__link62]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
+ [__link63]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
+ [__link64]: https://doc.rust-lang.org/stable/std/?search=sync::OnceLock
+ [__link65]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
  [__link7]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
  [__link8]: https://doc.rust-lang.org/stable/std/?search=io::Read
  [__link9]: https://doc.rust-lang.org/stable/std/?search=io::BufRead

--- a/crates/bytesbuf/docs/snippets/choosing_memory_provider.md
+++ b/crates/bytesbuf/docs/snippets/choosing_memory_provider.md
@@ -5,5 +5,7 @@ If you are writing bytes to or reading bytes from an object that either itself i
 you should use [`Memory::reserve()`][crate::mem::Memory::reserve] from this provider
 to obtain memory to store bytes in.
 
-Otherwise, use a shared instance of [`GlobalPool`][crate::mem::GlobalPool], which is a reasonable
-default when there is no specific reason use a different memory provider.
+Otherwise, use a shared instance of `GlobalPool` when the `std` feature is enabled. In `no_std`
+environments, applications that already own a specialized memory provider can integrate it by
+implementing [`Memory`][crate::mem::Memory]. This crate does not provide a general-purpose
+allocator-backed provider without `std`.

--- a/crates/bytesbuf/src/buf.rs
+++ b/crates/bytesbuf/src/buf.rs
@@ -1,15 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::any::type_name;
-use std::mem::{self, MaybeUninit};
-use std::num::NonZero;
-use std::ptr;
+use alloc::format;
+#[cfg(not(test))]
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::any::type_name;
+use core::mem::{self, MaybeUninit};
+use core::num::NonZero;
+use core::ptr;
 
 use smallvec::SmallVec;
 
+#[cfg(feature = "std")]
+use crate::BytesBufWriter;
 use crate::mem::{Block, BlockMeta, BlockSize, Memory};
-use crate::{BytesBufWriter, BytesView, MAX_INLINE_SPANS, MemoryGuard, Span, SpanBuilder};
+use crate::{BytesView, MAX_INLINE_SPANS, MemoryGuard, Span, SpanBuilder};
 
 /// Assembles byte sequences, exposing them as [`BytesView`]s.
 ///
@@ -52,6 +58,8 @@ use crate::{BytesBufWriter, BytesView, MAX_INLINE_SPANS, MemoryGuard, Span, Span
 /// # Example
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "std")] {
 /// # use bytesbuf::mem::{GlobalPool, Memory};
 /// use bytesbuf::BytesBuf;
 ///
@@ -69,6 +77,8 @@ use crate::{BytesBufWriter, BytesView, MAX_INLINE_SPANS, MemoryGuard, Span, Span
 /// // Consume the buffered data as an immutable BytesView.
 /// let message = buf.consume_all();
 /// assert_eq!(message.len(), 18);
+/// # }
+/// # }
 /// ```
 ///
 /// [memory provider]: crate::mem::Memory
@@ -174,6 +184,7 @@ impl BytesBuf {
     }
 
     /// Creates a buffer backed by the capacity of a single memory block.
+    #[cfg(feature = "std")]
     pub(crate) fn from_block(block: Block) -> Self {
         let span_builder = block.into_span_builder();
         let available = span_builder.remaining_capacity();
@@ -222,6 +233,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// use bytesbuf::BytesBuf;
     /// # use bytesbuf::mem::GlobalPool;
     ///
@@ -237,6 +250,8 @@ impl BytesBuf {
     /// // Can reserve more capacity at any time.
     /// buf.reserve(100, &memory);
     /// assert!(buf.remaining_capacity() >= 100);
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -394,6 +409,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -411,6 +428,8 @@ impl BytesBuf {
     ///
     /// let consumed = buf.consume_all();
     /// assert_eq!(consumed.len(), 4);
+    /// # }
+    /// # }
     /// ```
     ///
     /// [`consume_all()`]: Self::consume_all
@@ -444,6 +463,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -458,6 +479,8 @@ impl BytesBuf {
     ///
     /// _ = buf.consume(4);
     /// assert_eq!(buf.len(), 5);
+    /// # }
+    /// # }
     /// ```
     #[must_use]
     #[cfg_attr(debug_assertions, expect(clippy::missing_panics_doc, reason = "only unreachable panics"))]
@@ -493,6 +516,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// use bytesbuf::BytesBuf;
     /// # use bytesbuf::mem::GlobalPool;
     ///
@@ -511,6 +536,8 @@ impl BytesBuf {
     /// // Consuming reduces capacity (memory is transferred to the BytesView).
     /// _ = buf.consume(5);
     /// assert!(buf.capacity() < initial_capacity);
+    /// # }
+    /// # }
     /// ```
     #[must_use]
     pub fn capacity(&self) -> usize {
@@ -525,6 +552,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// use bytesbuf::BytesBuf;
     /// # use bytesbuf::mem::GlobalPool;
     ///
@@ -547,6 +576,8 @@ impl BytesBuf {
     /// let remaining_before_consume = buf.remaining_capacity();
     /// _ = buf.consume(5);
     /// assert_eq!(buf.remaining_capacity(), remaining_before_consume);
+    /// # }
+    /// # }
     /// ```
     #[cfg_attr(test, mutants::skip)] // Lying about buffer sizes is an easy way to infinite loops.
     pub fn remaining_capacity(&self) -> usize {
@@ -569,6 +600,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -588,6 +621,8 @@ impl BytesBuf {
     /// let mut rest = buf.consume(4);
     /// assert_eq!(rest.get_u16_be(), 0x2222);
     /// assert_eq!(rest.get_u16_be(), 0x3333);
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -691,6 +726,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -703,6 +740,8 @@ impl BytesBuf {
     ///
     /// assert_eq!(message, b"Hello, world!!!");
     /// assert!(buf.is_empty());
+    /// # }
+    /// # }
     /// ```
     pub fn consume_all(&mut self) -> BytesView {
         // Delegating to the general consume path is intentional. A dedicated all-at-once path that
@@ -722,6 +761,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -743,6 +784,8 @@ impl BytesBuf {
     /// // The split-off buffer can be used independently.
     /// split.put_u16_be(0xBEEF);
     /// assert_eq!(split.len(), 2);
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -887,6 +930,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -913,6 +958,8 @@ impl BytesBuf {
     /// }
     ///
     /// assert_eq!(buf.consume_all(), b"0123456789");
+    /// # }
+    /// # }
     /// ```
     ///
     /// [`advance()`]: Self::advance
@@ -934,6 +981,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// # struct PageAlignedMemory;
     /// use bytesbuf::mem::Memory;
@@ -945,6 +994,8 @@ impl BytesBuf {
     ///     .is_some_and(|meta| meta.is::<PageAlignedMemory>());
     ///
     /// println!("First unfilled slice is page-aligned: {is_page_aligned}");
+    /// # }
+    /// # }
     /// ```
     ///
     /// [`first_unfilled_slice()`]: Self::first_unfilled_slice
@@ -961,6 +1012,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -987,6 +1040,8 @@ impl BytesBuf {
     /// }
     ///
     /// assert_eq!(buf.consume_all(), b"0123456789");
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Safety
@@ -1053,6 +1108,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use std::ptr;
     ///
@@ -1081,6 +1138,8 @@ impl BytesBuf {
     /// }
     ///
     /// assert_eq!(buf.len(), capacity);
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -1147,6 +1206,9 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
+    /// # (|| {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use std::io::Write;
     ///
@@ -1160,14 +1222,19 @@ impl BytesBuf {
     ///
     /// assert_eq!(buf.consume_all(), b"Hello, world!");
     /// # Ok::<(), std::io::Error>(())
+    /// # })().unwrap();
+    /// # }
+    /// # }
     /// ```
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     #[inline]
     pub fn into_writer<M: Memory>(self, memory: M) -> BytesBufWriter<M> {
         BytesBufWriter::new(self, memory)
     }
 }
 
-impl std::fmt::Debug for BytesBuf {
+impl core::fmt::Debug for BytesBuf {
     #[cfg_attr(test, mutants::skip)] // We have no API contract here.
     #[cfg_attr(coverage_nightly, coverage(off))] // We have no API contract here.
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -1426,6 +1493,7 @@ mod tests {
     use testing_aids::assert_panic;
 
     use super::*;
+    #[cfg(feature = "std")]
     use crate::mem::GlobalPool;
     use crate::mem::testing::{FixedBlockMemory, TestMemoryBlock};
 
@@ -2182,6 +2250,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn from_view() {
         let memory = GlobalPool::new();
 
@@ -2620,6 +2689,7 @@ mod tests {
     }
 
     // Compile time test
+    #[cfg(feature = "std")]
     fn _can_use_in_dyn_traits(mem: &dyn Memory) {
         let buf = mem.reserve(123);
         let _ = buf.into_writer(mem);

--- a/crates/bytesbuf/src/buf_put.rs
+++ b/crates/bytesbuf/src/buf_put.rs
@@ -3,8 +3,8 @@
 
 //! We separate out the mutation functions for ease of maintenance.
 
-use std::borrow::Borrow;
-use std::ptr;
+use core::borrow::Borrow;
+use core::ptr;
 
 use crate::{BytesBuf, BytesView};
 
@@ -52,6 +52,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -61,6 +63,8 @@ impl BytesBuf {
     /// buf.put_slice(*b"world!");
     ///
     /// assert_eq!(buf.consume_all(), b"Hello, world!");
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -122,6 +126,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// use bytesbuf::BytesView;
     /// use bytesbuf::mem::Memory;
     /// # use bytesbuf::mem::GlobalPool;
@@ -136,6 +142,8 @@ impl BytesBuf {
     /// buf.put_bytes(header); // Zero-copy append
     ///
     /// assert_eq!(buf.consume_all(), b"dataHDR");
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -150,6 +158,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -159,6 +169,8 @@ impl BytesBuf {
     /// buf.put_byte(0xFE);
     ///
     /// assert_eq!(buf.consume_all(), &[0xCA, 0xFE]);
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -173,6 +185,8 @@ impl BytesBuf {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::mem::Memory;
     ///
@@ -188,6 +202,8 @@ impl BytesBuf {
     ///     data.first_slice(),
     ///     b"HDR:\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     /// );
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics

--- a/crates/bytesbuf/src/bytes_compat/from_bytes.rs
+++ b/crates/bytesbuf/src/bytes_compat/from_bytes.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::mem::MaybeUninit;
-use std::num::NonZero;
-use std::ptr::NonNull;
-use std::sync::atomic::{self, AtomicUsize};
+#[cfg(not(test))]
+use alloc::boxed::Box;
+use core::mem::MaybeUninit;
+use core::num::NonZero;
+use core::ptr::NonNull;
+use core::sync::atomic::{self, AtomicUsize};
 
 use bytes::Bytes;
 use smallvec::SmallVec;

--- a/crates/bytesbuf/src/bytes_compat/to_bytes.rs
+++ b/crates/bytesbuf/src/bytes_compat/to_bytes.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use bytes::{Bytes, BytesMut};
+#[cfg(feature = "std")]
 use nm::Event;
 
 use crate::BytesView;
@@ -12,6 +13,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytes::Buf;
     /// use bytesbuf::BytesView;
@@ -24,6 +27,8 @@ impl BytesView {
     /// assert_eq!(bytes.get_u16(), 0x1234);
     /// assert_eq!(bytes.get_u16(), 0x5678);
     /// assert!(!bytes.has_remaining());
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Performance
@@ -49,11 +54,13 @@ impl BytesView {
     #[expect(clippy::missing_panics_doc, reason = "only unreachable panics")]
     pub fn to_bytes(&self) -> Bytes {
         if self.spans_reversed.is_empty() {
+            #[cfg(feature = "std")]
             TO_BYTES_SHARED.with(|x| x.observe(0));
 
             Bytes::new()
         } else if self.spans_reversed.len() == 1 {
             // We are a single-span view, which can always be zero-copy represented.
+            #[cfg(feature = "std")]
             TO_BYTES_SHARED.with(|x| x.observe(self.len()));
 
             Bytes::from_owner(self.spans_reversed.first().expect("we verified there is one span").clone())
@@ -67,6 +74,7 @@ impl BytesView {
 
             debug_assert_eq!(self.len(), bytes.len());
 
+            #[cfg(feature = "std")]
             TO_BYTES_COPIED.with(|x| x.observe(self.len()));
 
             bytes.freeze()
@@ -80,7 +88,8 @@ impl From<BytesView> for Bytes {
     }
 }
 
-thread_local! {
+#[cfg(feature = "std")]
+std::thread_local! {
     static TO_BYTES_SHARED: Event = Event::builder()
         .name("bytesbuf_view_to_bytes_shared")
         .build();

--- a/crates/bytesbuf/src/bytes_compat/view.rs
+++ b/crates/bytesbuf/src/bytes_compat/view.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#[cfg(feature = "std")]
 use std::io::IoSlice;
 
 use bytes::Buf;
@@ -18,6 +19,7 @@ impl Buf for BytesView {
         self.first_slice()
     }
 
+    #[cfg(feature = "std")]
     #[cfg_attr(test, mutants::skip)] // Trivial forwarder.
     fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
         if dst.is_empty() {
@@ -40,7 +42,7 @@ impl Buf for BytesView {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use new_zealand::nz;
 

--- a/crates/bytesbuf/src/constants.rs
+++ b/crates/bytesbuf/src/constants.rs
@@ -3,6 +3,7 @@
 
 // If a lock is poisoned then safety invariants may have been violated and execution cannot
 // continue because we can no longer uphold our security and privacy guarantees.
+#[cfg(feature = "std")]
 pub(crate) const ERR_POISONED_LOCK: &str =
     "poisoned lock - cannot continue execution because security and privacy guarantees can no longer be upheld";
 

--- a/crates/bytesbuf/src/lib.rs
+++ b/crates/bytesbuf/src/lib.rs
@@ -3,8 +3,18 @@
 
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(test), no_std)]
 
 //! Types for creating and manipulating byte sequences.
+//!
+//! # Crate features
+//!
+//! * The **`std` Cargo feature** *(enabled by default)* enables the global memory pool, standard I/O
+//!   adapters, and metrics. Disable it for `#![no_std]` environments; the crate still requires
+//!   `alloc` and pointer-width atomics.
+//! * **`bytes-compat`** enables interoperability with the `bytes` crate and is available with or
+//!   without `std`.
+//! * **`test-util`** enables memory providers intended for tests and implies `std`.
 //!
 //! <img src="https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/bytesbuf/docs/diagrams/Introduction.png" alt="Diagram showing byte sequences inside BytesView and BytesBuf" />
 //!
@@ -35,10 +45,13 @@
 //! * [`get_byte()`] reads a single byte.
 //! * [`copy_to_slice()`] copies bytes into a provided slice.
 //! * [`copy_to_uninit_slice()`] copies bytes into a provided uninitialized slice.
-//! * [`BytesView`] implements [`std::io::Read`] and [`std::io::BufRead`] directly, since
+//! * With the `std` feature, [`BytesView`] implements [`std::io::Read`] and [`std::io::BufRead`]
+//!   directly, since
 //!   it is already a buffered byte sequence.
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # let memory = bytesbuf::mem::GlobalPool::new();
 //! # let message = BytesView::copied_from_slice(b"1234123412341234", &memory);
 //! use bytesbuf::BytesView;
@@ -55,6 +68,8 @@
 //!     println!("Message received. The sum of all words in the message is {sum}.");
 //! }
 //! # consume_message(message);
+//! # }
+//! # }
 //! ```
 //!
 //! If the helper methods are not sufficient, you can access the byte sequence behind the [`BytesView`]
@@ -69,6 +84,8 @@
 //!   will return a new slice of bytes starting from the new front position of the view.
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # let memory = bytesbuf::mem::GlobalPool::new();
 //! # let mut bytes = BytesView::copied_from_slice(b"1234123412341234", &memory);
 //! use bytesbuf::BytesView;
@@ -86,12 +103,16 @@
 //! }
 //!
 //! println!("Inspected a view over {len} bytes with slice lengths: {slice_lengths:?}");
+//! # }
+//! # }
 //! ```
 //!
 //! To reuse a [`BytesView`], clone it before consuming the contents. This is a cheap
 //! zero-copy operation.
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # let memory = bytesbuf::mem::GlobalPool::new();
 //! # let mut bytes = BytesView::copied_from_slice(b"1234123412341234", &memory);
 //! use bytesbuf::BytesView;
@@ -107,6 +128,8 @@
 //!
 //! // Operations on the clone have no effect on the original view.
 //! assert_eq!(bytes.len(), 16);
+//! # }
+//! # }
 //! ```
 //!
 //! # Producing Byte Sequences
@@ -127,12 +150,17 @@
 //!    instance of a shared [`GlobalPool`]. In a typical web application, the global memory pool
 //!    is a service exposed by the application framework. In a different context (e.g. example
 //!    or test code with no framework), you can create your own instance via [`GlobalPool::new()`].
+//!    In a `no_std` environment, applications that already own a specialized memory provider can
+//!    integrate it by implementing [`Memory`]. The crate does not provide a general-purpose
+//!    allocator-backed provider without `std`.
 //!
 //! Once you have a memory provider, you can reserve memory from it by calling
 //! [`Memory::reserve()`] on it. This returns a [`BytesBuf`] with at least the requested
 //! number of bytes of memory capacity.
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # struct Connection {}
 //! # impl Connection { fn memory(&self) -> impl Memory { bytesbuf::mem::GlobalPool::new() } }
 //! # let connection = Connection {};
@@ -141,6 +169,8 @@
 //! let memory = connection.memory();
 //!
 //! let mut buf = memory.reserve(100);
+//! # }
+//! # }
 //! ```
 //!
 //! Now that you have the memory capacity in a [`BytesBuf`], you can fill the memory
@@ -158,6 +188,8 @@
 //! * [`put_bytes()`] appends an existing [`BytesView`].
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # struct Connection {}
 //! # impl Connection { fn memory(&self) -> impl Memory { bytesbuf::mem::GlobalPool::new() } }
 //! # let connection = Connection {};
@@ -170,6 +202,8 @@
 //! buf.put_u64_be(1234);
 //! buf.put_u64_be(5678);
 //! buf.put_slice(*b"Hello, world!");
+//! # }
+//! # }
 //! ```
 //!
 //! If the helper methods are not sufficient, you can write contents directly into mutable byte slices
@@ -190,6 +224,8 @@
 //! to identify how much unused memory capacity is available.
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # struct Connection {}
 //! # impl Connection { fn memory(&self) -> impl Memory { bytesbuf::mem::GlobalPool::new() } }
 //! # let connection = Connection {};
@@ -207,12 +243,16 @@
 //! // Remember that a memory provider can always provide more memory than requested.
 //! assert!(buf.capacity() >= 100 + 80);
 //! assert!(buf.remaining_capacity() >= 80);
+//! # }
+//! # }
 //! ```
 //!
 //! When you have written your byte sequence into the memory capacity of the [`BytesBuf`], you can consume
 //! the data in the buffer as a [`BytesView`].
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # struct Connection {}
 //! # impl Connection { fn memory(&self) -> impl Memory { bytesbuf::mem::GlobalPool::new() } }
 //! # let connection = Connection {};
@@ -227,12 +267,16 @@
 //! buf.put_slice(*b"Hello, world!");
 //!
 //! let message = buf.consume_all();
+//! # }
+//! # }
 //! ```
 //!
 //! This can be done piece by piece, and you can continue writing to the [`BytesBuf`]
 //! after consuming some already written bytes.
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # struct Connection {}
 //! # impl Connection { fn memory(&self) -> impl Memory { bytesbuf::mem::GlobalPool::new() } }
 //! # let connection = Connection {};
@@ -251,6 +295,8 @@
 //! buf.put_slice(*b"Hello, world!");
 //!
 //! let final_contents = buf.consume_all();
+//! # }
+//! # }
 //! ```
 //!
 //! If you already have a [`BytesView`] that you want to write into a [`BytesBuf`], call
@@ -258,6 +304,8 @@
 //! that reuses the memory capacity of the view you are appending.
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # struct Connection {}
 //! # impl Connection { fn memory(&self) -> impl Memory { bytesbuf::mem::GlobalPool::new() } }
 //! # let connection = Connection {};
@@ -272,6 +320,8 @@
 //! let mut buf = memory.reserve(128);
 //! buf.put_bytes(header);
 //! buf.put_slice(*b"Hello, world!");
+//! # }
+//! # }
 //! ```
 //!
 //! Note that there is no requirement that the memory capacity of the buffer and the
@@ -307,6 +357,8 @@
 //! for full code):
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # #[derive(Debug)]
 //! # struct ConnectionZeroCounter {
 //! #     connection: Connection,
@@ -322,12 +374,16 @@
 //! # #[derive(Debug)] struct Connection;
 //! # impl Connection { fn write(&mut self, mut _message: BytesView) {} }
 //! # impl HasMemory for Connection { fn memory(&self) -> impl MemoryShared { bytesbuf::mem::GlobalPool::new() } }
+//! # }
+//! # }
 //! ```
 //!
 //! Example of returning a memory provider that performs configuration for optimal memory (see
 //! `examples/bb_has_memory_optimizing.rs` for full code):
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # #[derive(Debug)]
 //! # struct UdpConnection {
 //! #     io_context: IoContext,
@@ -373,12 +429,16 @@
 //! # }
 //! # #[derive(Clone, Copy)]
 //! # struct MemoryConfiguration { requires_page_alignment: bool, zero_memory_on_release: bool, requires_registered_memory: bool }
+//! # }
+//! # }
 //! ```
 //!
 //! Example of returning a global memory pool when the type is agnostic toward memory configuration
 //! (see `examples/bb_has_memory_global.rs` for full code):
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! # #[derive(Debug)]
 //! # struct ChecksumCalculator {
 //! #     memory: GlobalPool,
@@ -392,6 +452,8 @@
 //!         self.memory.clone()
 //!     }
 //! }
+//! # }
+//! # }
 //! ```
 //!
 //! It is generally expected that all types work with byte sequences using memory from any provider.
@@ -484,6 +546,8 @@
 //! intended usage.
 //!
 //! ```
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! use std::sync::OnceLock;
 //!
 //! use bytesbuf::BytesView;
@@ -518,6 +582,8 @@
 //! #     fn accept() -> Self { Connection }
 //! #     fn memory(&self) -> impl bytesbuf::mem::Memory { bytesbuf::mem::GlobalPool::new() }
 //! #     fn write(&self, _data: BytesView) {}
+//! # }
+//! # }
 //! # }
 //! ```
 //!
@@ -559,6 +625,10 @@
 #![doc(html_logo_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/bytesbuf/logo.png")]
 #![doc(html_favicon_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/bytesbuf/favicon.ico")]
 
+extern crate alloc;
+#[cfg(all(feature = "std", not(test)))]
+extern crate std;
+
 // The root level contains "byte sequence" types, whereas the closely related
 // "memory management" types are shoved away into the `mem` module. This is largely
 // for organizational purposes, to help navigate the API documentation better. Both
@@ -567,6 +637,8 @@ pub mod mem;
 
 mod buf;
 mod buf_put;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 mod buf_writer;
 #[cfg(any(test, feature = "bytes-compat"))]
 mod bytes_compat;
@@ -577,9 +649,12 @@ mod span_builder;
 mod vec;
 mod view;
 mod view_get;
+#[cfg(feature = "std")]
 mod view_read;
 
 pub use buf::{BytesBuf, BytesBufRemaining, BytesBufVectoredWrite};
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use buf_writer::BytesBufWriter;
 pub use constants::MAX_INLINE_SPANS;
 pub use memory_guard::MemoryGuard;

--- a/crates/bytesbuf/src/mem/block.rs
+++ b/crates/bytesbuf/src/mem/block.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::mem::MaybeUninit;
-use std::num::NonZero;
-use std::ptr::NonNull;
+use core::mem::MaybeUninit;
+use core::num::NonZero;
+use core::ptr::NonNull;
 
 use crate::SpanBuilder;
 use crate::mem::BlockRef;

--- a/crates/bytesbuf/src/mem/block_ref.rs
+++ b/crates/bytesbuf/src/mem/block_ref.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::any::Any;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::ptr::NonNull;
+use core::any::Any;
+use core::fmt::Debug;
+use core::marker::PhantomData;
+use core::ptr::NonNull;
 
 /// Metadata describing a memory block, as provided by the memory provider.
 ///

--- a/crates/bytesbuf/src/mem/callback_memory.rs
+++ b/crates/bytesbuf/src/mem/callback_memory.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use thread_aware::ThreadAware;
 
@@ -25,6 +25,8 @@ use crate::mem::Memory;
 /// anything.
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "std")] {
 /// use bytesbuf::mem::{CallbackMemory, Memory};
 /// # use bytesbuf::BytesBuf;
 /// # use bytesbuf::mem::GlobalPool;
@@ -36,12 +38,16 @@ use crate::mem::Memory;
 ///
 /// let buf = memory.reserve(64);
 /// assert!(buf.capacity() >= 64);
+/// # }
+/// # }
 /// ```
 ///
 /// The reservation logic often needs more than the wrapped provider alone. Pass a tuple (or any
 /// [`ThreadAware`] value) as the data and destructure it in the callback:
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "std")] {
 /// use bytesbuf::mem::{CallbackMemory, Memory};
 /// # use bytesbuf::BytesBuf;
 /// # use bytesbuf::mem::GlobalPool;
@@ -54,6 +60,8 @@ use crate::mem::Memory;
 ///
 /// let buf = memory.reserve(64);
 /// assert!(buf.capacity() >= 64);
+/// # }
+/// # }
 /// ```
 ///
 /// For a complete implementation pattern, see `examples/bb_has_memory_optimizing.rs`.
@@ -66,7 +74,7 @@ pub struct CallbackMemory<D: ThreadAware + Clone + Send + Sync + 'static> {
 }
 
 impl<D: ThreadAware + Clone + Send + Sync + 'static> Debug for CallbackMemory<D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // `data` is deliberately not formatted so that `CallbackMemory` is `Debug` regardless of
         // whether `D` is, which keeps it usable with thread-aware data that is intentionally not
         // `Debug` (e.g. a tuple containing a non-`Debug` field).
@@ -94,8 +102,7 @@ impl<D: ThreadAware + Clone + Send + Sync + 'static> CallbackMemory<D> {
     ///
     /// The memory provider may provide more memory than requested.
     ///
-    /// The memory reservation request will always be fulfilled, obtaining more memory from the
-    /// operating system if necessary.
+    /// If this method returns, the buffer has at least `min_bytes` bytes of capacity.
     ///
     /// # Zero-sized reservations
     ///
@@ -104,7 +111,7 @@ impl<D: ThreadAware + Clone + Send + Sync + 'static> CallbackMemory<D> {
     ///
     /// # Panics
     ///
-    /// May panic if the operating system runs out of memory.
+    /// The callback may panic or abort if the requested capacity cannot be obtained.
     #[must_use]
     pub fn reserve(&self, min_bytes: usize) -> BytesBuf {
         (self.reserve_fn)(&self.data, min_bytes)

--- a/crates/bytesbuf/src/mem/global.rs
+++ b/crates/bytesbuf/src/mem/global.rs
@@ -463,7 +463,7 @@ const RESERVATION_SIZE_BUCKETS: &[Magnitude] = &[
     0, 256, 512, 1024, 2048, 4096, 8192, 16_384, 32_768, 65_536, 131_072, 262_144, 524_288, 1_048_576,
 ];
 
-thread_local! {
+std::thread_local! {
     static BLOCK_RENTED_SIZE: Event = Event::builder()
         .name("bytesbuf_global_pool_block_rented_size")
         .histogram(BLOCK_SIZE_BUCKETS)

--- a/crates/bytesbuf/src/mem/has_memory.rs
+++ b/crates/bytesbuf/src/mem/has_memory.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::mem::MemoryShared;
 

--- a/crates/bytesbuf/src/mem/memory.rs
+++ b/crates/bytesbuf/src/mem/memory.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::BytesBuf;
 
@@ -22,8 +22,7 @@ pub trait Memory: Debug {
     ///
     /// The memory provider may provide more memory than requested.
     ///
-    /// The memory reservation request will always be fulfilled, obtaining more memory from the
-    /// operating system if necessary.
+    /// If this method returns, the buffer has at least `min_bytes` bytes of capacity.
     ///
     /// # Zero-sized reservations
     ///
@@ -32,7 +31,7 @@ pub trait Memory: Debug {
     ///
     /// # Panics
     ///
-    /// May panic if the operating system runs out of memory.
+    /// Implementations may panic or abort if the requested capacity cannot be obtained.
     #[must_use]
     fn reserve(&self, min_bytes: usize) -> BytesBuf;
 }

--- a/crates/bytesbuf/src/mem/memory_shared.rs
+++ b/crates/bytesbuf/src/mem/memory_shared.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#[cfg(not(test))]
+use alloc::boxed::Box;
+
 use thread_aware::ThreadAware;
 
 use crate::mem::Memory;

--- a/crates/bytesbuf/src/mem/mod.rs
+++ b/crates/bytesbuf/src/mem/mod.rs
@@ -3,9 +3,10 @@
 
 //! Types for using and implementing memory providers.
 //!
-//! The only production-grade memory provider published by this crate is [`GlobalPool`], which uses
-//! memory from the Rust global memory allocator and adds a layer of pooling to reduce the overhead
-//! from memory allocation churn.
+//! With the `std` feature, this crate provides `GlobalPool`, which uses memory from the Rust global
+//! allocator and adds pooling to reduce allocation churn. Without `std`, applications that already
+//! own a specialized memory provider can integrate it by implementing [`Memory`]; this crate does
+//! not provide a general-purpose allocator-backed provider in that configuration.
 //!
 //! Special-purpose memory providers can be implemented by other crates as needed, providing access
 //! to memory with particular characteristics (e.g. page-aligned memory, memory mapped to specific
@@ -39,6 +40,7 @@ mod block;
 mod block_ref;
 
 mod callback_memory;
+#[cfg(feature = "std")]
 mod global;
 mod has_memory;
 mod memory;
@@ -48,6 +50,8 @@ mod opaque_memory;
 pub use block::{Block, BlockSize};
 pub use block_ref::{BlockMeta, BlockRef, BlockRefDynamic, BlockRefDynamicWithMeta, BlockRefVTable};
 pub use callback_memory::CallbackMemory;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use global::GlobalPool;
 pub use has_memory::HasMemory;
 pub use memory::Memory;

--- a/crates/bytesbuf/src/mem/opaque_memory.rs
+++ b/crates/bytesbuf/src/mem/opaque_memory.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#[cfg(not(test))]
+use alloc::boxed::Box;
+
 use thread_aware::ThreadAware;
 
 use crate::mem::{Memory, MemoryShared};
@@ -32,8 +35,7 @@ impl OpaqueMemory {
     ///
     /// The memory provider may provide more memory than requested.
     ///
-    /// The memory reservation request will always be fulfilled, obtaining more memory from the
-    /// operating system if necessary.
+    /// If this method returns, the buffer has at least `min_bytes` bytes of capacity.
     ///
     /// # Zero-sized reservations
     ///
@@ -42,7 +44,7 @@ impl OpaqueMemory {
     ///
     /// # Panics
     ///
-    /// May panic if the operating system runs out of memory.
+    /// The wrapped provider may panic or abort if the requested capacity cannot be obtained.
     ///
     /// [1]: crate::BytesBuf
     #[must_use]
@@ -67,7 +69,7 @@ impl Memory for OpaqueMemory {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{self, AtomicUsize};

--- a/crates/bytesbuf/src/mem/testing/transparent.rs
+++ b/crates/bytesbuf/src/mem/testing/transparent.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#[cfg(not(test))]
+use alloc::vec::Vec;
 use std::num::NonZero;
 
 use thread_aware::ThreadAware;

--- a/crates/bytesbuf/src/memory_guard.rs
+++ b/crates/bytesbuf/src/memory_guard.rs
@@ -40,7 +40,7 @@ impl Default for MemoryGuard {
     ///
     /// Useless for real logic but potentially meaningful as a placeholder in tests.
     fn default() -> Self {
-        Self::new(vec![])
+        Self::new([])
     }
 }
 

--- a/crates/bytesbuf/src/span.rs
+++ b/crates/bytesbuf/src/span.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::ops::{Bound, Deref, RangeBounds};
-use std::ptr::NonNull;
-use std::{fmt, slice};
+use alloc::format;
+use core::ops::{Bound, Deref, RangeBounds};
+use core::ptr::NonNull;
+use core::{fmt, slice};
 
 use crate::mem::{BlockRef, BlockSize};
 

--- a/crates/bytesbuf/src/span_builder.rs
+++ b/crates/bytesbuf/src/span_builder.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use core::mem::MaybeUninit;
+use core::num::NonZero;
+use core::ptr::NonNull;
 use core::slice;
-use std::mem::MaybeUninit;
-use std::num::NonZero;
-use std::ptr::NonNull;
 
 use crate::Span;
 use crate::mem::{BlockRef, BlockSize};

--- a/crates/bytesbuf/src/vec.rs
+++ b/crates/bytesbuf/src/vec.rs
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::mem::MaybeUninit;
-use std::num::NonZero;
-use std::ptr::NonNull;
-use std::sync::atomic::{self, AtomicUsize};
+#[cfg(not(test))]
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::mem::{self, MaybeUninit};
+use core::num::NonZero;
+use core::ptr::NonNull;
+use core::sync::atomic::{self, AtomicUsize};
 
 use smallvec::SmallVec;
 
@@ -185,7 +188,7 @@ impl Iterator for VecBlockIterator {
         // We want to take the first `bytes_to_take` bytes, so we split_off at that index
         // and swap - what we split off becomes `remaining`, and what's left is what we return.
         let keep = self.remaining.split_off(bytes_to_take);
-        let take = std::mem::replace(&mut self.remaining, keep);
+        let take = mem::replace(&mut self.remaining, keep);
 
         Some(take)
     }

--- a/crates/bytesbuf/src/view.rs
+++ b/crates/bytesbuf/src/view.rs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::hash::{Hash, Hasher};
-use std::iter;
-use std::num::NonZero;
-use std::ops::{Bound, RangeBounds};
+use alloc::vec::Vec;
+use core::hash::{Hash, Hasher};
+use core::iter;
+use core::num::NonZero;
+use core::ops::{Bound, RangeBounds};
 
+#[cfg(feature = "std")]
 use nm::{Event, Magnitude};
 use smallvec::SmallVec;
 
@@ -33,6 +35,8 @@ use crate::{MAX_INLINE_SPANS, MemoryGuard, Span};
 /// # Example
 ///
 /// ```
+/// # fn main() {
+/// # #[cfg(feature = "std")] {
 /// # let memory = bytesbuf::mem::GlobalPool::new();
 /// use bytesbuf::BytesView;
 ///
@@ -45,6 +49,8 @@ use crate::{MAX_INLINE_SPANS, MemoryGuard, Span};
 /// }
 ///
 /// assert!(view.is_empty());
+/// # }
+/// # }
 /// ```
 ///
 /// [`BytesBuf`]: crate::BytesBuf
@@ -85,6 +91,7 @@ impl BytesView {
         spans_reversed.iter().for_each(|span| assert!(!span.is_empty()));
 
         // We can use this to fine-tune the inline span count once we have real-world data.
+        #[cfg(feature = "std")]
         VIEW_CREATED_SPANS.with(|x| x.observe(spans_reversed.len()));
 
         let len = spans_reversed.iter().fold(0_usize, |acc, span: &Span| {
@@ -114,6 +121,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -125,6 +134,8 @@ impl BytesView {
     ///
     /// assert_eq!(response_line.len(), 15);
     /// assert_eq!(response_line, b"HTTP/1.1 200 OK");
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -160,6 +171,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # struct TcpConnection;
     /// # impl TcpConnection {
     /// #     fn memory(&self) -> impl bytesbuf::mem::Memory { bytesbuf::mem::GlobalPool::new() }
@@ -172,6 +185,8 @@ impl BytesView {
     /// let header_key = BytesView::copied_from_slice(CONTENT_TYPE_KEY, &tcp_connection.memory());
     ///
     /// assert_eq!(header_key.len(), 14);
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Reusing without copying
@@ -204,6 +219,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -215,6 +232,8 @@ impl BytesView {
     ///
     /// _ = view.get_u16_le();
     /// assert_eq!(view.len(), 2);
+    /// # }
+    /// # }
     /// ```
     #[cfg_attr(test, mutants::skip)] // Mutating this can cause infinite loops.
     #[must_use]
@@ -249,6 +268,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -258,6 +279,8 @@ impl BytesView {
     /// assert_eq!(view.range(7..), b"world!");
     /// assert_eq!(view.range(..5), b"Hello");
     /// assert_eq!(view.range(..), b"Hello, world!");
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -496,6 +519,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -510,6 +535,8 @@ impl BytesView {
     /// });
     ///
     /// assert!(view.is_empty());
+    /// # }
+    /// # }
     /// ```
     pub fn consume_all_slices<F>(&mut self, mut f: F)
     where
@@ -532,6 +559,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -550,6 +579,8 @@ impl BytesView {
     /// }
     ///
     /// assert_eq!(ten_bytes, b"0123456789");
+    /// # }
+    /// # }
     /// ```
     #[cfg_attr(test, mutants::skip)] // Mutating this can cause infinite loops.
     #[must_use]
@@ -566,6 +597,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// # struct PageAlignedMemory;
     /// use bytesbuf::BytesView;
@@ -581,6 +614,8 @@ impl BytesView {
     ///         data.len()
     ///     );
     /// }
+    /// # }
+    /// # }
     /// ```
     ///
     /// See the stand-alone example `bb_optimal_path.rs` in the `bytesbuf` crate for
@@ -596,6 +631,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -604,6 +641,8 @@ impl BytesView {
     /// let bytes = view.to_vec();
     ///
     /// assert_eq!(bytes, b"Hello, world!");
+    /// # }
+    /// # }
     /// ```
     #[must_use]
     pub fn to_vec(&self) -> Vec<u8> {
@@ -624,6 +663,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// # struct PageAlignedMemory;
     /// use bytesbuf::BytesView;
@@ -635,6 +676,8 @@ impl BytesView {
     ///     .is_some_and(|meta| meta.is::<PageAlignedMemory>());
     ///
     /// println!("First slice is page-aligned: {is_page_aligned}");
+    /// # }
+    /// # }
     /// ```
     ///
     /// See the stand-alone example `bb_optimal_path.rs` in the `bytesbuf` crate for
@@ -656,6 +699,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -674,6 +719,8 @@ impl BytesView {
     /// }
     ///
     /// assert_eq!(ten_bytes, b"0123456789");
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -722,6 +769,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -731,6 +780,8 @@ impl BytesView {
     /// greeting.append(name);
     ///
     /// assert_eq!(greeting, b"Hello, world!");
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -752,6 +803,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -764,6 +817,8 @@ impl BytesView {
     /// assert_eq!(greeting, b"Hello, ");
     /// // New view contains the concatenation.
     /// assert_eq!(message, b"Hello, world!");
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -1035,9 +1090,11 @@ impl<'s> Iterator for BytesViewSlices<'s> {
     }
 }
 
+#[cfg(feature = "std")]
 const SPAN_COUNT_BUCKETS: &[Magnitude] = &[0, 1, 2, 4, 8, 16, 32];
 
-thread_local! {
+#[cfg(feature = "std")]
+std::thread_local! {
     static VIEW_CREATED_SPANS: Event = Event::builder()
         .name("bytesbuf_view_created_spans")
         .histogram(SPAN_COUNT_BUCKETS)

--- a/crates/bytesbuf/src/view_get.rs
+++ b/crates/bytesbuf/src/view_get.rs
@@ -3,8 +3,8 @@
 
 //! We separate out all the consumption methods for ease of maintenance.
 
-use std::mem::MaybeUninit;
-use std::ptr;
+use core::mem::MaybeUninit;
+use core::ptr;
 
 use crate::BytesView;
 
@@ -66,6 +66,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -75,6 +77,8 @@ impl BytesView {
     /// assert_eq!(view.get_byte(), b'B');
     /// assert_eq!(view.get_byte(), b'C');
     /// assert!(view.is_empty());
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -115,6 +119,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use bytesbuf::BytesView;
     ///
@@ -124,7 +130,9 @@ impl BytesView {
     /// view.copy_to_slice(&mut buffer);
     ///
     /// assert_eq!(&buffer, b"Hello");
-    /// assert_eq!(view.len(), 8); // ", world!" remains
+    /// assert_eq!(view.len(), 8);
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -158,6 +166,8 @@ impl BytesView {
     /// # Example
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(feature = "std")] {
     /// # let memory = bytesbuf::mem::GlobalPool::new();
     /// use std::mem::MaybeUninit;
     ///
@@ -171,6 +181,8 @@ impl BytesView {
     /// // SAFETY: The buffer has been fully initialized by copy_to_uninit_slice.
     /// let buffer: [u8; 5] = unsafe { std::mem::transmute(buffer) };
     /// assert_eq!(&buffer, b"Hello");
+    /// # }
+    /// # }
     /// ```
     ///
     /// # Panics

--- a/crates/bytesbuf_io/Cargo.toml
+++ b/crates/bytesbuf_io/Cargo.toml
@@ -29,7 +29,7 @@ futures-stream = ["dep:futures-core"]
 test-util = ["bytesbuf/test-util"]
 
 [dependencies]
-bytesbuf = { workspace = true }
+bytesbuf = { workspace = true, features = ["std"] }
 futures-core = { workspace = true, optional = true }
 ohno = { workspace = true }
 trait-variant = { workspace = true }

--- a/crates/cachet/Cargo.toml
+++ b/crates/cachet/Cargo.toml
@@ -52,7 +52,7 @@ telemetry = []
 
 [dependencies]
 anyspawn = { workspace = true, features = ["tokio"] }
-bytesbuf = { workspace = true, optional = true }
+bytesbuf = { workspace = true, features = ["std"], optional = true }
 cachet_memory = { workspace = true, optional = true }
 cachet_service = { workspace = true, optional = true }
 cachet_tier = { workspace = true }

--- a/crates/cachet_memory/Cargo.toml
+++ b/crates/cachet_memory/Cargo.toml
@@ -32,7 +32,7 @@ cachet_tier = { workspace = true }
 foldhash = { workspace = true }
 moka = { workspace = true, features = ["future"] }
 ohno = { workspace = true }
-thread_aware = { workspace = true, features = ["derive"] }
+thread_aware = { workspace = true, features = ["derive", "std"] }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/fetch/Cargo.toml
+++ b/crates/fetch/Cargo.toml
@@ -82,7 +82,7 @@ tokio = [
 [dependencies]
 # internal
 anyspawn = { workspace = true, optional = true }
-bytesbuf = { workspace = true }
+bytesbuf = { workspace = true, features = ["std"] }
 data_privacy = { workspace = true }
 fetch_hyper = { workspace = true, optional = true }
 fetch_options = { workspace = true }
@@ -97,7 +97,7 @@ ohno.workspace = true
 seatbelt = { workspace = true, features = ["timeout", "retry", "breaker", "hedging", "logs", "metrics"] }
 seatbelt_http = { workspace = true, features = ["timeout", "retry", "breaker", "hedging"] }
 templated_uri = { workspace = true, features = ["uuid"] }
-thread_aware = { workspace = true, features = ["derive"] }
+thread_aware = { workspace = true, features = ["derive", "std"] }
 tick = { workspace = true }
 
 # external

--- a/crates/fetch_azure/Cargo.toml
+++ b/crates/fetch_azure/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 
 [dependencies]
 # internal
-bytesbuf = { workspace = true, features = ["bytes-compat"] }
+bytesbuf = { workspace = true, features = ["bytes-compat", "std"] }
 fetch = { workspace = true }
 layered = { workspace = true }
 

--- a/crates/fetch_hyper/Cargo.toml
+++ b/crates/fetch_hyper/Cargo.toml
@@ -58,7 +58,7 @@ native-tls = [
 [dependencies]
 # internal
 anyspawn = { workspace = true }
-bytesbuf = { workspace = true }
+bytesbuf = { workspace = true, features = ["std"] }
 fetch_options = { workspace = true }
 fetch_tls = { workspace = true }
 http_extensions = { workspace = true }

--- a/crates/http_extensions/Cargo.toml
+++ b/crates/http_extensions/Cargo.toml
@@ -64,7 +64,7 @@ test-util = ["tick/test-util"]
 
 [dependencies]
 bytes = { workspace = true }
-bytesbuf = { workspace = true, features = ["bytes-compat"] }
+bytesbuf = { workspace = true, features = ["bytes-compat", "std"] }
 futures = { workspace = true, features = ["std"] }
 http = { workspace = true }
 http-body = { workspace = true }
@@ -76,7 +76,7 @@ recoverable = { workspace = true }
 serde_core = { workspace = true, optional = true }
 serde_json = { workspace = true, features = ["std"], optional = true }
 templated_uri = { workspace = true }
-thread_aware = { workspace = true, features = ["derive"] }
+thread_aware = { workspace = true, features = ["derive", "std"] }
 tick = { workspace = true, features = ["fmt"] }
 
 [dev-dependencies]

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -47,7 +47,7 @@ dst = ["ptr_meta/derive"]
 utf16 = ["dep:widestring"]
 bytes = ["dep:bytes"]
 bytemuck = ["dep:bytemuck", "dst"]
-bytesbuf = ["dep:bytesbuf", "std"]
+bytesbuf = ["dep:bytesbuf", "std", "bytesbuf/std"]
 zerocopy = ["dep:zerocopy", "dst"]
 hashbrown = ["dep:hashbrown"]
 # Marker feature selecting the loom model-checking test target via its

--- a/crates/seatbelt/Cargo.toml
+++ b/crates/seatbelt/Cargo.toml
@@ -66,7 +66,7 @@ layered = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 recoverable = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"], optional = true }
-thread_aware = { workspace = true }
+thread_aware = { workspace = true, default-features = false, features = ["std"] }
 tick = { workspace = true }
 tower-service = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }

--- a/crates/thread_aware/Cargo.toml
+++ b/crates/thread_aware/Cargo.toml
@@ -7,7 +7,7 @@ description = "Facilities to support thread-isolated state."
 version = "0.8.0"
 readme = "README.md"
 keywords = ["oxidizer", "thread", "aware"]
-categories = ["data-structures"]
+categories = ["data-structures", "no-std"]
 
 edition = { workspace = true }
 rust-version = { workspace = true }
@@ -55,9 +55,12 @@ allowed_external_types = [
 all-features = true
 
 [features]
-default = ["derive"]
+default = ["std", "derive"]
+# Enables the per-affinity Arc and hosted-only type impls. Disable for `#![no_std]`
+# environments; the crate then requires only `alloc`.
+std = []
 derive = ["dep:thread_aware_macros"]
-threads = ["dep:many_cpus"]
+threads = ["std", "dep:many_cpus"]
 
 # Optional `ThreadAware` impls for 3rd-party crate types. By default no such
 # features are enabled, so this crate does not pull in any additional
@@ -78,7 +81,7 @@ threads = ["dep:many_cpus"]
 #
 # See the `third_party` module for the list of types each feature covers.
 bytes = ["dep:bytes"]
-http = ["dep:http"]
+http = ["std", "dep:http"]
 jiff02 = ["dep:jiff"]
 uuid = ["dep:uuid"]
 

--- a/crates/thread_aware/README.md
+++ b/crates/thread_aware/README.md
@@ -15,42 +15,55 @@
 
 Essential building blocks for thread-per-core libraries.
 
+## Crate features
+
+* The **`std` Cargo feature** *(enabled by default)* enables the per-affinity `Arc` and
+  hosted-only type implementations.
+* **`derive`** *(default)* re-exports the `#[derive(ThreadAware)]` macro.
+* **`threads`** enables the `registry` module and implies `std`.
+* Disable default features for `#![no_std]` environments. The [`ThreadAware`][__link0] trait, affinity
+  identifiers, closures, wrappers, and implementations for `alloc` types remain available.
+  Enable `derive` explicitly if the derive macro is needed.
+
+`no_std` environments require `alloc` and pointer-width atomics.
+
 This crate allows you to express migrations between NUMA nodes, threads, or specific CPU cores.
 It can serve as a foundation for building components and runtimes that operate across multiple
 memory affinities.
 
 ## Theory of Operation
 
-At a high level, this crate enables thread migrations of state via the [`ThreadAware`][__link0] trait:
+At a high level, this crate enables thread migrations of state via the [`ThreadAware`][__link1] trait:
 
 * Runtimes (and similar) can use it to inform types that they were just moved across a thread or NUMA boundary.
 * The authors of said types can then act on this information to implement performance optimizations. Such optimizations
   might include re-allocating memory in a new NUMA region, connecting to a thread-local I/O scheduler,
   or detaching from shared, possibly contended memory with the previous thread.
 
-Similar to [`Clone`][__link1], there are no exact semantic prescriptions of how types should behave on relocation.
+Similar to [`Clone`][__link2], there are no exact semantic prescriptions of how types should behave on relocation.
 They might continue to share some state (e.g., a common cache) or fully detach from it for performance reasons.
 The primary goal is performance, so types should aim to minimize contention on synchronization primitives
 and cross-NUMA memory access. Like `Clone`, the relocation itself should be mostly transparent and predictable
 to users.
 
-### Implementing [`ThreadAware`][__link2], and `Arc<T, PerCore>`
+### Implementing [`ThreadAware`][__link3], and `Arc<T, PerCore>`
 
-In most cases [`ThreadAware`][__link3] should be implemented via the provided derive macro.
+In most cases [`ThreadAware`][__link4] should be implemented via the provided derive macro.
 As thread-awareness of a type usually involves letting all contained fields know of an ongoing
 relocation, the derive macro does just that. A default impl is provided for many `std` types,
 so the macro should ‘just work’ on most compounds of built-ins.
 
-External crates might often not implement [`ThreadAware`][__link4]. In many of these cases using our
-[`thread_aware::Arc`][__link5] offers a convenient solution: It combines an upstream
-[`std::sync::Arc`][__link6] with a relocation [`Strategy`][__link7], and implements [`ThreadAware`][__link8] for it. For
+External crates might often not implement [`ThreadAware`][__link5]. In many of these cases using our
+[`thread_aware::Arc`][__link6] offers a convenient solution when the `std` feature is enabled: it
+combines an upstream [`alloc::sync::Arc`][__link7] with a relocation [`Strategy`][__link8], and
+implements [`ThreadAware`][__link9] for it. For
 example, while an `Arc<Foo, PerProcess>` effectively acts as vanilla `Arc`, an
 `Arc<Foo, PerCore>` ensures a separate `Foo` is available any time the types moves a core boundary.
 
-### Relation to [`Send`][__link9]
+### Relation to [`Send`][__link10]
 
-[`ThreadAware`][__link10] requires [`Send`][__link11] as a supertrait. Types are first sent to another thread,
-then the [`ThreadAware`][__link12] relocation notification is invoked.
+[`ThreadAware`][__link11] requires [`Send`][__link12] as a supertrait. Types are first sent to another thread,
+then the [`ThreadAware`][__link13] relocation notification is invoked.
 
 ### Thread vs. Core Semantics
 
@@ -60,49 +73,54 @@ primarily relocate between different threads, where each thread is pinned to a d
 Should a runtime utilize more than one thread per core (e.g., for internal I/O) user code should
 be able to observe this fact.
 
-### [`ThreadAware`][__link13] vs. [`Unaware`][__link14]
+### [`ThreadAware`][__link14] vs. [`Unaware`][__link15]
 
 Sometimes you might need to move inert types as-is, essentially bypassing all
 thread-aware handling. These might be foreign types that carry no allocation, do
 no I/O, or otherwise do not require any thread-specific handling.
 
-[`Unaware`][__link15] can be used to encapsulate such types, a wrapper that itself implements [`ThreadAware`][__link16], but
+[`Unaware`][__link16] can be used to encapsulate such types, a wrapper that itself implements [`ThreadAware`][__link17], but
 otherwise does not react to it. You can think of it as a `MoveAsIs<T>`. However, it was
 deliberately named `Unaware` to signal that only types which are genuinely unaware of their
-thread relocations (i.e., don’t impl [`ThreadAware`][__link17]) should be wrapped in such.
+thread relocations (i.e., don’t impl [`ThreadAware`][__link18]) should be wrapped in such.
 
 Wrapping types that implement the trait is discouraged, as it will prevent them from properly
 relocating and might have an impact on their performance, but not correctness, see below.
 
 ### Performance vs. Correctness
 
-It is important to note that [`ThreadAware`][__link18] is a cooperative performance optimization and contention avoidance
+It is important to note that [`ThreadAware`][__link19] is a cooperative performance optimization and contention avoidance
 primitive, not a guarantee of behavior for either the caller or callee. In other words, callers and runtimes must
 continue to operate correctly if the trait is invoked incorrectly.
 
-In particular, [`ThreadAware`][__link19] may not always be invoked when a type leaves the current thread.
+In particular, [`ThreadAware`][__link20] may not always be invoked when a type leaves the current thread.
 While runtimes should reduce the incidence of that through their API design, it may nonetheless
-happen via [`std::thread::spawn`][__link20] and other means. In these cases types should still function
+happen via [`std::thread::spawn`][__link21] and other means. In these cases types should still function
 correctly, although they might experience degraded performance through contention of now-shared
 resources.
 
 ### Provided Implementations
 
-[`ThreadAware`][__link21] is implemented for many standard library types, including primitive types, Vec,
-String, Option, Result, tuples, etc. However, it’s explicitly not implemented for [`std::sync::Arc`][__link22]
+[`ThreadAware`][__link22] is implemented for many standard library types, including primitive types, Vec,
+String, Option, Result, tuples, etc. However, it’s explicitly not implemented for [`alloc::sync::Arc`][__link23]
 as that type implies some level of cross-thread sharing and thus needs special attention when used
-from types that implement [`ThreadAware`][__link23].
+from types that implement [`ThreadAware`][__link24].
 
 ## Features
 
+* The **`std` Cargo feature** *(enabled by default)* enables the per-affinity `Arc` and
+  hosted-only type implementations. Disable it for `#![no_std]` environments; the crate then
+  requires `alloc` and pointer-width atomics.
 * **`derive`** *(default)*: Re-exports the `#[derive(ThreadAware)]` macro from the companion
   `thread_aware_macros` crate. Disable to avoid pulling in proc-macro code in minimal
-  environments: `default-features = false`.
-* **`threads`**: Enables features mainly used by async runtimes for OS interactions.
+  environments. For derive support without `std`, use
+  `default-features = false, features = ["derive"]`.
+* **`threads`**: Enables features mainly used by async runtimes for OS interactions and implies
+  `std`.
 
 ### 3rd-party crate impls
 
-The following opt-in features provide [`ThreadAware`][__link24] implementations for
+The following opt-in features provide [`ThreadAware`][__link25] implementations for
 inert value types from popular 3rd-party crates. Enabling a feature pulls
 that crate in as a dependency. By default none are enabled and this crate
 brings in no extra dependencies.
@@ -119,7 +137,7 @@ the wrapped crate can be supported additively:
 
 * **`bytes`**: Impls for `bytes::Bytes`, `bytes::BytesMut`.
 
-* **`http`**: Impls for `http::StatusCode`, `http::Method`, `http::Version`,
+* **`http`**: Enables `std` and provides impls for `http::StatusCode`, `http::Method`, `http::Version`,
   `http::HeaderName`, `http::HeaderValue`, `http::HeaderMap<HeaderValue>`,
   `http::Uri`, `http::uri::Authority`, `http::uri::Scheme`,
   `http::uri::PathAndQuery`, `http::uri::Port<T>`, `http::Error`,
@@ -131,10 +149,11 @@ the wrapped crate can be supported additively:
 
 ## Examples
 
-### Deriving [`ThreadAware`][__link25]
+### Using the [`ThreadAware` derive macro][__link26]
 
 When the `derive` feature (enabled by default) is active you can simply
-derive [`ThreadAware`][__link26] instead of writing the implementation manually.
+use the [`ThreadAware` derive macro][__link27] instead of writing the
+implementation manually.
 
 ```rust
 use thread_aware::ThreadAware;
@@ -146,10 +165,10 @@ struct Point {
 }
 ```
 
-### Enabling [`ThreadAware`][__link27] via `Arc<T, S>`
+### Enabling [`ThreadAware`][__link28] via `Arc<T, S>`
 
-For types containing fields not [`ThreadAware`][__link28], you can use [`Arc`][__link29] to specify a
-strategy, and wrap them in an [`Arc`][__link30] that implements the trait.
+With the `std` feature, types containing fields not [`ThreadAware`][__link29] can use [`Arc`][__link30] to specify a
+strategy and wrap them in an [`Arc`][__link31] that implements the trait.
 
 ```rust
 use thread_aware::{Arc, PerCore, ThreadAware};
@@ -176,35 +195,36 @@ impl Service {
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/thread_aware">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbN-qa6ScfeXYbpUaqiTirDJMb-9jGY2W0shYbe4CUzbbLbn5hZIKCbHRocmVhZF9hd2FyZWUwLjguMIJzdGhyZWFkX2F3YXJlX21hY3Jvc2UwLjcuNQ
- [__link0]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link1]: https://doc.rust-lang.org/stable/std/clone/trait.Clone.html
- [__link10]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link11]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html
- [__link12]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link13]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link14]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=Unaware
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbUpEHEN0wyqMbT69q7SZ3jhAb-itdqiIRp1EbkJGs8OCz_nBhZIKCbHRocmVhZF9hd2FyZWUwLjguMIJzdGhyZWFkX2F3YXJlX21hY3Jvc2UwLjcuNQ
+ [__link0]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link1]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link10]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html
+ [__link11]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link12]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html
+ [__link13]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link14]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
  [__link15]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=Unaware
- [__link16]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link17]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link18]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link19]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link2]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link20]: https://doc.rust-lang.org/stable/std/?search=thread::spawn
- [__link21]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link22]: https://doc.rust-lang.org/stable/std/?search=sync::Arc
- [__link23]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link24]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link25]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
+ [__link16]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=Unaware
+ [__link17]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link18]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link19]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link2]: https://doc.rust-lang.org/stable/std/clone/trait.Clone.html
+ [__link20]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link21]: https://doc.rust-lang.org/stable/std/?search=thread::spawn
+ [__link22]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link23]: https://doc.rust-lang.org/stable/alloc/?search=sync::Arc
+ [__link24]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link25]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
  [__link26]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
  [__link27]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link28]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link29]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=Arc
- [__link3]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
+ [__link28]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link29]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link3]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
  [__link30]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=Arc
- [__link4]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link5]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=Arc
- [__link6]: https://doc.rust-lang.org/stable/std/?search=sync::Arc
- [__link7]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=storage::Strategy
- [__link8]: https://docs.rs/thread_aware_macros/0.7.5/thread_aware_macros/?search=ThreadAware
- [__link9]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html
+ [__link31]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=Arc
+ [__link4]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link5]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware
+ [__link6]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=Arc
+ [__link7]: https://doc.rust-lang.org/stable/alloc/?search=sync::Arc
+ [__link8]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=storage::Strategy
+ [__link9]: https://docs.rs/thread_aware/0.8.0/thread_aware/?search=core::ThreadAware

--- a/crates/thread_aware/src/__private.rs
+++ b/crates/thread_aware/src/__private.rs
@@ -3,9 +3,9 @@
 
 //! Private module for internal reexports.
 //!
-//! This module provides a separate reexport of the [`ThreadAware`] trait, which is also
+//! This module provides a separate reexport of the [`trait@ThreadAware`] trait, which is also
 //! available at the crate root. The purpose of this module is to allow downstream crates
-//! to selectively reexport just the trait without also bringing in the [`ThreadAware`]
+//! to selectively reexport just the trait without also bringing in the [`trait@ThreadAware`]
 //! derive macro (which is conditionally exported at the crate root when the `derive`
 //! feature is enabled).
 //!

--- a/crates/thread_aware/src/affinity.rs
+++ b/crates/thread_aware/src/affinity.rs
@@ -5,6 +5,9 @@
 
 #![allow(clippy::allow_attributes, reason = "Needed for conditional compilation")]
 
+#[cfg(not(test))]
+use alloc::vec::Vec;
+
 /// A `Affinity` represents a specific binding to a processor and memory region.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Affinity {

--- a/crates/thread_aware/src/cell/clone_fn.rs
+++ b/crates/thread_aware/src/cell/clone_fn.rs
@@ -7,6 +7,8 @@
 //! with a [`CloneAdapter`] that stores the original concrete value `V` and its
 //! clone function.
 
+#[cfg(not(test))]
+use alloc::boxed::Box;
 use std::{fmt, sync};
 
 use crate::ThreadAware;

--- a/crates/thread_aware/src/cell/factory.rs
+++ b/crates/thread_aware/src/cell/factory.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#[cfg(not(test))]
+use alloc::boxed::Box;
 use std::{fmt, sync};
 
 use super::clone_fn::ErasedCloneFn;

--- a/crates/thread_aware/src/cell/mod.rs
+++ b/crates/thread_aware/src/cell/mod.rs
@@ -10,6 +10,8 @@ mod builtin;
 #[cfg(test)]
 mod tests;
 
+#[cfg(not(test))]
+use alloc::boxed::Box;
 use std::cmp::Ordering;
 use std::hash::Hasher;
 use std::ops::Deref;
@@ -47,11 +49,11 @@ impl<T, F: ThreadAwareFnOnce<T>> ThreadAwareFnOnce<Box<T>> for BoxedRelocate<F> 
 /// Transferable reference counted type.
 ///
 /// This type works like a per-affinity (per-thread) [`sync::Arc`]. Each affinity gets a unique value that is shared by clones
-/// of the `Arc`, but the [`ThreadAware`] implementation ensures that when moving to another affinity, the resulting
+/// of the `Arc`, but the [`trait@ThreadAware`] implementation ensures that when moving to another affinity, the resulting
 /// `Arc` will point to the value in the destination affinity. See [`new`](`Arc::new`) for information on constructing instances.
 ///
 /// `ThreadAware` of different clones of the `Arc` result in "deduplication" in the destination affinity. The following
-/// example demonstrates this using the counter implemented in the documentation for the [`ThreadAware`] trait.
+/// example demonstrates this using the counter implemented in the documentation for the [`trait@ThreadAware`] trait.
 ///
 /// ```rust
 /// # use thread_aware::{Arc, ThreadAware, PerCore};
@@ -173,12 +175,12 @@ where
     /// * The provided function must be pure with respect to per-processor isolation (it should not
     ///   leak references into other processors). Any captured state should therefore be provided via
     ///   globally shareable mechanisms or prefer [`new_with`](Self::new_with) if you need to
-    ///   capture data that itself implements [`ThreadAware`].
+    ///   capture data that itself implements [`trait@ThreadAware`].
     ///
     /// When transferring to another affinity which doesn't yet contain a value, the constructor is
     /// called in the destination affinity to create a brand new instance.
     ///
-    /// For example, the counter type we implemented in the documentation for [`ThreadAware`] trait
+    /// For example, the counter type we implemented in the documentation for [`trait@ThreadAware`] trait
     /// can be used with `new` by passing the constructor function (note the absence of `()`):
     ///
     /// ```rust
@@ -299,7 +301,7 @@ where
     /// to another processor. The closure behaves like a `ThreadAwareFnOnce` to ensure it captures only values that are safe to
     /// transfer themselves.
     ///
-    /// This function can be used to create an `Arc` of a type that itself doesn't implement [`ThreadAware`] because
+    /// This function can be used to create an `Arc` of a type that itself doesn't implement [`trait@ThreadAware`] because
     /// we can ensure that each affinity will get its own, independently-initialized value:
     ///
     /// ```rust
@@ -320,8 +322,8 @@ where
     /// let container = Arc::<_, PerCore>::new_with((), |_| MyStruct::new());
     /// ```
     ///
-    /// The constructor can depend on other values that implement [`ThreadAware`] (this example uses the Counter
-    /// defined in [`ThreadAware`] documentation):
+    /// The constructor can depend on other values that implement [`trait@ThreadAware`] (this example uses the Counter
+    /// defined in [`trait@ThreadAware`] documentation):
     ///
     /// ```rust
     /// # use thread_aware::{ThreadAware, Arc, PerCore};
@@ -382,11 +384,11 @@ where
 {
     /// Creates a new `Arc` with the given value.
     ///
-    /// The value must implement [`ThreadAware`] and [`Clone`]. When transferring to another affinity
+    /// The value must implement [`trait@ThreadAware`] and [`Clone`]. When transferring to another affinity
     /// which doesn't yet contain a value, a new value is created by cloning the value in current
     /// affinity and transferring it to the new affinity.
     ///
-    /// For example, the counter type we implemented in the documentation for the [`ThreadAware`] trait
+    /// For example, the counter type we implemented in the documentation for the [`trait@ThreadAware`] trait
     /// can be used with new.
     #[cfg(test)]
     pub(crate) fn with_value(value: T) -> Self {
@@ -414,10 +416,10 @@ where
     /// which doesn't yet contain a value, a new value is created by cloning the value in current
     /// affinity and transferring it to the new affinity.
     ///
-    /// This is useful for types that do not implement [`ThreadAware`]. In such cases, the same value
+    /// This is useful for types that do not implement [`trait@ThreadAware`]. In such cases, the same value
     /// is cloned for each affinity without any relocation logic.
     ///
-    /// For example, the counter type we implemented in the documentation for [`ThreadAware`] trait
+    /// For example, the counter type we implemented in the documentation for [`trait@ThreadAware`] trait
     /// can be used with new:
     ///
     /// ```rust

--- a/crates/thread_aware/src/cell/storage.rs
+++ b/crates/thread_aware/src/cell/storage.rs
@@ -3,6 +3,8 @@
 
 //! Primitives for thread-aware data storage.
 
+#[cfg(not(test))]
+use alloc::vec::Vec;
 use std::marker::PhantomData;
 
 use crate::affinity::Affinity;

--- a/crates/thread_aware/src/closure/erased.rs
+++ b/crates/thread_aware/src/closure/erased.rs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#[cfg(not(test))]
+use alloc::boxed::Box;
+use core::any::type_name;
+use core::fmt;
+
 use crate::ThreadAware;
 use crate::affinity::Affinity;
 use crate::closure::ThreadAwareFnOnce;
@@ -11,11 +16,11 @@ pub(crate) struct ErasedClosureOnce<T: ?Sized> {
 }
 
 //TODO Refactor and call debug on the inner closure
-impl<T: ?Sized> std::fmt::Debug for ErasedClosureOnce<T> {
+impl<T: ?Sized> fmt::Debug for ErasedClosureOnce<T> {
     #[cfg_attr(test, mutants::skip)]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ErasedClosure")
-            .field("return_type", &std::any::type_name::<T>())
+            .field("return_type", &type_name::<T>())
             .finish_non_exhaustive()
     }
 }

--- a/crates/thread_aware/src/closure/mod.rs
+++ b/crates/thread_aware/src/closure/mod.rs
@@ -1,12 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Helpers for defining and calling [`ThreadAware`] closures.
+//! Helpers for defining and calling [`trait@ThreadAware`] closures.
 
+#[cfg(feature = "std")]
 mod erased;
 
-use std::pin::Pin;
+#[cfg(not(test))]
+use alloc::boxed::Box;
+use core::fmt;
+use core::pin::Pin;
 
+#[cfg(feature = "std")]
 pub(crate) use erased::ErasedClosureOnce;
 
 use crate::ThreadAware;
@@ -15,7 +20,7 @@ use crate::affinity::Affinity;
 /// A boxed, pinned, `Send` future - the return type of async closure calls.
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-/// Marks `FnOnce()`-like closures whose captured values all implement [`ThreadAware`].
+/// Marks `FnOnce()`-like closures whose captured values all implement [`trait@ThreadAware`].
 ///
 /// Use [`closure_once`] function to construct these.
 pub trait ThreadAwareFnOnce<T: ?Sized>: ThreadAware {
@@ -23,7 +28,7 @@ pub trait ThreadAwareFnOnce<T: ?Sized>: ThreadAware {
     fn call_once(self) -> T;
 }
 
-/// Marks `Fn()`-like closure whose captured values all implement [`ThreadAware`].
+/// Marks `Fn()`-like closure whose captured values all implement [`trait@ThreadAware`].
 ///
 /// This trait is used to define closures that can be called multiple times, without consuming the closure.
 pub trait ThreadAwareFn<T>: ThreadAware {
@@ -31,7 +36,7 @@ pub trait ThreadAwareFn<T>: ThreadAware {
     fn call(&self) -> T;
 }
 
-/// Marks `FnMut()`-like closure whose captured values all implement [`ThreadAware`].
+/// Marks `FnMut()`-like closure whose captured values all implement [`trait@ThreadAware`].
 ///
 /// This trait is used to define closures that can be called mutably, allowing the closure to modify its internal state.
 pub trait ThreadAwareFnMut<T>: ThreadAware {
@@ -211,7 +216,7 @@ where
 ///
 /// Create a closure-like object by explicitly providing closed-over
 /// value and a function pointer to operate on that value, essentially simulating a
-/// parameterless closure that ensures that captured data implements [`ThreadAware`].
+/// parameterless closure that ensures that captured data implements [`trait@ThreadAware`].
 pub fn closure<T, D>(data: D, f: fn(&D) -> T) -> Closure<T, D>
 where
     D: ThreadAware,
@@ -223,7 +228,7 @@ where
 ///
 /// Create a closure-like object by explicitly providing closed-over
 /// value and a function pointer to operate on that value, essentially simulating a
-/// parameterless closure that ensures that captured data implements [`ThreadAware`].
+/// parameterless closure that ensures that captured data implements [`trait@ThreadAware`].
 pub fn closure_mut<T, D>(data: D, f: fn(&mut D) -> T) -> ClosureMut<T, D>
 where
     D: ThreadAware,
@@ -235,7 +240,7 @@ where
 ///
 /// Create a closure-like object by explicitly providing closed-over
 /// value and a function pointer to operate on that value, essentially simulating a
-/// parameterless closure that ensures that captured data implements [`ThreadAware`].
+/// parameterless closure that ensures that captured data implements [`trait@ThreadAware`].
 ///
 /// Usage:
 /// ```rust
@@ -280,8 +285,8 @@ pub struct AsyncClosure<T, D> {
     f: for<'a> fn(&'a D) -> BoxFuture<'a, T>,
 }
 
-impl<T, D: std::fmt::Debug> std::fmt::Debug for AsyncClosure<T, D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T, D: fmt::Debug> fmt::Debug for AsyncClosure<T, D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AsyncClosure").field("data", &self.data).finish_non_exhaustive()
     }
 }
@@ -339,8 +344,8 @@ pub struct AsyncClosureOnce<T, D> {
     f: fn(D) -> BoxFuture<'static, T>,
 }
 
-impl<T, D: std::fmt::Debug> std::fmt::Debug for AsyncClosureOnce<T, D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T, D: fmt::Debug> fmt::Debug for AsyncClosureOnce<T, D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AsyncClosureOnce").field("data", &self.data).finish_non_exhaustive()
     }
 }
@@ -383,8 +388,8 @@ pub struct AsyncClosureMut<T, D> {
     f: for<'a> fn(&'a mut D) -> BoxFuture<'a, T>,
 }
 
-impl<T, D: std::fmt::Debug> std::fmt::Debug for AsyncClosureMut<T, D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T, D: fmt::Debug> fmt::Debug for AsyncClosureMut<T, D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AsyncClosureMut").field("data", &self.data).finish_non_exhaustive()
     }
 }

--- a/crates/thread_aware/src/core.rs
+++ b/crates/thread_aware/src/core.rs
@@ -22,8 +22,8 @@ use crate::affinity::Affinity;
 ///   approach can be also be achieved by wrapping a value in the
 ///   [`Unaware`](`crate::Unaware`) type.
 /// * Construct a per-affinity value - with this approach, each affinity gets its own
-///   independently-initialized value. The [`Arc::new_with`](`crate::Arc::new_with`)
-///   function facilitates this approach.
+///   independently-initialized value. With the `std` feature, `Arc::new_with`
+///   facilitates this approach.
 /// * Utilize true sharing in a controlled manner - have some data that is actually shared
 ///   between the values on different affinities, but in a controlled manner that minimizes
 ///   the contention for the synchronization primitives necessary. This is a more advanced

--- a/crates/thread_aware/src/impls.rs
+++ b/crates/thread_aware/src/impls.rs
@@ -1,9 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#[cfg(not(test))]
+use alloc::boxed::Box;
+#[cfg(not(test))]
+use alloc::string::String;
+#[cfg(not(test))]
+use alloc::vec::Vec;
+use core::time::Duration;
+#[cfg(feature = "std")]
 use std::collections::HashMap;
+#[cfg(feature = "std")]
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use crate::affinity::Affinity;
 use crate::core::ThreadAware;
@@ -33,8 +41,10 @@ impl_transfer!(f64);
 impl_transfer!(char);
 
 impl_transfer!(String);
+#[cfg(feature = "std")]
 impl_transfer!(PathBuf);
 impl_transfer!(Duration);
+#[cfg(feature = "std")]
 impl_transfer!(&Path);
 
 impl_transfer!(&'static str);
@@ -132,6 +142,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 // TODO: We should probably support custom hashers as well.
 #[expect(
     clippy::implicit_hasher,
@@ -139,11 +150,11 @@ where
 )]
 impl<K, V> ThreadAware for HashMap<K, V>
 where
-    K: ThreadAware + Eq + std::hash::Hash,
+    K: ThreadAware + Eq + core::hash::Hash,
     V: ThreadAware,
 {
     fn relocate(&mut self, source: Option<Affinity>, destination: Affinity) {
-        let old = std::mem::take(self);
+        let old = core::mem::take(self);
         for (mut key, mut value) in old {
             key.relocate(source, destination);
             value.relocate(source, destination);

--- a/crates/thread_aware/src/lib.rs
+++ b/crates/thread_aware/src/lib.rs
@@ -3,8 +3,21 @@
 
 #![cfg_attr(all(coverage_nightly, test), feature(coverage_attribute))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(test), no_std)]
 
 //! Essential building blocks for thread-per-core libraries.
+//!
+//! # Crate features
+//!
+//! * The **`std` Cargo feature** *(enabled by default)* enables the per-affinity `Arc` and
+//!   hosted-only type implementations.
+//! * **`derive`** *(default)* re-exports the `#[derive(ThreadAware)]` macro.
+//! * **`threads`** enables the `registry` module and implies `std`.
+//! * Disable default features for `#![no_std]` environments. The [`ThreadAware`] trait, affinity
+//!   identifiers, closures, wrappers, and implementations for `alloc` types remain available.
+//!   Enable `derive` explicitly if the derive macro is needed.
+//!
+//! `no_std` environments require `alloc` and pointer-width atomics.
 //!
 //! This crate allows you to express migrations between NUMA nodes, threads, or specific CPU cores.
 //! It can serve as a foundation for building components and runtimes that operate across multiple
@@ -32,8 +45,9 @@
 //! so the macro should 'just work' on most compounds of built-ins.
 //!
 //! External crates might often not implement [`ThreadAware`]. In many of these cases using our
-//! [`thread_aware::Arc`](Arc) offers a convenient solution: It combines an upstream
-//! [`std::sync::Arc`] with a relocation [`Strategy`](storage::Strategy), and implements [`ThreadAware`] for it. For
+//! [`thread_aware::Arc`](Arc) offers a convenient solution when the `std` feature is enabled: it
+//! combines an upstream [`alloc::sync::Arc`] with a relocation [`Strategy`](storage::Strategy), and
+//! implements [`ThreadAware`] for it. For
 //! example, while an `Arc<Foo, PerProcess>` effectively acts as vanilla `Arc`, an
 //! `Arc<Foo, PerCore>` ensures a separate `Foo` is available any time the types moves a core boundary.
 //!
@@ -81,16 +95,21 @@
 //! ## Provided Implementations
 //!
 //! [`ThreadAware`] is implemented for many standard library types, including primitive types, Vec,
-//! String, Option, Result, tuples, etc. However, it's explicitly not implemented for [`std::sync::Arc`]
+//! String, Option, Result, tuples, etc. However, it's explicitly not implemented for [`alloc::sync::Arc`]
 //! as that type implies some level of cross-thread sharing and thus needs special attention when used
 //! from types that implement [`ThreadAware`].
 //!
 //! # Features
 //!
+//! * The **`std` Cargo feature** *(enabled by default)* enables the per-affinity `Arc` and
+//!   hosted-only type implementations. Disable it for `#![no_std]` environments; the crate then
+//!   requires `alloc` and pointer-width atomics.
 //! * **`derive`** *(default)*: Re-exports the `#[derive(ThreadAware)]` macro from the companion
 //!   `thread_aware_macros` crate. Disable to avoid pulling in proc-macro code in minimal
-//!   environments: `default-features = false`.
-//! * **`threads`**: Enables features mainly used by async runtimes for OS interactions.
+//!   environments. For derive support without `std`, use
+//!   `default-features = false, features = ["derive"]`.
+//! * **`threads`**: Enables features mainly used by async runtimes for OS interactions and implies
+//!   `std`.
 //!
 //! ## 3rd-party crate impls
 //!
@@ -108,7 +127,7 @@
 //! * `0.x` → `<crate>0<minor>` (e.g. `jiff02` for `jiff 0.2.x`).
 //!
 //! * **`bytes`**: Impls for `bytes::Bytes`, `bytes::BytesMut`.
-//! * **`http`**: Impls for `http::StatusCode`, `http::Method`, `http::Version`,
+//! * **`http`**: Enables `std` and provides impls for `http::StatusCode`, `http::Method`, `http::Version`,
 //!   `http::HeaderName`, `http::HeaderValue`, `http::HeaderMap<HeaderValue>`,
 //!   `http::Uri`, `http::uri::Authority`, `http::uri::Scheme`,
 //!   `http::uri::PathAndQuery`, `http::uri::Port<T>`, `http::Error`,
@@ -118,12 +137,15 @@
 //!
 //! # Examples
 //!
-//! ## Deriving [`ThreadAware`]
+//! ## Using the [`ThreadAware` derive macro](thread_aware_macros::ThreadAware)
 //!
 //! When the `derive` feature (enabled by default) is active you can simply
-//! derive [`ThreadAware`] instead of writing the implementation manually.
+//! use the [`ThreadAware` derive macro](thread_aware_macros::ThreadAware) instead of writing the
+//! implementation manually.
 //!
 //! ```rust
+//! # fn main() {
+//! # #[cfg(feature = "derive")] {
 //! use thread_aware::ThreadAware;
 //!
 //! #[derive(Debug, Clone, ThreadAware)]
@@ -131,15 +153,19 @@
 //!     x: i32,
 //!     y: i32,
 //! }
+//! # }
+//! # }
 //! ```
 //!
 //! ## Enabling [`ThreadAware`] via `Arc<T, S>`
 //!
-//! For types containing fields not [`ThreadAware`], you can use [`Arc`] to specify a
-//! strategy, and wrap them in an [`Arc`] that implements the trait.
+//! With the `std` feature, types containing fields not [`ThreadAware`] can use [`Arc`] to specify a
+//! strategy and wrap them in an [`Arc`] that implements the trait.
 //!
 //!
 //! ```rust
+//! # fn main() {
+//! # #[cfg(feature = "std")] {
 //! use thread_aware::{Arc, PerCore, ThreadAware};
 //! # #[derive(Debug, Default)]
 //! # struct Client;
@@ -158,11 +184,21 @@
 //!         }
 //!     }
 //! }
+//! # }
+//! # }
 //! ```
+//!
+//! [`ThreadAware`]: crate::core::ThreadAware
 
 #![doc(html_logo_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/thread_aware/logo.png")]
 #![doc(html_favicon_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/thread_aware/favicon.ico")]
 
+extern crate alloc;
+#[cfg(all(feature = "std", not(test)))]
+extern crate std;
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 mod cell;
 mod core;
 mod impls;
@@ -229,5 +265,7 @@ pub use core::ThreadAware;
 /// ```
 #[cfg(feature = "derive")]
 pub use ::thread_aware_macros::ThreadAware;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use cell::{Arc, PerCore, PerNuma, PerProcess, storage};
 pub use wrappers::{Unaware, unaware};

--- a/crates/thread_aware/src/registry.rs
+++ b/crates/thread_aware/src/registry.rs
@@ -3,6 +3,7 @@
 
 //! Building blocks for runtimes and thread-aware hosts.
 
+use alloc::vec::Vec;
 use std::collections::HashMap;
 use std::num::NonZero;
 use std::sync::Mutex;

--- a/crates/thread_aware/src/third_party/mod.rs
+++ b/crates/thread_aware/src/third_party/mod.rs
@@ -24,7 +24,7 @@
 //!
 //! See this crate's `Cargo.toml` for the exact versions used.
 
-/// Generates a no-op [`ThreadAware`](crate::ThreadAware) impl for each listed type.
+/// Generates a no-op [`trait@ThreadAware`] impl for each listed type.
 ///
 /// The bodies of the implementations are empty because the listed types are
 /// inert value types: they hold no thread-local state, perform no I/O, and

--- a/crates/thread_aware/src/wrappers.rs
+++ b/crates/thread_aware/src/wrappers.rs
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use alloc::sync::Arc;
+use core::ops::{Deref, DerefMut};
 
 use crate::ThreadAware;
 use crate::affinity::Affinity;
 
-/// Allows transferring a value that doesn't implement [`ThreadAware`].
+/// Allows transferring a value that doesn't implement [`trait@ThreadAware`].
 ///
-/// Since the [`ThreadAware`] trait is not commonly implemented, this wrapper can
-/// be used to allow transferring values that don't implement [`ThreadAware`].
+/// Since the [`trait@ThreadAware`] trait is not commonly implemented, this wrapper can
+/// be used to allow transferring values that don't implement [`trait@ThreadAware`].
 ///
 /// # Performance Considerations
 ///
@@ -18,13 +18,13 @@ use crate::affinity::Affinity;
 /// as is, if it contains shared references to data other threads may use,
 /// it can introduce contention, resulting in performance impact.
 ///
-/// You should never wrap types that are immediately [`ThreadAware`], hence its
+/// You should never wrap types that are immediately [`trait@ThreadAware`], hence its
 /// name `Unaware`.
 ///
-/// In addition, if the wrapped value contains an [`std::sync::Arc`] with interior mutability
-/// somewhere inside, this wrapper should not be used, and an [`Arc`](crate::Arc) with a
-/// [`PerCore`](crate::PerCore) or [`PerNuma`](crate::PerNuma)
-/// with independent initialization per affinity is a better option.
+/// In addition, if the wrapped value contains an [`alloc::sync::Arc`] with interior mutability
+/// somewhere inside, this wrapper should not be used. With the `std` feature, a thread-aware
+/// [`Arc`](crate::Arc) using [`PerCore`](crate::PerCore) or [`PerNuma`](crate::PerNuma) with
+/// independent initialization per affinity is a better option.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[repr(transparent)]
 pub struct Unaware<T>(pub T);
@@ -64,7 +64,7 @@ impl<T> Unaware<T> {
     /// Converts an `Arc<Unaware<T>>` into an `Arc<T>`.
     pub fn into_arc(self: Arc<Self>) -> Arc<T> {
         // SAFETY: `Unaware` is a transparent wrapper around `T`,
-        unsafe { std::mem::transmute(self) }
+        unsafe { core::mem::transmute(self) }
     }
 }
 
@@ -72,8 +72,8 @@ impl<T> Unaware<T> {
 ///
 /// # Performance Considerations
 ///
-/// This function should not be called on types that are [`ThreadAware`] or contain
-/// an [`std::sync::Arc`], compare the [`Unaware`] documentation.
+/// This function should not be called on types that are [`trait@ThreadAware`] or contain
+/// an [`alloc::sync::Arc`], compare the [`Unaware`] documentation.
 pub const fn unaware<T>(value: T) -> Unaware<T> {
     Unaware(value)
 }

--- a/crates/tick/Cargo.toml
+++ b/crates/tick/Cargo.toml
@@ -48,7 +48,7 @@ futures-core = { workspace = true }
 jiff = { workspace = true, features = ["std"], optional = true }
 pin-project-lite = { workspace = true }
 serde_core = { workspace = true, features = ["std"], optional = true }
-thread_aware = { workspace = true }
+thread_aware = { workspace = true, default-features = false, features = ["std"] }
 tokio = { workspace = true, optional = true, features = ["time", "rt"] }
 
 [dev-dependencies]

--- a/crates/uniflight/Cargo.toml
+++ b/crates/uniflight/Cargo.toml
@@ -29,7 +29,7 @@ ahash = { workspace = true, default-features = false, features = ["std"] }
 async-once-cell = { workspace = true }
 dashmap = { workspace = true }
 futures-util = { workspace = true, default-features = false, features = ["std", "alloc"] }
-thread_aware = { workspace = true }
+thread_aware = { workspace = true, default-features = false, features = ["std"] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }


### PR DESCRIPTION
## Summary

- add default-on `std` features to `thread_aware` and `bytesbuf`, moving portable code to `core` and `alloc`
- keep per-affinity storage, `GlobalPool`, standard I/O adapters, hosted integrations, and metrics behind `std`
- let `no_std` applications that already own specialized memory providers integrate them through the existing `Memory` APIs
- preserve hosted behavior through explicit feature propagation and gate hosted-only tests, doctests, and benchmarks
- document the `alloc` and pointer-width atomic requirements and the `thread_aware` derive feature recipe

`bytesbuf` intentionally does not provide a general-purpose allocator-backed memory provider without `std`; its `no_std` surface is intended for applications that already own a specialized provider.

## Breaking change

Consumers that disable default features must now explicitly enable `std` to retain `bytesbuf`'s `GlobalPool` and standard I/O APIs or `thread_aware`'s per-affinity `Arc` and hosted implementations.

## Validation

- hosted package tests, doctests, clippy, formatting, generated READMEs, and spelling
- no-default unit-test and doctest compilation for both crates
- `thumbv7em-none-eabihf` checks for portable feature combinations
- no-default benchmark compilation and the hosted `multitude` integration
