### PR TITLE
fix(multitude): gate over-aligned doctest behind utc_backend cfg

### DIFF
--- a/crates/multitude/src/error.rs
+++ b/crates/multitude/src/error.rs
@@ -95,6 +95,8 @@ impl AllocError {
     /// succeed, regardless of how much memory is available.
     ///
     /// ```
+    /// # fn main() {
+    /// # #[cfg(not(utc_backend))] {
     /// #[repr(align(32768))]
     /// struct OverAligned;
     ///
@@ -103,6 +105,8 @@ impl AllocError {
     ///     panic!("over-aligned values must be rejected");
     /// };
     /// assert!(error.is_alignment_too_large());
+    /// # }
+    /// # }
     /// ```
     #[must_use]
     pub fn is_alignment_too_large(self) -> bool {


### PR DESCRIPTION
## Problem

`cargo test -p multitude --doc` fails on codegen backends that support a lower maximum type alignment than the default one.

The doctest on `AllocError::is_alignment_too_large` has to declare an over-aligned type in order to demonstrate the error it documents:

```rust
#[repr(align(32768))]
struct OverAligned;

let arena = multitude::Arena::new();
let Some(error) = arena.try_alloc(OverAligned).err() else {
    panic!("over-aligned values must be rejected");
};
assert!(error.is_alignment_too_large());
```

On a backend that caps alignment below that value, the type cannot be compiled at all, so the doctest fails.

#501 gated the equivalent *integration* tests behind `cfg(utc_backend)` and registered that cfg in the workspace `check-cfg` list, but this doctest was missed.

## Fix

Wrap the body in the hidden `#[cfg(...)]` shim documented in `AGENTS-feature-gated-doctests.md` (Pattern C — no `?`, no user `main`):

```rust
/// # fn main() {
/// # #[cfg(not(utc_backend))] {
/// ... existing body, unchanged ...
/// # }
/// # }
```

The `#` prefix keeps the shim out of the rendered documentation, so the published example is unchanged.

## Note for reviewers: `RUSTDOCFLAGS` is required

Doctests are compiled by `rustdoc`, and cargo passes `RUSTFLAGS` to `rustc` but **not** to `rustdoc`. Enabling the gate for doctests therefore needs both:

```
RUSTFLAGS=--cfg utc_backend
RUSTDOCFLAGS=--cfg utc_backend
```

Verified: with `RUSTFLAGS` alone the gate compiles in but the doctest still fails, because rustdoc never sees the cfg. Anything driving this build (for example a publish pipeline that currently sets only `RUSTFLAGS`) needs `RUSTDOCFLAGS` as well, otherwise this fix will appear to have no effect.

## Verification

- Doctests **with** the gate set (both env vars): **301 passed, 0 failed** — previously 1 failed.
- Doctests **without** the gate, on a normal toolchain: **301 passed, 0 failed** — the example still genuinely compiles and asserts, it is not silently skipped.
- `cargo clippy -p multitude --profile dev --all-targets --all-features --locked` — clean, zero warnings.
- `just package=multitude format-check` — clean.
- `just spellcheck` — clean.

Confirmed separately that the `multitude` **library** builds cleanly on such a backend and its 46 unit tests pass. The library declares no over-aligned types; alignment is handled at runtime via `align_of::<T>()`. Only test and doc code that must *construct* an over-aligned type is affected.

AB#7707893
