### PR TITLE
ci: restore advanced CodeQL setup so fork PRs are not blocked

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,13 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
+# Advanced setup is used deliberately, in preference to CodeQL default setup:
+# default setup never runs for pull requests from forks, so the code-scanning
+# merge-protection check stays pending forever and fork PRs can never merge.
+# An advanced-setup workflow triggered by `pull_request` does run for fork PRs,
+# and GitHub accepts its SARIF upload on public repositories. Do not switch this
+# repository back to default setup while fork PRs are accepted.
+#
 name: "CodeQL Advanced"
 
 on:
@@ -16,6 +23,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
   schedule:
     - cron: '16 20 * * 5'
 
@@ -67,11 +75,11 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     # github/codeql-action publishes immutable GitHub releases (verified via the GitHub API:
-    # "immutable": true on GET /repos/github/codeql-action/releases/tags/v4.36.2). The tag cannot
+    # "immutable": true on GET /repos/github/codeql-action/releases/tags/v4.37.3). The tag cannot
     # be retargeted, so init/analyze below are intentionally left pinned to the tag, not a SHA.
-    # See https://github.com/github/codeql-action/releases/tag/v4.36.2
+    # See https://github.com/github/codeql-action/releases/tag/v4.37.3
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.0
+      uses: github/codeql-action/init@v4.37.3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -101,6 +109,6 @@ jobs:
 
     # See the immutable-release note above (github/codeql-action) — same tag, same rationale.
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.0
+      uses: github/codeql-action/analyze@v4.37.3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Problem

Pull requests from forks can never merge. They sit forever on:

> Code scanning is waiting for results from CodeQL for the commits `<sha>` or `<sha>`.

Current example: #624 (from `sandersaares/oxidizer`).

**Root cause:** this repo uses CodeQL **default setup**, and default setup does not run for pull requests from forks — [that exclusion is documented behaviour](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types), not a bug. The code-scanning merge-protection rule still expects a `CodeQL` result, so the check stays pending indefinitely and the PR is permanently blocked.

Evidence gathered on this repo:

| PR | Head repo | Fork? | CodeQL run | CodeQL check |
|----|-----------|-------|-----------|--------------|
| #621, #632, #568, #570-#573 | `microsoft/oxidizer` | no | yes | yes |
| #624 | `sandersaares/oxidizer` | yes | none | none, blocked |
| #622 | `kate-shine/oxidizer` | yes | none | none, blocked |

## Why advanced setup fixes it

An advanced-setup workflow triggered by `pull_request` **does** run for fork PRs, and GitHub accepts its SARIF upload on public repositories even though the fork's `GITHUB_TOKEN` is read-only.

Verified empirically against `prettier/prettier`, a public repo on advanced setup. On fork PR head `bf2849cee9d467aedf3fbd42a95201ea4393f855` (from `splincode/prettier`):

- the only workflow runs are `pull_request` ones, including `.github/workflows/codeql.yml`; there is no `dynamic` (default setup) run at all;
- yet `github-advanced-security` posted check `CodeQL` with conclusion `success`.

## History

`.github/workflows/codeql.yml` already exists and is correct, but it has been in the `disabled_manually` state since **2026-01-22** and has not run since.

It was introduced by #219 ("ci: Switch to advanced CodeQL mode"), whose stated goal was, verbatim, *"Once this is checked in, then we can tweak to improve permissions on forks"* — exactly the problem above. It ran 33 times, all successful, and roughly 4.5 hours after that PR merged, default setup was switched back on in the repository settings, which automatically disabled this workflow. No PR, issue or comment records a reason. Since then #232, #237, #462, #470, #484, #543, #563 and #574 have all been maintaining a workflow that never runs.

## Changes

- Document why advanced setup is preferred, so this does not get silently reverted to default setup a second time.
- Add the `merge_group` trigger. `main.yml` and `anvil-pr.yml` both have it and `codeql.yml` did not; without it the merge queue stalls on this workflow once it is required.
- Bump `github/codeql-action` to `v4.37.3` (confirmed `"immutable": true` via the releases API, consistent with the existing tag-pinning rationale in the file).

## Required admin action, this PR alone is not sufficient

Merging this changes nothing by itself, because the workflow is still disabled and GitHub will keep it disabled while default setup is on. A repository admin must, **in this order**:

1. Settings, Advanced Security, **disable CodeQL default setup**.
2. Re-enable this workflow: `gh api -X PUT repos/microsoft/oxidizer/actions/workflows/codeql.yml/enable`.

Doing step 2 first does not work.

## Trade-off

Fork PRs from **first-time contributors** will show CodeQL as `action_required` until a maintainer clicks "Approve and run". That is standard GitHub Actions fork policy and it also applies to every other `pull_request` workflow in this repo today. It is a single click, versus the current situation where fork PRs cannot merge at all.

## Draft

Left as a draft until an admin confirms they will make the settings change, since merging without it is a no-op.




