### PR TITLE
fix(multitude, plurality): allow borrowed type arguments in trait-object coercion

### DIFF
--- a/crates/multitude/src/coerce.rs
+++ b/crates/multitude/src/coerce.rs
@@ -121,7 +121,7 @@ macro_rules! coerce {
         unsafe {
             $crate::Coercion::new({
                 #[allow(unused_parens)]
-                fn coerce<'lt, $($generic: 'lt),+>(
+                fn coerce<'lt, $($generic),+>(
                     ptr: *const (impl $($bounds)* + 'lt),
                 ) -> *const (dyn $($bounds)* + 'lt) {
                     ptr

--- a/crates/multitude/tests/unsize.rs
+++ b/crates/multitude/tests/unsize.rs
@@ -91,6 +91,21 @@ impl<T> Contains<T> for GenericValue<T> {
     }
 }
 
+// A handler that borrows its input. The handler owns nothing, so it is `'static`
+// no matter how short-lived the values it is invoked with are.
+#[multitude::dst::pointee]
+trait Handler<T> {
+    fn handle(&self, input: T) -> usize;
+}
+
+struct LengthHandler;
+
+impl<'a> Handler<&'a str> for LengthHandler {
+    fn handle(&self, input: &'a str) -> usize {
+        input.len()
+    }
+}
+
 struct PinnedOwner {
     value: u32,
     drops: StdArc<AtomicUsize>,
@@ -214,6 +229,26 @@ fn generic_trait_object_coercion_dispatches() {
     let arena = Arena::new();
     let value = erase(&arena, 42_u32);
     assert_eq!(*value.value(), 42);
+}
+
+// A trait object's lifetime bound constrains the erased concrete type, not the
+// trait's type arguments. `'a` is universally quantified here, so this compiles
+// only if coercion imposes no `'static` requirement on the type argument.
+fn erase_handler<'a>(arena: &Arena) -> Box<dyn Handler<&'a str>> {
+    fn erase<H: Handler<T> + 'static, T>(arena: &Arena, handler: H) -> Box<dyn Handler<T>> {
+        Box::unsize(arena.alloc_box(handler), coerce!(<T> dyn Handler<T>))
+    }
+
+    erase::<LengthHandler, &'a str>(arena, LengthHandler)
+}
+
+#[test]
+fn generic_trait_object_coercion_accepts_borrowed_type_argument() {
+    let arena = Arena::new();
+    let owned = String::from("borrowed");
+    let handler = erase_handler(&arena);
+
+    assert_eq!(handler.handle(owned.as_str()), 8);
 }
 
 #[test]

--- a/crates/plurality/src/coerce.rs
+++ b/crates/plurality/src/coerce.rs
@@ -127,7 +127,7 @@ macro_rules! coerce {
         unsafe {
             $crate::Coercion::new({
                 #[allow(unused_parens)]
-                fn coerce<'lt, $($generic: 'lt),+>(
+                fn coerce<'lt, $($generic),+>(
                     ptr: *const (impl $($bounds)* + 'lt),
                 ) -> *const (dyn $($bounds)* + 'lt) {
                     ptr

--- a/crates/plurality/tests/unsize.rs
+++ b/crates/plurality/tests/unsize.rs
@@ -76,6 +76,20 @@ impl<T> Contains<T> for GenericValue<T> {
     }
 }
 
+// A handler that borrows its input. The handler owns nothing, so it is `'static`
+// no matter how short-lived the values it is invoked with are.
+trait Handler<T> {
+    fn handle(&self, input: T) -> usize;
+}
+
+struct LengthHandler;
+
+impl<'a> Handler<&'a str> for LengthHandler {
+    fn handle(&self, input: &'a str) -> usize {
+        input.len()
+    }
+}
+
 struct Square(u32);
 impl Shape for Square {
     fn area(&self) -> u32 {
@@ -123,6 +137,26 @@ fn unsize_to_trait_object_with_generic_argument() {
     let pool = Pool::<GenericValue<u32>>::new();
     let value = erase(&pool, 42);
     assert_eq!(*value.value(), 42);
+}
+
+// A trait object's lifetime bound constrains the erased concrete type, not the
+// trait's type arguments. `'a` is universally quantified here, so this compiles
+// only if coercion imposes no `'static` requirement on the type argument.
+fn erase_handler<'a>(pool: &Pool<LengthHandler>) -> Box<dyn Handler<&'a str>> {
+    fn erase<H: Handler<T> + 'static, T>(pool: &Pool<H>, handler: H) -> Box<dyn Handler<T>> {
+        Box::unsize(pool.alloc_box(handler), coerce!(<T> dyn Handler<T>))
+    }
+
+    erase::<LengthHandler, &'a str>(pool, LengthHandler)
+}
+
+#[test]
+fn unsize_to_trait_object_with_borrowed_generic_argument() {
+    let pool = Pool::<LengthHandler>::new();
+    let owned = String::from("borrowed");
+    let handler = erase_handler(&pool);
+
+    assert_eq!(handler.handle(owned.as_str()), 8);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`coerce!(<T> dyn Trait<T>)` requires every one of the trait's type arguments to outlive the resulting trait object. Because a trait object's default lifetime bound is `'static` in most positions, this forces `T: 'static` on callers. The generic arm expands to:

```rust
fn coerce<'lt, T: 'lt>(ptr: *const (impl Trait<T> + 'lt)) -> *const (dyn Trait<T> + 'lt) {
    ptr
}
```

The `T: 'lt` bound is not needed for the coercion. A trait object's lifetime bound constrains the *erased concrete type*, not the trait's type arguments — `dyn Trait<T> + 'static` is well-formed for a non-`'static` `T`, because a `'static` type can implement `Trait<&'a str>` for any `'a`. The identical function without the bound compiles:

```rust
fn coerce<'lt, T>(ptr: *const (impl Trait<T> + 'lt)) -> *const (dyn Trait<T> + 'lt) {
    ptr
}
```

## Motivation

The restriction is most damaging when the trait's type argument appears in argument position, which is the common shape for handlers, visitors, and other callback-style traits.

Consider a handler that borrows the input it is invoked with. The handler itself owns nothing, so it is `'static`, and it can accept a borrow of any lifetime:

```rust
#[multitude::dst::pointee]
trait Handler<T> {
    fn handle(&self, input: T) -> usize;
}

struct LengthHandler;

impl<'a> Handler<&'a str> for LengthHandler {
    fn handle(&self, input: &'a str) -> usize {
        input.len()
    }
}

fn erase<H: Handler<T> + 'static, T>(arena: &Arena, handler: H) -> Box<dyn Handler<T>> {
    Box::unsize(arena.alloc_box(handler), coerce!(<T> dyn Handler<T>))
}
```

`erase` does not compile today. The only way to make it compile is to add `T: 'static`, and that bound then propagates to the erased handler's type: the erased `Box<dyn Handler<T>>` can only ever be `Box<dyn Handler<&'static str>>`. Storing the handler silently costs it the ability to accept borrowed input:

```rust
let arena = Arena::new();
let owned = String::from("borrowed");
let handler = erase(&arena, LengthHandler);

handler.handle(owned.as_str()); // rejected: requires `&'static str`
```

Nothing about `LengthHandler` justifies that. It reads the input's length and keeps no reference to it, so requiring the input to live forever is a restriction with no basis in the code. The same applies to any erased visitor, sink, or callback that borrows what it is given.

The type argument's lifetime is also independent of the object's, so the restriction cannot be avoided by shortening the trait object's lifetime: a handler stored for the program's duration should still accept short-lived input.

The constraint additionally leaks into generic code that merely forwards to a coercion, because `T: 'static` is not derivable from the surrounding bounds and so must be restated in every wrapper's public signature.

Both crates' existing tests already work around this, writing `fn erase<T: 'static>(..)` in `unsize.rs`, which suggests the bound was incidental rather than deliberate.

## Change

Drop `$generic: 'lt` from the generic arm of `coerce!` in `multitude` and `plurality` — the two macros are identical, so both carry the constraint.

Each crate gains a regression test that erases a `'static` handler to a trait object with a borrowed type argument and then invokes it with a locally owned value, so the coercion cannot silently reacquire a `'static` requirement.

This only relaxes a bound, so it is backward compatible: every program that compiled before still compiles.
