### PR TITLE
feat(stabilization)!: bytesbuf 1.0

### DIFF
--- a/crates/bytesbuf/docs/STABILIZATION.md
+++ b/crates/bytesbuf/docs/STABILIZATION.md
@@ -11,6 +11,8 @@ Stabilize the core owned byte-sequence types:
 - `BytesView` for sharing and consuming immutable byte sequences.
 - The iterator and cursor types returned by their stable operations:
   `BytesBufRemaining`, `BytesBufVectoredWrite`, and `BytesViewSlices`.
+- `BlockMeta`, because the current slice iterator types expose it in their
+  public item types.
 - `MemoryGuard` for keeping memory alive while native or unsafe I/O uses it.
 
 The stable operation groups should cover:
@@ -22,8 +24,9 @@ The stable operation groups should cover:
 - Slicing, ranging, concatenating, advancing, and iterating over view contents.
 - Accessing unfilled buffer memory, including vectored access, and committing
   the number of bytes initialized by an owned-buffer read operation.
-- Standard I/O and `bytes` crate adapters where their Cargo features are
-  enabled.
+
+Standard I/O and `bytes` crate adapters require separate review before they
+join the stable boundary.
 
 ## Memory-provider boundary
 
@@ -31,7 +34,8 @@ Stabilize the provider contracts needed by consumers and I/O implementations:
 
 - `Memory` for reserving owned writable capacity.
 - `MemoryShared` and `HasMemory` for sharing an endpoint-compatible provider.
-- `GlobalPool` as the standard pooled provider.
+- `GlobalPool` as the standard pooled provider when the `std` feature is
+  enabled.
 - `OpaqueMemory` for storing a provider without exposing its concrete type.
 
 The provider surface must preserve ownership, reuse, and cross-thread release
@@ -39,15 +43,16 @@ semantics needed by asynchronous operating-system I/O.
 
 ## Deferred surface
 
-Keep convenience providers, test utilities, constants, and low-level block and
+Keep convenience providers, test utilities, constants, and low-level
 reference-counting machinery outside the stable surface unless the provider
 implementation review proves they are required. This includes
-`CallbackMemory`, `Block`, `BlockRef`, their metadata and vtable APIs, and
+`CallbackMemory`, `BlockRef`, its dynamic traits and vtable API, and
 `MAX_INLINE_SPANS`.
 
-If stable custom memory providers require any of these types, expose only the
-smallest reviewed construction boundary instead of stabilizing implementation
-details by default.
+These APIs are public today, so excluding them requires removing or hiding them
+before 1.0. The current custom-provider workflow also requires `Block` and the
+`BlockRef` family. Either stabilize the smallest reviewed subset of that
+machinery or replace it with a narrower stable construction API.
 
 ## Pending review
 
@@ -59,8 +64,11 @@ details by default.
 - [ ] Validate ownership transfer, reuse, cloning, range, and conversion
       semantics for asynchronous I/O.
 - [ ] Decide whether `BytesBufWriter` belongs in the stable standard-library
-      adapter surface.
+      adapter surface enabled by the `std` feature.
 - [ ] Decide which `bytes` compatibility implementations are stable.
-- [ ] Determine the minimal stable API for implementing custom memory providers.
+- [ ] Determine the minimal stable API for implementing custom memory providers,
+      including whether `Block`, `BlockRef`, and related traits remain public.
+- [ ] Confirm whether the metadata-returning iterator shapes remain stable; if
+      they change, reconsider whether `BlockMeta` belongs in the stable surface.
 - [ ] Confirm stable downstream crates expose no deferred `bytesbuf` types.
 - [ ] Identify all remaining APIs as stable, unstable, or unnecessary for 1.0.

--- a/crates/bytesbuf/docs/STABILIZATION.md
+++ b/crates/bytesbuf/docs/STABILIZATION.md
@@ -68,8 +68,9 @@ machinery or replace it with a narrower stable construction API.
 - [ ] Decide which `bytes` compatibility implementations are stable.
 - [ ] Determine the minimal stable API for implementing custom memory providers,
       including whether `Block`, `BlockRef`, and related traits remain public.
-- [ ] Confirm whether the metadata-returning iterator shapes and direct
-      `first_slice_meta()` methods remain stable. Removing `BlockMeta` from the
-      stable surface requires redesigning all of these exposure points.
+- [ ] Confirm whether the metadata-returning iterator shapes,
+      `first_slice_meta()`, and `first_unfilled_slice_meta()` remain stable.
+      Removing `BlockMeta` from the stable surface requires redesigning all of
+      these exposure points.
 - [ ] Confirm stable downstream crates expose no deferred `bytesbuf` types.
 - [ ] Identify all remaining APIs as stable, unstable, or unnecessary for 1.0.

--- a/crates/bytesbuf/docs/STABILIZATION.md
+++ b/crates/bytesbuf/docs/STABILIZATION.md
@@ -1,0 +1,66 @@
+# Stabilization Notes
+
+These notes capture the pending decisions for stabilizing `bytesbuf`. They
+describe proposals under review, not a finalized stable API.
+
+## Proposed stable boundary
+
+Stabilize the core owned byte-sequence types:
+
+- `BytesBuf` for assembling and owning writable byte sequences.
+- `BytesView` for sharing and consuming immutable byte sequences.
+- The iterator and cursor types returned by their stable operations:
+  `BytesBufRemaining`, `BytesBufVectoredWrite`, and `BytesViewSlices`.
+- `MemoryGuard` for keeping memory alive while native or unsafe I/O uses it.
+
+The stable operation groups should cover:
+
+- Creating empty buffers and views, reserving capacity, and querying length,
+  capacity, and emptiness.
+- Appending copied bytes or existing views, then consuming or peeking buffered
+  data as immutable views.
+- Slicing, ranging, concatenating, advancing, and iterating over view contents.
+- Accessing unfilled buffer memory, including vectored access, and committing
+  the number of bytes initialized by an owned-buffer read operation.
+- Standard I/O and `bytes` crate adapters where their Cargo features are
+  enabled.
+
+## Memory-provider boundary
+
+Stabilize the provider contracts needed by consumers and I/O implementations:
+
+- `Memory` for reserving owned writable capacity.
+- `MemoryShared` and `HasMemory` for sharing an endpoint-compatible provider.
+- `GlobalPool` as the standard pooled provider.
+- `OpaqueMemory` for storing a provider without exposing its concrete type.
+
+The provider surface must preserve ownership, reuse, and cross-thread release
+semantics needed by asynchronous operating-system I/O.
+
+## Deferred surface
+
+Keep convenience providers, test utilities, constants, and low-level block and
+reference-counting machinery outside the stable surface unless the provider
+implementation review proves they are required. This includes
+`CallbackMemory`, `Block`, `BlockRef`, their metadata and vtable APIs, and
+`MAX_INLINE_SPANS`.
+
+If stable custom memory providers require any of these types, expose only the
+smallest reviewed construction boundary instead of stabilizing implementation
+details by default.
+
+## Pending review
+
+- [ ] Explicitly list and review every method included for `BytesBuf` and
+      `BytesView`.
+- [ ] Confirm the writable-slice and vectored-write APIs support the approved
+      owned-buffer Read/Write design without exposing uninitialized memory
+      unsafely.
+- [ ] Validate ownership transfer, reuse, cloning, range, and conversion
+      semantics for asynchronous I/O.
+- [ ] Decide whether `BytesBufWriter` belongs in the stable standard-library
+      adapter surface.
+- [ ] Decide which `bytes` compatibility implementations are stable.
+- [ ] Determine the minimal stable API for implementing custom memory providers.
+- [ ] Confirm stable downstream crates expose no deferred `bytesbuf` types.
+- [ ] Identify all remaining APIs as stable, unstable, or unnecessary for 1.0.

--- a/crates/bytesbuf/docs/STABILIZATION.md
+++ b/crates/bytesbuf/docs/STABILIZATION.md
@@ -11,8 +11,8 @@ Stabilize the core owned byte-sequence types:
 - `BytesView` for sharing and consuming immutable byte sequences.
 - The iterator and cursor types returned by their stable operations:
   `BytesBufRemaining`, `BytesBufVectoredWrite`, and `BytesViewSlices`.
-- `BlockMeta`, because the current slice iterator types expose it in their
-  public item types.
+- `BlockMeta`, because the current slice iterator types and direct slice
+  metadata methods expose it in their public signatures.
 - `MemoryGuard` for keeping memory alive while native or unsafe I/O uses it.
 
 The stable operation groups should cover:
@@ -68,7 +68,8 @@ machinery or replace it with a narrower stable construction API.
 - [ ] Decide which `bytes` compatibility implementations are stable.
 - [ ] Determine the minimal stable API for implementing custom memory providers,
       including whether `Block`, `BlockRef`, and related traits remain public.
-- [ ] Confirm whether the metadata-returning iterator shapes remain stable; if
-      they change, reconsider whether `BlockMeta` belongs in the stable surface.
+- [ ] Confirm whether the metadata-returning iterator shapes and direct
+      `first_slice_meta()` methods remain stable. Removing `BlockMeta` from the
+      stable surface requires redesigning all of these exposure points.
 - [ ] Confirm stable downstream crates expose no deferred `bytesbuf` types.
 - [ ] Identify all remaining APIs as stable, unstable, or unnecessary for 1.0.


### PR DESCRIPTION
## Summary

Adds pending stabilization notes for the `bytesbuf` crate based on [O365 Core work item 7688114](https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7688114). The notes record the proposed `BytesBuf`, `BytesView`, owned-buffer I/O, and memory-provider stable boundary, along with deferred low-level APIs and unresolved review items. Also adds an empty `docs/DESIGN.md` placeholder.

## Validation

- `just package=bytesbuf format`
- `just package=bytesbuf readme`
- `cargo build -p bytesbuf`
- `cargo test -p bytesbuf`
- `git diff --check`
- GitHub required checks and Codecov passed
- Spellcheck attempted locally, but the installed `cargo-spellcheck` process exits during startup on this machine; the GitHub spell-check job passed.

## Review

- Multi-model review completed with Opus, Sonnet, and GPT reviewers.
- Review findings about feature gates, memory-provider implementation dependencies, and `BlockMeta` exposure points were addressed.
- Final review found no remaining substantive issues.