### PR TITLE
fix(templated_uri): isolate macro compatibility boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "templated_uri"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "criterion",
  "data_privacy",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "templated_uri_macros"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "mutants",
  "templated_uri_macros_impl",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "templated_uri_macros_impl"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "chumsky",
  "darling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,9 +205,9 @@ string-interner = { version = "0.20.0", default-features = false }
 string_cache = { version = "0.10.0", default-features = false }
 symbol_table = { version = "0.5.0", default-features = false }
 syn = { version = "2.0.111", default-features = false }
-templated_uri = { path = "crates/templated_uri", default-features = false, version = "0.3.5" }
-templated_uri_macros = { path = "crates/templated_uri_macros", default-features = false, version = "0.2.7" }
-templated_uri_macros_impl = { path = "crates/templated_uri_macros_impl", default-features = false, version = "0.2.7" }
+templated_uri = { path = "crates/templated_uri", default-features = false, version = "0.3.6" }
+templated_uri_macros = { path = "crates/templated_uri_macros", default-features = false, version = "0.3.0" }
+templated_uri_macros_impl = { path = "crates/templated_uri_macros_impl", default-features = false, version = "0.3.0" }
 testing_aids = { path = "crates/testing_aids", default-features = false }
 thiserror = { version = "2.0.17", default-features = false }
 thread_aware = { path = "crates/thread_aware", default-features = false, version = "0.8.0" }

--- a/crates/fetch/README.md
+++ b/crates/fetch/README.md
@@ -712,7 +712,7 @@ fetch = { version = "*", features = ["json", "tokio"] }
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/fetch">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbRcdYrc3P77cbVjz14MYzPFkbTKiKwHYuBbcbSr09Rcd_lPZhZIeCZWJ5dGVzZjEuMTIuMIJoYnl0ZXNidWZlMC43LjCCZWZldGNoZjAuMTQuMIJvaHR0cF9leHRlbnNpb25zZTAuOC4wgmdsYXllcmVkZTAuMy42gmhzZWF0YmVsdGUwLjYuMYJtdGVtcGxhdGVkX3VyaWUwLjMuNQ
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbRcdYrc3P77cbVjz14MYzPFkbTKiKwHYuBbcbSr09Rcd_lPZhZIeCZWJ5dGVzZjEuMTIuMIJoYnl0ZXNidWZlMC43LjCCZWZldGNoZjAuMTQuMIJvaHR0cF9leHRlbnNpb25zZTAuOC4wgmdsYXllcmVkZTAuMy42gmhzZWF0YmVsdGUwLjYuMYJtdGVtcGxhdGVkX3VyaWUwLjMuNg
  [__link0]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpClient
  [__link1]: https://docs.rs/http_extensions/0.8.0/http_extensions/?search=RequestHandler
  [__link10]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpClient::post
@@ -721,7 +721,7 @@ This crate was developed as part of <a href="https://github.com/microsoft/oxidiz
  [__link13]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpClient::request
  [__link14]: https://docs.rs/http_extensions/0.8.0/http_extensions/?search=HttpRequestBuilder
  [__link15]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpClientBuilder::base_uri
- [__link16]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=BaseUri
+ [__link16]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=BaseUri
  [__link17]: https://docs.rs/http_extensions/0.8.0/http_extensions/?search=HttpRequestBuilder::fetch
  [__link18]: https://docs.rs/http_extensions/0.8.0/http_extensions/?search=HttpResponse
  [__link19]: https://docs.rs/fetch/0.14.0/fetch/?search=http::Response
@@ -745,14 +745,14 @@ This crate was developed as part of <a href="https://github.com/microsoft/oxidiz
  [__link35]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpRequestBuilder::fetch_text_body
  [__link36]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpRequestBuilder::fetch_bytes_body
  [__link37]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpRequestBuilder::fetch_json_body
- [__link38]: https://crates.io/crates/templated_uri/0.3.5
- [__link39]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Uri
+ [__link38]: https://crates.io/crates/templated_uri/0.3.6
+ [__link39]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Uri
  [__link4]: https://docs.rs/fetch/0.14.0/fetch/?search=custom::create_builder
  [__link40]: https://datatracker.ietf.org/doc/html/rfc6570
- [__link41]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Uri
+ [__link41]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Uri
  [__link42]: https://docs.rs/fetch/0.14.0/fetch/?search=handlers::Logging
- [__link43]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Uri
- [__link44]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=PathAndQueryTemplate
+ [__link43]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Uri
+ [__link44]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=PathAndQueryTemplate
  [__link45]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpRequestBuilder::json
  [__link46]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpRequestBuilder::fetch_json
  [__link47]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpRequestBuilder::fetch_json_ref
@@ -779,7 +779,7 @@ This crate was developed as part of <a href="https://github.com/microsoft/oxidiz
  [__link66]: https://docs.rs/bytes/1.12.0/bytes/?search=BufMut
  [__link67]: https://docs.rs/bytes
  [__link68]: https://docs.rs/fetch/0.14.0/fetch/?search=HttpClient
- [__link69]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Uri
+ [__link69]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Uri
  [__link7]: https://docs.rs/fetch/0.14.0/fetch/custom/index.html
  [__link70]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView
  [__link71]: https://docs.rs/bytesbuf/0.7.0/bytesbuf/?search=BytesView

--- a/crates/templated_uri/CHANGELOG.md
+++ b/crates/templated_uri/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.6] - 2026-07-31
+
+- 🐛 Bug Fixes
+
+  - require `templated_uri_macros` 0.3 to prevent Cargo from unifying macros across incompatible runtime lines
+
 ## [0.3.5] - 2026-07-24
 
 - 🔧 Maintenance

--- a/crates/templated_uri/Cargo.toml
+++ b/crates/templated_uri/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "templated_uri"
 description = "Standards-compliant URI handling with templating, validation, and data classification"
-version = "0.3.5"
+version = "0.3.6"
 readme = "README.md"
 keywords = ["oxidizer", "url", "parsing", "templates", "uri"]
 categories = ["encoding", "parser-implementations", "template-engine", "web-programming"]

--- a/crates/templated_uri/README.md
+++ b/crates/templated_uri/README.md
@@ -198,22 +198,22 @@ and servers based on [`hyper`][__link16] like [`reqwest`][__link17].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/templated_uri">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbreJMElgxp0kbqex4QSgBMK8bdglL8RqN6aobvSfumN6CAithZIKCZGh0dHBlMS40LjKCbXRlbXBsYXRlZF91cmllMC4zLjU
- [__link0]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Uri
- [__link1]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=BaseUri
- [__link10]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Escape
- [__link11]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Raw
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbreJMElgxp0kbqex4QSgBMK8bdglL8RqN6aobvSfumN6CAithZIKCZGh0dHBlMS40LjKCbXRlbXBsYXRlZF91cmllMC4zLjY
+ [__link0]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Uri
+ [__link1]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=BaseUri
+ [__link10]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Escape
+ [__link11]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Raw
  [__link12]: https://datatracker.ietf.org/doc/html/rfc6570#section-2.3
  [__link13]: https://docs.rs/http/latest/http/
- [__link14]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Uri
+ [__link14]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Uri
  [__link15]: https://docs.rs/http/1.4.2/http/?search=Uri
  [__link16]: https://docs.rs/hyper/latest/hyper/
  [__link17]: https://docs.rs/reqwest/latest/reqwest/
- [__link2]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=BaseUri
- [__link3]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=BasePath
- [__link4]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=PathAndQueryTemplate
- [__link5]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Escaped
- [__link6]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=EscapedString
- [__link7]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=Escaped
- [__link8]: https://docs.rs/templated_uri/0.3.5/templated_uri/?search=EscapedString
+ [__link2]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=BaseUri
+ [__link3]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=BasePath
+ [__link4]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=PathAndQueryTemplate
+ [__link5]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Escaped
+ [__link6]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=EscapedString
+ [__link7]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=Escaped
+ [__link8]: https://docs.rs/templated_uri/0.3.6/templated_uri/?search=EscapedString
  [__link9]: https://datatracker.ietf.org/doc/html/rfc6570

--- a/crates/templated_uri_macros/CHANGELOG.md
+++ b/crates/templated_uri_macros/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.0] - 2026-07-31
+
+- ⚠️ Breaking
+
+  - establish a compatibility boundary for macros that generate code against `templated_uri` 0.3
+
+- 🔧 Maintenance
+
+  - require `templated_uri_macros_impl` 0.3
+
 ## [0.2.7] - 2026-07-24
 
 - 🔧 Maintenance

--- a/crates/templated_uri_macros/Cargo.toml
+++ b/crates/templated_uri_macros/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "templated_uri_macros"
 description = "Macros for the templated_uri crate."
-version = "0.2.7"
+version = "0.3.0"
 readme = "README.md"
 keywords = ["oxidizer", "url", "parsing", "templates", "uri"]
 categories = ["encoding", "parser-implementations", "template-engine", "web-programming"]

--- a/crates/templated_uri_macros_impl/CHANGELOG.md
+++ b/crates/templated_uri_macros_impl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.0] - 2026-07-31
+
+- ⚠️ Breaking
+
+  - establish a compatibility boundary for generated code that targets `templated_uri` 0.3
+
 ## [0.2.7] - 2026-07-24
 
 - 🔧 Maintenance

--- a/crates/templated_uri_macros_impl/Cargo.toml
+++ b/crates/templated_uri_macros_impl/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "templated_uri_macros_impl"
 description = "Macros for the templated_uri crate."
-version = "0.2.7"
+version = "0.3.0"
 readme = "README.md"
 keywords = ["oxidizer", "url", "parsing", "templates", "uri"]
 categories = ["encoding", "parser-implementations", "template-engine", "web-programming"]


### PR DESCRIPTION
🤖 Fixes the macro/runtime SemVer boundary by releasing `templated_uri_macros_impl` and `templated_uri_macros` as `0.3.0`, then releasing `templated_uri` as `0.3.6` with a `^0.3.0` macro requirement.

## Why this does not use `release-packages.ps1`

The release script unconditionally cascades a patch release to every published transitive dependent because it assumes each dependent must be republished to pick up the dependency version. That is unnecessary here: all published dependents currently require `templated_uri ^0.3.5`, which already accepts `0.3.6`. Their manifests and public APIs do not need to change, and normal Cargo resolution will select the repaired runtime release.

Running the script would therefore produce unrelated releases of `http_extensions`, `seatbelt_http`, `fetch`, `fetch_hyper`, and `fetch_azure`. This PR intentionally prepares only the compatibility bundle that must be published together:

- `templated_uri_macros_impl 0.3.0`
- `templated_uri_macros 0.3.0`, requiring `templated_uri_macros_impl ^0.3.0`
- `templated_uri 0.3.6`, requiring `templated_uri_macros ^0.3.0`

The generated `fetch` README changes only because its links now point at the accepted `templated_uri 0.3.6`; `fetch` itself does not need to be republished.

## Why `templated_uri` remains patch-compatible

I compared this PR directly with the `templated_uri 0.3.5` / macro `0.2.7` release commit (`94229b8`):

- There are no changes under `templated_uri/src`, its tests or examples, `templated_uri_macros/src`, or `templated_uri_macros_impl/src`. The `0.3.0` macro crates contain the same macro names, accepted syntax, diagnostics, and generated output as `0.2.7`; their code is being republished behind a corrected version boundary.
- `templated_uri 0.3.5` already provides the `templated_uri::__private` API targeted by the `0.2.7` macro expansions. Moving that identical expansion contract to macro version `0.3.0` therefore introduces no new behavior or generated-code requirements for the `templated_uri 0.3.x` runtime line.
- The macro bump is marked breaking because macro versions `0.2.3` through `0.2.7` generate code incompatible with the older `templated_uri 0.2.x` runtime, despite Cargo considering them compatible with macro `0.2.2`. It corrects that historical compatibility classification; it does not represent a new incompatibility between macro `0.2.7` and `0.3.0`.
- An independent `cargo semver-checks --package templated_uri --baseline-rev 94229b8` run completed 196 checks with 196 passes and reported `no semver update required`. The runtime patch bump is needed only to publish the corrected `^0.3.0` macro requirement.
## Backwards compatibility checks

The repository's version-bump compatibility checks ran for this isolated publishing set:

- The SemVer report compares each ordinary library with its previous version-bump commit. It confirmed that `templated_uri 0.3.5 -> 0.3.6` meets the minimum required version (`0.3.6`) and that `templated_uri_macros_impl 0.2.7 -> 0.3.0` exceeds its minimum (`0.2.8`).
- `templated_uri_macros` is proc-macro-only, so `cargo-semver-checks` cannot inspect its expansion contract. The check therefore requires manual review of its exported macro names, accepted syntax, diagnostics, and generated output, and propagates that review requirement to `templated_uri`. This PR changes none of those surfaces; it deliberately republishes the existing expansion contract behind the correct breaking version boundary.
- The external-type-exposure check also passes, confirming that the runtime release does not introduce an unreviewed public dependency-type exposure.

[View the SemVer check run](https://github.com/microsoft/oxidizer/actions/runs/30626233734).
## Follow-up after publishing

Yank `templated_uri 0.3.0` through `0.3.5`, `templated_uri_macros 0.2.3` through `0.2.7`, and `templated_uri_macros_impl 0.2.3` through `0.2.7`. This leaves old `templated_uri 0.2.x` resolutions on the compatible macro line while fresh `0.3.x` resolutions select this repaired bundle.

## Validation

- `cargo test -p templated_uri -p templated_uri_macros -p templated_uri_macros_impl`
- `cargo package -p templated_uri_macros_impl -p templated_uri_macros -p templated_uri --allow-dirty --no-verify`
- `just format`
- `just readme-check`
- `just spellcheck`



