### PR TITLE
refactor(fetch_tls): unify client identity configuration

### DIFF
--- a/crates/fetch_tls/src/native_tls.rs
+++ b/crates/fetch_tls/src/native_tls.rs
@@ -34,7 +34,7 @@ impl NativeTlsOptions {
             .request_alpns(map_to_alpn(shared.resolved_supported_http_versions(defaults)))
             .min_protocol_version(Some(native_tls::Protocol::Tlsv12));
 
-        if let Some(identity) = shared.client_identity.as_ref() {
+        if let Some(identity) = shared.client_identity() {
             identity
                 .build_native_identity()
                 .map(|i| {
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn builder_native_tls_starts_empty() {
         let builder = TlsOptions::builder_native_tls();
-        assert!(builder.shared.client_identity.is_none());
+        assert!(builder.shared.client_auth.is_none());
     }
 
     #[test]
@@ -109,7 +109,7 @@ mod tests {
     fn new_native_tls_produces_native_tls_options() {
         let tls = TlsOptions::new_native_tls();
         assert!(matches!(tls.inner, TlsOptionsKind::NativeTls(_)));
-        assert!(tls.shared.client_identity.is_none());
+        assert!(tls.shared.client_auth.is_none());
     }
 
     #[test]

--- a/crates/fetch_tls/src/options.rs
+++ b/crates/fetch_tls/src/options.rs
@@ -3,7 +3,11 @@
 
 //! [`TlsOptions`] and its type-state builder [`TlsOptionsBuilder`].
 
+use std::sync::Arc;
+
 use http::Version;
+#[cfg(any(feature = "rustls", test))]
+use rustls::client::ResolvesClientCert;
 
 use crate::client_identity::ClientIdentity;
 use crate::{TlsBackend, TlsBackendBuilder};
@@ -103,7 +107,14 @@ pub struct TlsOptions {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SharedOptions {
     pub(crate) supported_http_versions: Option<Vec<Version>>,
-    pub(crate) client_identity: Option<ClientIdentity>,
+    pub(crate) client_auth: Option<ClientAuth>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ClientAuth {
+    Identity(Arc<ClientIdentity>),
+    #[cfg(any(feature = "rustls", test))]
+    Resolver(Arc<dyn ResolvesClientCert>),
 }
 
 impl SharedOptions {
@@ -116,6 +127,15 @@ impl SharedOptions {
         self.supported_http_versions
             .as_deref()
             .unwrap_or(defaults.supported_http_versions.as_slice())
+    }
+
+    #[cfg(any(feature = "native-tls", test))]
+    pub(crate) fn client_identity(&self) -> Option<&ClientIdentity> {
+        match self.client_auth.as_ref()? {
+            ClientAuth::Identity(identity) => Some(identity.as_ref()),
+            #[cfg(any(feature = "rustls", test))]
+            ClientAuth::Resolver(_) => None,
+        }
     }
 }
 
@@ -210,8 +230,10 @@ impl<B> TlsOptionsBuilder<B> {
     /// The same identity works for either backend; backend-specific
     /// conversion happens when the options are materialized into a backend.
     /// The native-tls backend requires the private key to be `PKCS#8`.
+    ///
+    /// Replaces any previously configured client identity resolver.
     pub fn client_identity(mut self, identity: ClientIdentity) -> Self {
-        self.shared.client_identity = Some(identity);
+        self.shared.client_auth = Some(ClientAuth::Identity(Arc::new(identity)));
         self
     }
 }
@@ -249,7 +271,7 @@ mod tests {
         let tls = TlsOptions::builder().build();
         assert!(matches!(tls.inner, TlsOptionsKind::Auto));
         assert!(tls.shared.supported_http_versions.is_none());
-        assert!(tls.shared.client_identity.is_none());
+        assert!(tls.shared.client_auth.is_none());
     }
 
     #[test]

--- a/crates/fetch_tls/src/rustls.rs
+++ b/crates/fetch_tls/src/rustls.rs
@@ -13,14 +13,13 @@ use rustls::crypto::CryptoProvider;
 
 use crate::alpn::map_to_alpn;
 use crate::backend::BackendError;
-use crate::options::{SharedOptions, TlsOptions, TlsOptionsBuilder, TlsOptionsKind};
+use crate::options::{ClientAuth, SharedOptions, TlsOptions, TlsOptionsBuilder, TlsOptionsKind};
 
 /// Rustls TLS backend configuration.
 #[derive(Clone, Debug)]
 pub struct RustlsOptions {
     crypto_provider: Option<Arc<CryptoProvider>>,
     verifier_factory: Option<ServerCertVerifierFactory>,
-    client_identity_resolver: Option<Arc<dyn ResolvesClientCert>>,
 }
 
 impl RustlsOptions {
@@ -28,7 +27,6 @@ impl RustlsOptions {
         Self {
             crypto_provider: None,
             verifier_factory: None,
-            client_identity_resolver: None,
         }
     }
 
@@ -58,12 +56,12 @@ impl RustlsOptions {
             .dangerous()
             .with_custom_certificate_verifier(verifier);
 
-        let mut config = match (self.client_identity_resolver, shared.client_identity.as_ref()) {
-            (Some(resolver), _) => Ok(builder.with_client_cert_resolver(resolver)),
-            (None, Some(identity)) => builder
+        let mut config = match shared.client_auth.as_ref() {
+            Some(ClientAuth::Resolver(resolver)) => Ok(builder.with_client_cert_resolver(Arc::clone(resolver))),
+            Some(ClientAuth::Identity(identity)) => builder
                 .with_client_auth_cert(identity.cert_chain().to_vec(), identity.private_key().clone_key())
                 .map_err(BackendError::caused_by),
-            (None, None) => Ok(builder.with_no_client_auth()),
+            None => Ok(builder.with_no_client_auth()),
         }?;
         config.alpn_protocols = map_to_alpn(shared.resolved_supported_http_versions(backend_defaults))
             .iter()
@@ -151,10 +149,12 @@ impl TlsOptionsBuilder<RustlsOptions> {
     /// Sets a [`ResolvesClientCert`] for mutual TLS authentication.
     ///
     /// Use this when the private key lives behind an external signing oracle
-    /// (`HSM`, secure enclave, etc.) instead of in memory. Takes precedence
-    /// over [`TlsOptionsBuilder::client_identity`](crate::TlsOptionsBuilder::client_identity).
+    /// (`HSM`, secure enclave, etc.) instead of in memory.
+    ///
+    /// Replaces any previously configured
+    /// [`ClientIdentity`](crate::ClientIdentity).
     pub fn client_identity_resolver(mut self, resolver: Arc<dyn ResolvesClientCert>) -> Self {
-        self.backend.client_identity_resolver = Some(resolver);
+        self.shared.client_auth = Some(ClientAuth::Resolver(resolver));
         self
     }
 
@@ -211,7 +211,7 @@ mod tests {
 
     fn shared_with(identity: Option<ClientIdentity>) -> SharedOptions {
         SharedOptions {
-            client_identity: identity,
+            client_auth: identity.map(|identity| ClientAuth::Identity(Arc::new(identity))),
             ..SharedOptions::default()
         }
     }
@@ -221,7 +221,6 @@ mod tests {
         let rustls = RustlsOptions::new();
         assert!(rustls.crypto_provider.is_none());
         assert!(rustls.verifier_factory.is_none());
-        assert!(rustls.client_identity_resolver.is_none());
     }
 
     #[test]
@@ -229,7 +228,7 @@ mod tests {
         let builder = TlsOptions::builder_rustls();
         assert!(builder.backend.crypto_provider.is_none());
         assert!(builder.backend.verifier_factory.is_none());
-        assert!(builder.backend.client_identity_resolver.is_none());
+        assert!(builder.shared.client_auth.is_none());
     }
 
     #[test]
@@ -250,7 +249,6 @@ mod tests {
                 CALLED.store(true, Ordering::SeqCst);
                 Arc::new(AcceptAll)
             })),
-            client_identity_resolver: None,
         };
         rustls_backend.build(&crate::TlsBackendBuilder::new(), &shared_with(None)).unwrap();
         assert!(CALLED.load(Ordering::SeqCst));
@@ -266,7 +264,7 @@ mod tests {
     fn client_identity_sets_identity_in_shared() {
         let identity = ClientIdentity::from_der(vec![vec![0x30u8, 0x00]], vec![0x30u8, 0x00]);
         let builder = TlsOptions::builder_rustls().client_identity(identity);
-        assert!(builder.shared.client_identity.is_some());
+        assert!(matches!(builder.shared.client_auth, Some(ClientAuth::Identity(_))));
     }
 
     #[test]
@@ -279,7 +277,7 @@ mod tests {
     fn new_rustls_produces_rustls_tls_options() {
         let tls = TlsOptions::new_rustls();
         assert!(matches!(tls.inner, TlsOptionsKind::Rustls(_)));
-        assert!(tls.shared.client_identity.is_none());
+        assert!(tls.shared.client_auth.is_none());
     }
 
     #[test]
@@ -293,7 +291,6 @@ mod tests {
         let rustls_backend = RustlsOptions {
             crypto_provider: None,
             verifier_factory: Some(ServerCertVerifierFactory::new(|_| Arc::new(AcceptAll))),
-            client_identity_resolver: None,
         };
         let config = rustls_backend
             .build(
@@ -310,11 +307,10 @@ mod tests {
         let rustls_backend = RustlsOptions {
             crypto_provider: None,
             verifier_factory: Some(ServerCertVerifierFactory::new(|_| Arc::new(AcceptAll))),
-            client_identity_resolver: None,
         };
         let shared = SharedOptions {
             supported_http_versions: Some(vec![http::Version::HTTP_11]),
-            client_identity: None,
+            client_auth: None,
         };
         let config = rustls_backend
             .build(
@@ -332,7 +328,6 @@ mod tests {
         let rustls_backend = RustlsOptions {
             crypto_provider: None,
             verifier_factory: Some(ServerCertVerifierFactory::new(|_| Arc::new(AcceptAll))),
-            client_identity_resolver: None,
         };
         let err = rustls_backend
             .build(
@@ -371,7 +366,6 @@ mod tests {
         let rustls_backend = RustlsOptions {
             crypto_provider: Some(provider()),
             verifier_factory: None,
-            client_identity_resolver: None,
         };
         let err = rustls_backend
             .build(&crate::TlsBackendBuilder::new(), &shared_with(None))
@@ -386,7 +380,6 @@ mod tests {
         let rustls_backend = RustlsOptions {
             crypto_provider: Some(provider()),
             verifier_factory: Some(ServerCertVerifierFactory::new(|_| Arc::new(AcceptAll))),
-            client_identity_resolver: None,
         };
         rustls_backend
             .build(
@@ -422,13 +415,13 @@ mod tests {
         );
         let tls = TlsOptions::from(Arc::clone(&config));
         assert!(matches!(tls.inner, TlsOptionsKind::PreConfigured(_)));
-        assert!(tls.shared.client_identity.is_none());
+        assert!(tls.shared.client_auth.is_none());
     }
 
     #[test]
     fn client_identity_resolver_stores_resolver() {
         let builder = TlsOptions::builder_rustls().client_identity_resolver(Arc::new(StubResolver));
-        assert!(builder.backend.client_identity_resolver.is_some());
+        assert!(matches!(builder.shared.client_auth, Some(ClientAuth::Resolver(_))));
     }
 
     #[test]
@@ -437,34 +430,36 @@ mod tests {
         let rustls_backend = RustlsOptions {
             crypto_provider: None,
             verifier_factory: Some(ServerCertVerifierFactory::new(|_| Arc::new(AcceptAll))),
-            client_identity_resolver: Some(Arc::new(StubResolver)),
         };
         rustls_backend
             .build(
                 &crate::TlsBackendBuilder::new().configure_rustls(provider(), Arc::new(AcceptAll)),
-                &shared_with(None),
+                &SharedOptions {
+                    client_auth: Some(ClientAuth::Resolver(Arc::new(StubResolver))),
+                    ..SharedOptions::default()
+                },
             )
             .unwrap();
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
-    fn build_resolver_takes_precedence_over_identity() {
-        // Identity bytes are intentionally invalid; if precedence is wrong,
-        // build would error trying to parse them. The resolver path skips
-        // identity parsing entirely.
+    fn client_identity_resolver_replaces_identity() {
         let identity = ClientIdentity::from_der(vec![vec![0x30u8, 0x00]], vec![0x30u8, 0x00]);
-        let rustls_backend = RustlsOptions {
-            crypto_provider: None,
-            verifier_factory: Some(ServerCertVerifierFactory::new(|_| Arc::new(AcceptAll))),
-            client_identity_resolver: Some(Arc::new(StubResolver)),
-        };
-        rustls_backend
-            .build(
-                &crate::TlsBackendBuilder::new().configure_rustls(provider(), Arc::new(AcceptAll)),
-                &shared_with(Some(identity)),
-            )
-            .unwrap();
+        let builder = TlsOptions::builder_rustls()
+            .client_identity(identity)
+            .client_identity_resolver(Arc::new(StubResolver));
+
+        assert!(matches!(builder.shared.client_auth, Some(ClientAuth::Resolver(_))));
+    }
+
+    #[test]
+    fn client_identity_replaces_resolver() {
+        let identity = ClientIdentity::from_der(vec![vec![0x30u8, 0x00]], vec![0x30u8, 0x00]);
+        let builder = TlsOptions::builder_rustls()
+            .client_identity_resolver(Arc::new(StubResolver))
+            .client_identity(identity);
+
+        assert!(matches!(builder.shared.client_auth, Some(ClientAuth::Identity(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- represent key-material identities and rustls client-certificate resolvers with one internal `ClientAuth` state
- preserve the portable `client_identity` and rustls-specific `client_identity_resolver` APIs
- make repeated identity configuration predictable: the last builder call wins instead of the resolver silently taking precedence
- share configured key material through `Arc` so cloning TLS options does not duplicate private-key bytes

## Validation

- `fetch_tls` formatting
- 71 crate tests
- Clippy across all targets and features with warnings denied
- API docs with no features and all features
- generated README and spelling checks