### PR TITLE
fix: hide documentation modules from public API

### DIFF
--- a/crates/fetch/src/_documentation/mod.rs
+++ b/crates/fetch/src/_documentation/mod.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 //! Longer-form documentation for [`fetch`](crate).
+//!
+//! See also the [`http_extensions` recipes](https://docs.rs/http_extensions/latest/http_extensions/_documentation/recipes/).
 
 pub mod examples;
 pub mod telemetry;
-
-pub use http_extensions::_documentation::recipes as http_recipes;

--- a/crates/fetch/src/lib.rs
+++ b/crates/fetch/src/lib.rs
@@ -856,6 +856,7 @@ pub mod resilience;
 pub mod pipeline;
 
 /// Longer-form documentation for [`fetch`](crate).
+#[cfg(any(doc, test))]
 pub mod _documentation;
 
 // Installs a silent, always-interested global `tracing` subscriber before any

--- a/crates/http_extensions/src/lib.rs
+++ b/crates/http_extensions/src/lib.rs
@@ -255,4 +255,5 @@ pub use fake_handler::FakeHandler;
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod testing;
 
+#[cfg(any(doc, test))]
 pub mod _documentation;

--- a/crates/recoverable/src/lib.rs
+++ b/crates/recoverable/src/lib.rs
@@ -78,6 +78,7 @@ use std::time::Duration;
 
 mod io;
 
+#[cfg(any(doc, test))]
 pub mod _documentation;
 
 // Naming Convention for Get/Set:

--- a/crates/templated_uri/src/lib.rs
+++ b/crates/templated_uri/src/lib.rs
@@ -185,6 +185,7 @@
 
 #[doc(hidden)]
 pub mod __private;
+#[cfg(any(doc, test))]
 pub mod _documentation;
 
 mod base_path;


### PR DESCRIPTION
No need for _documentation module to be exposed as part of APIs. 