### PR TITLE
docs: clarify no_std support policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,12 @@ Pull request titles must follow [Conventional Commits](https://www.conventionalc
 
 Doctests that reference items behind a Cargo feature must compile both with and without that feature; wrap their bodies in hidden `#[cfg(...)]` shims. See [AGENTS-feature-gated-doctests.md](AGENTS-feature-gated-doctests.md).
 
+## `no_std` Support
+
+`no_std` support is a best-effort, nice-to-have capability, not a requirement to support every embedded target. Preserve it when it comes with little implementation complexity, but do not complicate code, add extensive `cfg` branching, or introduce specialized fallbacks solely to support constrained targets such as platforms without pointer-width atomics.
+
+Public crate documentation must state the actual prerequisites and supported boundary, including requirements such as `alloc`, pointer-width atomics, or specific target capabilities. CI should cover the configurations the crate explicitly promises.
+
 ## Required CI Checks
 
 The `required-checks` job in `.github/workflows/main.yml` is a "fan-in"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,9 @@ Doctests that reference items behind a Cargo feature must compile both with and 
 
 ## `no_std` Support
 
-`no_std` support is a best-effort, nice-to-have capability, not a requirement to support every embedded target. Preserve it when it comes with little implementation complexity, but do not complicate code, add extensive `cfg` branching, or introduce specialized fallbacks solely to support constrained targets such as platforms without pointer-width atomics.
+`no_std` support is optional when deciding whether to adopt or expand it. Support for constrained targets must not justify disproportionate implementation complexity, such as extensive `cfg` branching or specialized fallbacks for platforms without pointer-width atomics.
 
-Public crate documentation must state the actual prerequisites and supported boundary, including requirements such as `alloc`, pointer-width atomics, or specific target capabilities. CI should cover the configurations the crate explicitly promises.
+Once a crate documents a `no_std` configuration as supported, that configuration is a real compatibility promise, not best-effort support. It must work correctly, be tested in CI, and be documented with its actual prerequisites and support boundary, including requirements such as `alloc`, pointer-width atomics, or specific target capabilities.
 
 ## Required CI Checks
 


### PR DESCRIPTION
[Copilot speaking]

## Summary
- treats adoption or expansion of `no_std` support as optional when it would add disproportionate implementation complexity
- defines every documented `no_std` configuration as a real compatibility promise rather than best-effort support
- requires supported configurations to work correctly, be covered by CI, and document their prerequisites and target boundary

## Validation
- `just spellcheck`
