### PR TITLE
fix(release): cascade exposed dependency breaks

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -395,10 +395,10 @@ suppress a change type the API analysis requires.
   analysis requires the planner errors instead of silently overriding
   the caller. Pass `-Force` to override: the pin is honored verbatim, the
   package's effective change-type tag is still upgraded to record the
-  stronger unmet requirement and support warnings/bookkeeping. Exposure
-  propagation follows the actual current-to-pinned version transition: a
-  compatible forced pin stops propagation, while an incompatible forced pin
-  continues it. A warning is printed flagging that consumers may break.)
+  stronger unmet requirement, and a warning is printed flagging that
+  consumers may break. Exposure propagation continues past a forced pin:
+  the pin lowers the version number, not the incompatibility, so dependents
+  that expose the crate still inherit the break.)
 
 ---
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -225,17 +225,22 @@ published content lags the source), and it means an aborted release that
 bumped a crate to `4.0.0` without publishing is still the baseline the
 next change is measured against.
 
-This replaces the former
-`[package.metadata.cargo_check_external_types]` allowlist heuristic. That
-allowlist is a hand-maintained list of the external types a crate is
-*permitted* to expose; it was repurposed as a proxy for the types a
-crate *actually* re-exports. When the two drift apart — an entry missing
-or stale — the heuristic misjudged whether a dependent re-exports a
-changed dependency, so a breaking change in an exposed dependency could
-be cascaded as `patch` instead of `breaking` (the motivating defect: a
-breaking change in `bytesbuf` was not propagated to `bytesbuf_io`, which
-re-exports `bytesbuf` types). Analysing the real API with
-`cargo semver-checks` removes the proxy entirely.
+`cargo semver-checks` is combined with an exposed-dependency cascade.
+Rustdoc comparison cannot detect that an otherwise-unchanged signature
+now names a type from an incompatible version of an external crate. For
+each direct dependency edge, the planner therefore also consults
+`[package.metadata.cargo_check_external_types].allowed_external_types`.
+If the dependency's planned version transition is breaking and the
+dependent allows that dependency's types in its public API, the dependent
+is floored at `breaking`. The planner repeats this check to a fixpoint so
+the result propagates through chains such as `bytesbuf` → `bytesbuf_io` →
+another facade.
+
+Missing external-type metadata and wildcard roots are handled
+conservatively as possible exposure. The policy must remain validated by
+`cargo-check-external-types`: an extra allowlist entry can cause an
+unnecessary breaking bump, while omitting an actually exposed type is a
+policy-validation failure.
 
 **How the change type is determined.** `cargo semver-checks` is invoked
 as a CLI (not as a library) and its textual result is parsed into one of
@@ -253,8 +258,8 @@ notion (major / minor / none); the exact parsing lives in
 
 Cascade dependents are floored at `patch` (they must re-release to pick
 up the new dependency version even when their own public API is
-unchanged), then raised to whatever their own `cargo semver-checks`
-result requires.
+unchanged), then raised to the stronger of their own
+`cargo semver-checks` result and the exposed-dependency cascade.
 
 #### Proc-macro-only packages require manual SemVer review
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -245,10 +245,12 @@ differently:
   unknown must not ship a break as compatible.
 
 - **Indirect edges to a transitive dependency** require the dependent's
-  allowlist to explicitly name that dependency, under whichever name its
-  crate root actually carries: a `package = "..."` alias on the
-  dependency, or a `[lib] name = "..."` set by the dependency itself, in
-  preference to the package name. This exists because `cargo-check-external-types` attributes a
+  allowlist to explicitly name that dependency, under the crate root the
+  dependency itself defines: its `[lib] name = "..."` when it sets one,
+  otherwise its package name. A `package = "..."` alias cannot apply
+  here -- only a crate that *declares* a dependency can rename it, and an
+  indirect dependent declares no edge to the target at all. This exists
+  because `cargo-check-external-types` attributes a
   re-exported type to the crate that *defines* it: `fetch_azure`
   allowlists `typespec_client_core::*` for a trait `azure_core`
   re-exports, while depending only on `azure_core`. Such an edge is

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -214,8 +214,9 @@ rebuilds the baseline rustdoc from the crate's source at that commit, so
 **no registry access is required** and the check behaves identically for
 open-source (crates.io) and enterprise/offline consumers. The current
 working-tree API is analysed, so a coordinated release's in-progress
-edits — including a dependency whose public types a dependent re-exports
-— are reflected in the dependent's own API diff.
+edits are reflected rather than only what has been committed. That is
+necessary but not sufficient on its own — see the exposed-dependency
+cascade below, which covers the breaks a rustdoc diff cannot show.
 
 Versioning is treated as a **source-level** concern: the baseline is the
 version the repository last *declared*, regardless of whether it was ever

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -228,8 +228,8 @@ next change is measured against.
 
 `cargo semver-checks` is combined with an exposed-dependency cascade.
 Rustdoc comparison cannot detect that an otherwise-unchanged signature
-now names a type from an incompatible version of an external crate. For
-each direct dependency edge, the planner therefore also consults
+now names a type from an incompatible version of an external crate. The
+planner therefore also consults
 `[package.metadata.cargo_check_external_types].allowed_external_types`.
 If the dependency's planned version transition is breaking and the
 dependent allows that dependency's types in its public API, the dependent
@@ -237,11 +237,31 @@ is floored at `breaking`. The planner repeats this check to a fixpoint so
 the result propagates through chains such as `bytesbuf` → `bytesbuf_io` →
 another facade.
 
-Missing external-type metadata and wildcard roots are handled
-conservatively as possible exposure. The policy must remain validated by
-`cargo-check-external-types`: an extra allowlist entry can cause an
-unnecessary breaking bump, while omitting an actually exposed type is a
-policy-validation failure.
+Two kinds of edge are considered, and they treat missing evidence
+differently:
+
+- **Direct dependency edges** fail closed. Absent metadata, a malformed
+  entry, or a wildcard root all count as possible exposure, because an
+  unknown must not ship a break as compatible.
+
+- **Indirect edges to a transitive dependency** require the dependent's
+  allowlist to explicitly name that dependency (or a rename alias of it).
+  This exists because `cargo-check-external-types` attributes a
+  re-exported type to the crate that *defines* it: `fetch_azure`
+  allowlists `typespec_client_core::*` for a trait `azure_core`
+  re-exports, while depending only on `azure_core`. Such an edge is
+  invisible to a direct-dependency scan.
+
+  Here absent or malformed metadata is *not* read as exposure. Failing
+  closed on an indirect edge would match every transitive dependency of
+  every crate that declares no allowlist, forcing unrelated crates to
+  breaking. Nothing is missed: a crate with no allowlist that really does
+  expose the type still fails closed on its direct edge to whichever
+  intermediate carries it, and the fixpoint propagates that upward.
+
+The policy must remain validated by `cargo-check-external-types`: an
+extra allowlist entry can cause an unnecessary breaking bump, while
+omitting an actually exposed type is a policy-validation failure.
 
 **How the change type is determined.** `cargo semver-checks` is invoked
 as a CLI (not as a library) and its textual result is parsed into one of

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -245,8 +245,10 @@ differently:
   unknown must not ship a break as compatible.
 
 - **Indirect edges to a transitive dependency** require the dependent's
-  allowlist to explicitly name that dependency (or a rename alias of it).
-  This exists because `cargo-check-external-types` attributes a
+  allowlist to explicitly name that dependency, under whichever name its
+  crate root actually carries: a `package = "..."` alias on the
+  dependency, or a `[lib] name = "..."` set by the dependency itself, in
+  preference to the package name. This exists because `cargo-check-external-types` attributes a
   re-exported type to the crate that *defines* it: `fetch_azure`
   allowlists `typespec_client_core::*` for a trait `azure_core`
   re-exports, while depending only on `azure_core`. Such an edge is

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -244,10 +244,10 @@ differently:
   entry, or a wildcard root all count as possible exposure, because an
   unknown must not ship a break as compatible.
 
-- **Indirect edges to a transitive dependency** require the dependent's
-  allowlist to explicitly name that dependency, under the crate root the
-  dependency itself defines: its `[lib] name = "..."` when it sets one,
-  otherwise its package name. A `package = "..."` alias cannot apply
+- **Indirect edges to a transitive dependency** require positive allowlist
+  evidence: either a literal root naming the dependency under the crate root
+  it defines (`[lib] name = "..."` when set, otherwise its package name), or
+  a wildcard root that may expand to it. A `package = "..."` alias cannot apply
   here -- only a crate that *declares* a dependency can rename it, and an
   indirect dependent declares no edge to the target at all. This exists
   because `cargo-check-external-types` attributes a
@@ -394,9 +394,11 @@ suppress a change type the API analysis requires.
   semver token as a hard pin — if the explicit version is below what the
   analysis requires the planner errors instead of silently overriding
   the caller. Pass `-Force` to override: the pin is honored verbatim, the
-  package's effective change-type tag is still upgraded so further
-  cascade decisions are correct, and a warning is printed flagging that
-  consumers may break.)
+  package's effective change-type tag is still upgraded to record the
+  stronger unmet requirement and support warnings/bookkeeping. Exposure
+  propagation follows the actual current-to-pinned version transition: a
+  compatible forced pin stops propagation, while an incompatible forced pin
+  continues it. A warning is printed flagging that consumers may break.)
 
 ---
 

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -346,8 +346,21 @@ function Test-EntryPlansBreakingRelease {
 }
 
 # Returns the baseline packages that must inherit a breaking bump from
-# $TargetPackage: those already in the release set that depend on it directly
-# and name its types in their own public API.
+# $TargetPackage: those already in the release set that reach it and name its
+# types in their own public API.
+#
+# Two kinds of edge qualify:
+#
+#   * A DIRECT dependency that may expose the target. "May" is the operative
+#     word: an absent or malformed allowlist fails closed here, because an
+#     unknown must not ship a break as compatible.
+#   * An INDIRECT dependency whose allowlist explicitly names the target.
+#     cargo-check-external-types attributes a re-exported type to its defining
+#     crate, so a crate reaching `a::T` through `b` allowlists `a` while
+#     depending only on `b`. Requiring a direct edge missed these entirely.
+#     This branch demands positive evidence rather than failing closed, so it
+#     cannot drag in transitive dependents that merely lack metadata -- those
+#     are already covered by their own direct edges, walked up by the fixpoint.
 #
 # Proc-macro-only dependents are excluded because they have no rustdoc API to
 # expose anything through; they reach the release set via the manual-review
@@ -360,18 +373,41 @@ function Get-PublishedDependentsExposingTarget {
         # IDictionary rather than [hashtable] because the caller's dictionary is
         # [ordered], which is not a Hashtable -- PowerShell would satisfy a
         # [hashtable] annotation by silently substituting a converted copy.
-        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Resolved
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Resolved,
+        # Optional memo of target cargo name -> reachable published dependent
+        # folders. The baseline is fixed for the duration of a resolve, so the
+        # BFS answer is stable; the fixpoint would otherwise recompute it for
+        # every breaking source on every pass.
+        [System.Collections.IDictionary]$TransitiveDependentCache
     )
 
     # Cargo dependency names use underscores; package names may use hyphens.
     $targetCargoName = $TargetPackage.Name.Replace('-', '_')
 
+    if ($null -ne $TransitiveDependentCache -and $TransitiveDependentCache.Contains($targetCargoName)) {
+        $reachable = $TransitiveDependentCache[$targetCargoName]
+    } else {
+        $reachable = [System.Collections.Generic.HashSet[string]]::new(
+            [string[]]@(Get-TransitivePublishedDependentsFromBaseline `
+                    -Baseline $WorkspaceBaseline -TargetCargoName $targetCargoName),
+            [System.StringComparer]::Ordinal)
+        if ($null -ne $TransitiveDependentCache) {
+            $TransitiveDependentCache[$targetCargoName] = $reachable
+        }
+    }
+
     return @($WorkspaceBaseline | Where-Object {
             $_.Published -and
             -not $_.IsProcMacroOnly -and
-            $_.Deps -contains $targetCargoName -and
             $Resolved.Contains($_.Folder) -and
-            (Test-PackageExposesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name)
+            $(
+                if ($_.Deps -contains $targetCargoName) {
+                    Test-PackageExposesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name
+                } else {
+                    $reachable.Contains($_.Folder) -and
+                    (Test-PackageAllowlistNamesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name)
+                }
+            )
         })
 }
 
@@ -644,10 +680,12 @@ function Resolve-ReleaseSet {
 
     # cargo-semver-checks compares one crate's rustdoc API and cannot identify
     # that an unchanged signature now names a type from an incompatible version
-    # of an external crate. Propagate that condition over direct dependency edges
-    # until no dependent is strengthened. Use the version that will actually be
-    # written, not EffectiveChangeType, so -Force pins do not create a fictitious
-    # breaking transition farther up the graph.
+    # of an external crate. Propagate that condition over dependency edges --
+    # direct, plus indirect edges where a re-exported type is allowlisted under
+    # its defining crate -- until no dependent is strengthened. Use the version
+    # that will actually be written, not EffectiveChangeType, so -Force pins do
+    # not create a fictitious breaking transition farther up the graph.
+    $transitiveDependentCache = @{}
     $exposureChanged = $true
     while ($exposureChanged) {
         $exposureChanged = $false
@@ -658,7 +696,8 @@ function Resolve-ReleaseSet {
             if (-not (Test-EntryPlansBreakingRelease -Entry $sourceEntry)) { continue }
 
             $dependentPkgs = Get-PublishedDependentsExposingTarget -TargetPackage $sourcePkg `
-                -WorkspaceBaseline $WorkspaceBaseline -Resolved $resolved
+                -WorkspaceBaseline $WorkspaceBaseline -Resolved $resolved `
+                -TransitiveDependentCache $transitiveDependentCache
 
             foreach ($dependentPkg in $dependentPkgs) {
                 $strengthened = Update-EntryForExposedDependency `

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -2535,10 +2535,14 @@ function Invoke-ReleasePackagesMain {
     # the targeted flow.
     $planReviewMode = if ($Mode -eq 'targeted') { 'targeted' } else { 'all-changed' }
 
-    # Classifier passed to the planner: decides every change type in the plan
-    # (user-source and cascade) from each crate's real API diff vs its previous
-    # version-bump commit in git history — no allowed_external_types heuristic,
-    # no registry, no fallback. $script:DefaultSemverClassifier is a module-scope
+    # Classifier passed to the planner: decides each crate's OWN change-type
+    # floor (user-source and cascade alike) from its real API diff vs its
+    # previous version-bump commit in git history — no registry, no fallback.
+    # This is only half the verdict: Resolve-ReleaseSet's exposed-dependency
+    # cascade can raise an entry above this floor, using
+    # allowed_external_types to decide exposure (a dependency version bump
+    # changes type identity without changing any rustdoc, so no API diff can
+    # surface it). $script:DefaultSemverClassifier is a module-scope
     # scriptblock (defined below Resolve-ReleaseSet) so it resolves
     # Get-CrateRequiredChangeType and $script:ReleaseRepoRoot in the module
     # session state; that also lets the test suites Mock Get-CrateRequiredChangeType.

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -495,9 +495,14 @@ function Update-EntryForExposedDependency {
 #          bump only the change-type tag.
 #        - or create a new cascade-source entry.
 #      Ordinary library dependents use their own cargo-semver-checks result,
-#      floored at patch. A second direct-edge pass raises a dependent to breaking
-#      when it exposes a dependency whose planned version transition is
-#      incompatible. The pass repeats to a fixpoint so exposure chains cascade.
+#      floored at patch. A second pass raises a dependent to breaking when it
+#      exposes a dependency whose planned version transition is incompatible.
+#      That pass considers direct dependency edges (failing closed on absent or
+#      malformed allowlist metadata) plus indirect edges to a transitive
+#      dependency whose types the dependent explicitly allowlists, which is how
+#      a re-exported type -- attributed by cargo-check-external-types to its
+#      defining crate -- is caught. The pass repeats to a fixpoint so exposure
+#      chains cascade.
 #      Proc-macro-only dependents use a provisional patch floor and are explicitly
 #      classified in the interactive review.
 #      Cascade reasons are recorded per (target → dep) edge with dedup by

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -306,9 +306,27 @@ function Update-EntryForRequiredChangeType {
 }
 
 # Records one cascade reason on an entry, keyed by target package name.
-# Re-encountering the same (target -> dependent) edge on a later strengthening
-# pass overwrites the prior reason in place instead of appending a duplicate, so
-# the list stays one-per-edge however many fixpoint iterations run.
+# Re-recording the same target on a later strengthening pass overwrites the
+# prior reason in place instead of appending a duplicate, so the list stays
+# one-per-target however many fixpoint iterations run.
+#
+# The key is a package, not a graph edge. CascadeReasons answers "which
+# released packages forced this entry into the set, and did any of them force
+# it breaking?", and its entries arrive from two different relationships:
+#
+#   * MEMBERSHIP -- the target this entry was reached from during the
+#     Get-TransitivePublishedDependentsFromBaseline walk. That walk is
+#     transitive, so the target need not be a direct dependency; it can sit
+#     several crates away, possibly behind unpublished conduits.
+#   * EXPOSURE -- a target whose types this entry names in its own public API,
+#     recorded by Update-EntryForExposedDependency. Since re-exported types are
+#     attributed to their defining crate, this too can name a package the entry
+#     does not depend on directly.
+#
+# So a reason means "this package caused that release", not "this package is a
+# direct dependency". Changelog attribution needs the narrower direct-dependency
+# relation and must derive it from the dependency graph rather than reading it
+# out of this collection.
 function Set-CascadeReason {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Entry,
@@ -427,7 +445,7 @@ function Update-EntryForExposedDependency {
 
     Update-EntryForRequiredChangeType -Entry $Entry -RequiredChangeType 'breaking' `
         -RequirementLabel 'exposed-dependency cascade' `
-        -RequirementDetail "the incompatible planned version of '$TargetPackageName' exposed in its public API" `
+        -RequirementDetail "this crate's own public API naming types from the incompatible planned version of '$TargetPackageName'" `
         -Force:$Force
 
     Set-CascadeReason -Entry $Entry -Reason ([pscustomobject]@{ Target = $TargetPackageName; Breaking = $true })
@@ -653,8 +671,10 @@ function Resolve-ReleaseSet {
                 $existing = $resolved[$depFolder]
 
                 # Dedup cascade reasons by target name (re-encountering the
-                # same edge after a strengthening pass overwrites the prior
-                # reason in place rather than adding a duplicate).
+                # same target after a strengthening pass overwrites the prior
+                # reason in place rather than adding a duplicate). This target
+                # was reached transitively, so it is not necessarily a direct
+                # dependency of $depFolder -- see Set-CascadeReason.
                 Set-CascadeReason -Entry $existing -Reason $cascadeReason
 
                 $reasonsNames = ($existing.CascadeReasons | ForEach-Object { $_.Target } | Sort-Object -Unique) -join ', '

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -305,6 +305,101 @@ function Update-EntryForRequiredChangeType {
     }
 }
 
+# Records one cascade reason on an entry, keyed by target package name.
+# Re-encountering the same (target -> dependent) edge on a later strengthening
+# pass overwrites the prior reason in place instead of appending a duplicate, so
+# the list stays one-per-edge however many fixpoint iterations run.
+function Set-CascadeReason {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Entry,
+        [Parameter(Mandatory = $true)][pscustomobject]$Reason
+    )
+
+    for ($i = 0; $i -lt $Entry.CascadeReasons.Count; $i++) {
+        if ($Entry.CascadeReasons[$i].Target -eq $Reason.Target) {
+            $Entry.CascadeReasons[$i] = $Reason
+            return
+        }
+    }
+
+    $Entry.CascadeReasons.Add($Reason)
+}
+
+# Returns $true when the version this entry will actually write is an
+# incompatible transition from the version currently on disk.
+#
+# Deliberately derived from EffectiveTargetVersion rather than
+# EffectiveChangeType: a -Force pin honored below the cascade-required version
+# carries a 'breaking' tag while writing a version that is not in fact a
+# breaking transition, and cascading from the tag would invent a break farther
+# up the graph that consumers never actually see.
+function Test-EntryPlansBreakingRelease {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Entry
+    )
+
+    $plannedChangeType = Get-ChangeTypeFromVersions `
+        -oldVersion $Entry.CurrentVersion `
+        -newVersion $Entry.EffectiveTargetVersion
+
+    return Test-IsBreakingChange -oldVersion $Entry.CurrentVersion -ChangeType $plannedChangeType
+}
+
+# Returns the baseline packages that must inherit a breaking bump from
+# $TargetPackage: those already in the release set that depend on it directly
+# and name its types in their own public API.
+#
+# Proc-macro-only dependents are excluded because they have no rustdoc API to
+# expose anything through; they reach the release set via the manual-review
+# queue instead.
+function Get-PublishedDependentsExposingTarget {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$TargetPackage,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$WorkspaceBaseline,
+        # Read-only: used only to test release-set membership. Typed as
+        # IDictionary rather than [hashtable] because the caller's dictionary is
+        # [ordered], which is not a Hashtable -- PowerShell would satisfy a
+        # [hashtable] annotation by silently substituting a converted copy.
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Resolved
+    )
+
+    # Cargo dependency names use underscores; package names may use hyphens.
+    $targetCargoName = $TargetPackage.Name.Replace('-', '_')
+
+    return @($WorkspaceBaseline | Where-Object {
+            $_.Published -and
+            -not $_.IsProcMacroOnly -and
+            $_.Deps -contains $targetCargoName -and
+            $Resolved.Contains($_.Folder) -and
+            (Test-PackageExposesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name)
+        })
+}
+
+# Raises one dependent entry to 'breaking' because it exposes an incompatibly
+# versioned dependency, records the reason, and returns $true when that actually
+# strengthened the entry. The return value is what drives fixpoint termination:
+# once a pass strengthens nothing, the cascade is complete.
+function Update-EntryForExposedDependency {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Entry,
+        [Parameter(Mandatory = $true)][string]$TargetPackageName,
+        [switch]$Force
+    )
+
+    $previousChangeType    = $Entry.EffectiveChangeType
+    $previousTargetVersion = $Entry.EffectiveTargetVersion
+
+    Update-EntryForRequiredChangeType -Entry $Entry -RequiredChangeType 'breaking' `
+        -RequirementLabel 'exposed-dependency cascade' `
+        -RequirementDetail "the incompatible planned version of '$TargetPackageName' exposed in its public API" `
+        -Force:$Force
+
+    Set-CascadeReason -Entry $Entry -Reason ([pscustomobject]@{ Target = $TargetPackageName; Breaking = $true })
+
+    return ($Entry.EffectiveChangeType -ne $previousChangeType -or
+        $Entry.EffectiveTargetVersion -ne $previousTargetVersion)
+}
+
 # Turns the parsed token entries from Parse-ReleaseTokens into a *resolved
 # release set* — every package that will receive a release in this invocation,
 # whether the user asked for it directly or it was pulled in by cascade.
@@ -458,14 +553,18 @@ function Resolve-ReleaseSet {
         }
     }
 
-    # Snapshot the user-source folder names before cascade adds cascade-source
-    # entries.
-    $userFolders = @($resolved.Keys) | ForEach-Object { $_ }
+    # Snapshot the folders requested for release before cascade adds pulled-in
+    # entries: these are the origins the cascade expands from, and everything
+    # added later is derived from them. Must stay a snapshot -- the loops below
+    # add to $resolved, and $resolved.Keys is a live view that throws if
+    # enumerated during mutation.
+    $requestedFolders = @($resolved.Keys) | ForEach-Object { $_ }
 
-    # Self-floor user roots before dependency exposure is evaluated. A root the
-    # caller requested as patch may itself require a breaking release, and that
-    # stronger planned transition must cascade to consumers exposing its types.
-    foreach ($folder in $userFolders) {
+    # Self-floor requested folders before dependency exposure is evaluated. A
+    # crate the caller requested as patch may itself require a breaking release,
+    # and that stronger planned transition must cascade to consumers exposing
+    # its types.
+    foreach ($folder in $requestedFolders) {
         $entry = $resolved[$folder]
         if ($entry.IsProcMacroOnly) { continue }
         $required = & $GetRequiredChangeType $entry.Folder $entry.Name
@@ -477,7 +576,7 @@ function Resolve-ReleaseSet {
             -RequirementLabel 'cargo-semver-checks' -RequirementDetail "the crate's own public API changes" -Force:$Force
     }
 
-    foreach ($targetFolder in $userFolders) {
+    foreach ($targetFolder in $requestedFolders) {
         $targetEntry = $resolved[$targetFolder]
         $targetPkg   = $baselineByFolder[$targetFolder]
 
@@ -515,18 +614,7 @@ function Resolve-ReleaseSet {
                 # Dedup cascade reasons by target name (re-encountering the
                 # same edge after a strengthening pass overwrites the prior
                 # reason in place rather than adding a duplicate).
-                $existingReasonIdx = -1
-                for ($i = 0; $i -lt $existing.CascadeReasons.Count; $i++) {
-                    if ($existing.CascadeReasons[$i].Target -eq $cascadeReason.Target) {
-                        $existingReasonIdx = $i
-                        break
-                    }
-                }
-                if ($existingReasonIdx -ge 0) {
-                    $existing.CascadeReasons[$existingReasonIdx] = $cascadeReason
-                } else {
-                    $existing.CascadeReasons.Add($cascadeReason)
-                }
+                Set-CascadeReason -Entry $existing -Reason $cascadeReason
 
                 $reasonsNames = ($existing.CascadeReasons | ForEach-Object { $_.Target } | Sort-Object -Unique) -join ', '
                 Update-EntryForRequiredChangeType -Entry $existing -RequiredChangeType $dependentChangeType `
@@ -567,50 +655,18 @@ function Resolve-ReleaseSet {
         foreach ($sourceEntry in @($resolved.Values)) {
             $sourcePkg = $baselineByFolder[$sourceEntry.Folder]
             if ($null -eq $sourcePkg -or $sourcePkg.IsProcMacroOnly) { continue }
+            if (-not (Test-EntryPlansBreakingRelease -Entry $sourceEntry)) { continue }
 
-            $plannedChangeType = Get-ChangeTypeFromVersions `
-                -oldVersion $sourceEntry.CurrentVersion `
-                -newVersion $sourceEntry.EffectiveTargetVersion
-            if (-not (Test-IsBreakingChange -oldVersion $sourceEntry.CurrentVersion -ChangeType $plannedChangeType)) {
-                continue
-            }
+            $dependentPkgs = Get-PublishedDependentsExposingTarget -TargetPackage $sourcePkg `
+                -WorkspaceBaseline $WorkspaceBaseline -Resolved $resolved
 
-            $sourceCargoName = $sourcePkg.Name.Replace('-', '_')
-            foreach ($dependentPkg in $WorkspaceBaseline) {
-                if (-not $dependentPkg.Published -or $dependentPkg.IsProcMacroOnly) { continue }
-                if ($dependentPkg.Deps -notcontains $sourceCargoName) { continue }
-                if (-not $resolved.Contains($dependentPkg.Folder)) { continue }
-                if (-not (Test-PackageExposesTarget -Dependent $dependentPkg -TargetPackageName $sourcePkg.Name)) {
-                    continue
-                }
-
-                $dependentEntry = $resolved[$dependentPkg.Folder]
-                $previousChangeType = $dependentEntry.EffectiveChangeType
-                $previousTargetVersion = $dependentEntry.EffectiveTargetVersion
-
-                Update-EntryForRequiredChangeType -Entry $dependentEntry -RequiredChangeType 'breaking' `
-                    -RequirementLabel 'exposed-dependency cascade' `
-                    -RequirementDetail "the incompatible planned version of '$($sourcePkg.Name)' exposed in its public API" `
+            foreach ($dependentPkg in $dependentPkgs) {
+                $strengthened = Update-EntryForExposedDependency `
+                    -Entry $resolved[$dependentPkg.Folder] `
+                    -TargetPackageName $sourcePkg.Name `
                     -Force:$Force
 
-                $reasonIndex = -1
-                for ($i = 0; $i -lt $dependentEntry.CascadeReasons.Count; $i++) {
-                    if ($dependentEntry.CascadeReasons[$i].Target -eq $sourcePkg.Name) {
-                        $reasonIndex = $i
-                        break
-                    }
-                }
-                $reason = [pscustomobject]@{ Target = $sourcePkg.Name; Breaking = $true }
-                if ($reasonIndex -ge 0) {
-                    $dependentEntry.CascadeReasons[$reasonIndex] = $reason
-                } else {
-                    $dependentEntry.CascadeReasons.Add($reason)
-                }
-
-                if ($dependentEntry.EffectiveChangeType -ne $previousChangeType -or
-                    $dependentEntry.EffectiveTargetVersion -ne $previousTargetVersion) {
-                    $exposureChanged = $true
-                }
+                if ($strengthened) { $exposureChanged = $true }
             }
         }
     }

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -746,9 +746,11 @@ function Resolve-ReleaseSet {
     # that an unchanged signature now names a type from an incompatible version
     # of an external crate. Propagate that condition over dependency edges --
     # direct, plus indirect edges where a re-exported type is allowlisted under
-    # its defining crate -- until no dependent is strengthened. Use the version
-    # that will actually be written, not EffectiveChangeType, so -Force pins do
-    # not create a fictitious breaking transition farther up the graph.
+    # its defining crate -- until no dependent is strengthened. Each source is
+    # classified by Test-EntryPlansBreakingRelease, which asks whether the entry
+    # ships an incompatible API: normally the version it will actually write,
+    # and additionally a -Force pin that suppressed a breaking requirement,
+    # since such a pin lowers the version number without removing the break.
     $transitiveDependentCache = @{}
     $exposureChanged = $true
     while ($exposureChanged) {

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -364,20 +364,22 @@ function Update-EntryForRequiredChangeType {
 #          bump only the change-type tag.
 #        - or create a new cascade-source entry.
 #      Ordinary library dependents use their own cargo-semver-checks result,
-#      floored at patch. Proc-macro-only dependents use a provisional patch floor
-#      and are explicitly classified in the interactive review.
+#      floored at patch. A second direct-edge pass raises a dependent to breaking
+#      when it exposes a dependency whose planned version transition is
+#      incompatible. The pass repeats to a fixpoint so exposure chains cascade.
+#      Proc-macro-only dependents use a provisional patch floor and are explicitly
+#      classified in the interactive review.
 #      Cascade reasons are recorded per (target → dep) edge with dedup by
 #      target name (re-encountering an edge for an already-strengthened target
 #      overwrites the prior reason in place).
 #
-# Note: cascade is one-level. The set of dependents reachable from a user
-# target is the transitive published dependents BFS. For an ordinary library,
-# the dependent's cascade-applied change type is derived from cargo-semver-checks
-# analysing its OWN current working-tree public API vs its previous version-bump
-# commit, floored at patch because it must re-release to pick up the dependency
-# version. A proc-macro-only dependent starts at that mechanical patch floor and
-# is then classified by the user in the standard review dialog. This replaces
-# the former allowed_external_types exposure heuristic.
+# The release-set membership walk starts from user targets and includes every
+# transitive published dependent. Severity is then resolved from two independent
+# signals: cargo-semver-checks analyses each crate's own API diff, while
+# allowed_external_types detects incompatible version changes in dependencies
+# exposed through otherwise-unchanged public signatures. A proc-macro-only
+# dependent starts at the mechanical patch floor and is then classified by the
+# user in the standard review dialog.
 function Resolve-ReleaseSet {
     param(
         [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$ParsedTokens,
@@ -457,9 +459,23 @@ function Resolve-ReleaseSet {
     }
 
     # Snapshot the user-source folder names before cascade adds cascade-source
-    # entries — cascade-source entries are not themselves iterated for further
-    # cascades (one-level cascade semantics).
+    # entries.
     $userFolders = @($resolved.Keys) | ForEach-Object { $_ }
+
+    # Self-floor user roots before dependency exposure is evaluated. A root the
+    # caller requested as patch may itself require a breaking release, and that
+    # stronger planned transition must cascade to consumers exposing its types.
+    foreach ($folder in $userFolders) {
+        $entry = $resolved[$folder]
+        if ($entry.IsProcMacroOnly) { continue }
+        $required = & $GetRequiredChangeType $entry.Folder $entry.Name
+        if ($required -eq 'manual') {
+            throw "Internal error: '$($entry.Name)' requires manual SemVer review but cargo metadata did not classify it as proc-macro-only."
+        }
+        if ([string]::IsNullOrEmpty($required) -or $required -eq 'none') { continue }
+        Update-EntryForRequiredChangeType -Entry $entry -RequiredChangeType $required `
+            -RequirementLabel 'cargo-semver-checks' -RequirementDetail "the crate's own public API changes" -Force:$Force
+    }
 
     foreach ($targetFolder in $userFolders) {
         $targetEntry = $resolved[$targetFolder]
@@ -538,22 +554,65 @@ function Resolve-ReleaseSet {
         }
     }
 
-    # Self-floor: raise each USER-source entry's change type to at least what
-    # cargo-semver-checks requires for its OWN public API vs its previous
-    # version-bump commit. The cascade above already floored dependents; this catches
-    # user-source ROOTS that nothing cascades into (e.g. releasing a single leaf
-    # crate whose own API broke). Author intent is never downgraded — only raised
-    # when the real API diff demands a stronger change type.
-    foreach ($folder in $userFolders) {
-        $entry    = $resolved[$folder]
-        if ($entry.IsProcMacroOnly) { continue }
-        $required = & $GetRequiredChangeType $entry.Folder $entry.Name
-        if ($required -eq 'manual') {
-            throw "Internal error: '$($entry.Name)' requires manual SemVer review but cargo metadata did not classify it as proc-macro-only."
+    # cargo-semver-checks compares one crate's rustdoc API and cannot identify
+    # that an unchanged signature now names a type from an incompatible version
+    # of an external crate. Propagate that condition over direct dependency edges
+    # until no dependent is strengthened. Use the version that will actually be
+    # written, not EffectiveChangeType, so -Force pins do not create a fictitious
+    # breaking transition farther up the graph.
+    $exposureChanged = $true
+    while ($exposureChanged) {
+        $exposureChanged = $false
+
+        foreach ($sourceEntry in @($resolved.Values)) {
+            $sourcePkg = $baselineByFolder[$sourceEntry.Folder]
+            if ($null -eq $sourcePkg -or $sourcePkg.IsProcMacroOnly) { continue }
+
+            $plannedChangeType = Get-ChangeTypeFromVersions `
+                -oldVersion $sourceEntry.CurrentVersion `
+                -newVersion $sourceEntry.EffectiveTargetVersion
+            if (-not (Test-IsBreakingChange -oldVersion $sourceEntry.CurrentVersion -ChangeType $plannedChangeType)) {
+                continue
+            }
+
+            $sourceCargoName = $sourcePkg.Name.Replace('-', '_')
+            foreach ($dependentPkg in $WorkspaceBaseline) {
+                if (-not $dependentPkg.Published -or $dependentPkg.IsProcMacroOnly) { continue }
+                if ($dependentPkg.Deps -notcontains $sourceCargoName) { continue }
+                if (-not $resolved.Contains($dependentPkg.Folder)) { continue }
+                if (-not (Test-PackageExposesTarget -Dependent $dependentPkg -TargetPackageName $sourcePkg.Name)) {
+                    continue
+                }
+
+                $dependentEntry = $resolved[$dependentPkg.Folder]
+                $previousChangeType = $dependentEntry.EffectiveChangeType
+                $previousTargetVersion = $dependentEntry.EffectiveTargetVersion
+
+                Update-EntryForRequiredChangeType -Entry $dependentEntry -RequiredChangeType 'breaking' `
+                    -RequirementLabel 'exposed-dependency cascade' `
+                    -RequirementDetail "the incompatible planned version of '$($sourcePkg.Name)' exposed in its public API" `
+                    -Force:$Force
+
+                $reasonIndex = -1
+                for ($i = 0; $i -lt $dependentEntry.CascadeReasons.Count; $i++) {
+                    if ($dependentEntry.CascadeReasons[$i].Target -eq $sourcePkg.Name) {
+                        $reasonIndex = $i
+                        break
+                    }
+                }
+                $reason = [pscustomobject]@{ Target = $sourcePkg.Name; Breaking = $true }
+                if ($reasonIndex -ge 0) {
+                    $dependentEntry.CascadeReasons[$reasonIndex] = $reason
+                } else {
+                    $dependentEntry.CascadeReasons.Add($reason)
+                }
+
+                if ($dependentEntry.EffectiveChangeType -ne $previousChangeType -or
+                    $dependentEntry.EffectiveTargetVersion -ne $previousTargetVersion) {
+                    $exposureChanged = $true
+                }
+            }
         }
-        if ([string]::IsNullOrEmpty($required) -or $required -eq 'none') { continue }
-        Update-EntryForRequiredChangeType -Entry $entry -RequiredChangeType $required `
-            -RequirementLabel 'cargo-semver-checks' -RequirementDetail "the crate's own public API changes" -Force:$Force
     }
 
     return @($resolved.Values)

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -423,8 +423,7 @@ function Get-PublishedDependentsExposingTarget {
             $Resolved.Contains($_.Folder) -and
             $(
                 if ($_.Deps -contains $targetCargoName) {
-                    Test-PackageExposesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name `
-                        -TargetCrateRoot $TargetPackage.CrateRoot
+                    Test-PackageExposesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name
                 } else {
                     $reachable.Contains($_.Folder) -and
                     (Test-PackageAllowlistNamesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name `

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -376,6 +376,9 @@ function Test-EntryPlansBreakingRelease {
 #     cargo-check-external-types attributes a re-exported type to its defining
 #     crate, so a crate reaching `a::T` through `b` allowlists `a` while
 #     depending only on `b`. Requiring a direct edge missed these entirely.
+#     The root matched here is the target's own crate root (its [lib] name),
+#     not a rename alias: renames live on edges, and an indirect dependent
+#     declares no edge to the target to rename.
 #     This branch demands positive evidence rather than failing closed, so it
 #     cannot drag in transitive dependents that merely lack metadata -- those
 #     are already covered by their own direct edges, walked up by the fixpoint.
@@ -420,10 +423,12 @@ function Get-PublishedDependentsExposingTarget {
             $Resolved.Contains($_.Folder) -and
             $(
                 if ($_.Deps -contains $targetCargoName) {
-                    Test-PackageExposesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name
+                    Test-PackageExposesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name `
+                        -TargetCrateRoot $TargetPackage.CrateRoot
                 } else {
                     $reachable.Contains($_.Folder) -and
-                    (Test-PackageAllowlistNamesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name)
+                    (Test-PackageAllowlistNamesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name `
+                        -TargetCrateRoot $TargetPackage.CrateRoot)
                 }
             )
         })

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -352,19 +352,27 @@ function Set-CascadeReason {
 # breaking).
 #
 # PinHonoredAgainstCascade is the second signal, and it is not redundant. It is
-# set only when -Force honored an explicit pin BELOW a required breaking
-# version, which writes a numerically compatible version over a genuinely
-# incompatible API. The break is real: a crate pinned to 1.1.0 while exposing a
-# dependency that went 2.0.0 is still compiled against that 2.0.0, so its
-# public API names different types than 1.0.0 did. Under caret semantics a
-# consumer of `1.0` upgrades into it silently. Judging that entry by its
-# version alone stops the cascade at exactly the crate whose break was
-# suppressed, letting dependents ship compatible releases over it -- the silent
-# SemVer break this cascade exists to prevent.
+# set only when -Force honored an explicit pin BELOW a required version, which
+# writes a numerically compatible version over an API that the requirement says
+# is not. When the suppressed requirement was itself breaking, the break is
+# real: a crate pinned to 1.1.0 while exposing a dependency that went 2.0.0 is
+# still compiled against that 2.0.0, so its public API names different types
+# than 1.0.0 did. Under caret semantics a consumer of `1.0` upgrades into it
+# silently. Judging that entry by its version alone stops the cascade at
+# exactly the crate whose break was suppressed, letting dependents ship
+# compatible releases over it -- the silent SemVer break this cascade exists to
+# prevent.
 #
 # -Force means "write my number and warn me", not "the incompatibility is not
 # there". Propagation must follow the API, so it follows the unmet requirement
 # too.
+#
+# The suppressed requirement is tested with the same Test-IsBreakingChange used
+# for the planned transition, NOT compared against the literal 'breaking'. The
+# flag is set for any suppressed requirement, including a merely additive one,
+# and a forced non-breaking pin must not drag exposing dependents to a major
+# release. Routing it through the same predicate also keeps 0.x semantics
+# consistent between the two branches.
 #
 # Only the exposure fixpoint calls this, and it already skips proc-macro-only
 # sources -- so a 'breaking' tag arising from proc-macro manual review, which
@@ -374,7 +382,8 @@ function Test-EntryPlansBreakingRelease {
         [Parameter(Mandatory = $true)][pscustomobject]$Entry
     )
 
-    if ($Entry.PinHonoredAgainstCascade) {
+    if ($Entry.PinHonoredAgainstCascade -and
+        (Test-IsBreakingChange -oldVersion $Entry.CurrentVersion -ChangeType $Entry.EffectiveChangeType)) {
         return $true
     }
 

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -292,8 +292,8 @@ function Update-EntryForRequiredChangeType {
                 throw "Cannot release '$($Entry.Folder)' as v$($Entry.RequestedTargetVersion): $RequirementLabel requires at least v$requiredVersion because of $RequirementDetail. Specify a higher version pin, use a change-type keyword, or pass -Force to honor the pin verbatim (consumers may break)."
             }
         } else {
-            # Pin still satisfies. Bump the tag so downstream cascade decisions
-            # are correct, but keep the pinned version.
+            # Pin still satisfies. Bump the tag to record the stronger
+            # requirement for diagnostics, but keep the pinned version.
             $Entry.EffectiveChangeType = $RequiredChangeType
         }
     } else {
@@ -473,11 +473,12 @@ function Update-EntryForExposedDependency {
 #   -Force            : if set, an explicit version pin that numerically
 #                       undershoots the cascade-required version is honored
 #                       verbatim instead of throwing. EffectiveChangeType is
-#                       still upgraded so dependent cascade decisions are
-#                       correct; PinHonoredAgainstCascade is set so callers
-#                       (and Show-ReleasePlan) can warn the user. -Force does
-#                       NOT relax the always-fatal "pin is not strictly
-#                       greater than the current on-disk version" check.
+#                       still upgraded to record the stronger unmet requirement;
+#                       PinHonoredAgainstCascade lets callers warn the user.
+#                       Exposure propagation uses the actual CurrentVersion to
+#                       EffectiveTargetVersion transition, not the severity tag.
+#                       -Force does NOT relax the always-fatal "pin is not
+#                       strictly greater than the current on-disk version" check.
 #
 # Returns: an array of pscustomobject entries, one per resolved package:
 #
@@ -494,7 +495,7 @@ function Update-EntryForExposedDependency {
 #     PinHonoredAgainstCascade  = $true|$false   # -Force kept an explicit pin below cascade-required version
 #     IsProcMacroOnly           = $true|$false   # cargo metadata target classification
 #     RequiresManualSemverReview = $true|$false  # proc-macro API cannot be checked automatically
-#     CascadeReasons            = [List<{Target,Breaking}>]                  # one per (target → dep) edge
+#     CascadeReasons            = [List<{Target,Breaking}>]                  # one per target package cause
 #     RawToken                  = '<original token>'|$null                   # null for cascade-source
 #   }
 #
@@ -512,9 +513,9 @@ function Update-EntryForExposedDependency {
 #          auto-upgrade silently and set AutoUpgraded=$true. For user-source
 #          entries with an explicit version pin, throw if the pin would
 #          numerically undershoot the cascade-required version (or, with
-#          -Force, honor the pin verbatim, upgrade the change-type tag, and
-#          set PinHonoredAgainstCascade=$true); otherwise honour the pin and
-#          bump only the change-type tag.
+#          -Force, honor the pin verbatim, record the unmet requirement in the
+#          change-type tag, and set PinHonoredAgainstCascade=$true); otherwise
+#          honour the pin and bump only the diagnostic change-type tag.
 #        - or create a new cascade-source entry.
 #      Ordinary library dependents use their own cargo-semver-checks result,
 #      floored at patch. A second pass raises a dependent to breaking when it
@@ -527,9 +528,10 @@ function Update-EntryForExposedDependency {
 #      chains cascade.
 #      Proc-macro-only dependents use a provisional patch floor and are explicitly
 #      classified in the interactive review.
-#      Cascade reasons are recorded per (target → dep) edge with dedup by
-#      target name (re-encountering an edge for an already-strengthened target
-#      overwrites the prior reason in place).
+#      Cascade reasons are package-level release causes, recorded once per
+#      target package name for membership or exposure strengthening. They do
+#      not assert a direct dependency edge; callers needing edges must query
+#      the dependency graph.
 #
 # The release-set membership walk starts from user targets and includes every
 # transitive published dependent. Severity is then resolved from two independent

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -343,18 +343,40 @@ function Set-CascadeReason {
     $Entry.CascadeReasons.Add($Reason)
 }
 
-# Returns $true when the version this entry will actually write is an
-# incompatible transition from the version currently on disk.
+# Returns $true when this entry ships an API incompatible with its previous
+# release -- whether or not the version number admits it.
 #
-# Deliberately derived from EffectiveTargetVersion rather than
-# EffectiveChangeType: a -Force pin honored below the cascade-required version
-# carries a 'breaking' tag while writing a version that is not in fact a
-# breaking transition, and cascading from the tag would invent a break farther
-# up the graph that consumers never actually see.
+# The version transition is the primary signal, derived from the versions
+# rather than from EffectiveChangeType so that 0.x semantics are applied by
+# the same rules that produced the number (under 0.x a minor bump is itself
+# breaking).
+#
+# PinHonoredAgainstCascade is the second signal, and it is not redundant. It is
+# set only when -Force honored an explicit pin BELOW a required breaking
+# version, which writes a numerically compatible version over a genuinely
+# incompatible API. The break is real: a crate pinned to 1.1.0 while exposing a
+# dependency that went 2.0.0 is still compiled against that 2.0.0, so its
+# public API names different types than 1.0.0 did. Under caret semantics a
+# consumer of `1.0` upgrades into it silently. Judging that entry by its
+# version alone stops the cascade at exactly the crate whose break was
+# suppressed, letting dependents ship compatible releases over it -- the silent
+# SemVer break this cascade exists to prevent.
+#
+# -Force means "write my number and warn me", not "the incompatibility is not
+# there". Propagation must follow the API, so it follows the unmet requirement
+# too.
+#
+# Only the exposure fixpoint calls this, and it already skips proc-macro-only
+# sources -- so a 'breaking' tag arising from proc-macro manual review, which
+# need not imply any rustdoc-visible break, never reaches here.
 function Test-EntryPlansBreakingRelease {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Entry
     )
+
+    if ($Entry.PinHonoredAgainstCascade) {
+        return $true
+    }
 
     $plannedChangeType = Get-ChangeTypeFromVersions `
         -oldVersion $Entry.CurrentVersion `
@@ -474,9 +496,10 @@ function Update-EntryForExposedDependency {
 #                       undershoots the cascade-required version is honored
 #                       verbatim instead of throwing. EffectiveChangeType is
 #                       still upgraded to record the stronger unmet requirement;
-#                       PinHonoredAgainstCascade lets callers warn the user.
-#                       Exposure propagation uses the actual CurrentVersion to
-#                       EffectiveTargetVersion transition, not the severity tag.
+#                       PinHonoredAgainstCascade lets callers warn the user and
+#                       keeps the exposure cascade running past the pin, since
+#                       the pin lowers the version number rather than the
+#                       incompatibility of the API being shipped.
 #                       -Force does NOT relax the always-fatal "pin is not
 #                       strictly greater than the current on-disk version" check.
 #
@@ -519,7 +542,8 @@ function Update-EntryForExposedDependency {
 #        - or create a new cascade-source entry.
 #      Ordinary library dependents use their own cargo-semver-checks result,
 #      floored at patch. A second pass raises a dependent to breaking when it
-#      exposes a dependency whose planned version transition is incompatible.
+#      exposes a dependency that ships an incompatible API -- an incompatible
+#      planned version transition, or a forced pin that suppressed one.
 #      That pass considers direct dependency edges (failing closed on absent or
 #      malformed allowlist metadata) plus indirect edges to a transitive
 #      dependency whose types the dependent explicitly allowlists, which is how

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -572,8 +572,9 @@ function Get-CrateRequiredChangeType {
 #   Published             - $true if the package is published to crates.io
 #   Deps                  - array of normalized dependency names (kind 'normal' or 'build', not 'dev')
 #   DepAliases            - hashtable mapping a normalized dependency name to the normalized
-#                           aliases it is renamed to, for the deps that declare `package = "..."`;
-#                           empty when nothing is renamed
+#                           crate roots it is reachable under when those differ from the
+#                           package name -- the `package = "..."` alias, or the dependency's
+#                           own `[lib] name`; empty when every dep is nameable by its own name
 #   AllowedExternalTypes  - array of strings from [package.metadata.cargo_check_external_types],
 #                           or $null if the package does not declare them
 #   HasLibraryTarget      - $true when cargo metadata reports a regular 'lib' target
@@ -585,6 +586,27 @@ function Get-WorkspacePackages {
     $cratesDir = [System.IO.Path]::GetFullPath((Join-Path $repoRoot "crates"))
 
     $packages = @()
+
+    # A dependency is nameable in Rust source -- and so in an
+    # allowed_external_types entry -- by its *crate root*, which is not always
+    # its package name: `[lib] name = "..."` renames the crate root while the
+    # package keeps its own name. Map each workspace package to its crate root
+    # so the dependency loop below can resolve the name an allowlist will
+    # actually carry.
+    #
+    # Only workspace members are covered, because `cargo metadata --no-deps`
+    # reports targets for nothing else. That is sufficient here: the exposure
+    # cascade only ever asks about workspace packages, since a registry crate
+    # is never a release target.
+    $crateRootByPackage = @{}
+    foreach ($package in $metadata.packages) {
+        $libTarget = $package.targets |
+            Where-Object { @($_.kind) -contains 'lib' -or @($_.kind) -contains 'proc-macro' } |
+            Select-Object -First 1
+        if ($null -eq $libTarget) { continue }
+        $crateRootByPackage[$package.name.Replace('-', '_')] = ([string]$libTarget.name).Replace('-', '_')
+    }
+
     foreach ($package in $metadata.packages) {
         $manifestDir = [System.IO.Path]::GetFullPath((Split-Path $package.manifest_path -Parent))
         if (-not $manifestDir.StartsWith($cratesDir, [System.StringComparison]::OrdinalIgnoreCase)) {
@@ -612,6 +634,22 @@ function Get-WorkspacePackages {
                 # aliases (per-target or per-feature), so collect them all.
                 $depAliases[$depCargoName] = @(@($depAliases[$depCargoName]) + $alias |
                         Where-Object { $_ } | Sort-Object -Unique)
+            }
+            else {
+                # No `package = "..."`, so the crate root is whatever the
+                # dependency's own manifest calls its lib target. A crate whose
+                # `[lib] name` differs from its package name is nameable only
+                # under the lib name, so that -- not the package name -- is what
+                # an allowlist entry carries.
+                #
+                # Only reached when `rename` is absent, because `rename` wins:
+                # `foo = { package = "bar" }` makes the crate nameable as `foo`
+                # regardless of what bar calls its lib target.
+                $crateRoot = $crateRootByPackage[$depCargoName]
+                if ($crateRoot -and $crateRoot -ne $depCargoName) {
+                    $depAliases[$depCargoName] = @(@($depAliases[$depCargoName]) + $crateRoot |
+                            Where-Object { $_ } | Sort-Object -Unique)
+                }
             }
         }
 
@@ -647,12 +685,17 @@ function Get-WorkspacePackages {
 }
 
 # Returns the allowlist roots that count as naming $TargetPackageName in the
-# dependent's public API: the target's own normalized name, plus any alias it is
-# declared under.
+# dependent's public API: the target's own normalized name, plus any crate root
+# it is reachable under.
 #
-# A dependency declared with `package = "..."` is nameable in Rust source only
-# under its alias, so that is the root an allowed_external_types entry will
-# carry. Matching solely on the real package name would find nothing and report
+# A package name is not always the name its types are written under. Two things
+# divert it, both recorded in DepAliases by Get-WorkspacePackages:
+#   - `package = "..."` on the dependency, which makes the crate nameable only
+#     under the alias; and
+#   - `[lib] name = "..."` in the dependency's own manifest, which renames the
+#     crate root for every consumer.
+# Either way that is the root an allowed_external_types entry will carry.
+# Matching solely on the real package name would find nothing and report
 # "not exposed" -- a fail-open that ships a break as compatible.
 function Get-AcceptedExposureRoots {
     param(

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -806,6 +806,9 @@ function Test-PackageExposesTarget {
         }
 
         $root = ($entry -split '::', 2)[0]
+        if ([string]::IsNullOrWhiteSpace($root)) {
+            return $true
+        }
         if ($root.Contains('*') -or $root.Contains('?') -or $root.Contains('[')) {
             return $true
         }
@@ -864,12 +867,15 @@ function Test-PackageAllowlistNamesTarget {
     # This predicate is called only when no dependency edge to the target
     # exists. DepAliases is therefore irrelevant: production can populate an
     # alias only while processing a declared edge, which would take the direct
-    # branch instead. The only roots possible here belong to the target itself.
-    $acceptedRoots = @($TargetPackageName.Replace('-', '_'))
+    # branch instead. When the target's crate root is known it is exclusive:
+    # `[lib] name` replaces the package name as the usable Rust root. The
+    # package name remains only as compatibility for older synthetic records
+    # that predate CrateRoot.
     if (-not [string]::IsNullOrWhiteSpace($TargetCrateRoot)) {
-        $acceptedRoots += $TargetCrateRoot.Replace('-', '_')
+        $acceptedRoots = @($TargetCrateRoot.Replace('-', '_'))
+    } else {
+        $acceptedRoots = @($TargetPackageName.Replace('-', '_'))
     }
-    $acceptedRoots = @($acceptedRoots | Sort-Object -Unique)
 
     foreach ($entry in $Dependent.AllowedExternalTypes) {
         if ($entry -isnot [string] -or [string]::IsNullOrWhiteSpace($entry)) {

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -646,6 +646,30 @@ function Get-WorkspacePackages {
     return $packages
 }
 
+# Returns the allowlist roots that count as naming $TargetPackageName in the
+# dependent's public API: the target's own normalized name, plus any alias it is
+# declared under.
+#
+# A dependency declared with `package = "..."` is nameable in Rust source only
+# under its alias, so that is the root an allowed_external_types entry will
+# carry. Matching solely on the real package name would find nothing and report
+# "not exposed" -- a fail-open that ships a break as compatible.
+function Get-AcceptedExposureRoots {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
+        [Parameter(Mandatory = $true)][string]$TargetPackageName
+    )
+
+    $normalizedTarget = $TargetPackageName.Replace('-', '_')
+
+    $roots = @($normalizedTarget)
+    if ($Dependent.PSObject.Properties['DepAliases'] -and $null -ne $Dependent.DepAliases) {
+        $roots += @($Dependent.DepAliases[$normalizedTarget])
+    }
+
+    return @($roots | Where-Object { $_ })
+}
+
 # Returns $true unless the package's cargo-check-external-types allowlist is
 # positive evidence that its public API cannot name types rooted at the target
 # package. Anything short of that evidence counts as exposure: an unknown must
@@ -679,15 +703,7 @@ function Test-PackageExposesTarget {
 
     $normalizedTarget = $TargetPackageName.Replace('-', '_')
 
-    # A dependency declared with `package = "..."` is nameable in Rust source
-    # only under its alias, so that is the root an allowed_external_types entry
-    # will carry. Matching solely on the real package name would find nothing
-    # and report "not exposed" -- a fail-open that ships a break as compatible.
-    $acceptedRoots = @($normalizedTarget)
-    if ($Dependent.PSObject.Properties['DepAliases'] -and $null -ne $Dependent.DepAliases) {
-        $acceptedRoots += @($Dependent.DepAliases[$normalizedTarget])
-    }
-    $acceptedRoots = @($acceptedRoots | Where-Object { $_ })
+    $acceptedRoots = Get-AcceptedExposureRoots -Dependent $Dependent -TargetPackageName $TargetPackageName
 
     foreach ($entry in $Dependent.AllowedExternalTypes) {
         # An entry that is not a usable non-empty string carries no information
@@ -698,6 +714,61 @@ function Test-PackageExposesTarget {
         # it silently collapses to '' and matches nothing, which is worse.)
         if ($entry -isnot [string] -or [string]::IsNullOrWhiteSpace($entry)) {
             return $true
+        }
+
+        $root = ($entry -split '::', 2)[0]
+        if ($root.Contains('*') -or $root.Contains('?') -or $root.Contains('[')) {
+            return $true
+        }
+        if ($acceptedRoots -contains $root) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+# Returns $true when the dependent's allowlist is positive evidence that its
+# public API names types rooted at $TargetPackageName.
+#
+# This is the affirmative half of Test-PackageExposesTarget with none of its
+# fail-closed branches: absent or malformed metadata answers $false here.
+# The two are used for different edges, and the difference is deliberate.
+#
+# Test-PackageExposesTarget answers "may this crate expose the target?" for a
+# DIRECT dependency, where absent metadata is a genuine unknown that must fail
+# closed.
+#
+# This function answers "does this crate claim to name the target's types?" for
+# an INDIRECT dependency. cargo-check-external-types attributes a re-exported
+# type to its DEFINING crate, so a crate that reaches `a::T` through `b`
+# allowlists `a` while depending only on `b` (fetch_azure documents exactly this
+# for typespec_client_core). Such an edge is invisible to a direct-dependency
+# scan, so it needs its own check.
+#
+# It must not inherit the fail-closed branches, because "no allowlist" would
+# then match every transitive dependency in the graph and force unrelated
+# crates breaking. A crate with no allowlist that truly does expose the target
+# is still caught: it fails closed on its direct edge to whichever intermediate
+# carries the type, and the fixpoint walks that up the graph.
+#
+# A wildcard root is the one unknown still treated as a match: it can expand to
+# the target, and unlike absent metadata it is a deliberate, rare declaration.
+function Test-PackageAllowlistNamesTarget {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
+        [Parameter(Mandatory = $true)][string]$TargetPackageName
+    )
+
+    if ($null -eq $Dependent.AllowedExternalTypes) {
+        return $false
+    }
+
+    $acceptedRoots = Get-AcceptedExposureRoots -Dependent $Dependent -TargetPackageName $TargetPackageName
+
+    foreach ($entry in $Dependent.AllowedExternalTypes) {
+        if ($entry -isnot [string] -or [string]::IsNullOrWhiteSpace($entry)) {
+            continue
         }
 
         $root = ($entry -split '::', 2)[0]

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -709,13 +709,24 @@ function Get-WorkspacePackages {
 #     edge, and so is available whether or not the dependency is declared.
 #
 # $TargetCrateRoot belongs to the third case ONLY, and the caller must withhold
-# it for the first two. On a declared edge DepAliases is already the complete
-# and *authoritative* answer, because a `package = "..."` rename shadows the
-# lib name entirely: a dependent that imports the crate as `aliased_dep` cannot
-# write `dep_core::Handle` no matter what the target's manifest says. Adding
-# the target's global root back on such an edge re-accepts a name the dependent
+# it for the first two. On a declared edge DepAliases already records the name
+# the target is reachable under, and it is authoritative *over the target's
+# global crate root*, because a `package = "..."` rename shadows the lib name
+# entirely: a dependent that imports the crate as `aliased_dep` cannot write
+# `dep_core::Handle` no matter what the target's manifest says. Adding the
+# target's global root back on such an edge re-accepts a name the dependent
 # provably cannot use, turning an unrelated allowlist entry that happens to
 # collide with it into a false exposure and a spurious breaking bump.
+#
+# The real package name below is a known over-acceptance, not a considered
+# exception to that rule: a rename shadows the package name exactly as it
+# shadows the lib name, so `dependency::*` is equally unwritable on an edge
+# reachable only as `aliased_dep`. Narrowing it needs data this record does not
+# carry -- whether an *unrenamed* edge to the target also exists, since a
+# package may be depended on twice, once aliased and once not. Dropping the
+# name without that would fail open on the ordinary unrenamed edge, which is
+# the far worse direction, so it stays until the edge data can distinguish the
+# two. It errs toward a spurious bump, never toward a missed break.
 #
 # Any of them is the root an allowed_external_types entry may carry. Matching
 # solely on the real package name would find nothing and report "not exposed"

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -708,6 +708,15 @@ function Get-WorkspacePackages {
 #     $TargetCrateRoot, which is a property of the target rather than of any
 #     edge, and so is available whether or not the dependency is declared.
 #
+# $TargetCrateRoot belongs to the third case ONLY, and the caller must withhold
+# it for the first two. On a declared edge DepAliases is already the complete
+# and *authoritative* answer, because a `package = "..."` rename shadows the
+# lib name entirely: a dependent that imports the crate as `aliased_dep` cannot
+# write `dep_core::Handle` no matter what the target's manifest says. Adding
+# the target's global root back on such an edge re-accepts a name the dependent
+# provably cannot use, turning an unrelated allowlist entry that happens to
+# collide with it into a false exposure and a spurious breaking bump.
+#
 # Any of them is the root an allowed_external_types entry may carry. Matching
 # solely on the real package name would find nothing and report "not exposed"
 # -- a fail-open that ships a break as compatible.
@@ -715,8 +724,9 @@ function Get-AcceptedExposureRoots {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
         [Parameter(Mandatory = $true)][string]$TargetPackageName,
-        # The target's own crate root, from its package record. Optional so
-        # callers that only have a name still get the package-name behaviour.
+        # The target's own crate root, from its package record. Supplied only
+        # for an undeclared (indirect) edge -- see the note above on why a
+        # declared edge must rely on DepAliases instead.
         [string]$TargetCrateRoot
     )
 
@@ -737,11 +747,15 @@ function Get-AcceptedExposureRoots {
 # positive evidence that its public API cannot name types rooted at the target
 # package. Anything short of that evidence counts as exposure: an unknown must
 # not permit a breaking dependency bump to ship as a compatible release.
+#
+# This predicate is for DECLARED edges only, so it deliberately takes no
+# TargetCrateRoot: the dependent's own DepAliases entry already records the
+# name the target is reachable under on this edge, rename included, and is
+# authoritative over the target's global crate root.
 function Test-PackageExposesTarget {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
-        [Parameter(Mandatory = $true)][string]$TargetPackageName,
-        [string]$TargetCrateRoot
+        [Parameter(Mandatory = $true)][string]$TargetPackageName
     )
 
     # `$null` here means the crate declares no allowed_external_types policy at
@@ -766,7 +780,7 @@ function Test-PackageExposesTarget {
     }
 
     $acceptedRoots = Get-AcceptedExposureRoots -Dependent $Dependent `
-        -TargetPackageName $TargetPackageName -TargetCrateRoot $TargetCrateRoot
+        -TargetPackageName $TargetPackageName
 
     foreach ($entry in $Dependent.AllowedExternalTypes) {
         # An entry that is not a usable non-empty string carries no information

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -575,6 +575,11 @@ function Get-CrateRequiredChangeType {
 #                           crate roots it is reachable under when those differ from the
 #                           package name -- the `package = "..."` alias, or the dependency's
 #                           own `[lib] name`; empty when every dep is nameable by its own name
+#   CrateRoot             - the package's own normalized crate root (its `[lib] name` when it
+#                           sets one, else its normalized package name), or $null when the
+#                           package has no library target at all. This is the name a crate's
+#                           types are written under by anything that does not rename it, so it
+#                           is the root an allowlist carries for a re-exported type.
 #   AllowedExternalTypes  - array of strings from [package.metadata.cargo_check_external_types],
 #                           or $null if the package does not declare them
 #   HasLibraryTarget      - $true when cargo metadata reports a regular 'lib' target
@@ -675,6 +680,7 @@ function Get-WorkspacePackages {
             Published            = -not ($null -ne $package.publish -and $package.publish.Count -eq 0)
             Deps                 = $deps
             DepAliases           = $depAliases
+            CrateRoot            = $crateRootByPackage[$package.name.Replace('-', '_')]
             AllowedExternalTypes = $allowedTypes
             HasLibraryTarget     = $hasLibraryTarget
             IsProcMacroOnly      = (-not $hasLibraryTarget) -and ($targetKinds -contains 'proc-macro')
@@ -688,19 +694,30 @@ function Get-WorkspacePackages {
 # dependent's public API: the target's own normalized name, plus any crate root
 # it is reachable under.
 #
-# A package name is not always the name its types are written under. Two things
-# divert it, both recorded in DepAliases by Get-WorkspacePackages:
+# A package name is not always the name its types are written under. Three
+# things divert it:
 #   - `package = "..."` on the dependency, which makes the crate nameable only
-#     under the alias; and
+#     under the alias (recorded per-edge in the dependent's DepAliases);
 #   - `[lib] name = "..."` in the dependency's own manifest, which renames the
-#     crate root for every consumer.
-# Either way that is the root an allowed_external_types entry will carry.
-# Matching solely on the real package name would find nothing and report
-# "not exposed" -- a fail-open that ships a break as compatible.
+#     crate root for every consumer (recorded in DepAliases too, for the
+#     dependents that declare the edge); and
+#   - the same `[lib] name`, seen from a crate that does NOT declare the edge.
+#     A re-exported type is attributed to its defining crate, so a dependent
+#     several hops away names it without depending on it -- and having no edge,
+#     it has no DepAliases entry for it either. That case is covered by
+#     $TargetCrateRoot, which is a property of the target rather than of any
+#     edge, and so is available whether or not the dependency is declared.
+#
+# Any of them is the root an allowed_external_types entry may carry. Matching
+# solely on the real package name would find nothing and report "not exposed"
+# -- a fail-open that ships a break as compatible.
 function Get-AcceptedExposureRoots {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
-        [Parameter(Mandatory = $true)][string]$TargetPackageName
+        [Parameter(Mandatory = $true)][string]$TargetPackageName,
+        # The target's own crate root, from its package record. Optional so
+        # callers that only have a name still get the package-name behaviour.
+        [string]$TargetCrateRoot
     )
 
     $normalizedTarget = $TargetPackageName.Replace('-', '_')
@@ -709,8 +726,11 @@ function Get-AcceptedExposureRoots {
     if ($Dependent.PSObject.Properties['DepAliases'] -and $null -ne $Dependent.DepAliases) {
         $roots += @($Dependent.DepAliases[$normalizedTarget])
     }
+    if (-not [string]::IsNullOrWhiteSpace($TargetCrateRoot)) {
+        $roots += $TargetCrateRoot.Replace('-', '_')
+    }
 
-    return @($roots | Where-Object { $_ })
+    return @($roots | Where-Object { $_ } | Sort-Object -Unique)
 }
 
 # Returns $true unless the package's cargo-check-external-types allowlist is
@@ -720,7 +740,8 @@ function Get-AcceptedExposureRoots {
 function Test-PackageExposesTarget {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
-        [Parameter(Mandatory = $true)][string]$TargetPackageName
+        [Parameter(Mandatory = $true)][string]$TargetPackageName,
+        [string]$TargetCrateRoot
     )
 
     # `$null` here means the crate declares no allowed_external_types policy at
@@ -744,9 +765,8 @@ function Test-PackageExposesTarget {
         return $true
     }
 
-    $normalizedTarget = $TargetPackageName.Replace('-', '_')
-
-    $acceptedRoots = Get-AcceptedExposureRoots -Dependent $Dependent -TargetPackageName $TargetPackageName
+    $acceptedRoots = Get-AcceptedExposureRoots -Dependent $Dependent `
+        -TargetPackageName $TargetPackageName -TargetCrateRoot $TargetCrateRoot
 
     foreach ($entry in $Dependent.AllowedExternalTypes) {
         # An entry that is not a usable non-empty string carries no information
@@ -789,6 +809,10 @@ function Test-PackageExposesTarget {
 # for typespec_client_core). Such an edge is invisible to a direct-dependency
 # scan, so it needs its own check.
 #
+# Because there is no declared edge, the name the allowlist carries comes from
+# the target itself -- its crate root -- and never from a rename, which only a
+# crate that declares the dependency can apply. Hence -TargetCrateRoot.
+#
 # It must not inherit the fail-closed branches, because "no allowlist" would
 # then match every transitive dependency in the graph and force unrelated
 # crates breaking. A crate with no allowlist that truly does expose the target
@@ -800,14 +824,19 @@ function Test-PackageExposesTarget {
 function Test-PackageAllowlistNamesTarget {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
-        [Parameter(Mandatory = $true)][string]$TargetPackageName
+        [Parameter(Mandatory = $true)][string]$TargetPackageName,
+        # Matters most on this path: a crate reached indirectly declares no edge
+        # to the target, so it has no DepAliases entry for it. The target's own
+        # crate root is the only place the diverted name can come from.
+        [string]$TargetCrateRoot
     )
 
     if ($null -eq $Dependent.AllowedExternalTypes) {
         return $false
     }
 
-    $acceptedRoots = Get-AcceptedExposureRoots -Dependent $Dependent -TargetPackageName $TargetPackageName
+    $acceptedRoots = Get-AcceptedExposureRoots -Dependent $Dependent `
+        -TargetPackageName $TargetPackageName -TargetCrateRoot $TargetCrateRoot
 
     foreach ($entry in $Dependent.AllowedExternalTypes) {
         if ($entry -isnot [string] -or [string]::IsNullOrWhiteSpace($entry)) {

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -571,10 +571,11 @@ function Get-CrateRequiredChangeType {
 #   Folder                - folder name under crates/ (used as the script's PackageName argument)
 #   Published             - $true if the package is published to crates.io
 #   Deps                  - array of normalized dependency names (kind 'normal' or 'build', not 'dev')
-#   DepAliases            - hashtable mapping a normalized dependency name to the normalized
-#                           crate roots it is reachable under when those differ from the
-#                           package name -- the `package = "..."` alias, or the dependency's
-#                           own `[lib] name`; empty when every dep is nameable by its own name
+#   DepAliases            - hashtable mapping a normalized dependency name to additional
+#                           normalized crate roots observed for it -- a `package = "..."`
+#                           alias, or the dependency's own `[lib] name`. An entry does not say
+#                           whether a separate unrenamed declaration also exists, so this is
+#                           not a complete or exclusive set of reachable roots.
 #   CrateRoot             - the package's own normalized crate root (its `[lib] name` when it
 #                           sets one, else its normalized package name), or $null when the
 #                           package has no library target at all. This is the name a crate's
@@ -860,8 +861,15 @@ function Test-PackageAllowlistNamesTarget {
         return $false
     }
 
-    $acceptedRoots = Get-AcceptedExposureRoots -Dependent $Dependent `
-        -TargetPackageName $TargetPackageName -TargetCrateRoot $TargetCrateRoot
+    # This predicate is called only when no dependency edge to the target
+    # exists. DepAliases is therefore irrelevant: production can populate an
+    # alias only while processing a declared edge, which would take the direct
+    # branch instead. The only roots possible here belong to the target itself.
+    $acceptedRoots = @($TargetPackageName.Replace('-', '_'))
+    if (-not [string]::IsNullOrWhiteSpace($TargetCrateRoot)) {
+        $acceptedRoots += $TargetCrateRoot.Replace('-', '_')
+    }
+    $acceptedRoots = @($acceptedRoots | Sort-Object -Unique)
 
     foreach ($entry in $Dependent.AllowedExternalTypes) {
         if ($entry -isnot [string] -or [string]::IsNullOrWhiteSpace($entry)) {

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -571,6 +571,9 @@ function Get-CrateRequiredChangeType {
 #   Folder                - folder name under crates/ (used as the script's PackageName argument)
 #   Published             - $true if the package is published to crates.io
 #   Deps                  - array of normalized dependency names (kind 'normal' or 'build', not 'dev')
+#   DepAliases            - hashtable mapping a normalized dependency name to the normalized
+#                           aliases it is renamed to, for the deps that declare `package = "..."`;
+#                           empty when nothing is renamed
 #   AllowedExternalTypes  - array of strings from [package.metadata.cargo_check_external_types],
 #                           or $null if the package does not declare them
 #   HasLibraryTarget      - $true when cargo metadata reports a regular 'lib' target
@@ -589,9 +592,26 @@ function Get-WorkspacePackages {
         }
 
         $deps = @()
+        $depAliases = @{}
         foreach ($dep in $package.dependencies) {
-            if ($dep.kind -ne 'dev') {
-                $deps += $dep.name.Replace('-', '_')
+            if ($dep.kind -eq 'dev') {
+                continue
+            }
+
+            $depCargoName = $dep.name.Replace('-', '_')
+            $deps += $depCargoName
+
+            # `rename` is the `package = "..."` form in Cargo.toml: the crate is
+            # declared under one name but reachable in Rust source -- and hence
+            # in an allowed_external_types entry -- only under the alias. Record
+            # it so Test-PackageExposesTarget can recognize the aliased root.
+            $renameProp = $dep.PSObject.Properties['rename']
+            if ($renameProp -and -not [string]::IsNullOrWhiteSpace($renameProp.Value)) {
+                $alias = ([string]$renameProp.Value).Replace('-', '_')
+                # A package may be depended on more than once under different
+                # aliases (per-target or per-feature), so collect them all.
+                $depAliases[$depCargoName] = @(@($depAliases[$depCargoName]) + $alias |
+                        Where-Object { $_ } | Sort-Object -Unique)
             }
         }
 
@@ -616,6 +636,7 @@ function Get-WorkspacePackages {
             Version              = $package.version
             Published            = -not ($null -ne $package.publish -and $package.publish.Count -eq 0)
             Deps                 = $deps
+            DepAliases           = $depAliases
             AllowedExternalTypes = $allowedTypes
             HasLibraryTarget     = $hasLibraryTarget
             IsProcMacroOnly      = (-not $hasLibraryTarget) -and ($targetKinds -contains 'proc-macro')
@@ -657,6 +678,17 @@ function Test-PackageExposesTarget {
     }
 
     $normalizedTarget = $TargetPackageName.Replace('-', '_')
+
+    # A dependency declared with `package = "..."` is nameable in Rust source
+    # only under its alias, so that is the root an allowed_external_types entry
+    # will carry. Matching solely on the real package name would find nothing
+    # and report "not exposed" -- a fail-open that ships a break as compatible.
+    $acceptedRoots = @($normalizedTarget)
+    if ($Dependent.PSObject.Properties['DepAliases'] -and $null -ne $Dependent.DepAliases) {
+        $acceptedRoots += @($Dependent.DepAliases[$normalizedTarget])
+    }
+    $acceptedRoots = @($acceptedRoots | Where-Object { $_ })
+
     foreach ($entry in $Dependent.AllowedExternalTypes) {
         # An entry that is not a usable non-empty string carries no information
         # about what this crate exposes. Skipping it would let the loop fall
@@ -672,7 +704,7 @@ function Test-PackageExposesTarget {
         if ($root.Contains('*') -or $root.Contains('?') -or $root.Contains('[')) {
             return $true
         }
-        if ($root -eq $normalizedTarget) {
+        if ($acceptedRoots -contains $root) {
             return $true
         }
     }

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -571,6 +571,8 @@ function Get-CrateRequiredChangeType {
 #   Folder                - folder name under crates/ (used as the script's PackageName argument)
 #   Published             - $true if the package is published to crates.io
 #   Deps                  - array of normalized dependency names (kind 'normal' or 'build', not 'dev')
+#   AllowedExternalTypes  - array of strings from [package.metadata.cargo_check_external_types],
+#                           or $null if the package does not declare them
 #   HasLibraryTarget      - $true when cargo metadata reports a regular 'lib' target
 #   IsProcMacroOnly       - $true when the package has a 'proc-macro' target and no regular 'lib' target
 function Get-WorkspacePackages {
@@ -593,6 +595,18 @@ function Get-WorkspacePackages {
             }
         }
 
+        $allowedTypes = $null
+        $pkgMeta = $package.PSObject.Properties['metadata']
+        if ($pkgMeta -and $null -ne $pkgMeta.Value) {
+            $externalTypes = $pkgMeta.Value.PSObject.Properties['cargo_check_external_types']
+            if ($externalTypes -and $null -ne $externalTypes.Value) {
+                $allowed = $externalTypes.Value.PSObject.Properties['allowed_external_types']
+                if ($allowed -and $null -ne $allowed.Value) {
+                    $allowedTypes = @($allowed.Value)
+                }
+            }
+        }
+
         $targetKinds = @($package.targets | ForEach-Object { @($_.kind) } | Sort-Object -Unique)
         $hasLibraryTarget = $targetKinds -contains 'lib'
 
@@ -602,12 +616,41 @@ function Get-WorkspacePackages {
             Version              = $package.version
             Published            = -not ($null -ne $package.publish -and $package.publish.Count -eq 0)
             Deps                 = $deps
+            AllowedExternalTypes = $allowedTypes
             HasLibraryTarget     = $hasLibraryTarget
             IsProcMacroOnly      = (-not $hasLibraryTarget) -and ($targetKinds -contains 'proc-macro')
         }
     }
 
     return $packages
+}
+
+# Returns $true when a package's external-type policy allows public API types
+# rooted at the target package. Missing metadata is treated conservatively:
+# an unknown exposure must not permit a breaking dependency bump to ship as a
+# compatible release.
+function Test-PackageExposesTarget {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
+        [Parameter(Mandatory = $true)][string]$TargetPackageName
+    )
+
+    if ($null -eq $Dependent.AllowedExternalTypes) {
+        return $true
+    }
+
+    $normalizedTarget = $TargetPackageName.Replace('-', '_')
+    foreach ($entry in $Dependent.AllowedExternalTypes) {
+        $root = ($entry -split '::', 2)[0]
+        if ($root.Contains('*') -or $root.Contains('?') -or $root.Contains('[')) {
+            return $true
+        }
+        if ($root -eq $normalizedTarget) {
+            return $true
+        }
+    }
+
+    return $false
 }
 
 # Runs `cargo semver-checks` for a single crate against its previous version-bump

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -625,16 +625,33 @@ function Get-WorkspacePackages {
     return $packages
 }
 
-# Returns $true when a package's external-type policy allows public API types
-# rooted at the target package. Missing or malformed metadata is treated
-# conservatively: an unknown exposure must not permit a breaking dependency
-# bump to ship as a compatible release.
+# Returns $true unless the package's cargo-check-external-types allowlist is
+# positive evidence that its public API cannot name types rooted at the target
+# package. Anything short of that evidence counts as exposure: an unknown must
+# not permit a breaking dependency bump to ship as a compatible release.
 function Test-PackageExposesTarget {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
         [Parameter(Mandatory = $true)][string]$TargetPackageName
     )
 
+    # `$null` here means the crate declares no allowed_external_types policy at
+    # all. That is deliberately *not* the same as declaring an empty one:
+    # `@()` is a positive claim -- "my public API names nothing foreign" -- so
+    # it skips this branch, matches nothing in the loop below, and correctly
+    # returns $false. Absent metadata makes no claim at all, so it cannot be
+    # read as the stricter of the two. Hence absent => $true, empty => $false.
+    #
+    # Absent is *nearly* proof of non-exposure anyway: CI runs
+    # cargo-check-external-types with an empty allowlist when a crate declares
+    # none, so any foreign type in the public API fails the required
+    # external-type-exposure job.
+    #
+    # It is not proof, because CI validates *merged* code while release
+    # planning analyses the *working tree* (see Invoke-CrateSemverCheck): an
+    # in-progress edit that exposes a dependency's type without adding the
+    # allowlist entry has never been checked by anything. A brand-new crate has
+    # the same gap until its first CI run. Assume exposure.
     if ($null -eq $Dependent.AllowedExternalTypes) {
         return $true
     }

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -626,9 +626,9 @@ function Get-WorkspacePackages {
 }
 
 # Returns $true when a package's external-type policy allows public API types
-# rooted at the target package. Missing metadata is treated conservatively:
-# an unknown exposure must not permit a breaking dependency bump to ship as a
-# compatible release.
+# rooted at the target package. Missing or malformed metadata is treated
+# conservatively: an unknown exposure must not permit a breaking dependency
+# bump to ship as a compatible release.
 function Test-PackageExposesTarget {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
@@ -641,6 +641,16 @@ function Test-PackageExposesTarget {
 
     $normalizedTarget = $TargetPackageName.Replace('-', '_')
     foreach ($entry in $Dependent.AllowedExternalTypes) {
+        # An entry that is not a usable non-empty string carries no information
+        # about what this crate exposes. Skipping it would let the loop fall
+        # through to "not exposed" and ship a breaking dependency bump as a
+        # compatible release, so treat it the same as absent metadata. (`-split`
+        # coerces anything to a string, so a malformed entry does not throw --
+        # it silently collapses to '' and matches nothing, which is worse.)
+        if ($entry -isnot [string] -or [string]::IsNullOrWhiteSpace($entry)) {
+            return $true
+        }
+
         $root = ($entry -split '::', 2)[0]
         if ($root.Contains('*') -or $root.Contains('?') -or $root.Contains('[')) {
             return $true

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -727,10 +727,23 @@ function Test-PackageExposesTarget {
 # or 'none' when there is no prior version-bump commit to compare against (a
 # brand-new crate).
 #
-# The current API is analysed from the working tree, so a coordinated release's
-# in-progress source edits (including a dependency whose public types this crate
-# re-exports) are reflected — this is what lets an exposed-dependency breaking
-# change cascade correctly, without the old allowed_external_types heuristic.
+# The current API is analysed from the working tree, not from HEAD, so a
+# coordinated release's in-progress source edits are reflected rather than only
+# what has been committed.
+#
+# That is necessary but NOT sufficient for exposed-dependency breaks, and this
+# function must not be read as covering them. When a dependency's version bump
+# is incompatible without its type *shapes* changing, this crate's rustdoc is
+# identical on both sides of the comparison, so semver-checks correctly reports
+# no required bump — yet releasing this crate compatibly is still wrong, because
+# type identity in Rust is per-version: a consumer cannot hand a `dep 0.7` type
+# to an API expecting `dep 0.8`. Nothing in a rustdoc diff can show that.
+#
+# Exposure is therefore decided separately, from the crate's declared
+# allowed_external_types (Test-PackageExposesTarget), and propagated to a
+# fixpoint by Resolve-ReleaseSet. The two are complementary: semver-checks
+# supplies each crate's own floor, the exposure cascade supplies the floor its
+# dependencies impose on it.
 function Invoke-CrateSemverCheck {
     [CmdletBinding()]
     param(

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -695,29 +695,31 @@ function Get-WorkspacePackages {
 # dependent's public API: the target's own normalized name, plus any crate root
 # it is reachable under.
 #
-# A package name is not always the name its types are written under. Three
-# things divert it:
+# This is for DECLARED edges only -- it is called solely by
+# Test-PackageExposesTarget. A package name is not always the name its types
+# are written under, and on a declared edge two things divert it, both already
+# recorded in the dependent's DepAliases:
 #   - `package = "..."` on the dependency, which makes the crate nameable only
-#     under the alias (recorded per-edge in the dependent's DepAliases);
+#     under the alias; and
 #   - `[lib] name = "..."` in the dependency's own manifest, which renames the
-#     crate root for every consumer (recorded in DepAliases too, for the
-#     dependents that declare the edge); and
-#   - the same `[lib] name`, seen from a crate that does NOT declare the edge.
-#     A re-exported type is attributed to its defining crate, so a dependent
-#     several hops away names it without depending on it -- and having no edge,
-#     it has no DepAliases entry for it either. That case is covered by
-#     $TargetCrateRoot, which is a property of the target rather than of any
-#     edge, and so is available whether or not the dependency is declared.
+#     crate root for every consumer.
 #
-# $TargetCrateRoot belongs to the third case ONLY, and the caller must withhold
-# it for the first two. On a declared edge DepAliases already records the name
-# the target is reachable under, and it is authoritative *over the target's
-# global crate root*, because a `package = "..."` rename shadows the lib name
-# entirely: a dependent that imports the crate as `aliased_dep` cannot write
-# `dep_core::Handle` no matter what the target's manifest says. Adding the
-# target's global root back on such an edge re-accepts a name the dependent
-# provably cannot use, turning an unrelated allowlist entry that happens to
-# collide with it into a false exposure and a spurious breaking bump.
+# DepAliases is therefore the whole story here, and deliberately so. It is
+# authoritative *over the target's global crate root*, because a
+# `package = "..."` rename shadows the lib name entirely: a dependent that
+# imports the crate as `aliased_dep` cannot write `dep_core::Handle` no matter
+# what the target's manifest says. Adding the target's global root back on such
+# an edge would re-accept a name the dependent provably cannot use, turning an
+# unrelated allowlist entry that happens to collide with it into a false
+# exposure and a spurious breaking bump. That is why this function takes no
+# crate-root parameter.
+#
+# A third diversion exists but is not this function's problem: the same
+# `[lib] name` seen from a crate that does NOT declare the edge. A re-exported
+# type is attributed to its defining crate, so a dependent several hops away
+# names it without depending on it -- and having no edge, it has no DepAliases
+# entry for it either. Test-PackageAllowlistNamesTarget handles that case,
+# building its roots from the target's own record instead.
 #
 # The real package name below is a known over-acceptance, not a considered
 # exception to that rule: a rename shadows the package name exactly as it
@@ -729,17 +731,13 @@ function Get-WorkspacePackages {
 # the far worse direction, so it stays until the edge data can distinguish the
 # two. It errs toward a spurious bump, never toward a missed break.
 #
-# Any of them is the root an allowed_external_types entry may carry. Matching
+# Any of these roots is one an allowed_external_types entry may carry. Matching
 # solely on the real package name would find nothing and report "not exposed"
 # -- a fail-open that ships a break as compatible.
 function Get-AcceptedExposureRoots {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
-        [Parameter(Mandatory = $true)][string]$TargetPackageName,
-        # The target's own crate root, from its package record. Supplied only
-        # for an undeclared (indirect) edge -- see the note above on why a
-        # declared edge must rely on DepAliases instead.
-        [string]$TargetCrateRoot
+        [Parameter(Mandatory = $true)][string]$TargetPackageName
     )
 
     $normalizedTarget = $TargetPackageName.Replace('-', '_')
@@ -747,9 +745,6 @@ function Get-AcceptedExposureRoots {
     $roots = @($normalizedTarget)
     if ($Dependent.PSObject.Properties['DepAliases'] -and $null -ne $Dependent.DepAliases) {
         $roots += @($Dependent.DepAliases[$normalizedTarget])
-    }
-    if (-not [string]::IsNullOrWhiteSpace($TargetCrateRoot)) {
-        $roots += $TargetCrateRoot.Replace('-', '_')
     }
 
     return @($roots | Where-Object { $_ } | Sort-Object -Unique)

--- a/scripts/release-packages.ps1
+++ b/scripts/release-packages.ps1
@@ -163,10 +163,11 @@
     version than an explicit `<name>@<major>.<minor>.<patch>` pin
     allows, the release plan is rejected (the script refuses to
     silently override an explicit pin). With -Force, the explicit pin
-    is honored verbatim, the package's EffectiveChangeType tag is
-    upgraded to match the cascade so any further cascade decisions are
-    correct, and a warning is printed flagging that consumers
-    may break.
+    is honored verbatim, and the package's EffectiveChangeType tag is
+    upgraded to record the stronger unmet requirement for warnings and
+    bookkeeping. Further exposure propagation is based on the actual
+    current-to-pinned version transition, not that tag. A warning is printed
+    flagging that consumers may break.
 
     -Force does NOT relax the always-fatal "pin is not strictly greater
     than the current on-disk version" check, and has no effect on

--- a/scripts/release-packages.ps1
+++ b/scripts/release-packages.ps1
@@ -165,9 +165,10 @@
     silently override an explicit pin). With -Force, the explicit pin
     is honored verbatim, and the package's EffectiveChangeType tag is
     upgraded to record the stronger unmet requirement for warnings and
-    bookkeeping. Further exposure propagation is based on the actual
-    current-to-pinned version transition, not that tag. A warning is printed
-    flagging that consumers may break.
+    bookkeeping. Exposure propagation continues past the forced pin: the
+    pin lowers the version number, not the incompatibility of the API
+    being shipped, so dependents exposing the crate still inherit the
+    break. A warning is printed flagging that consumers may break.
 
     -Force does NOT relax the always-fatal "pin is not strictly greater
     than the current on-disk version" check, and has no effect on

--- a/scripts/release-packages.ps1
+++ b/scripts/release-packages.ps1
@@ -65,7 +65,11 @@
     dependency type, the planner also consults each dependent's
     `[package.metadata.cargo_check_external_types].allowed_external_types`.
     Exposing a dependency whose planned version transition is breaking floors
-    the dependent at `breaking`, recursively through direct dependency edges.
+    the dependent at `breaking`, recursively. This applies to direct dependency
+    edges, and also to a transitive dependency whose types the dependent
+    explicitly allowlists — cargo-check-external-types attributes a re-exported
+    type to the crate that defines it, so `fetch_azure` allowlists
+    `typespec_client_core` while depending on `azure_core`.
     Other unaffected dependents cascade as `patch` so they still pick up the new
     dependency version. Dev-only dependents are skipped — they automatically
     pick up the new workspace version.

--- a/scripts/release-packages.ps1
+++ b/scripts/release-packages.ps1
@@ -60,12 +60,15 @@
     commit in git history (the most recent commit that changed the crate's
     `[package] version`, with the baseline rustdoc rebuilt from source via
     `--baseline-rev`, so no registry access is required and it works in OSS and
-    enterprise/offline environments alike): a dependent whose own public API is
-    unaffected by the release cascades as a `patch` (it still re-releases to pick
-    up the new dependency version), while a dependent whose API actually changes
-    (e.g. because it re-exports a changed type) cascades at the severity
-    `cargo semver-checks` reports. Dev-only dependents are skipped — they
-    automatically pick up the new workspace version.
+    enterprise/offline environments alike). Because rustdoc comparison cannot
+    identify an incompatible version change in an otherwise-unchanged exposed
+    dependency type, the planner also consults each dependent's
+    `[package.metadata.cargo_check_external_types].allowed_external_types`.
+    Exposing a dependency whose planned version transition is breaking floors
+    the dependent at `breaking`, recursively through direct dependency edges.
+    Other unaffected dependents cascade as `patch` so they still pick up the new
+    dependency version. Dev-only dependents are skipped — they automatically
+    pick up the new workspace version.
 
     Proc-macro-only packages are detected from `cargo metadata` before
     cargo-semver-checks runs. The tool cannot inspect procedural macro names,
@@ -81,7 +84,8 @@
     consumer's final result is breaking, and stops on any weaker result.
 
     cargo-semver-checks remains a hard dependency for ordinary library packages
-    (install the version pinned in constants.env); there is no heuristic fallback.
+    (install the version pinned in constants.env). Missing external-type metadata
+    is treated conservatively as possible exposure.
 
     User-provided change types may be automatically upgraded by this analysis
     if the crate's real API diff requires a stronger change type (e.g. a

--- a/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
+++ b/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
@@ -191,6 +191,17 @@ function Write-PackageCargoToml {
         $lines += ''
         $lines += '[lib]'
         $lines += 'proc-macro = true'
+        if ($Package.ContainsKey('LibName') -and -not [string]::IsNullOrWhiteSpace($Package.LibName)) {
+            $lines += "name = `"$($Package.LibName)`""
+        }
+    }
+    elseif ($Package.ContainsKey('LibName') -and -not [string]::IsNullOrWhiteSpace($Package.LibName)) {
+        # `[lib] name` renames the crate root without renaming the package, so
+        # consumers must `use <LibName>::...` while still depending on Name.
+        # src/lib.rs stays where it is; cargo only needs the target name.
+        $lines += ''
+        $lines += '[lib]'
+        $lines += "name = `"$($Package.LibName)`""
     }
 
     $allDeps = @()

--- a/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
+++ b/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
@@ -203,25 +203,43 @@ function Write-PackageCargoToml {
         $lines += ''
         $lines += '[dependencies]'
         foreach ($d in $deps) {
-            $lines += "$($d.Name).workspace = true"
+            $lines += Format-DependencyLine -Dep $d
         }
     }
     if ($buildDeps.Count -gt 0) {
         $lines += ''
         $lines += '[build-dependencies]'
         foreach ($d in $buildDeps) {
-            $lines += "$($d.Name).workspace = true"
+            $lines += Format-DependencyLine -Dep $d
         }
     }
     if ($devDeps.Count -gt 0) {
         $lines += ''
         $lines += '[dev-dependencies]'
         foreach ($d in $devDeps) {
-            $lines += "$($d.Name).workspace = true"
+            $lines += Format-DependencyLine -Dep $d
         }
     }
 
     Set-Content -Path $Path -Value ($lines -join "`n") -NoNewline
+}
+
+# Renders one dependency line for a member manifest.
+#
+# Ordinary deps use workspace inheritance (`bar.workspace = true`), matching the
+# real repo. A dep carrying `Rename` is emitted in the inline `package = "..."`
+# form instead, mirroring production (see multitude's `allocator-api2-02`):
+# workspace inheritance keys the [workspace.dependencies] table by real name, so
+# it cannot express an alias without also rewriting that table. Path-only is
+# sufficient here because these fixtures are read via `cargo metadata` and never
+# packaged.
+function Format-DependencyLine {
+    param([Parameter(Mandatory = $true)][hashtable]$Dep)
+
+    if ($Dep.ContainsKey('Rename') -and -not [string]::IsNullOrWhiteSpace($Dep.Rename)) {
+        return "$($Dep.Rename) = { package = `"$($Dep.Name)`", path = `"../$($Dep.Name)`" }"
+    }
+    return "$($Dep.Name).workspace = true"
 }
 
 function Write-RootCargoToml {

--- a/scripts/tests/Pester/_common/TestHelpers.ps1
+++ b/scripts/tests/Pester/_common/TestHelpers.ps1
@@ -10,6 +10,10 @@
     test file. Test files dot-source the shared script libraries
     (scripts/lib/release-flow.ps1 etc.) directly using
     Join-Path (Get-OxiRepoRoot) 'scripts\lib\<file>.ps1'.
+
+    Also provides Get-BytesBufIoAllowlist, the one canonical copy of a real
+    manifest literal shared by a unit test and the integration test that pins
+    it against the manifest.
 #>
 
 # Returns the repo root (the directory containing this scripts/tests/Pester
@@ -17,4 +21,23 @@
 # test files never need brittle `..\..\..` chains of their own.
 function Get-OxiRepoRoot {
     return (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+}
+
+# Returns crates/bytesbuf_io's allowed_external_types, copied verbatim from its
+# Cargo.toml.
+#
+# bytesbuf_io -> bytesbuf is the production instance the whole exposure cascade
+# exists for, so its allowlist is asserted from two directions:
+#
+#   * unit  (PureFunctions.Tests.ps1) feeds this literal to
+#     Test-PackageExposesTarget, proving the matching logic against a shape
+#     that really occurs rather than an invented one; and
+#   * integration (ExposureCascade-RealWorkspace.Tests.ps1) asserts the live
+#     manifest still equals it exactly.
+#
+# It lives here so those two cannot drift apart: a second copy would let the
+# unit test keep passing against a literal the manifest had already abandoned,
+# which is the staleness the integration test is there to prevent.
+function Get-BytesBufIoAllowlist {
+    return @('bytesbuf::*', 'ohno::*', 'futures_core::stream::Stream')
 }

--- a/scripts/tests/Pester/integration/DependencyRename.Tests.ps1
+++ b/scripts/tests/Pester/integration/DependencyRename.Tests.ps1
@@ -1,0 +1,115 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Covers the renamed-dependency exposure path end-to-end, from a real Cargo
+# manifest through `cargo metadata` to the cascade decision.
+#
+# The unit tests for this construct DepAliases by hand, already normalized, so
+# they prove the matching logic but not the extraction that feeds it. A
+# regression in reading `dependency.rename`, or in converting `aliased-dep` to
+# `aliased_dep`, would restore the original fail-open with every unit test
+# still green. These tests close that gap by building an actual workspace with
+# `package = "..."` and loading it through Get-WorkspacePackages.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\_common\TestHelpers.ps1')
+    . (Join-Path $PSScriptRoot '..\_common\New-SyntheticWorkspace.ps1')
+    . (Join-Path (Get-OxiRepoRoot) 'scripts\lib\release-flow.ps1')
+
+    # dependent depends on `dependency` but declares it under the alias
+    # `aliased-dep`, so Rust source -- and therefore the allowlist -- can only
+    # name it as `aliased_dep`.
+    function New-RenamedDepWorkspace {
+        param(
+            [Parameter(Mandatory = $true)][string]$Path,
+            [string[]]$AllowedExternalTypes = @('aliased_dep::Handle')
+        )
+        $spec = @{
+            Packages = @(
+                @{
+                    Name = 'dependent'; Version = '1.0.0'
+                    Deps = @(@{ Name = 'dependency'; Rename = 'aliased-dep' })
+                    AllowedExternalTypes = $AllowedExternalTypes
+                }
+                @{ Name = 'dependency'; Version = '1.0.0' }
+            )
+        }
+        return New-SyntheticWorkspace -Spec $spec -Path $Path
+    }
+}
+
+Describe 'Renamed dependency exposure (via cargo metadata)' {
+    BeforeEach {
+        Reset-ReleaseScriptCaches
+    }
+
+    It 'records the rename alias from cargo metadata, normalized to underscores' {
+        $ws = New-RenamedDepWorkspace -Path (Join-Path $TestDrive 'rename-extract')
+        $pkgs = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependent = $pkgs | Where-Object { $_.Folder -eq 'dependent' }
+
+        # The edge is keyed by the REAL package name; only the alias is extra.
+        $dependent.Deps | Should -Contain 'dependency'
+        $dependent.DepAliases.ContainsKey('dependency') | Should -BeTrue
+        # 'aliased-dep' in the manifest, 'aliased_dep' in Rust paths.
+        @($dependent.DepAliases['dependency']) | Should -Contain 'aliased_dep'
+    }
+
+    It 'leaves DepAliases empty for a package with no renamed dependencies' {
+        $ws = New-RenamedDepWorkspace -Path (Join-Path $TestDrive 'rename-none')
+        $pkgs = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependency = $pkgs | Where-Object { $_.Folder -eq 'dependency' }
+
+        $dependency.DepAliases.Count | Should -Be 0
+    }
+
+    It 'reports exposure for an allowlist entry rooted at the alias' {
+        $ws = New-RenamedDepWorkspace -Path (Join-Path $TestDrive 'rename-exposes')
+        $pkgs = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependent = $pkgs | Where-Object { $_.Folder -eq 'dependent' }
+
+        Test-PackageExposesTarget -Dependent $dependent -TargetPackageName 'dependency' | Should -BeTrue
+    }
+
+    It 'reports no exposure when the allowlist names neither the alias nor the real name' {
+        # Negative control: proves the test above passes because of the alias
+        # and not because something upstream fails closed.
+        $ws = New-RenamedDepWorkspace -Path (Join-Path $TestDrive 'rename-unrelated') `
+            -AllowedExternalTypes @('unrelated_crate::Handle')
+        $pkgs = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependent = $pkgs | Where-Object { $_.Folder -eq 'dependent' }
+
+        Test-PackageExposesTarget -Dependent $dependent -TargetPackageName 'dependency' | Should -BeFalse
+    }
+
+    It 'cascades a breaking dependency through the aliased exposure edge' {
+        $ws = New-RenamedDepWorkspace -Path (Join-Path $TestDrive 'rename-cascade')
+        $baseline = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $stub = { param([string]$Folder, [string]$CargoName) 'none' }
+
+        $resolved = Resolve-ReleaseSet `
+            -ParsedTokens (Parse-ReleaseTokens -Tokens @('dependency@breaking')) `
+            -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType $stub
+        $dependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+        $dependent.EffectiveChangeType    | Should -Be 'breaking'
+        $dependent.EffectiveTargetVersion | Should -Be '2.0.0'
+    }
+
+    It 'does not cascade when the aliased dependency is absent from the allowlist' {
+        $ws = New-RenamedDepWorkspace -Path (Join-Path $TestDrive 'rename-nocascade') `
+            -AllowedExternalTypes @('unrelated_crate::Handle')
+        $baseline = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $stub = { param([string]$Folder, [string]$CargoName) 'none' }
+
+        $resolved = Resolve-ReleaseSet `
+            -ParsedTokens (Parse-ReleaseTokens -Tokens @('dependency@breaking')) `
+            -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType $stub
+        $dependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+        $dependent.EffectiveChangeType    | Should -Be 'patch'
+        $dependent.EffectiveTargetVersion | Should -Be '1.0.1'
+    }
+}

--- a/scripts/tests/Pester/integration/DependencyRename.Tests.ps1
+++ b/scripts/tests/Pester/integration/DependencyRename.Tests.ps1
@@ -226,6 +226,33 @@ Describe 'Renamed crate root via [lib] name (via cargo metadata)' {
         Test-PackageExposesTarget -Dependent $dependent -TargetPackageName 'dependency' | Should -BeTrue
     }
 
+    It 'does not accept the lib name on an edge where a rename shadows it' {
+        # The other half of the precedence rule, and the half that actually
+        # bites. The test above pins what DepAliases *contains*; this one pins
+        # what the predicate *does*, which is what a regression breaks. A
+        # dependent importing the crate as `aliased_dep` cannot write
+        # `dep_core::Handle` -- the rename shadows the lib name completely -- so
+        # such an entry must be some unrelated crate and must not count as
+        # exposure here. Reintroducing the target's global crate root on a
+        # declared edge turns that collision into a spurious breaking bump.
+        $ws = New-LibNameWorkspace -Path (Join-Path $TestDrive 'libname-rename-shadows') `
+            -Rename 'aliased-dep' -AllowedExternalTypes @('dep_core::Handle')
+        $baseline = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependent = $baseline | Where-Object { $_.Folder -eq 'dependent' }
+
+        Test-PackageExposesTarget -Dependent $dependent -TargetPackageName 'dependency' | Should -BeFalse
+
+        $stub = { param([string]$Folder, [string]$CargoName) 'none' }
+        $resolved = Resolve-ReleaseSet `
+            -ParsedTokens (Parse-ReleaseTokens -Tokens @('dependency@breaking')) `
+            -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType $stub
+        $resolvedDependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+        $resolvedDependent.EffectiveChangeType    | Should -Be 'patch'
+        $resolvedDependent.EffectiveTargetVersion | Should -Be '1.0.1'
+    }
+
     It 'cascades a breaking dependency through the lib-name exposure edge' {
         $ws = New-LibNameWorkspace -Path (Join-Path $TestDrive 'libname-cascade')
         $baseline = @(Get-WorkspacePackages -repoRoot $ws.Path)

--- a/scripts/tests/Pester/integration/DependencyRename.Tests.ps1
+++ b/scripts/tests/Pester/integration/DependencyRename.Tests.ps1
@@ -62,6 +62,32 @@ BeforeAll {
         }
         return New-SyntheticWorkspace -Spec $spec -Path $Path
     }
+    # defining -> relay -> facade, where defining's crate root is `def_core`
+    # and facade reaches a def_core type re-exported through relay. facade
+    # declares no edge to defining, so nothing on any edge it owns can tell it
+    # what defining's crate root is -- the root has to come from the target.
+    function New-IndirectLibNameWorkspace {
+        param(
+            [Parameter(Mandatory = $true)][string]$Path,
+            [string[]]$FacadeAllowedExternalTypes = @('def_core::Handle')
+        )
+        $spec = @{
+            Packages = @(
+                @{
+                    Name = 'facade'; Version = '1.0.0'
+                    Deps = @(@{ Name = 'relay' })
+                    AllowedExternalTypes = $FacadeAllowedExternalTypes
+                }
+                @{
+                    Name = 'relay'; Version = '1.0.0'
+                    Deps = @(@{ Name = 'defining' })
+                    AllowedExternalTypes = @()
+                }
+                @{ Name = 'defining'; Version = '1.0.0'; LibName = 'def_core'; AllowedExternalTypes = @() }
+            )
+        }
+        return New-SyntheticWorkspace -Spec $spec -Path $Path
+    }
 }
 
 Describe 'Renamed dependency exposure (via cargo metadata)' {
@@ -229,5 +255,47 @@ Describe 'Renamed crate root via [lib] name (via cargo metadata)' {
 
         $dependent.EffectiveChangeType    | Should -Be 'patch'
         $dependent.EffectiveTargetVersion | Should -Be '1.0.1'
+    }
+}
+
+Describe 'Indirect exposure of a diverted crate root (via cargo metadata)' {
+    BeforeEach {
+        Reset-ReleaseScriptCaches
+    }
+
+    It 'cascades to an indirect dependent whose allowlist is rooted at the lib name' {
+        $ws = New-IndirectLibNameWorkspace -Path (Join-Path $TestDrive 'indirect-libname-cascade')
+        $baseline = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $stub = { param([string]$Folder, [string]$CargoName) 'none' }
+
+        $resolved = Resolve-ReleaseSet `
+            -ParsedTokens (Parse-ReleaseTokens -Tokens @('defining@breaking')) `
+            -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType $stub
+        $facade = $resolved | Where-Object { $_.Folder -eq 'facade' }
+
+        $facade.EffectiveChangeType    | Should -Be 'breaking'
+        $facade.EffectiveTargetVersion | Should -Be '2.0.0'
+        # relay claims to expose nothing, so it correctly stays at its floor --
+        # facade is reached on its own allowlist evidence, not through relay.
+        ($resolved | Where-Object { $_.Folder -eq 'relay' }).EffectiveChangeType | Should -Be 'patch'
+    }
+
+    It 'does not cascade to an indirect dependent that names an unrelated root' {
+        # Negative control: proves the test above passes because the allowlist
+        # names defining's crate root, not because the indirect branch fails open.
+        $ws = New-IndirectLibNameWorkspace -Path (Join-Path $TestDrive 'indirect-libname-nocascade') `
+            -FacadeAllowedExternalTypes @('unrelated_crate::Handle')
+        $baseline = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $stub = { param([string]$Folder, [string]$CargoName) 'none' }
+
+        $resolved = Resolve-ReleaseSet `
+            -ParsedTokens (Parse-ReleaseTokens -Tokens @('defining@breaking')) `
+            -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType $stub
+        $facade = $resolved | Where-Object { $_.Folder -eq 'facade' }
+
+        $facade.EffectiveChangeType    | Should -Be 'patch'
+        $facade.EffectiveTargetVersion | Should -Be '1.0.1'
     }
 }

--- a/scripts/tests/Pester/integration/DependencyRename.Tests.ps1
+++ b/scripts/tests/Pester/integration/DependencyRename.Tests.ps1
@@ -1,15 +1,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Covers the renamed-dependency exposure path end-to-end, from a real Cargo
-# manifest through `cargo metadata` to the cascade decision.
+# Covers the exposure paths where a dependency's crate root differs from its
+# package name, end-to-end from a real Cargo manifest through `cargo metadata`
+# to the cascade decision. Two constructs do this: `package = "..."` on the
+# dependency (rename) and `[lib] name = "..."` in the dependency's own manifest.
 #
 # The unit tests for this construct DepAliases by hand, already normalized, so
 # they prove the matching logic but not the extraction that feeds it. A
-# regression in reading `dependency.rename`, or in converting `aliased-dep` to
-# `aliased_dep`, would restore the original fail-open with every unit test
-# still green. These tests close that gap by building an actual workspace with
-# `package = "..."` and loading it through Get-WorkspacePackages.
+# regression in reading `dependency.rename` or the lib target name, or in
+# converting `aliased-dep` to `aliased_dep`, would restore the original
+# fail-open with every unit test still green. These tests close that gap by
+# building actual workspaces and loading them through Get-WorkspacePackages.
 
 BeforeAll {
     . (Join-Path $PSScriptRoot '..\_common\TestHelpers.ps1')
@@ -32,6 +34,30 @@ BeforeAll {
                     AllowedExternalTypes = $AllowedExternalTypes
                 }
                 @{ Name = 'dependency'; Version = '1.0.0' }
+            )
+        }
+        return New-SyntheticWorkspace -Spec $spec -Path $Path
+    }
+
+    # `dependency` renames its own crate root with `[lib] name = "dep_core"`.
+    # The package is still depended on as `dependency`, but Rust source -- and
+    # therefore the allowlist -- can only name it as `dep_core`.
+    function New-LibNameWorkspace {
+        param(
+            [Parameter(Mandatory = $true)][string]$Path,
+            [string[]]$AllowedExternalTypes = @('dep_core::Handle'),
+            [string]$Rename = $null
+        )
+        $dep = @{ Name = 'dependency' }
+        if (-not [string]::IsNullOrWhiteSpace($Rename)) { $dep['Rename'] = $Rename }
+        $spec = @{
+            Packages = @(
+                @{
+                    Name = 'dependent'; Version = '1.0.0'
+                    Deps = @($dep)
+                    AllowedExternalTypes = $AllowedExternalTypes
+                }
+                @{ Name = 'dependency'; Version = '1.0.0'; LibName = 'dep_core' }
             )
         }
         return New-SyntheticWorkspace -Spec $spec -Path $Path
@@ -99,6 +125,98 @@ Describe 'Renamed dependency exposure (via cargo metadata)' {
 
     It 'does not cascade when the aliased dependency is absent from the allowlist' {
         $ws = New-RenamedDepWorkspace -Path (Join-Path $TestDrive 'rename-nocascade') `
+            -AllowedExternalTypes @('unrelated_crate::Handle')
+        $baseline = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $stub = { param([string]$Folder, [string]$CargoName) 'none' }
+
+        $resolved = Resolve-ReleaseSet `
+            -ParsedTokens (Parse-ReleaseTokens -Tokens @('dependency@breaking')) `
+            -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType $stub
+        $dependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+        $dependent.EffectiveChangeType    | Should -Be 'patch'
+        $dependent.EffectiveTargetVersion | Should -Be '1.0.1'
+    }
+}
+
+Describe 'Renamed crate root via [lib] name (via cargo metadata)' {
+    BeforeEach {
+        Reset-ReleaseScriptCaches
+    }
+
+    It 'records the dependency''s lib target name as an alias' {
+        $ws = New-LibNameWorkspace -Path (Join-Path $TestDrive 'libname-extract')
+        $pkgs = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependent = $pkgs | Where-Object { $_.Folder -eq 'dependent' }
+
+        # The edge is still keyed by the package name; the crate root is extra.
+        $dependent.Deps | Should -Contain 'dependency'
+        $dependent.DepAliases.ContainsKey('dependency') | Should -BeTrue
+        @($dependent.DepAliases['dependency']) | Should -Contain 'dep_core'
+    }
+
+    It 'records no alias when the lib target name matches the package name' {
+        # Negative control for the extraction: the alias must come from a real
+        # divergence, not be manufactured for every dependency.
+        $ws = New-RenamedDepWorkspace -Path (Join-Path $TestDrive 'libname-matching')
+        $pkgs = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependency = $pkgs | Where-Object { $_.Folder -eq 'dependency' }
+
+        $dependency.DepAliases.Count | Should -Be 0
+    }
+
+    It 'reports exposure for an allowlist entry rooted at the lib name' {
+        $ws = New-LibNameWorkspace -Path (Join-Path $TestDrive 'libname-exposes')
+        $pkgs = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependent = $pkgs | Where-Object { $_.Folder -eq 'dependent' }
+
+        Test-PackageExposesTarget -Dependent $dependent -TargetPackageName 'dependency' | Should -BeTrue
+    }
+
+    It 'reports no exposure when the allowlist names neither the lib name nor the package' {
+        $ws = New-LibNameWorkspace -Path (Join-Path $TestDrive 'libname-unrelated') `
+            -AllowedExternalTypes @('unrelated_crate::Handle')
+        $pkgs = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependent = $pkgs | Where-Object { $_.Folder -eq 'dependent' }
+
+        Test-PackageExposesTarget -Dependent $dependent -TargetPackageName 'dependency' | Should -BeFalse
+    }
+
+    It 'prefers the rename over the lib name when the dependency declares both' {
+        # `aliased-dep = { package = "dependency" }` against a dependency whose
+        # lib target is `dep_core`. Rust names it `aliased_dep`: the rename is
+        # applied to the dependency edge, so the lib name never surfaces in the
+        # consumer. Recording `dep_core` here would be inert at best and, for a
+        # crate that allowlists `dep_core` through some *other* path, a false
+        # exposure on this edge.
+        $ws = New-LibNameWorkspace -Path (Join-Path $TestDrive 'libname-rename-wins') `
+            -Rename 'aliased-dep' -AllowedExternalTypes @('aliased_dep::Handle')
+        $pkgs = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $dependent = $pkgs | Where-Object { $_.Folder -eq 'dependent' }
+
+        @($dependent.DepAliases['dependency']) | Should -Contain 'aliased_dep'
+        @($dependent.DepAliases['dependency']) | Should -Not -Contain 'dep_core'
+        Test-PackageExposesTarget -Dependent $dependent -TargetPackageName 'dependency' | Should -BeTrue
+    }
+
+    It 'cascades a breaking dependency through the lib-name exposure edge' {
+        $ws = New-LibNameWorkspace -Path (Join-Path $TestDrive 'libname-cascade')
+        $baseline = @(Get-WorkspacePackages -repoRoot $ws.Path)
+        $stub = { param([string]$Folder, [string]$CargoName) 'none' }
+
+        $resolved = Resolve-ReleaseSet `
+            -ParsedTokens (Parse-ReleaseTokens -Tokens @('dependency@breaking')) `
+            -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType $stub
+        $dependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+        $dependent.EffectiveChangeType    | Should -Be 'breaking'
+        $dependent.EffectiveTargetVersion | Should -Be '2.0.0'
+    }
+
+    It 'does not cascade when the lib-name root is absent from the allowlist' {
+        $ws = New-LibNameWorkspace -Path (Join-Path $TestDrive 'libname-nocascade') `
             -AllowedExternalTypes @('unrelated_crate::Handle')
         $baseline = @(Get-WorkspacePackages -repoRoot $ws.Path)
         $stub = { param([string]$Folder, [string]$CargoName) 'none' }

--- a/scripts/tests/Pester/integration/ExposureCascade-RealWorkspace.Tests.ps1
+++ b/scripts/tests/Pester/integration/ExposureCascade-RealWorkspace.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'Exposed-dependency cascade over the live workspace' {
         }
 
         It 'still declares a bytesbuf-rooted entry in the real bytesbuf_io allowlist' {
-            # Pins the manifest against the literal allowlist asserted in
+            # Pins the manifest against the literal asserted in
             # PureFunctions.Tests.ps1. Deleting `bytesbuf::*` here is precisely
             # how the fail-open would be reintroduced.
             $allowed = @((Get-LivePackage -Folder 'bytesbuf_io').AllowedExternalTypes)
@@ -62,6 +62,22 @@ Describe 'Exposed-dependency cascade over the live workspace' {
 
             $roots = @($allowed | ForEach-Object { ($_ -split '::', 2)[0] })
             $roots | Should -Contain 'bytesbuf'
+        }
+
+        It 'still matches the shared allowlist literal entry for entry' {
+            # The unit tests assert exposure of `ohno` and `futures_core` too,
+            # using the same literal. Checking only the bytesbuf root would
+            # leave those two asserted against a copy nothing pins, so the unit
+            # tests could keep passing on entries the manifest had dropped.
+            # Compare the whole set, which is what makes the "copied verbatim"
+            # comment in _common a fact rather than an intention.
+            $allowed = @((Get-LivePackage -Folder 'bytesbuf_io').AllowedExternalTypes)
+
+            # Order is irrelevant -- this pins the contents of the allowlist,
+            # not how the manifest happens to sort them.
+            ($allowed | Sort-Object) -join '|' |
+                Should -Be ((Get-BytesBufIoAllowlist | Sort-Object) -join '|') `
+                -Because 'crates/bytesbuf_io/Cargo.toml and Get-BytesBufIoAllowlist must not drift apart'
         }
 
         It 'reports bytesbuf_io as exposing bytesbuf using the real package records' {

--- a/scripts/tests/Pester/integration/ExposureCascade-RealWorkspace.Tests.ps1
+++ b/scripts/tests/Pester/integration/ExposureCascade-RealWorkspace.Tests.ps1
@@ -64,7 +64,7 @@ Describe 'Exposed-dependency cascade over the live workspace' {
             $roots | Should -Contain 'bytesbuf'
         }
 
-        It 'still matches the shared allowlist literal entry for entry' {
+        It 'still matches every shared allowlist literal entry' {
             # The unit tests assert exposure of `ohno` and `futures_core` too,
             # using the same literal. Checking only the bytesbuf root would
             # leave those two asserted against a copy nothing pins, so the unit

--- a/scripts/tests/Pester/integration/ExposureCascade-RealWorkspace.Tests.ps1
+++ b/scripts/tests/Pester/integration/ExposureCascade-RealWorkspace.Tests.ps1
@@ -127,3 +127,83 @@ Describe 'Exposed-dependency cascade over the live workspace' {
         }
     }
 }
+
+Describe 'Re-exported type edges in the live workspace' {
+    # cargo-check-external-types attributes a re-exported type to its DEFINING
+    # crate, so a crate can allowlist a workspace crate it does not directly
+    # depend on. These edges exist today and were invisible to a direct-edge
+    # scan. Pinning them against real manifests, because the whole failure mode
+    # is a mismatch between what manifests say and what the planner assumed.
+
+    BeforeAll {
+        # Every (crate, allowlisted workspace crate) pair where the crate does
+        # not depend on that workspace crate directly. Self-references are
+        # excluded: a crate cannot cascade from itself.
+        $script:IndirectPairs = @()
+        $byName = @{}
+        foreach ($p in $script:LiveBaseline) { $byName[$p.Name.Replace('-', '_')] = $p }
+
+        foreach ($pkg in $script:LiveBaseline) {
+            if ($null -eq $pkg.AllowedExternalTypes) { continue }
+            $self = $pkg.Name.Replace('-', '_')
+            $roots = @($pkg.AllowedExternalTypes |
+                    Where-Object { $_ -is [string] -and -not [string]::IsNullOrWhiteSpace($_) } |
+                    ForEach-Object { ($_ -split '::', 2)[0] } | Sort-Object -Unique)
+            foreach ($root in $roots) {
+                if (-not $byName.ContainsKey($root)) { continue }
+                if ($root -eq $self) { continue }
+                if ($pkg.Deps -contains $root) { continue }
+                $script:IndirectPairs += [pscustomobject]@{ Dependent = $pkg; TargetName = $byName[$root].Name }
+            }
+        }
+    }
+
+    It 'still contains at least one indirect allowlist edge to pin' {
+        # If this ever fails the workspace changed shape; the tests below would
+        # then be silently vacuous, so fail loudly instead.
+        @($script:IndirectPairs).Count | Should -BeGreaterThan 0
+    }
+
+    It 'treats every indirect allowlist edge as exposure of the defining crate' {
+        foreach ($pair in $script:IndirectPairs) {
+            Test-PackageAllowlistNamesTarget -Dependent $pair.Dependent -TargetPackageName $pair.TargetName |
+                Should -BeTrue -Because "$($pair.Dependent.Folder) allowlists $($pair.TargetName) without depending on it directly"
+        }
+    }
+
+    It 'selects those crates as dependents of the defining crate' {
+        # The direct-edge scan could not: none of these appear in the target's
+        # direct dependent list at all.
+        foreach ($pair in $script:IndirectPairs) {
+            $target = $script:LiveBaseline | Where-Object { $_.Name -eq $pair.TargetName }
+            $resolvedStub = [ordered]@{}
+            foreach ($p in $script:LiveBaseline) { $resolvedStub[$p.Folder] = $true }
+
+            $selected = @(Get-PublishedDependentsExposingTarget -TargetPackage $target `
+                    -WorkspaceBaseline $script:LiveBaseline -Resolved $resolvedStub)
+
+            @($selected | Where-Object { $_.Folder -eq $pair.Dependent.Folder }).Count |
+                Should -Be 1 -Because "$($pair.Dependent.Folder) reaches $($pair.TargetName) and names its types"
+        }
+    }
+
+    It 'cascades a breaking bump of each defining crate into those dependents' {
+        $targets = @($script:IndirectPairs | ForEach-Object { $_.TargetName } | Sort-Object -Unique)
+        foreach ($targetName in $targets) {
+            $resolved = Resolve-ReleaseSet `
+                -ParsedTokens (Parse-ReleaseTokens -Tokens @("$targetName@breaking")) `
+                -WorkspaceBaseline $script:LiveBaseline `
+                -GetRequiredChangeType $script:NoSelfChangeClassifier
+            $byFolder = @{}
+            foreach ($entry in $resolved) { $byFolder[$entry.Folder] = $entry }
+
+            $expected = @($script:IndirectPairs | Where-Object { $_.TargetName -eq $targetName })
+            foreach ($pair in $expected) {
+                $folder = $pair.Dependent.Folder
+                $byFolder.ContainsKey($folder) | Should -BeTrue -Because "$folder depends on $targetName transitively"
+                $byFolder[$folder].EffectiveChangeType |
+                    Should -Be 'breaking' -Because "$folder names $targetName's types in its public API"
+            }
+        }
+    }
+}

--- a/scripts/tests/Pester/integration/ExposureCascade-RealWorkspace.Tests.ps1
+++ b/scripts/tests/Pester/integration/ExposureCascade-RealWorkspace.Tests.ps1
@@ -1,0 +1,129 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# End-to-end regression coverage for the exposed-dependency cascade, run
+# against the LIVE workspace rather than synthetic package records.
+#
+# Every other test of this logic builds its own [pscustomobject] baseline, so
+# the planner is only ever proven correct about graphs the test itself
+# invented. That leaves the real failure mode unpinned: bytesbuf_io exposes
+# bytesbuf types across its public API, so a breaking bytesbuf release must
+# force a breaking bytesbuf_io release. Before this cascade existed,
+# bytesbuf_io took a mechanical patch floor and shipped a silent break.
+#
+# These tests read the actual manifests. That coupling is deliberate: if the
+# bytesbuf/bytesbuf_io relationship changes, or bytesbuf_io's allowlist is
+# edited, this file must fail and be consciously updated. A snapshot fixture
+# would re-create exactly the staleness problem it is meant to catch.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\_common\TestHelpers.ps1')
+    . (Join-Path (Get-OxiRepoRoot) 'scripts\lib\release-flow.ps1')
+
+    $script:RepoRoot = Get-OxiRepoRoot
+    # cargo metadata over the whole workspace is slow; resolve it once.
+    $script:LiveBaseline = @(Get-WorkspacePackages -repoRoot $script:RepoRoot)
+
+    function Get-LivePackage {
+        param([string]$Folder)
+        return $script:LiveBaseline | Where-Object { $_.Folder -eq $Folder }
+    }
+
+    # Keeps the planner off cargo-semver-checks: every crate reports 'none', so
+    # the only thing that can raise a version is the cascade under test.
+    $script:NoSelfChangeClassifier = {
+        param([string]$Folder, [string]$CargoName)
+        return 'none'
+    }
+}
+
+Describe 'Exposed-dependency cascade over the live workspace' {
+    Context 'the bytesbuf -> bytesbuf_io topology' {
+        It 'still has both crates present and published' {
+            foreach ($folder in @('bytesbuf', 'bytesbuf_io')) {
+                $pkg = Get-LivePackage -Folder $folder
+                $pkg | Should -Not -BeNullOrEmpty -Because "crates/$folder underpins this regression test"
+                $pkg.Published | Should -BeTrue -Because "an unpublished $folder would drop out of the cascade entirely"
+            }
+        }
+
+        It 'still records bytesbuf as a non-dev dependency of bytesbuf_io' {
+            # The edge itself. Without it the cascade never even considers the
+            # pair, and every assertion below would pass vacuously.
+            (Get-LivePackage -Folder 'bytesbuf_io').Deps | Should -Contain 'bytesbuf'
+        }
+
+        It 'still declares a bytesbuf-rooted entry in the real bytesbuf_io allowlist' {
+            # Pins the manifest against the literal allowlist asserted in
+            # PureFunctions.Tests.ps1. Deleting `bytesbuf::*` here is precisely
+            # how the fail-open would be reintroduced.
+            $allowed = @((Get-LivePackage -Folder 'bytesbuf_io').AllowedExternalTypes)
+            $allowed | Should -Not -BeNullOrEmpty -Because 'absent metadata would mask the real assertion behind the fail-closed branch'
+
+            $roots = @($allowed | ForEach-Object { ($_ -split '::', 2)[0] })
+            $roots | Should -Contain 'bytesbuf'
+        }
+
+        It 'reports bytesbuf_io as exposing bytesbuf using the real package records' {
+            Test-PackageExposesTarget `
+                -Dependent (Get-LivePackage -Folder 'bytesbuf_io') `
+                -TargetPackageName 'bytesbuf' | Should -BeTrue
+        }
+    }
+
+    Context 'planning a breaking bytesbuf release' {
+        BeforeAll {
+            $parsed = Parse-ReleaseTokens -Tokens @('bytesbuf@breaking')
+            $resolved = Resolve-ReleaseSet `
+                -ParsedTokens $parsed `
+                -WorkspaceBaseline $script:LiveBaseline `
+                -GetRequiredChangeType $script:NoSelfChangeClassifier
+
+            $script:ByFolder = @{}
+            foreach ($entry in $resolved) { $script:ByFolder[$entry.Folder] = $entry }
+        }
+
+        It 'pulls bytesbuf_io into the release set' {
+            $script:ByFolder.ContainsKey('bytesbuf_io') | Should -BeTrue
+        }
+
+        It 'raises bytesbuf_io to breaking rather than leaving it on the patch floor' {
+            # THE regression. A 'patch' here is the original bug: a compatible
+            # release that silently breaks every bytesbuf_io consumer.
+            $script:ByFolder['bytesbuf_io'].EffectiveChangeType | Should -Be 'breaking'
+        }
+
+        It 'writes a version for bytesbuf_io that is an incompatible transition' {
+            $entry = $script:ByFolder['bytesbuf_io']
+            # Asserted via the change-type calculation rather than a hardcoded
+            # version so routine bytesbuf_io releases do not break this test.
+            $planned = Get-ChangeTypeFromVersions `
+                -oldVersion $entry.CurrentVersion `
+                -newVersion $entry.EffectiveTargetVersion
+            Test-IsBreakingChange -oldVersion $entry.CurrentVersion -ChangeType $planned |
+                Should -BeTrue -Because "$($entry.CurrentVersion) -> $($entry.EffectiveTargetVersion) must be incompatible"
+        }
+
+        It 'attributes the bytesbuf_io bump to bytesbuf' {
+            $reason = @($script:ByFolder['bytesbuf_io'].CascadeReasons | Where-Object { $_.Target -eq 'bytesbuf' })
+            $reason.Count       | Should -Be 1 -Because 'one reason per edge, however many fixpoint passes run'
+            $reason[0].Breaking | Should -BeTrue
+        }
+    }
+
+    Context 'planning a compatible bytesbuf release' {
+        It 'does not raise bytesbuf_io to breaking when bytesbuf stays compatible' {
+            # The negative control: exposure alone must not force a break. If
+            # this fails, the cascade is bumping on the edge rather than on the
+            # incompatibility, and every release becomes a major.
+            $parsed = Parse-ReleaseTokens -Tokens @('bytesbuf@patch')
+            $resolved = Resolve-ReleaseSet `
+                -ParsedTokens $parsed `
+                -WorkspaceBaseline $script:LiveBaseline `
+                -GetRequiredChangeType $script:NoSelfChangeClassifier
+
+            $entry = $resolved | Where-Object { $_.Folder -eq 'bytesbuf_io' }
+            $entry.EffectiveChangeType | Should -Not -Be 'breaking'
+        }
+    }
+}

--- a/scripts/tests/Pester/scenarios/S13-pin-with-cascade-satisfied.scenario.psd1
+++ b/scripts/tests/Pester/scenarios/S13-pin-with-cascade-satisfied.scenario.psd1
@@ -3,7 +3,7 @@
 
 @{
     Name        = 'S13-pin-with-cascade-satisfied'
-    Description = 'Bundled-input feature: user explicitly pins a target version for one package, and a cascade from another user-source package strengthens the change-type tag but the pin still numerically satisfies the cascade requirement. Validates that Resolve-ReleaseSet keeps the pinned version verbatim (does not bump it to the cascade-required minimum) while still updating EffectiveChangeType so any dependent cascade decisions are correct.'
+    Description = 'Bundled-input feature: user explicitly pins a target version for one package, and a cascade from another user-source package strengthens the change-type tag but the pin still numerically satisfies the cascade requirement. Validates that Resolve-ReleaseSet keeps the pinned version verbatim (does not bump it to the cascade-required minimum) while recording the stronger requirement in EffectiveChangeType; dependent exposure propagation follows the actual version transition instead of that tag.'
 
     Workspace = @{
         Spec = @{

--- a/scripts/tests/Pester/scenarios/S15-auto-upgrade-of-user-source.scenario.psd1
+++ b/scripts/tests/Pester/scenarios/S15-auto-upgrade-of-user-source.scenario.psd1
@@ -8,7 +8,12 @@
     Workspace = @{
         Spec = @{
             Packages = @(
-                @{ Name = 'dependent'; Version = '1.0.0'; Deps = @(@{ Name = 'target' }) }
+                @{
+                    Name = 'dependent'
+                    Version = '1.0.0'
+                    Deps = @(@{ Name = 'target' })
+                    AllowedExternalTypes = @('target::*')
+                }
                 @{ Name = 'target';    Version = '1.0.0' }
             )
         }
@@ -23,7 +28,6 @@
         # dependent's EffectiveChangeType to breaking and EffectiveTargetVersion
         # to 2.0.0.
         Packages = @('target@breaking', 'dependent@patch')
-        SemverVerdicts = @{ dependent = 'breaking' }
         Answers  = @()
     }
 

--- a/scripts/tests/Pester/scenarios/S27-proc-macro-recursive-review.scenario.psd1
+++ b/scripts/tests/Pester/scenarios/S27-proc-macro-recursive-review.scenario.psd1
@@ -8,7 +8,12 @@
     Workspace = @{
         Spec = @{
             Packages = @(
-                @{ Name = 'app'; Version = '1.0.0'; Deps = @(@{ Name = 'facade' }) }
+                @{
+                    Name = 'app'
+                    Version = '1.0.0'
+                    Deps = @(@{ Name = 'facade' })
+                    AllowedExternalTypes = @()
+                }
                 @{ Name = 'facade'; Version = '1.0.0'; Deps = @(@{ Name = 'macros' }) }
                 @{ Name = 'macros'; Version = '1.0.0'; ProcMacro = $true }
             )

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -876,3 +876,206 @@ Describe 'Resolve-ReleaseSet' {
         }
     }
 }
+
+Describe 'Resolve-ReleaseSet exposure cascade over re-exported types' {
+    # cargo-check-external-types attributes a re-exported type to its DEFINING
+    # crate. A crate that reaches `defining::T` through an intermediate
+    # therefore allowlists `defining` while depending only on the intermediate.
+    # fetch_azure documents exactly this in its own manifest:
+    #
+    #   # azure_core re-exports its HttpClient trait from this crate;
+    #   # cargo-check-external-types reports re-exports by their defining crate.
+    #   "typespec_client_core::*",
+    #
+    # Requiring a direct dependency edge missed every such crate, which is a
+    # fail-open: a breaking bump of the defining crate shipped as compatible.
+
+    It 'raises an indirect dependent whose allowlist names the defining crate' {
+        # relay does NOT expose defining, so it cannot carry the break upward on
+        # its own; the edge exists only because facade allowlists `defining`.
+        $baseline = @(
+            New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                -AllowedExternalTypes @('defining::Handle')
+            New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('relay') `
+                -AllowedExternalTypes @('defining::Handle')
+        )
+        $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+        $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType (New-StubClassifier)
+        $facade = $resolved | Where-Object { $_.Folder -eq 'facade' }
+
+        $facade.EffectiveChangeType    | Should -Be 'breaking'
+        $facade.EffectiveTargetVersion | Should -Be '2.0.0'
+    }
+
+    It 'records the defining crate as the cascade reason, not the intermediate' {
+        $baseline = @(
+            New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                -AllowedExternalTypes @('unrelated::Thing')
+            New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('relay') `
+                -AllowedExternalTypes @('defining::Handle')
+        )
+        $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+        $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType (New-StubClassifier)
+        $facade = $resolved | Where-Object { $_.Folder -eq 'facade' }
+
+        $facade.EffectiveChangeType | Should -Be 'breaking'
+        @($facade.CascadeReasons | Where-Object { $_.Target -eq 'defining' }).Count |
+            Should -Be 1 -Because 'the break originates at the crate the type is defined in'
+    }
+
+    It 'raises an indirect dependent even when the intermediate stays compatible' {
+        # relay explicitly claims to expose nothing, so it correctly stays at
+        # its patch floor while facade above it must still break. This is the
+        # unmasked case: with a direct-edge-only scan nothing reaches facade.
+        $baseline = @(
+            New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('relay') `
+                -AllowedExternalTypes @('defining::Handle')
+        )
+        $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+        $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType (New-StubClassifier)
+
+        ($resolved | Where-Object { $_.Folder -eq 'relay' }).EffectiveChangeType  | Should -Be 'patch'
+        ($resolved | Where-Object { $_.Folder -eq 'facade' }).EffectiveChangeType | Should -Be 'breaking'
+    }
+
+    It 'matches an indirect allowlist entry rooted at a rename alias' {
+        $baseline = @(
+            New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('relay') `
+                -DepAliases @{ defining = @('def_v1') } -AllowedExternalTypes @('def_v1::Handle')
+        )
+        $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+        $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType (New-StubClassifier)
+
+        ($resolved | Where-Object { $_.Folder -eq 'facade' }).EffectiveChangeType | Should -Be 'breaking'
+    }
+
+    Context 'the indirect edge demands positive evidence' {
+        # The direct edge fails closed on "no evidence" because an unknown must
+        # not ship a break as compatible. Carrying that rule to indirect edges
+        # would force every transitive dependent that lacks metadata to
+        # breaking, which is a large and wrong over-cascade. These pin the
+        # narrower rule.
+
+        It 'does not raise an indirect dependent that declares no allowlist' {
+            # relay's empty allowlist is a positive claim that it exposes
+            # nothing, so no type of defining's can reach facade through it.
+            # facade's absent metadata is not evidence to the contrary.
+            $baseline = @(
+                New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+                New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                    -AllowedExternalTypes @()
+                New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('relay') `
+                    -AllowedExternalTypes $null
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType (New-StubClassifier)
+            $facade = $resolved | Where-Object { $_.Folder -eq 'facade' }
+
+            $facade.EffectiveChangeType    | Should -Be 'patch'
+            $facade.EffectiveTargetVersion | Should -Be '1.0.1'
+        }
+
+        It 'still fails closed for a DIRECT dependent that declares no allowlist' {
+            # Same absent metadata, direct edge: must fail closed.
+            $baseline = @(
+                New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+                New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                    -AllowedExternalTypes $null
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType (New-StubClassifier)
+
+            ($resolved | Where-Object { $_.Folder -eq 'relay' }).EffectiveChangeType | Should -Be 'breaking'
+        }
+
+        It 'does not raise an indirect dependent whose allowlist names only the intermediate' {
+            # facade names relay, not defining. relay itself does not expose
+            # defining, so facade cannot be holding one of defining's types.
+            $baseline = @(
+                New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+                New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                    -AllowedExternalTypes @()
+                New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('relay') `
+                    -AllowedExternalTypes @('relay::Adapter')
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType (New-StubClassifier)
+
+            ($resolved | Where-Object { $_.Folder -eq 'facade' }).EffectiveChangeType | Should -Be 'patch'
+        }
+
+        It 'does not raise a crate that names the target but cannot reach it' {
+            # No dependency path at all: an allowlist entry naming a same-named
+            # crate from elsewhere must not manufacture a cascade edge.
+            $baseline = @(
+                New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+                New-BaselinePackage -Folder 'stranger' -Version '1.0.0' `
+                    -AllowedExternalTypes @('defining::Handle')
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType (New-StubClassifier)
+
+            @($resolved | Where-Object { $_.Folder -eq 'stranger' }).Count |
+                Should -Be 0 -Because 'stranger is not a dependent of defining at all'
+        }
+    }
+
+    It 'reaches an indirect dependent through an unpublished conduit' {
+        # Unpublished crates are not released themselves but still carry types
+        # between published ones, so they must not break the reachability walk.
+        $baseline = @(
+            New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'internal' -Version '1.0.0' -Deps @('defining') `
+                -Published $false -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('internal') `
+                -AllowedExternalTypes @('defining::Handle')
+        )
+        $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+        $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType (New-StubClassifier)
+
+        ($resolved | Where-Object { $_.Folder -eq 'facade' }).EffectiveChangeType | Should -Be 'breaking'
+    }
+
+    It 'excludes a proc-macro-only crate from the indirect edge' {
+        $baseline = @(
+            New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'macros' -Version '1.0.0' -Deps @('relay') `
+                -IsProcMacroOnly $true -AllowedExternalTypes @('defining::Handle')
+        )
+        $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+        $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+            -GetRequiredChangeType (New-StubClassifier)
+        $macros = $resolved | Where-Object { $_.Folder -eq 'macros' }
+
+        $macros.EffectiveChangeType | Should -Be 'patch' -Because 'a proc-macro crate has no rustdoc API to expose types through'
+    }
+}

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -747,13 +747,14 @@ Describe 'Resolve-ReleaseSet' {
             $byFolder['b'].PinHonoredAgainstCascade  | Should -BeTrue
         }
 
-        It '-Force stops the exposure cascade at the pinned crate rather than at its tag' {
-            # Exposed chain a -> b -> c. a@breaking would normally drive both b
-            # and c to breaking, but b is pinned to 1.1.0 -- a compatible
-            # transition from 1.0.0. c never sees an incompatible b, so it must
-            # stay at its BFS patch floor. Cascading from b's 'breaking' *tag*
-            # instead of its planned version would invent a break for c that no
-            # consumer of b can observe.
+        It '-Force does not stop the exposure cascade at the pinned crate' {
+            # Exposed chain a -> b -> c. a@breaking drives b breaking, but b is
+            # pinned to 1.1.0 -- numerically compatible from 1.0.0. The pin
+            # changes b's version, not b's API: b@1.1.0 is still built against
+            # a@2.0.0 and exposes `a::*`, so its public API names different
+            # types than b@1.0.0 did, and a consumer of `b = "1.0"` upgrades
+            # into that silently. c must inherit the break even though b's own
+            # version transition looks compatible.
             $baseline = @(
                 (New-BaselinePackage -Folder 'a' -Version '1.0.0')
                 (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a') `
@@ -767,12 +768,14 @@ Describe 'Resolve-ReleaseSet' {
             $byFolder = @{}
             foreach ($e in $resolved) { $byFolder[$e.Folder] = $e }
 
+            # The pin is still honored verbatim -- -Force writes the number the
+            # user asked for, and only the propagation decision changes.
             $byFolder['b'].EffectiveTargetVersion   | Should -Be '1.1.0'
             $byFolder['b'].EffectiveChangeType      | Should -Be 'breaking'
             $byFolder['b'].PinHonoredAgainstCascade | Should -BeTrue
 
-            $byFolder['c'].EffectiveChangeType      | Should -Be 'patch'
-            $byFolder['c'].EffectiveTargetVersion   | Should -Be '1.0.1'
+            $byFolder['c'].EffectiveChangeType      | Should -Be 'breaking'
+            $byFolder['c'].EffectiveTargetVersion   | Should -Be '2.0.0'
         }
 
         It 'resumes the exposure cascade past a pinned crate when the pin is itself breaking' {
@@ -794,6 +797,29 @@ Describe 'Resolve-ReleaseSet' {
             $byFolder['b'].EffectiveTargetVersion | Should -Be '2.0.0'
             $byFolder['c'].EffectiveChangeType    | Should -Be 'breaking'
             $byFolder['c'].EffectiveTargetVersion | Should -Be '2.0.0'
+        }
+
+        It 'does not propagate from a compatible release that no pin suppressed' {
+            # Boundary guard for the forced-pin clause: propagation is widened
+            # only by PinHonoredAgainstCascade, not by every entry in the set.
+            # a releases non-breaking, so b's own release stays compatible and
+            # nothing was suppressed -- c must remain at its patch floor.
+            $baseline = @(
+                (New-BaselinePackage -Folder 'a' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a') `
+                    -AllowedExternalTypes @('a::*'))
+                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('b') `
+                    -AllowedExternalTypes @('b::*'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('a@nonbreaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline -WarningAction SilentlyContinue
+            $byFolder = @{}
+            foreach ($e in $resolved) { $byFolder[$e.Folder] = $e }
+
+            $byFolder['b'].PinHonoredAgainstCascade | Should -BeFalse
+            $byFolder['b'].EffectiveChangeType      | Should -Be 'patch'
+            $byFolder['c'].EffectiveChangeType      | Should -Be 'patch'
         }
 
         It '-Force emits a warning naming the package, the pin, the required minimum, and the sources' {

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -730,7 +730,8 @@ Describe 'Resolve-ReleaseSet' {
         It '-Force honors the explicit pin verbatim when a higher version is required' {
             # b's own API broke => normally requires 2.0.0; user pinned b at
             # 1.1.0. With -Force, b stays at 1.1.0 but the change-type tag is
-            # upgraded so any further cascade decisions for b would be correct.
+            # upgraded to record the unmet requirement. Further exposure
+            # propagation follows the actual 1.0.0 -> 1.1.0 transition.
             $baseline = @(
                 (New-BaselinePackage -Folder 'a' -Version '1.0.0' -Deps @())
                 (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a'))
@@ -913,8 +914,9 @@ Describe 'Resolve-ReleaseSet exposure cascade over re-exported types' {
     # fail-open: a breaking bump of the defining crate shipped as compatible.
 
     It 'raises an indirect dependent whose allowlist names the defining crate' {
-        # relay does NOT expose defining, so it cannot carry the break upward on
-        # its own; the edge exists only because facade allowlists `defining`.
+        # relay is raised directly because it exposes defining. facade requires
+        # the indirect defining-crate path: it depends on relay, but its
+        # allowlist names defining rather than its declared dependency.
         $baseline = @(
             New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
             New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -26,9 +26,16 @@ BeforeAll {
             [bool]     $Published = $true,
             [bool]     $IsProcMacroOnly = $false,
             [hashtable] $DepAliases = @{},
+            # The crate's rustdoc name -- its [lib] name, which defaults to the
+            # normalized package name. Allowlists of INDIRECT dependents are
+            # rooted at this, never at a rename alias: a rename only exists on
+            # an edge the renaming crate declares, and an indirect dependent
+            # declares no such edge.
+            [string]   $CrateRoot = $null,
             [AllowNull()][string[]] $AllowedExternalTypes = @()
         )
         if ([string]::IsNullOrEmpty($Name)) { $Name = $Folder }
+        if ([string]::IsNullOrEmpty($CrateRoot)) { $CrateRoot = $Name.Replace('-', '_') }
         return [pscustomobject]@{
             Folder    = $Folder
             Name      = $Name
@@ -36,6 +43,7 @@ BeforeAll {
             Published = $Published
             Deps      = $Deps
             DepAliases = $DepAliases
+            CrateRoot = $CrateRoot
             IsProcMacroOnly = $IsProcMacroOnly
             AllowedExternalTypes = $AllowedExternalTypes
         }
@@ -963,13 +971,18 @@ Describe 'Resolve-ReleaseSet exposure cascade over re-exported types' {
         ($resolved | Where-Object { $_.Folder -eq 'facade' }).EffectiveChangeType | Should -Be 'breaking'
     }
 
-    It 'matches an indirect allowlist entry rooted at a rename alias' {
+    It "matches an indirect allowlist entry rooted at the target's [lib] name" {
+        # facade names def_v1::Handle because that is what rustdoc calls the
+        # type: the crate root follows defining's [lib] name, not its package
+        # name. facade cannot learn this from a rename alias -- it has no edge
+        # to defining to rename -- so the root has to come from the target.
         $baseline = @(
-            New-BaselinePackage -Folder 'defining' -Version '1.0.0' -AllowedExternalTypes @()
+            New-BaselinePackage -Folder 'defining' -Version '1.0.0' -CrateRoot 'def_v1' `
+                -AllowedExternalTypes @()
             New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
                 -AllowedExternalTypes @()
             New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('relay') `
-                -DepAliases @{ defining = @('def_v1') } -AllowedExternalTypes @('def_v1::Handle')
+                -AllowedExternalTypes @('def_v1::Handle')
         )
         $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
 

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -822,6 +822,35 @@ Describe 'Resolve-ReleaseSet' {
             $byFolder['c'].EffectiveChangeType      | Should -Be 'patch'
         }
 
+        It 'does not propagate from a forced pin that suppressed only a non-breaking requirement' {
+            # PinHonoredAgainstCascade is set for ANY suppressed requirement,
+            # not only a breaking one. Here b's own self-check requires
+            # non-breaking (1.1.0) and the user pins 1.0.1 with -Force, so the
+            # flag is set while the suppressed requirement was merely additive.
+            # An additive API change breaks no consumer, so c must stay at its
+            # patch floor rather than being dragged to a major release.
+            $baseline = @(
+                (New-BaselinePackage -Folder 'a' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a') `
+                    -AllowedExternalTypes @('a::*'))
+                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('b') `
+                    -AllowedExternalTypes @('b::*'))
+            )
+            $classifier = { param($folder) if ($folder -eq 'b') { 'non-breaking' } else { 'patch' } }
+            $parsed = Parse-ReleaseTokens -Tokens @('b@1.0.1')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType $classifier -Force -WarningAction SilentlyContinue
+            $byFolder = @{}
+            foreach ($e in $resolved) { $byFolder[$e.Folder] = $e }
+
+            $byFolder['b'].PinHonoredAgainstCascade | Should -BeTrue
+            $byFolder['b'].EffectiveChangeType      | Should -Be 'non-breaking'
+            $byFolder['b'].EffectiveTargetVersion   | Should -Be '1.0.1'
+
+            $byFolder['c'].EffectiveChangeType      | Should -Not -Be 'breaking'
+        }
+
         It '-Force emits a warning naming the package, the pin, the required minimum, and the sources' {
             $baseline = @(
                 (New-BaselinePackage -Folder 'a' -Version '1.0.0' -Deps @())

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -16,6 +16,7 @@ BeforeAll {
             [string[]] $Deps = @(),
             [bool]     $Published = $true,
             [bool]     $IsProcMacroOnly = $false,
+            [hashtable] $DepAliases = @{},
             [AllowNull()][string[]] $AllowedExternalTypes = $null
         )
         if ([string]::IsNullOrEmpty($Name)) { $Name = $Folder }
@@ -25,6 +26,7 @@ BeforeAll {
             Version   = $Version
             Published = $Published
             Deps      = $Deps
+            DepAliases = $DepAliases
             IsProcMacroOnly = $IsProcMacroOnly
             AllowedExternalTypes = $AllowedExternalTypes
         }
@@ -525,6 +527,41 @@ Describe 'Resolve-ReleaseSet' {
             $byFolder['c'].CascadeReasons.Target | Should -Contain 'b'
         }
 
+        It 'cascades through an allowlist entry rooted at a renamed dependency alias' {
+            # `dependent` declares `dependency` under `package = "..."` as
+            # `aliased_dep`, so its allowlist can only name the alias. Matching
+            # on the real package name alone would miss it and ship the break.
+            $baseline = @(
+                (New-BaselinePackage -Folder 'dependency' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'dependent' -Version '1.0.0' -Deps @('dependency') `
+                    -DepAliases @{ dependency = @('aliased_dep') } `
+                    -AllowedExternalTypes @('aliased_dep::Handle'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('dependency@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline
+            $dependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+            $dependent.EffectiveChangeType    | Should -Be 'breaking'
+            $dependent.EffectiveTargetVersion | Should -Be '2.0.0'
+        }
+
+        It 'does not cascade when the alias in the allowlist belongs to a different dependency' {
+            $baseline = @(
+                (New-BaselinePackage -Folder 'dependency' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'dependent' -Version '1.0.0' -Deps @('dependency') `
+                    -DepAliases @{ other_crate = @('aliased_dep') } `
+                    -AllowedExternalTypes @('aliased_dep::Handle'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('dependency@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline
+            $dependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+            $dependent.EffectiveChangeType    | Should -Be 'patch'
+            $dependent.EffectiveTargetVersion | Should -Be '1.0.1'
+        }
+
         It 'uses a self-floor breaking verdict before cascading exposed dependency versions' {
             $baseline = @(
                 (New-BaselinePackage -Folder 'dependency' -Version '1.0.0')
@@ -685,6 +722,55 @@ Describe 'Resolve-ReleaseSet' {
             $byFolder['b'].RequestedTargetVersion    | Should -Be '1.1.0'
             $byFolder['b'].EffectiveChangeType       | Should -Be 'breaking'
             $byFolder['b'].PinHonoredAgainstCascade  | Should -BeTrue
+        }
+
+        It '-Force stops the exposure cascade at the pinned crate rather than at its tag' {
+            # Exposed chain a -> b -> c. a@breaking would normally drive both b
+            # and c to breaking, but b is pinned to 1.1.0 -- a compatible
+            # transition from 1.0.0. c never sees an incompatible b, so it must
+            # stay at its BFS patch floor. Cascading from b's 'breaking' *tag*
+            # instead of its planned version would invent a break for c that no
+            # consumer of b can observe.
+            $baseline = @(
+                (New-BaselinePackage -Folder 'a' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a') `
+                    -AllowedExternalTypes @('a::*'))
+                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('b') `
+                    -AllowedExternalTypes @('b::*'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('a@breaking', 'b@1.1.0')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline -Force -WarningAction SilentlyContinue
+            $byFolder = @{}
+            foreach ($e in $resolved) { $byFolder[$e.Folder] = $e }
+
+            $byFolder['b'].EffectiveTargetVersion   | Should -Be '1.1.0'
+            $byFolder['b'].EffectiveChangeType      | Should -Be 'breaking'
+            $byFolder['b'].PinHonoredAgainstCascade | Should -BeTrue
+
+            $byFolder['c'].EffectiveChangeType      | Should -Be 'patch'
+            $byFolder['c'].EffectiveTargetVersion   | Should -Be '1.0.1'
+        }
+
+        It 'resumes the exposure cascade past a pinned crate when the pin is itself breaking' {
+            # Same chain, but b is pinned to 2.0.0 -- an incompatible
+            # transition -- so c must inherit the break.
+            $baseline = @(
+                (New-BaselinePackage -Folder 'a' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a') `
+                    -AllowedExternalTypes @('a::*'))
+                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('b') `
+                    -AllowedExternalTypes @('b::*'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('a@breaking', 'b@2.0.0')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline -Force -WarningAction SilentlyContinue
+            $byFolder = @{}
+            foreach ($e in $resolved) { $byFolder[$e.Folder] = $e }
+
+            $byFolder['b'].EffectiveTargetVersion | Should -Be '2.0.0'
+            $byFolder['c'].EffectiveChangeType    | Should -Be 'breaking'
+            $byFolder['c'].EffectiveTargetVersion | Should -Be '2.0.0'
         }
 
         It '-Force emits a warning naming the package, the pin, the required minimum, and the sources' {

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -8,6 +8,15 @@ BeforeAll {
     # Helper that builds a baseline package record. Underscore-only cargo
     # names by default so the test stays focused on the cascade/resolve logic
     # rather than name normalization.
+    #
+    # AllowedExternalTypes defaults to @() -- "this crate's public API names
+    # nothing foreign" -- and NOT to $null. $null is the fail-closed branch
+    # (absent metadata => assume exposure), so defaulting to it would make
+    # every package in every baseline expose every dependency for free. That
+    # masks the signal under test: a cascade assertion would pass on the
+    # fallback even when the behaviour it is meant to pin is broken. @() is
+    # inert, so a test that needs exposure has to ask for it -- either with a
+    # real allowlist entry or by passing $null explicitly.
     function New-BaselinePackage {
         param(
             [string]   $Folder,
@@ -17,7 +26,7 @@ BeforeAll {
             [bool]     $Published = $true,
             [bool]     $IsProcMacroOnly = $false,
             [hashtable] $DepAliases = @{},
-            [AllowNull()][string[]] $AllowedExternalTypes = $null
+            [AllowNull()][string[]] $AllowedExternalTypes = @()
         )
         if ([string]::IsNullOrEmpty($Name)) { $Name = $Folder }
         return [pscustomobject]@{
@@ -480,9 +489,14 @@ Describe 'Resolve-ReleaseSet' {
         }
 
         It 'treats missing external-type metadata conservatively' {
+            # $null is passed explicitly: this test is *about* absent metadata,
+            # so the signal must come from the arguments and not from a helper
+            # default. New-BaselinePackage defaults to @() precisely so that no
+            # other test silently depends on the fail-closed branch.
             $baseline = @(
                 (New-BaselinePackage -Folder 'dependency' -Version '1.0.0')
-                (New-BaselinePackage -Folder 'dependent' -Version '1.0.0' -Deps @('dependency'))
+                (New-BaselinePackage -Folder 'dependent' -Version '1.0.0' -Deps @('dependency') `
+                    -AllowedExternalTypes $null)
             )
             $parsed = Parse-ReleaseTokens -Tokens @('dependency@breaking')
 

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -15,7 +15,8 @@ BeforeAll {
             [string]   $Version = '0.1.0',
             [string[]] $Deps = @(),
             [bool]     $Published = $true,
-            [bool]     $IsProcMacroOnly = $false
+            [bool]     $IsProcMacroOnly = $false,
+            [AllowNull()][string[]] $AllowedExternalTypes = $null
         )
         if ([string]::IsNullOrEmpty($Name)) { $Name = $Folder }
         return [pscustomobject]@{
@@ -25,6 +26,7 @@ BeforeAll {
             Published = $Published
             Deps      = $Deps
             IsProcMacroOnly = $IsProcMacroOnly
+            AllowedExternalTypes = $AllowedExternalTypes
         }
     }
 
@@ -402,7 +404,8 @@ Describe 'Resolve-ReleaseSet' {
             $baseline = @(
                 (New-BaselinePackage -Folder 'a' -Version '1.0.0' -Deps @())
                 (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a'))
-                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('a'))
+                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('a') `
+                    -AllowedExternalTypes @())
             )
             $classifier = New-StubClassifier @{ b = 'breaking' }
             $parsed = Parse-ReleaseTokens -Tokens @('a@breaking')
@@ -430,7 +433,8 @@ Describe 'Resolve-ReleaseSet' {
             $baseline = @(
                 (New-BaselinePackage -Folder 'a' -Version '1.0.0' -Deps @())
                 (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a'))
-                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('b'))
+                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('b') `
+                    -AllowedExternalTypes @())
             )
             $classifier = New-StubClassifier @{ b = 'non-breaking' }
             $parsed = Parse-ReleaseTokens -Tokens @('a@patch')
@@ -439,6 +443,106 @@ Describe 'Resolve-ReleaseSet' {
             foreach ($e in $resolved) { $byFolder[$e.Folder] = $e }
             $byFolder['b'].EffectiveChangeType | Should -Be 'non-breaking'
             $byFolder['c'].EffectiveChangeType | Should -Be 'patch'
+        }
+
+        It 'raises an unchanged dependent when it exposes an incompatibly bumped dependency' {
+            $baseline = @(
+                (New-BaselinePackage -Folder 'bytesbuf' -Version '0.7.0')
+                (New-BaselinePackage -Folder 'bytesbuf_io' -Version '0.7.0' -Deps @('bytesbuf') `
+                    -AllowedExternalTypes @('bytesbuf::*'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('bytesbuf@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline
+            $byFolder = @{}
+            foreach ($entry in $resolved) { $byFolder[$entry.Folder] = $entry }
+
+            $byFolder['bytesbuf_io'].EffectiveChangeType | Should -Be 'breaking'
+            $byFolder['bytesbuf_io'].EffectiveTargetVersion | Should -Be '0.8.0'
+            $byFolder['bytesbuf_io'].CascadeReasons[0].Breaking | Should -BeTrue
+        }
+
+        It 'keeps an unchanged dependent at patch when it does not expose the bumped dependency' {
+            $baseline = @(
+                (New-BaselinePackage -Folder 'dependency' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'dependent' -Version '1.0.0' -Deps @('dependency') `
+                    -AllowedExternalTypes @('other_crate::*'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('dependency@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline
+            $dependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+            $dependent.EffectiveChangeType | Should -Be 'patch'
+            $dependent.EffectiveTargetVersion | Should -Be '1.0.1'
+        }
+
+        It 'treats missing external-type metadata conservatively' {
+            $baseline = @(
+                (New-BaselinePackage -Folder 'dependency' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'dependent' -Version '1.0.0' -Deps @('dependency'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('dependency@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline
+            $dependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+            $dependent.EffectiveChangeType | Should -Be 'breaking'
+            $dependent.EffectiveTargetVersion | Should -Be '2.0.0'
+        }
+
+        It 'treats wildcard external-type metadata as possible exposure' {
+            $baseline = @(
+                (New-BaselinePackage -Folder 'dependency' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'dependent' -Version '1.0.0' -Deps @('dependency') `
+                    -AllowedExternalTypes @('*'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('dependency@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline
+            $dependent = $resolved | Where-Object { $_.Folder -eq 'dependent' }
+
+            $dependent.EffectiveChangeType | Should -Be 'breaking'
+            $dependent.EffectiveTargetVersion | Should -Be '2.0.0'
+        }
+
+        It 'propagates exposed incompatible dependency versions through multiple direct edges' {
+            $baseline = @(
+                (New-BaselinePackage -Folder 'a' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a') `
+                    -AllowedExternalTypes @('a::*'))
+                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('b') `
+                    -AllowedExternalTypes @('b::*'))
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('a@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline
+            $byFolder = @{}
+            foreach ($entry in $resolved) { $byFolder[$entry.Folder] = $entry }
+
+            $byFolder['b'].EffectiveChangeType | Should -Be 'breaking'
+            $byFolder['c'].EffectiveChangeType | Should -Be 'breaking'
+            $byFolder['c'].CascadeReasons.Target | Should -Contain 'b'
+        }
+
+        It 'uses a self-floor breaking verdict before cascading exposed dependency versions' {
+            $baseline = @(
+                (New-BaselinePackage -Folder 'dependency' -Version '1.0.0')
+                (New-BaselinePackage -Folder 'dependent' -Version '1.0.0' -Deps @('dependency') `
+                    -AllowedExternalTypes @('dependency::*'))
+            )
+            $classifier = New-StubClassifier @{ dependency = 'breaking' }
+            $parsed = Parse-ReleaseTokens -Tokens @('dependency@patch')
+
+            $resolved = Resolve-ReleaseSet `
+                -ParsedTokens $parsed `
+                -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType $classifier
+            $byFolder = @{}
+            foreach ($entry in $resolved) { $byFolder[$entry.Folder] = $entry }
+
+            $byFolder['dependency'].EffectiveChangeType | Should -Be 'breaking'
+            $byFolder['dependent'].EffectiveChangeType | Should -Be 'breaking'
         }
 
         It 'adds a proc-macro-only cascade dependent at the mechanical patch floor for manual review' {
@@ -659,7 +763,8 @@ Describe 'Resolve-ReleaseSet' {
             $baseline = @(
                 (New-BaselinePackage -Folder 'a' -Version '1.0.0' -Deps @())
                 (New-BaselinePackage -Folder 'b' -Version '1.0.0' -Deps @('a'))
-                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('b'))
+                (New-BaselinePackage -Folder 'c' -Version '1.0.0' -Deps @('b') `
+                    -AllowedExternalTypes @())
             )
             $classifier = New-StubClassifier @{ b = 'breaking' }
             $parsed = Parse-ReleaseTokens -Tokens @('b@patch', 'a@breaking')

--- a/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
@@ -620,4 +620,50 @@ Describe 'Test-PackageExposesTarget' {
         $dep = [pscustomobject]@{ AllowedExternalTypes = @('std::io::Error') }
         Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeFalse
     }
+
+    Context 'bytesbuf_io -> bytesbuf (real workspace topology)' {
+        # The production instance this whole cascade exists for. bytesbuf_io
+        # describes itself as "Asynchronous I/O abstractions expressed via
+        # `bytesbuf` types" and its public API says so literally --
+        # `pub fn reserve(&self, ...) -> BytesBuf`, `pub fn contents(&self) ->
+        # &BytesBuf`, plus BytesView/Memory/HasMemory in trait signatures. A
+        # breaking bytesbuf release is therefore a breaking bytesbuf_io release.
+        #
+        # The allowlist below is copied verbatim from
+        # crates/bytesbuf_io/Cargo.toml. ExposureCascade-RealWorkspace.Tests.ps1
+        # asserts the real manifest still matches it, so this stays honest.
+        BeforeAll {
+            $script:BytesBufIoAllowed = @('bytesbuf::*', 'ohno::*', 'futures_core::stream::Stream')
+        }
+
+        It 'reports exposure of bytesbuf' {
+            Test-PackageExposesTarget -Dependent (New-Dependent -Allowed $script:BytesBufIoAllowed) `
+                -TargetPackageName 'bytesbuf' | Should -BeTrue
+        }
+
+        It 'reports exposure of the other allowlisted roots' {
+            foreach ($target in @('ohno', 'futures_core')) {
+                Test-PackageExposesTarget -Dependent (New-Dependent -Allowed $script:BytesBufIoAllowed) `
+                    -TargetPackageName $target | Should -BeTrue -Because "'$target' is an allowlisted root"
+            }
+        }
+
+        It 'does not report exposure of a dependency that is absent from the allowlist' {
+            # bytesbuf_io depends on trait-variant, but it is a macro crate that
+            # never surfaces in the public API, so it is deliberately not
+            # allowlisted. This is the branch that must stay $false -- if it ever
+            # returns $true the cascade degenerates into "bump everything".
+            Test-PackageExposesTarget -Dependent (New-Dependent -Allowed $script:BytesBufIoAllowed) `
+                -TargetPackageName 'trait-variant' | Should -BeFalse
+        }
+
+        It 'is not fooled by a crate whose name merely prefixes an allowlisted root' {
+            # 'bytesbuf' is a strict prefix of 'bytesbuf_io'. Root comparison is
+            # exact, so an allowlist naming one must not report the other.
+            Test-PackageExposesTarget -Dependent (New-Dependent -Allowed @('bytesbuf::BytesBuf')) `
+                -TargetPackageName 'bytesbuf_io' | Should -BeFalse
+            Test-PackageExposesTarget -Dependent (New-Dependent -Allowed @('bytesbuf_io::Read')) `
+                -TargetPackageName 'bytesbuf' | Should -BeFalse
+        }
+    }
 }

--- a/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
@@ -531,7 +531,10 @@ Describe 'Reduce-DependencyChains' {
 
 Describe 'Test-PackageExposesTarget' {
     BeforeAll {
-        function New-Dependent { param($Allowed) [pscustomobject]@{ AllowedExternalTypes = $Allowed } }
+        function New-Dependent {
+            param($Allowed, $DepAliases = @{})
+            [pscustomobject]@{ AllowedExternalTypes = $Allowed; DepAliases = $DepAliases }
+        }
     }
 
     It 'reports exposure when an entry is rooted at the target package' {
@@ -581,5 +584,40 @@ Describe 'Test-PackageExposesTarget' {
         # An explicit empty list means the crate exposes no external types at
         # all, which is information -- unlike absent metadata.
         Test-PackageExposesTarget -Dependent (New-Dependent -Allowed @()) -TargetPackageName 'bytesbuf' | Should -BeFalse
+    }
+
+    It 'reports exposure when the entry is rooted at the alias of a renamed dependency' {
+        # `bytesbuf = { package = "bytesbuf", ... }` renamed to `buf`: Rust
+        # source -- and therefore the allowlist -- can only name it as `buf`.
+        $dep = New-Dependent -Allowed @('buf::Bytes') -DepAliases @{ bytesbuf = @('buf') }
+        Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeTrue
+    }
+
+    It 'normalizes hyphens in a rename alias' {
+        $dep = New-Dependent -Allowed @('bytes_buf::Bytes') -DepAliases @{ bytesbuf = @('bytes_buf') }
+        Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeTrue
+    }
+
+    It 'reports exposure under any one of several aliases for the same dependency' {
+        $aliases = @{ bytesbuf = @('buf_v1', 'buf_v2') }
+        foreach ($root in @('buf_v1', 'buf_v2')) {
+            Test-PackageExposesTarget -Dependent (New-Dependent -Allowed @("$root::Bytes") -DepAliases $aliases) `
+                -TargetPackageName 'bytesbuf' | Should -BeTrue -Because "'$root' is an alias of the target"
+        }
+    }
+
+    It 'does not treat an alias of a different dependency as exposure of the target' {
+        $dep = New-Dependent -Allowed @('buf::Bytes') -DepAliases @{ other_crate = @('buf') }
+        Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeFalse
+    }
+
+    It 'still matches the real package name when that dependency is also aliased elsewhere' {
+        $dep = New-Dependent -Allowed @('bytesbuf::Bytes') -DepAliases @{ bytesbuf = @('buf') }
+        Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeTrue
+    }
+
+    It 'tolerates a package record that predates the DepAliases field' {
+        $dep = [pscustomobject]@{ AllowedExternalTypes = @('std::io::Error') }
+        Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeFalse
     }
 }

--- a/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
@@ -629,11 +629,14 @@ Describe 'Test-PackageExposesTarget' {
         # &BytesBuf`, plus BytesView/Memory/HasMemory in trait signatures. A
         # breaking bytesbuf release is therefore a breaking bytesbuf_io release.
         #
-        # The allowlist below is copied verbatim from
-        # crates/bytesbuf_io/Cargo.toml. ExposureCascade-RealWorkspace.Tests.ps1
-        # asserts the real manifest still matches it, so this stays honest.
+        # The allowlist comes from Get-BytesBufIoAllowlist (_common), which
+        # holds the literal copied from crates/bytesbuf_io/Cargo.toml.
+        # ExposureCascade-RealWorkspace.Tests.ps1 asserts the real manifest
+        # still equals that literal exactly, so this stays honest: if the
+        # manifest gains or loses an entry, that test fails rather than this
+        # one quietly asserting against a stale copy.
         BeforeAll {
-            $script:BytesBufIoAllowed = @('bytesbuf::*', 'ohno::*', 'futures_core::stream::Stream')
+            $script:BytesBufIoAllowed = Get-BytesBufIoAllowlist
         }
 
         It 'reports exposure of bytesbuf' {

--- a/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
@@ -667,3 +667,81 @@ Describe 'Test-PackageExposesTarget' {
         }
     }
 }
+Describe 'Test-PackageAllowlistNamesTarget' {
+    BeforeAll {
+        function New-Dependent {
+            param($Allowed, $DepAliases = @{})
+            [pscustomobject]@{ AllowedExternalTypes = $Allowed; DepAliases = $DepAliases }
+        }
+    }
+
+    It 'reports a match when an entry is rooted at the target package' {
+        $dep = New-Dependent -Allowed @('recoverable::Recovery', 'std::io::Error')
+        Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'recoverable' | Should -BeTrue
+    }
+
+    It 'normalizes hyphens in the target package name' {
+        $dep = New-Dependent -Allowed @('data_privacy_core::Sensitive')
+        Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'data-privacy-core' | Should -BeTrue
+    }
+
+    It 'reports a match when an entry is rooted at a rename alias' {
+        $dep = New-Dependent -Allowed @('buf::Bytes') -DepAliases @{ bytesbuf = @('buf') }
+        Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeTrue
+    }
+
+    It 'reports no match when no entry is rooted at the target' {
+        $dep = New-Dependent -Allowed @('std::io::Error', 'core::fmt::Debug')
+        Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'recoverable' | Should -BeFalse
+    }
+
+    Context 'divergence from Test-PackageExposesTarget' {
+        # These are the cases the two functions answer differently, and the
+        # difference is the whole point: this predicate gates the INDIRECT
+        # dependency edge, where "no evidence" must not be read as exposure.
+        # Treating absent metadata as a match there would force every transitive
+        # dependent in the graph to breaking.
+
+        It 'reports no match for absent metadata, where exposure fails closed' {
+            $dep = New-Dependent -Allowed $null
+            Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'recoverable' | Should -BeFalse
+            # Contrast: the direct-edge predicate must fail closed on the same input.
+            Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'recoverable' | Should -BeTrue
+        }
+
+        It 'skips malformed entries instead of failing closed on them' {
+            foreach ($bad in @($null, '', '   ', 42, @{ a = 1 })) {
+                $dep = New-Dependent -Allowed @($bad)
+                Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'recoverable' |
+                    Should -BeFalse -Because 'a malformed entry is not positive evidence'
+                Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'recoverable' |
+                    Should -BeTrue -Because 'the direct edge still fails closed'
+            }
+        }
+
+        It 'still finds a valid entry that follows a malformed one' {
+            # Skipping malformed entries must not abandon the rest of the list.
+            $dep = New-Dependent -Allowed @($null, 'recoverable::Recovery')
+            Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'recoverable' | Should -BeTrue
+        }
+
+        It 'treats a wildcard root as a match, unlike other unknowns' {
+            # A wildcard is a deliberate declaration that can expand to the
+            # target, not an absence of information.
+            foreach ($pattern in @('*', 'recover?ble::Recovery', '[rs]ecoverable::Recovery')) {
+                Test-PackageAllowlistNamesTarget -Dependent (New-Dependent -Allowed @($pattern)) `
+                    -TargetPackageName 'recoverable' | Should -BeTrue -Because "'$pattern' may expand to the target"
+            }
+        }
+    }
+
+    It 'reports no match for an explicit empty allowlist' {
+        Test-PackageAllowlistNamesTarget -Dependent (New-Dependent -Allowed @()) `
+            -TargetPackageName 'recoverable' | Should -BeFalse
+    }
+
+    It 'tolerates a package record that predates the DepAliases field' {
+        $dep = [pscustomobject]@{ AllowedExternalTypes = @('recoverable::Recovery') }
+        Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'recoverable' | Should -BeTrue
+    }
+}

--- a/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
@@ -587,7 +587,7 @@ Describe 'Test-PackageExposesTarget' {
     }
 
     It 'reports exposure when the entry is rooted at the alias of a renamed dependency' {
-        # `bytesbuf = { package = "bytesbuf", ... }` renamed to `buf`: Rust
+        # `buf = { package = "bytesbuf", ... }`: Rust
         # source -- and therefore the allowlist -- can only name it as `buf`.
         $dep = New-Dependent -Allowed @('buf::Bytes') -DepAliases @{ bytesbuf = @('buf') }
         Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeTrue
@@ -688,9 +688,18 @@ Describe 'Test-PackageAllowlistNamesTarget' {
         Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'data-privacy-core' | Should -BeTrue
     }
 
-    It 'reports a match when an entry is rooted at a rename alias' {
+    It "reports a match when an entry is rooted at the target's divergent crate root" {
+        $dep = New-Dependent -Allowed @('buf_core::Bytes')
+        Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'bytesbuf' `
+            -TargetCrateRoot 'buf_core' | Should -BeTrue
+    }
+
+    It 'does not consult dependency-edge aliases for an indirect target' {
+        # An indirect dependent declares no edge to the target, so production
+        # can never populate this alias. Pin that the helper does not turn an
+        # impossible fixture state into supported behaviour.
         $dep = New-Dependent -Allowed @('buf::Bytes') -DepAliases @{ bytesbuf = @('buf') }
-        Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeTrue
+        Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeFalse
     }
 
     It 'reports no match when no entry is rooted at the target' {

--- a/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
@@ -575,6 +575,14 @@ Describe 'Test-PackageExposesTarget' {
         }
     }
 
+    It 'fails closed when an entry has an empty root' {
+        foreach ($bad in @('::Bytes', ' ::Bytes')) {
+            Test-PackageExposesTarget -Dependent (New-Dependent -Allowed @($bad)) `
+                -TargetPackageName 'bytesbuf' | Should -BeTrue `
+                -Because "'$bad' has no usable crate root"
+        }
+    }
+
     It 'fails closed when a malformed entry follows valid ones' {
         $dep = New-Dependent -Allowed @('std::io::Error', $null)
         Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeTrue
@@ -692,6 +700,15 @@ Describe 'Test-PackageAllowlistNamesTarget' {
         $dep = New-Dependent -Allowed @('buf_core::Bytes')
         Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'bytesbuf' `
             -TargetCrateRoot 'buf_core' | Should -BeTrue
+    }
+
+    It 'does not match the package name when a divergent crate root is known' {
+        # `[lib] name` replaces the package name as the Rust root. Keeping both
+        # would let an unrelated crate with the package-name root force a
+        # spurious breaking bump on this indirect target.
+        $dep = New-Dependent -Allowed @('bytesbuf::Bytes')
+        Test-PackageAllowlistNamesTarget -Dependent $dep -TargetPackageName 'bytesbuf' `
+            -TargetCrateRoot 'buf_core' | Should -BeFalse
     }
 
     It 'does not consult dependency-edge aliases for an indirect target' {

--- a/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/PureFunctions.Tests.ps1
@@ -528,3 +528,58 @@ Describe 'Reduce-DependencyChains' {
         ($a | ForEach-Object { $_ -join ' -> ' }) -join '|' | Should -Be 'a -> baz|z -> baz'
     }
 }
+
+Describe 'Test-PackageExposesTarget' {
+    BeforeAll {
+        function New-Dependent { param($Allowed) [pscustomobject]@{ AllowedExternalTypes = $Allowed } }
+    }
+
+    It 'reports exposure when an entry is rooted at the target package' {
+        $dep = New-Dependent -Allowed @('bytesbuf::Bytes', 'std::io::Error')
+        Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeTrue
+    }
+
+    It 'normalizes hyphens in the target package name to underscores' {
+        # Crate `bytesbuf-io` is referred to as `bytesbuf_io` in Rust paths.
+        $dep = New-Dependent -Allowed @('bytesbuf_io::Reader')
+        Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf-io' | Should -BeTrue
+    }
+
+    It 'reports no exposure when no entry is rooted at the target package' {
+        $dep = New-Dependent -Allowed @('std::io::Error', 'core::fmt::Debug')
+        Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeFalse
+    }
+
+    It 'fails closed when the metadata is absent entirely' {
+        Test-PackageExposesTarget -Dependent (New-Dependent -Allowed $null) -TargetPackageName 'bytesbuf' | Should -BeTrue
+    }
+
+    It 'fails closed on a wildcard root that could match anything' {
+        foreach ($pattern in @('*', 'byte?buf::Bytes', '[bc]ytesbuf::Bytes')) {
+            Test-PackageExposesTarget -Dependent (New-Dependent -Allowed @($pattern)) -TargetPackageName 'bytesbuf' |
+                Should -BeTrue -Because "'$pattern' may match the target"
+        }
+    }
+
+    It 'fails closed on a malformed entry rather than silently reporting no exposure' {
+        # `-split` coerces anything to a string, so these do not throw: they
+        # collapse to '' and match nothing, which would let a breaking
+        # dependency bump ship as a compatible release.
+        foreach ($bad in @($null, '', '   ', 42, @{ a = 1 })) {
+            $rendered = if ($null -eq $bad) { '$null' } else { "'$bad'" }
+            Test-PackageExposesTarget -Dependent (New-Dependent -Allowed @($bad)) -TargetPackageName 'bytesbuf' |
+                Should -BeTrue -Because "$rendered carries no exposure information"
+        }
+    }
+
+    It 'fails closed when a malformed entry follows valid ones' {
+        $dep = New-Dependent -Allowed @('std::io::Error', $null)
+        Test-PackageExposesTarget -Dependent $dep -TargetPackageName 'bytesbuf' | Should -BeTrue
+    }
+
+    It 'reports no exposure for an empty allowlist' {
+        # An explicit empty list means the crate exposes no external types at
+        # all, which is information -- unlike absent metadata.
+        Test-PackageExposesTarget -Dependent (New-Dependent -Allowed @()) -TargetPackageName 'bytesbuf' | Should -BeFalse
+    }
+}


### PR DESCRIPTION
## Summary

Release planning could ship a **breaking API change inside a semver-compatible version**.

`cargo-semver-checks` analyses each crate in isolation. But a crate's public API is not only what it declares — it is also every foreign type it re-exports. When `bytesbuf` breaks, `bytesbuf_io` breaks too, because `bytesbuf_io`'s API *is* `bytesbuf` types:

```rust
// crates/bytesbuf_io/src/testing/fake_write.rs
pub fn contents(&self) -> &BytesBuf
pub fn reserve(&self, min_bytes: usize) -> BytesBuf
```

`bytesbuf_io` never changed, so semver-checks saw nothing, and the planner gave it the mechanical patch floor:

| | before | after |
|---|---|---|
| `bytesbuf` | 0.7.0 → **0.8.0** | 0.7.0 → **0.8.0** |
| `bytesbuf_io` | 0.7.0 → **0.7.1** ❌ | 0.7.0 → **0.8.0** ✅ |

That `0.7.1` is the bug: a patch release that breaks every downstream build, delivered automatically by `cargo update`.

This PR teaches the planner to combine semver-checks with the `cargo_check_external_types` allowlists each crate already declares, and to propagate incompatibility across public-API exposure edges to a fixpoint.

Work item: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7705926

---

## What the cascade actually does

Running `release-packages bytesbuf@breaking` against today's workspace pulls in **9 crates, all breaking**. Solid arrows are exposure edges; dashed arrows are dependencies that do *not* surface the type in their public API:

```mermaid
graph LR
    bytesbuf["bytesbuf 0.7.0 → 0.8.0"]
    bytesbuf_io["bytesbuf_io 0.7.0 → 0.8.0"]
    cachet["cachet 0.10.0 → 0.11.0"]
    multitude["multitude 0.7.1 → 0.8.0"]
    http_extensions["http_extensions 0.8.0 → 0.9.0"]
    seatbelt_http["seatbelt_http 0.6.0 → 0.7.0"]
    fetch["fetch 0.14.0 → 0.15.0"]
    fetch_hyper["fetch_hyper 0.5.0 → 0.6.0"]
    fetch_azure["fetch_azure 0.4.0 → 0.5.0"]

    bytesbuf --> bytesbuf_io
    bytesbuf --> cachet
    bytesbuf --> multitude
    bytesbuf --> http_extensions
    bytesbuf --> fetch
    bytesbuf -.-> fetch_hyper
    bytesbuf -.-> fetch_azure

    http_extensions --> seatbelt_http
    http_extensions --> fetch_hyper
    http_extensions --> fetch
    seatbelt_http --> fetch
    fetch_hyper -.-> fetch
    fetch --> fetch_azure
```

### Why this needs a fixpoint, not a single pass

Look at `fetch_hyper`. It depends on `bytesbuf` but does **not** expose it — a single pass over `bytesbuf`'s dependents would correctly leave it alone. It becomes breaking only on a later pass, through `http_extensions`:

```mermaid
graph LR
    A["bytesbuf — breaking"] -->|exposed| B["http_extensions — raised on pass 1"]
    B -->|exposed| C["fetch_hyper — raised on pass 2"]
    A -.->|"not exposed, no direct effect"| C
```

`fetch_azure` reaches breaking the same way, via `fetch`. So the cascade iterates until a pass strengthens nothing.

Each pass only ever *raises*, through a single choke point (`Update-EntryForRequiredChangeType`), which is what guarantees termination.

---

## Planner flow

```mermaid
flowchart TD
    A["Parse tokens, e.g. bytesbuf@breaking"] --> B["requestedFolders"]
    B --> C["Self-floor: cargo-semver-checks per requested crate"]
    C --> D["BFS: every transitive published dependent joins at a patch floor"]
    D --> E{"Exposure fixpoint"}
    E --> F["Select entries whose planned version is an incompatible transition"]
    F --> G["Find selected published dependents: declared edges that may expose them, or reachable indirect crates that positively allowlist the defining crate"]
    G --> H["Raise to breaking, record cascade reason"]
    H -->|"something changed"| E
    E -->|"nothing changed"| I["Manual-review queue for proc-macro crates"]
```

---

## Fail-closed policy

Exposure is decided from `[package.metadata.cargo_check_external_types]`. The guiding rule: **an unknown must never permit a break to ship as compatible.**

| `allowed_external_types` | verdict | rationale |
|---|---|---|
| absent (`$null`) | **exposed** | no claim was made; CI validates *merged* code, the planner reads the *working tree* |
| `[]` (empty) | not exposed | a positive claim: "my API names nothing foreign" |
| root matches target | **exposed** | e.g. `bytesbuf::*` vs `bytesbuf` |
| root is an alias of target | **exposed** | `package = "..."` renames — see below |
| wildcard root (`*`, `?`, `[`) | **exposed** | could match anything |
| malformed entry (non-string, blank) | **exposed** | carries no information |
| no matching root | not exposed | |

Note the asymmetry between absent and empty — that distinction is the one thing that makes the condition look inverted at a glance, so it is documented at the call site.

Two of these were fixed during review:

- **Malformed entries** (`d42c6cb1`) — `-split` coerces any operand to a string, so a non-string entry silently collapsed to `''` and matched nothing. A typo'd allowlist therefore read as "not exposed".
- **Renamed dependencies** (`7373a040`) — a dependency declared `package = "..."` is nameable in Rust *only* under its alias, so its allowlist entry carries the alias while the planner compared against the real package name. The edge was detected, but the exposure test missed, and the break shipped tagged compatible. `Get-WorkspacePackages` now records a `DepAliases` map and the exposure test accepts either name.

---

## `-Force` semantics

`-Force` writes the number you asked for and warns you. It does not assert that the incompatibility is absent, so it does not stop the cascade.

A pin honoured below a required **breaking** version writes a numerically compatible version over an API that is genuinely incompatible: `b@1.1.0` is still compiled against `a@2.0.0` and still exposes `a::*`, so its public API names different types than `b@1.0.0` did — and a consumer of `b = "1.0"` upgrades into it silently under caret semantics. Keying the cascade off the planned version alone would stop it at exactly the crate whose break was suppressed:

```mermaid
graph LR
    a["a: 1.0.0 → 2.0.0, breaking"] -->|exposed| b["b: pinned 1.1.0 with --force, pin honoured, break suppressed not removed"]
    b -->|"cascade continues: the pin lowered the number, not the API"| c["c: raised to 2.0.0"]
```

The pin itself is still honoured verbatim — only the propagation decision changed.

Propagation is widened solely by `PinHonoredAgainstCascade`, and only when the **suppressed requirement was itself breaking**. That flag is set for any suppressed requirement, so a pin that merely undercuts an additive `non-breaking` requirement does *not* drag exposing dependents to a major release. Both branches route through the same `Test-IsBreakingChange`, which keeps 0.x semantics consistent between them.

---

## Testing

**497 Pester tests pass.**

Regression coverage is deliberately split in two, because everything else in the suite builds synthetic package records and so only ever proves the planner correct about graphs the tests themselves invented:

- **Unit** — the exposure decision table above, including the negatives: `trait-variant` is a `bytesbuf_io` dependency that is deliberately *not* allowlisted and must stay unexposed, and `bytesbuf` being a strict prefix of `bytesbuf_io` must not cross-match either way.
- **End-to-end** (`integration/ExposureCascade-RealWorkspace.Tests.ps1`) — resolves a release set over the **live workspace metadata** and asserts the real `bytesbuf → bytesbuf_io` cascade, plus a negative control that `bytesbuf@patch` does *not* force a break.

The e2e test reads real manifests on purpose. Deleting `bytesbuf::*` from `bytesbuf_io`'s allowlist is exactly how this fail-open would be reintroduced, and that must break the suite rather than pass against a stale snapshot.

Both regression layers were **mutation-checked** rather than assumed green:

| mutation | result |
|---|---|
| `Test-PackageExposesTarget` reverted to the original fail-open | **4 of 9** e2e assertions fail |
| `Test-EntryPlansBreakingRelease` keyed off the change-type tag instead of the planned version | **1** test fails — and it is the new one; nothing else in 454 noticed |

---

## Commits

| | |
|---|---|
| `40b112bc` | cascade exposed dependency breaks |
| `d42c6cb1` | fail closed on malformed `allowed_external_types` entries |
| `0a9ec0c5` | document why an absent allowlist still counts as exposure |
| `895ed215` | split the exposure fixpoint into named helpers |
| `7373a040` | match exposure allowlists against renamed dependency aliases |
| `58ab2412` | pin the `bytesbuf`/`bytesbuf_io` cascade against real manifests |

## Known gap (not in scope)

`Deps` retains both `normal` and `build` dependency kinds, so a build-only edge could over-cascade. It is unreachable today — all four workspace build edges originate from `publish = false` crates, which the `Published` filter already excludes — and it fails in the safe direction (an unnecessary bump, never a silent break). The fix needs per-edge `kind` metadata, tracked in [AB#7729476](https://dev.azure.com/O365Exchange/O365%20Core/_workitems/edit/7729476).


