### PR TITLE
fix(fetch)!: stop the `tokio` feature from selecting a rustls crypto provider

### DIFF
--- a/crates/fetch/Cargo.toml
+++ b/crates/fetch/Cargo.toml
@@ -53,13 +53,22 @@ ignored = ["ctor"]
 
 [features]
 default = []
-tls = ["rustls"]
+# Batteries-included TLS: the `rustls` backend together with the `aws-lc-rs`
+# crypto provider.
+tls = ["rustls", "rustls-aws-lc-rs"]
+# The `rustls` backend without a crypto provider. Callers must either enable
+# `rustls-aws-lc-rs` (or `tls`), or install a process-wide provider through
+# `rustls::crypto::CryptoProvider::install_default`.
 rustls = [
     "dep:rustls",
     "dep:rustls-platform-verifier",
     "fetch_hyper?/rustls",
     "fetch_tls/rustls",
 ]
+# Opt-in crypto provider for the `rustls` backend. Kept separate from the
+# runtime/transport features so that selecting a runtime never selects a crypto
+# provider (and never drags in `aws-lc-sys`' native build).
+rustls-aws-lc-rs = ["rustls", "rustls/aws-lc-rs"]
 native-tls = ["dep:native-tls", "fetch_hyper?/native-tls", "fetch_tls/native-tls"]
 json = ["http_extensions/json"]
 test-util = ["tick/test-util", "http_extensions/test-util"]
@@ -73,10 +82,6 @@ tokio = [
     "hyper-util/http1",
     "hyper-util/http2",
     "tick/tokio",
-    # The aws-lc-rs crypto provider is only pulled in when both `tokio` and
-    # `rustls` are enabled, because it is exclusively used by the Tokio
-    # transport's rustls backend (`tokio::build_tls_backend`).
-    "rustls?/aws-lc-rs",
 ]
 
 [dependencies]
@@ -187,7 +192,7 @@ required-features = ["test-util"]
 
 [[example]]
 name = "http_client_tokio"
-required-features = ["tokio", "rustls"]
+required-features = ["tokio", "tls"]
 
 [[example]]
 name = "http_client_native_tls"
@@ -214,7 +219,7 @@ required-features = ["native-tls", "tokio"]
 
 [[example]]
 name = "http_client_advanced"
-required-features = ["tokio", "rustls"]
+required-features = ["tokio", "tls"]
 
 [[example]]
 name = "http_client_api_with_templated_uri"
@@ -222,11 +227,11 @@ required-features = ["test-util", "json"]
 
 [[example]]
 name = "http_client_app"
-required-features = ["tokio", "rustls"]
+required-features = ["tokio", "tls"]
 
 [[example]]
 name = "http_client_connection_scaling"
-required-features = ["tokio", "rustls"]
+required-features = ["tokio", "tls"]
 
 [[example]]
 name = "http_client_json"
@@ -234,11 +239,11 @@ required-features = ["test-util", "json"]
 
 [[example]]
 name = "http_client_minimal_pipeline"
-required-features = ["tokio", "rustls"]
+required-features = ["tokio", "tls"]
 
 [[example]]
 name = "http_client_mtls"
-required-features = ["tokio", "rustls"]
+required-features = ["tokio", "tls"]
 
 [[example]]
 name = "http_client_pooling"
@@ -246,7 +251,7 @@ required-features = ["test-util"]
 
 [[example]]
 name = "http_client_streaming"
-required-features = ["tokio", "rustls"]
+required-features = ["tokio", "tls"]
 
 [[bench]]
 harness = false
@@ -260,11 +265,11 @@ required-features = ["test-util"]
 
 [[test]]
 name = "requests"
-required-features = ["tokio", "rustls", "test-util"]
+required-features = ["tokio", "tls", "test-util"]
 
 [[test]]
 name = "telemetry_scope"
-required-features = ["tokio", "rustls", "test-util"]
+required-features = ["tokio", "tls", "test-util"]
 
 [[test]]
 name = "uri_handling"
@@ -272,7 +277,7 @@ required-features = ["test-util"]
 
 [[test]]
 name = "thread_aware"
-required-features = ["tokio", "rustls", "test-util"]
+required-features = ["tokio", "tls", "test-util"]
 
 [[test]]
 name = "resilience"

--- a/crates/fetch/README.md
+++ b/crates/fetch/README.md
@@ -626,9 +626,11 @@ These patterns are already configured in the [standard pipeline][__link77] with 
 
 The HTTP client supports two TLS backends for making HTTPS requests:
 
-* **`rustls`** (default): Uses [`rustls`][__link78] with the
-  [`aws-lc-rs`][__link79] crypto provider. This is the recommended
-  backend and is selected by default when the `tls` feature is enabled.
+* **`rustls`** (default): Uses [`rustls`][__link78] with a pluggable
+  crypto provider. This is the recommended backend and is selected by default when the
+  `tls` feature is enabled. `tls` also brings in the
+  [`aws-lc-rs`][__link79] crypto provider; enabling `rustls` on its own
+  leaves the provider choice to the application (see below).
 * **`native-tls`**: Uses the platform’s native TLS implementation (`SChannel` on Windows,
   Security Framework on `macOS`, `OpenSSL` on Linux). This can be explicitly selected, or is
   chosen automatically when the `native-tls` feature is enabled and `rustls` is not.
@@ -669,6 +671,31 @@ To use native TLS instead, enable the `native-tls` feature explicitly:
 fetch = { version = "*", features = ["native-tls", "tokio"] }
 ```
 
+### Choosing a rustls crypto provider
+
+rustls has no built-in cryptography; it delegates to a *crypto provider*. `fetch` never
+derives that choice from the runtime you select, so a transport feature such as `tokio`
+never pulls a provider (and its native build) into your dependency graph.
+
+* `tls` (or `rustls-aws-lc-rs`) enables the `aws-lc-rs` provider. This is what most
+  applications want.
+* `rustls` on its own enables the backend without a provider. The client then uses the
+  process-wide default provider, which the application must install before creating a
+  client:
+
+```toml
+fetch = { version = "*", features = ["rustls", "tokio"] }
+```
+
+```rust
+rustls::crypto::CryptoProvider::install_default(my_provider())
+    .expect("a crypto provider must not already be installed");
+let client = fetch::HttpClient::new_tokio();
+```
+
+Creating a Tokio client with the `rustls` backend and no installed provider panics with a
+message pointing at these two options.
+
 You can also select the TLS backend at runtime via [`TlsOptions::builder_rustls()`][__link81] or
 `TlsOptions::builder_native_tls()` when both features are enabled, allowing different client
 instances to use different backends.
@@ -683,16 +710,22 @@ fetch = { version = "*", features = ["json", "tokio"] }
 ```
 
 * **`tokio`**: Enables integration with the Tokio runtime. This feature provides the `HttpClient::builder_tokio`
-  constructor and related APIs for using the HTTP client in a Tokio-based application.
+  constructor and related APIs for using the HTTP client in a Tokio-based application. It selects a
+  runtime only; it never selects a TLS backend or a crypto provider.
 
 * **`json`**: Adds support for JSON serialization and deserialization, enabling methods like
   `HttpRequestBuilder::json` for sending JSON data and `HttpRequestBuilder::fetch_json` for receiving JSON responses.
 
 * **`tls`**: Enables TLS support using `rustls` with the `aws-lc-rs` crypto provider. This is the
-  recommended way to enable HTTPS support and is an alias for the `rustls` feature.
+  recommended way to enable HTTPS support and is an alias for `rustls` plus `rustls-aws-lc-rs`.
 
-* **`rustls`**: Enables the `rustls` TLS backend with `aws-lc-rs`. This is the default TLS backend
-  and is selected automatically by the `tls` feature.
+* **`rustls`**: Enables the `rustls` TLS backend without choosing a crypto provider. Use this when
+  your application installs its own provider through
+  `rustls::crypto::CryptoProvider::install_default`; otherwise prefer `tls`.
+
+* **`rustls-aws-lc-rs`**: Adds the `aws-lc-rs` crypto provider to the `rustls` backend. Enabling it
+  pulls in `aws-lc-rs` (and its `aws-lc-sys` native build), which is why it is opt-in and is not
+  implied by any runtime feature.
 
 * **`native-tls`**: Enables the platform native TLS backend (`SChannel` on Windows, Security Framework
   on `macOS`, `OpenSSL` on Linux). Use this when you need the platform’s native TLS stack. When both
@@ -712,7 +745,7 @@ fetch = { version = "*", features = ["json", "tokio"] }
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/fetch">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbRcdYrc3P77cbVjz14MYzPFkbTKiKwHYuBbcbSr09Rcd_lPZhZIeCZWJ5dGVzZjEuMTIuMIJoYnl0ZXNidWZlMC43LjCCZWZldGNoZjAuMTQuMIJvaHR0cF9leHRlbnNpb25zZTAuOC4wgmdsYXllcmVkZTAuMy42gmhzZWF0YmVsdGUwLjYuMYJtdGVtcGxhdGVkX3VyaWUwLjMuNQ
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbl-MLyTSa2MobUw1FTHfV81EbEjYZ7vzL3AYbQW-j4o0rOPphZIeCZWJ5dGVzZjEuMTIuMIJoYnl0ZXNidWZlMC43LjCCZWZldGNoZjAuMTQuMIJvaHR0cF9leHRlbnNpb25zZTAuOC4wgmdsYXllcmVkZTAuMy42gmhzZWF0YmVsdGUwLjYuMYJtdGVtcGxhdGVkX3VyaWUwLjMuNQ
  [__link0]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpClient
  [__link1]: https://docs.rs/http_extensions/0.8.0/http_extensions/?search=RequestHandler
  [__link10]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpClient::post

--- a/crates/fetch/src/lib.rs
+++ b/crates/fetch/src/lib.rs
@@ -717,9 +717,11 @@
 //!
 //! The HTTP client supports two TLS backends for making HTTPS requests:
 //!
-//! - **`rustls`** (default): Uses [`rustls`](https://docs.rs/rustls) with the
-//!   [`aws-lc-rs`](https://docs.rs/aws-lc-rs) crypto provider. This is the recommended
-//!   backend and is selected by default when the `tls` feature is enabled.
+//! - **`rustls`** (default): Uses [`rustls`](https://docs.rs/rustls) with a pluggable
+//!   crypto provider. This is the recommended backend and is selected by default when the
+//!   `tls` feature is enabled. `tls` also brings in the
+//!   [`aws-lc-rs`](https://docs.rs/aws-lc-rs) crypto provider; enabling `rustls` on its own
+//!   leaves the provider choice to the application (see below).
 //! - **`native-tls`**: Uses the platform's native TLS implementation (`SChannel` on Windows,
 //!   Security Framework on `macOS`, `OpenSSL` on Linux). This can be explicitly selected, or is
 //!   chosen automatically when the `native-tls` feature is enabled and `rustls` is not.
@@ -763,6 +765,31 @@
 //! fetch = { version = "*", features = ["native-tls", "tokio"] }
 //! ```
 //!
+//! ## Choosing a rustls crypto provider
+//!
+//! rustls has no built-in cryptography; it delegates to a *crypto provider*. `fetch` never
+//! derives that choice from the runtime you select, so a transport feature such as `tokio`
+//! never pulls a provider (and its native build) into your dependency graph.
+//!
+//! - `tls` (or `rustls-aws-lc-rs`) enables the `aws-lc-rs` provider. This is what most
+//!   applications want.
+//! - `rustls` on its own enables the backend without a provider. The client then uses the
+//!   process-wide default provider, which the application must install before creating a
+//!   client:
+//!
+//! ```toml
+//! fetch = { version = "*", features = ["rustls", "tokio"] }
+//! ```
+//!
+//! ```rust,ignore
+//! rustls::crypto::CryptoProvider::install_default(my_provider())
+//!     .expect("a crypto provider must not already be installed");
+//! let client = fetch::HttpClient::new_tokio();
+//! ```
+//!
+//! Creating a Tokio client with the `rustls` backend and no installed provider panics with a
+//! message pointing at these two options.
+//!
 //! You can also select the TLS backend at runtime via [`TlsOptions::builder_rustls()`](tls::TlsOptions::builder_rustls) or
 //! `TlsOptions::builder_native_tls()` when both features are enabled, allowing different client
 //! instances to use different backends.
@@ -777,16 +804,22 @@
 //! ```
 //!
 //! - **`tokio`**: Enables integration with the Tokio runtime. This feature provides the `HttpClient::builder_tokio`
-//!   constructor and related APIs for using the HTTP client in a Tokio-based application.
+//!   constructor and related APIs for using the HTTP client in a Tokio-based application. It selects a
+//!   runtime only; it never selects a TLS backend or a crypto provider.
 //!
 //! - **`json`**: Adds support for JSON serialization and deserialization, enabling methods like
 //!   `HttpRequestBuilder::json` for sending JSON data and `HttpRequestBuilder::fetch_json` for receiving JSON responses.
 //!
 //! - **`tls`**: Enables TLS support using `rustls` with the `aws-lc-rs` crypto provider. This is the
-//!   recommended way to enable HTTPS support and is an alias for the `rustls` feature.
+//!   recommended way to enable HTTPS support and is an alias for `rustls` plus `rustls-aws-lc-rs`.
 //!
-//! - **`rustls`**: Enables the `rustls` TLS backend with `aws-lc-rs`. This is the default TLS backend
-//!   and is selected automatically by the `tls` feature.
+//! - **`rustls`**: Enables the `rustls` TLS backend without choosing a crypto provider. Use this when
+//!   your application installs its own provider through
+//!   `rustls::crypto::CryptoProvider::install_default`; otherwise prefer `tls`.
+//!
+//! - **`rustls-aws-lc-rs`**: Adds the `aws-lc-rs` crypto provider to the `rustls` backend. Enabling it
+//!   pulls in `aws-lc-rs` (and its `aws-lc-sys` native build), which is why it is opt-in and is not
+//!   implied by any runtime feature.
 //!
 //! - **`native-tls`**: Enables the platform native TLS backend (`SChannel` on Windows, Security Framework
 //!   on `macOS`, `OpenSSL` on Linux). Use this when you need the platform's native TLS stack. When both

--- a/crates/fetch/src/tokio.rs
+++ b/crates/fetch/src/tokio.rs
@@ -128,10 +128,12 @@ fn build_tokio_handler(cx: CustomContext<TokioDeps>) -> fetch_hyper::HyperTransp
 
 /// Materializes the client's [`TlsOptions`] into a concrete [`TlsBackend`].
 ///
-/// When the `rustls` feature is enabled, rustls is wired up with the aws-lc-rs
-/// crypto provider and the platform certificate verifier (the OS trust store),
-/// and rustls becomes the default backend. When only `native-tls` is enabled it
-/// becomes the default backend instead.
+/// When the `rustls` feature is enabled, rustls is wired up with the platform
+/// certificate verifier (the OS trust store) and becomes the default backend.
+/// The crypto provider comes from the `rustls-aws-lc-rs` feature when it is
+/// enabled, and otherwise from the process-wide default installed via
+/// [`rustls::crypto::CryptoProvider::install_default`]. When only `native-tls`
+/// is enabled it becomes the default backend instead.
 fn build_tls_backend(options: &TransportOptions, tls: TlsOptions) -> TlsBackend {
     let mut builder = TlsBackendBuilder::new();
     if !options.supported_http_versions.is_empty() {
@@ -140,11 +142,10 @@ fn build_tls_backend(options: &TransportOptions, tls: TlsOptions) -> TlsBackend 
 
     #[cfg(any(feature = "rustls", test))]
     {
-        // aws-lc-rs is the default crypto provider when rustls is enabled.
-        let provider = std::sync::Arc::new(::rustls::crypto::aws_lc_rs::default_provider());
+        let provider = rustls_crypto_provider();
         let verifier = std::sync::Arc::new(
             rustls_platform_verifier::Verifier::new(std::sync::Arc::clone(&provider))
-                .expect("the platform certificate verifier must initialize with the aws-lc-rs crypto provider"),
+                .expect("the platform certificate verifier must initialize with the rustls crypto provider"),
         );
         // `configure_rustls` auto-promotes rustls to the default backend.
         builder = builder.configure_rustls(provider, verifier);
@@ -162,6 +163,26 @@ fn build_tls_backend(options: &TransportOptions, tls: TlsOptions) -> TlsBackend 
     builder
         .build_backend(tls)
         .expect("TLS backend construction must succeed for the configured TlsOptions")
+}
+
+/// Returns the aws-lc-rs crypto provider selected by the `rustls-aws-lc-rs` feature.
+#[cfg(any(feature = "rustls-aws-lc-rs", test))]
+fn rustls_crypto_provider() -> std::sync::Arc<::rustls::crypto::CryptoProvider> {
+    std::sync::Arc::new(::rustls::crypto::aws_lc_rs::default_provider())
+}
+
+/// Returns the process-wide default crypto provider.
+///
+/// `fetch` deliberately does not pick a crypto provider for the `rustls`
+/// feature alone, so applications can supply their own (for example a
+/// FIPS-validated one). Enable the `rustls-aws-lc-rs` (or `tls`) feature to get
+/// aws-lc-rs wired up automatically instead.
+#[cfg(all(feature = "rustls", not(any(feature = "rustls-aws-lc-rs", test))))]
+fn rustls_crypto_provider() -> std::sync::Arc<::rustls::crypto::CryptoProvider> {
+    ::rustls::crypto::CryptoProvider::get_default().cloned().expect(
+        "no rustls crypto provider is installed: enable the `rustls-aws-lc-rs` (or `tls`) feature of `fetch`, \
+             or call `rustls::crypto::CryptoProvider::install_default` before creating the client",
+    )
 }
 
 #[cfg(test)]

--- a/crates/fetch_azure/Cargo.toml
+++ b/crates/fetch_azure/Cargo.toml
@@ -45,7 +45,7 @@ http = { workspace = true }
 # internal
 anyspawn = { path = "../anyspawn", features = ["tokio"] }
 anyspawn_azure = { path = "../anyspawn_azure", features = ["azure-identity"] }
-fetch = { path = "../fetch", features = ["test-util", "tokio", "rustls"] }
+fetch = { path = "../fetch", features = ["test-util", "tokio", "tls"] }
 tick = { path = "../tick", features = ["tokio"] }
 
 # external


### PR DESCRIPTION
`fetch`'s `tokio` feature enabled `rustls?/aws-lc-rs`. `tokio` is a runtime/transport selector and must not choose a TLS crypto provider.

Because `rustls?/...` is a weak dependency feature it looks inert in isolation, but as soon as anything else in the same workspace enables `dep:rustls` (for example via `fetch/rustls`), Cargo's workspace-wide feature unification activates it and forces rustls onto aws-lc-rs, dragging in `aws-lc-rs` + `aws-lc-sys` and its native NASM/C build.

This bit a real consumer: crates selecting only
`fetch = { features = ["tokio", "native-tls"] }` still ended up with `aws-lc-rs`/`aws-lc-sys` in `Cargo.lock` in a workspace that deliberately drives rustls with `default-features = false` plus a different provider. Dropping `"tokio"` from those manifests made aws-lc-rs disappear, confirming `fetch/tokio` was the trigger.

Changes:

- `tokio` no longer implies any crypto provider.
- New opt-in `rustls-aws-lc-rs` feature carries `rustls/aws-lc-rs`.
- `tls` is now `rustls` + `rustls-aws-lc-rs`, so it keeps its documented "rustls with aws-lc-rs" meaning and stays the recommended way to turn on HTTPS.
- `rustls` alone is provider-neutral: the Tokio transport resolves the process-wide default installed via `CryptoProvider::install_default`, and panics with an actionable message when none is installed.
- Examples/tests that actually negotiate TLS now require `tls` instead of `rustls`, as does `fetch_azure`'s dev-dependency on `fetch`.
- Crate docs/README describe the provider choice and the new feature.

Verified with `cargo tree -e normal -i aws-lc-rs`: `fetch` with `tokio,rustls` no longer pulls aws-lc-rs, while `tokio,rustls,rustls-aws-lc-rs` (and `tokio,tls`) still does.

BREAKING CHANGE: `fetch/tokio` no longer implies the `aws-lc-rs` rustls crypto provider. Users who relied on `features = ["tokio", "rustls"]` giving them a working provider must switch to `features = ["tokio", "tls"]` (or add `rustls-aws-lc-rs`), or install a provider themselves with `rustls::crypto::CryptoProvider::install_default`.