### PR TITLE
feat(testing_aids): add manual future-polling test helpers

### DIFF
--- a/crates/bytesbuf_io/src/testing/pending.rs
+++ b/crates/bytesbuf_io/src/testing/pending.rs
@@ -194,10 +194,8 @@ impl PendingBuilder {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use std::pin::pin;
-    use std::task::{Context, Poll, Waker};
-
     use bytesbuf::mem::CallbackMemory;
+    use testing_aids::FutureTestExt;
 
     use super::*;
 
@@ -255,15 +253,9 @@ mod tests {
         let mut stream = Pending::new();
         let buffer = BytesBuf::new();
 
-        let mut future = pin!(stream.read_at_most_into(100, buffer));
-        let waker = Waker::noop();
-        let mut cx = Context::from_waker(waker);
-
-        let result = future.as_mut().poll(&mut cx);
-        assert!(
-            matches!(result, Poll::Pending),
-            "read_at_most_into should return Pending on first poll"
-        );
+        stream
+            .read_at_most_into(100, buffer)
+            .unwrap_pending_for(1, "read_at_most_into should return Pending on first poll");
     }
 
     #[test]
@@ -271,27 +263,18 @@ mod tests {
         let mut stream = Pending::new();
         let buffer = BytesBuf::new();
 
-        let mut future = pin!(stream.read_more_into(buffer));
-        let waker = Waker::noop();
-        let mut cx = Context::from_waker(waker);
-
-        let result = future.as_mut().poll(&mut cx);
-        assert!(
-            matches!(result, Poll::Pending),
-            "read_more_into should return Pending on first poll"
-        );
+        stream
+            .read_more_into(buffer)
+            .unwrap_pending_for(1, "read_more_into should return Pending on first poll");
     }
 
     #[test]
     fn read_any_returns_pending_on_first_poll() {
         let mut stream = Pending::new();
 
-        let mut future = pin!(stream.read_any());
-        let waker = Waker::noop();
-        let mut cx = Context::from_waker(waker);
-
-        let result = future.as_mut().poll(&mut cx);
-        assert!(matches!(result, Poll::Pending), "read_any should return Pending on first poll");
+        stream
+            .read_any()
+            .unwrap_pending_for(1, "read_any should return Pending on first poll");
     }
 
     #[test]
@@ -299,11 +282,8 @@ mod tests {
         let mut stream = Pending::new();
         let data = BytesView::default();
 
-        let mut future = pin!(stream.write(data));
-        let waker = Waker::noop();
-        let mut cx = Context::from_waker(waker);
-
-        let result = future.as_mut().poll(&mut cx);
-        assert!(matches!(result, Poll::Pending), "write should return Pending on first poll");
+        stream
+            .write(data)
+            .unwrap_pending_for(1, "write should return Pending on first poll");
     }
 }

--- a/crates/cachet/src/telemetry/cache.rs
+++ b/crates/cachet/src/telemetry/cache.rs
@@ -705,39 +705,31 @@ mod tests {
 
     #[test]
     fn nested_with_request_id_restores_outer_id() {
-        use std::task::{Context, Poll, Waker};
+        use testing_aids::FutureTestExt;
 
         let outer_id = next_request_id();
         let inner_id = next_request_id();
 
-        let waker = Waker::noop();
-
         // Poll outer WithRequestId, which sets outer_id
-        let mut outer = std::pin::pin!(
+        async {
+            assert_eq!(CacheTelemetry::current_request_id(), outer_id);
+
+            // Poll inner WithRequestId — sets inner_id, should restore outer_id on completion
             async {
-                assert_eq!(CacheTelemetry::current_request_id(), outer_id);
-
-                // Poll inner WithRequestId — sets inner_id, should restore outer_id on completion
-                let mut inner = std::pin::pin!(
-                    async {
-                        assert_eq!(CacheTelemetry::current_request_id(), inner_id);
-                    }
-                    .with_request_id(inner_id)
-                );
-                let mut inner_cx = Context::from_waker(waker);
-                assert!(matches!(inner.as_mut().poll(&mut inner_cx), Poll::Ready(())));
-
-                // After inner completes, outer_id should be restored
-                assert_eq!(
-                    CacheTelemetry::current_request_id(),
-                    outer_id,
-                    "outer request_id should be restored after nested WithRequestId"
-                );
+                assert_eq!(CacheTelemetry::current_request_id(), inner_id);
             }
-            .with_request_id(outer_id)
-        );
-        let mut outer_cx = Context::from_waker(waker);
-        assert!(matches!(outer.as_mut().poll(&mut outer_cx), Poll::Ready(())));
+            .with_request_id(inner_id)
+            .unwrap_ready();
+
+            // After inner completes, outer_id should be restored
+            assert_eq!(
+                CacheTelemetry::current_request_id(),
+                outer_id,
+                "outer request_id should be restored after nested WithRequestId"
+            );
+        }
+        .with_request_id(outer_id)
+        .unwrap_ready();
 
         // After outer completes, should be reset to 0
         assert_eq!(CacheTelemetry::current_request_id(), 0);

--- a/crates/testing_aids/src/lib.rs
+++ b/crates/testing_aids/src/lib.rs
@@ -20,11 +20,13 @@ use std::{env, process, thread};
 mod io;
 mod macros;
 mod metrics;
+mod poll;
 pub mod tracing_logs;
 mod yielding;
 
 pub use io::*;
 pub use metrics::*;
+pub use poll::*;
 pub use yielding::*;
 
 /// If something (whatever) does not happen in a test within this time, the test will fail.

--- a/crates/testing_aids/src/poll.rs
+++ b/crates/testing_aids/src/poll.rs
@@ -283,8 +283,10 @@ mod tests {
         assert_eq!(polls.get(), 3);
     }
 
-    /// An output type deliberately without a [`Debug`](std::fmt::Debug) impl,
-    /// pinning that the helpers stay usable with opaque outputs.
+    /// An output type deliberately without a [`Debug`](std::fmt::Debug) impl.
+    ///
+    /// Any helper that requires one would fail to compile against this type,
+    /// so it keeps the assertions usable with opaque outputs.
     struct NotDebug(u32);
 
     /// Returns `Pending` on its first poll, then `Ready`.

--- a/crates/testing_aids/src/poll.rs
+++ b/crates/testing_aids/src/poll.rs
@@ -10,7 +10,6 @@
 //! lower-level [`poll_once`] primitive performs exactly one poll of an unpinned
 //! future.
 
-use std::fmt::Debug;
 use std::task::{Context, Poll, Waker};
 
 /// Polls a future exactly once with a no-op waker.
@@ -103,18 +102,12 @@ pub trait FutureTestExt: Future + Sized {
     /// Panics (using `message_if_not_pending`) if any of the first `n_pending`
     /// polls returns `Ready`, or if the final poll is still `Pending`.
     #[track_caller]
-    fn unwrap_ready_after(self, n_pending: usize, message_if_not_pending: &str) -> Self::Output
-    where
-        Self::Output: Debug,
-    {
+    fn unwrap_ready_after(self, n_pending: usize, message_if_not_pending: &str) -> Self::Output {
         let mut fut = std::pin::pin!(self);
         for i in 0..n_pending {
             match poll_once(&mut fut) {
                 Poll::Pending => {}
-                Poll::Ready(value) => panic!(
-                    "{message_if_not_pending}: got Ready({value:?}) after {} polls, expected Pending",
-                    i + 1
-                ),
+                Poll::Ready(_) => panic!("{message_if_not_pending}: got Ready after {} polls, expected Pending", i + 1),
             }
         }
 
@@ -288,6 +281,34 @@ mod tests {
         let (fut, polls) = ScriptedFuture::with_poll_count(vec![Poll::Pending, Poll::Pending, Poll::Ready(9)]);
         assert_eq!(fut.unwrap_ready_after(2, "should be pending"), 9);
         assert_eq!(polls.get(), 3);
+    }
+
+    /// An output type deliberately without a [`Debug`](std::fmt::Debug) impl,
+    /// pinning that the helpers stay usable with opaque outputs.
+    struct NotDebug(u32);
+
+    /// Returns `Pending` on its first poll, then `Ready`.
+    struct PendingOnce {
+        polled: bool,
+    }
+
+    impl Future for PendingOnce {
+        type Output = NotDebug;
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<NotDebug> {
+            if self.polled {
+                Poll::Ready(NotDebug(4))
+            } else {
+                self.polled = true;
+                Poll::Pending
+            }
+        }
+    }
+
+    #[test]
+    fn unwrap_ready_after_accepts_non_debug_output() {
+        let value = PendingOnce { polled: false }.unwrap_ready_after(1, "should be pending once");
+        assert_eq!(value.0, 4);
     }
 
     #[test]

--- a/crates/testing_aids/src/poll.rs
+++ b/crates/testing_aids/src/poll.rs
@@ -47,6 +47,7 @@ pub trait FutureTestExt: Future + Sized {
     /// # Panics
     ///
     /// Panics if the future returns [`Poll::Pending`].
+    #[track_caller]
     fn unwrap_ready(self) -> Self::Output {
         let mut fut = std::pin::pin!(self);
         match poll_once(&mut fut) {
@@ -60,6 +61,7 @@ pub trait FutureTestExt: Future + Sized {
     /// # Panics
     ///
     /// Panics if the future returns [`Poll::Ready`].
+    #[track_caller]
     fn unwrap_pending(self) {
         let mut fut = std::pin::pin!(self);
         assert!(
@@ -73,6 +75,7 @@ pub trait FutureTestExt: Future + Sized {
     /// # Panics
     ///
     /// Panics with `timeout_msg` if the future never completes within `max_polls` polls.
+    #[track_caller]
     fn unwrap_ready_within(self, max_polls: usize, timeout_msg: &str) -> Self::Output {
         let mut fut = std::pin::pin!(self);
         for _ in 0..max_polls {
@@ -93,6 +96,7 @@ pub trait FutureTestExt: Future + Sized {
     ///
     /// Panics (using `message_if_not_pending`) if any of the first `n_pending`
     /// polls returns `Ready`, or if the final poll is still `Pending`.
+    #[track_caller]
     fn unwrap_ready_after(self, n_pending: usize, message_if_not_pending: &str) -> Self::Output
     where
         Self::Output: Debug,
@@ -110,7 +114,10 @@ pub trait FutureTestExt: Future + Sized {
 
         match poll_once(&mut fut) {
             Poll::Ready(value) => value,
-            Poll::Pending => panic!("expected Ready after {} polls, but got Pending", n_pending + 1),
+            Poll::Pending => panic!(
+                "{message_if_not_pending}: expected Ready after {} polls, but got Pending",
+                n_pending + 1
+            ),
         }
     }
 
@@ -118,8 +125,11 @@ pub trait FutureTestExt: Future + Sized {
     ///
     /// # Panics
     ///
-    /// Panics (using `message`) if any poll returns `Ready`.
+    /// Panics (using `message`) if any poll returns `Ready`, and panics if `n`
+    /// is zero, because zero polls would assert nothing.
+    #[track_caller]
     fn unwrap_pending_for(self, n: usize, message: &str) {
+        assert!(n > 0, "unwrap_pending_for requires n > 0; zero polls would assert nothing");
         let mut fut = std::pin::pin!(self);
         for _ in 0..n {
             assert!(poll_once(&mut fut).is_pending(), "{message}");
@@ -131,22 +141,38 @@ impl<F: Future> FutureTestExt for F {}
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
     use std::collections::VecDeque;
     use std::pin::Pin;
+    use std::rc::Rc;
 
     use super::*;
 
-    /// A future returning a scripted sequence of polls, defaulting to `Pending`
-    /// once the script is exhausted.
+    /// A future returning a scripted sequence of polls.
+    ///
+    /// It counts every poll it receives and panics once the script is
+    /// exhausted, so a helper that polls more times than it documents fails
+    /// loudly instead of silently observing `Pending` forever.
     struct ScriptedFuture {
         steps: VecDeque<Poll<u32>>,
+        polls: Rc<Cell<usize>>,
     }
 
     impl ScriptedFuture {
         fn new(steps: Vec<Poll<u32>>) -> Self {
             Self {
                 steps: VecDeque::from(steps),
+                polls: Rc::new(Cell::new(0)),
             }
+        }
+
+        /// Returns the future together with a handle that observes how many
+        /// times it has been polled, so a test can assert the exact poll count
+        /// after the helper has consumed the future.
+        fn with_poll_count(steps: Vec<Poll<u32>>) -> (Self, Rc<Cell<usize>>) {
+            let future = Self::new(steps);
+            let polls = Rc::clone(&future.polls);
+            (future, polls)
         }
     }
 
@@ -154,7 +180,10 @@ mod tests {
         type Output = u32;
 
         fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<u32> {
-            self.steps.pop_front().unwrap_or(Poll::Pending)
+            self.polls.set(self.polls.get() + 1);
+            self.steps
+                .pop_front()
+                .unwrap_or_else(|| panic!("ScriptedFuture polled after its script was exhausted"))
         }
     }
 
@@ -165,8 +194,23 @@ mod tests {
     }
 
     #[test]
+    fn poll_once_returns_pending_and_can_be_repeated() {
+        let (mut fut, polls) = ScriptedFuture::with_poll_count(vec![Poll::Pending, Poll::Ready(5)]);
+        assert_eq!(poll_once(&mut fut), Poll::Pending);
+        assert_eq!(poll_once(&mut fut), Poll::Ready(5));
+        assert_eq!(polls.get(), 2, "each call must poll the future exactly once");
+    }
+
+    #[test]
     fn unwrap_ready_returns_value() {
         assert_eq!(ScriptedFuture::new(vec![Poll::Ready(42)]).unwrap_ready(), 42);
+    }
+
+    #[test]
+    fn unwrap_ready_polls_exactly_once() {
+        let (fut, polls) = ScriptedFuture::with_poll_count(vec![Poll::Ready(42)]);
+        assert_eq!(fut.unwrap_ready(), 42);
+        assert_eq!(polls.get(), 1);
     }
 
     #[test]
@@ -187,6 +231,13 @@ mod tests {
     }
 
     #[test]
+    fn unwrap_pending_polls_exactly_once() {
+        let (fut, polls) = ScriptedFuture::with_poll_count(vec![Poll::Pending]);
+        fut.unwrap_pending();
+        assert_eq!(polls.get(), 1);
+    }
+
+    #[test]
     #[should_panic(expected = "Pending after one poll")]
     fn unwrap_pending_panics_when_ready() {
         ScriptedFuture::new(vec![Poll::Ready(3)]).unwrap_pending();
@@ -196,6 +247,13 @@ mod tests {
     fn unwrap_ready_within_drives_to_completion() {
         let fut = ScriptedFuture::new(vec![Poll::Pending, Poll::Pending, Poll::Ready(7)]);
         assert_eq!(fut.unwrap_ready_within(10, "never finished"), 7);
+    }
+
+    #[test]
+    fn unwrap_ready_within_stops_polling_once_ready() {
+        let (fut, polls) = ScriptedFuture::with_poll_count(vec![Poll::Pending, Poll::Pending, Poll::Ready(7)]);
+        assert_eq!(fut.unwrap_ready_within(10, "never finished"), 7);
+        assert_eq!(polls.get(), 3, "must stop at the first Ready, not exhaust max_polls");
     }
 
     #[test]
@@ -212,6 +270,13 @@ mod tests {
     }
 
     #[test]
+    fn unwrap_ready_after_polls_exactly_n_plus_one_times() {
+        let (fut, polls) = ScriptedFuture::with_poll_count(vec![Poll::Pending, Poll::Pending, Poll::Ready(9)]);
+        assert_eq!(fut.unwrap_ready_after(2, "should be pending"), 9);
+        assert_eq!(polls.get(), 3);
+    }
+
+    #[test]
     #[should_panic(expected = "expected Pending")]
     fn unwrap_ready_after_panics_when_early_ready() {
         let fut = ScriptedFuture::new(vec![Poll::Ready(1)]);
@@ -219,10 +284,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "but got Pending")]
+    #[should_panic(expected = "custom context: expected Ready after 2 polls, but got Pending")]
     fn unwrap_ready_after_panics_when_never_ready() {
         let fut = ScriptedFuture::new(vec![Poll::Pending, Poll::Pending]);
-        let _ = fut.unwrap_ready_after(1, "should be pending");
+        let _ = fut.unwrap_ready_after(1, "custom context");
     }
 
     #[test]
@@ -231,8 +296,21 @@ mod tests {
     }
 
     #[test]
+    fn unwrap_pending_for_polls_exactly_n_times() {
+        let (fut, polls) = ScriptedFuture::with_poll_count(vec![Poll::Pending, Poll::Pending]);
+        fut.unwrap_pending_for(2, "should stay pending");
+        assert_eq!(polls.get(), 2);
+    }
+
+    #[test]
     #[should_panic(expected = "should stay pending")]
     fn unwrap_pending_for_panics_on_ready() {
         ScriptedFuture::new(vec![Poll::Ready(0)]).unwrap_pending_for(1, "should stay pending");
+    }
+
+    #[test]
+    #[should_panic(expected = "requires n > 0")]
+    fn unwrap_pending_for_panics_on_zero_polls() {
+        std::future::ready(1_u32).unwrap_pending_for(0, "should stay pending");
     }
 }

--- a/crates/testing_aids/src/poll.rs
+++ b/crates/testing_aids/src/poll.rs
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Utilities for driving futures by hand in unit tests.
+//!
+//! [`FutureTestExt`] adds consuming manual-polling assertions (`unwrap_ready`,
+//! `unwrap_pending`, `unwrap_ready_within`, `unwrap_ready_after`,
+//! `unwrap_pending_for`) that let a test poll a future a fixed number of times
+//! and assert the outcome, without spinning up an async runtime. The
+//! lower-level [`poll_once`] primitive performs exactly one poll of an unpinned
+//! future.
+
+use std::fmt::Debug;
+use std::task::{Context, Poll, Waker};
+
+/// Polls a future exactly once with a no-op waker.
+///
+/// Use this when a test needs to inspect external state between polls, or poll
+/// the same future from several places. For the common
+/// "drive to a known outcome" case, prefer [`FutureTestExt`].
+pub fn poll_once<F>(future: &mut F) -> Poll<F::Output>
+where
+    F: Future + Unpin,
+{
+    let mut cx = Context::from_waker(Waker::noop());
+    let mut future = std::pin::pin!(future);
+    future.as_mut().poll(&mut cx)
+}
+
+/// Extension trait adding consuming manual-polling assertions for futures in tests.
+///
+/// Every method takes the future **by value** and pins it internally, so the
+/// helpers work directly on `!Unpin` futures (such as the future returned by an
+/// `async fn`) with no manual `pin!`.
+///
+/// # Examples
+///
+/// ```
+/// use testing_aids::FutureTestExt;
+///
+/// assert_eq!(async { 7 }.unwrap_ready(), 7);
+/// ```
+pub trait FutureTestExt: Future + Sized {
+    /// Polls the future exactly once and returns its output, panicking if it is
+    /// still `Pending`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the future returns [`Poll::Pending`].
+    fn unwrap_ready(self) -> Self::Output {
+        let mut fut = std::pin::pin!(self);
+        match poll_once(&mut fut) {
+            Poll::Ready(value) => value,
+            Poll::Pending => panic!("expected future to be Ready after one poll, but it was Pending"),
+        }
+    }
+
+    /// Polls the future exactly once, asserting it is `Pending`, then drops it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the future returns [`Poll::Ready`].
+    fn unwrap_pending(self) {
+        let mut fut = std::pin::pin!(self);
+        assert!(
+            poll_once(&mut fut).is_pending(),
+            "expected future to be Pending after one poll, but it was Ready"
+        );
+    }
+
+    /// Polls up to `max_polls` times, returning the first `Ready` output.
+    ///
+    /// # Panics
+    ///
+    /// Panics with `timeout_msg` if the future never completes within `max_polls` polls.
+    fn unwrap_ready_within(self, max_polls: usize, timeout_msg: &str) -> Self::Output {
+        let mut fut = std::pin::pin!(self);
+        for _ in 0..max_polls {
+            if let Poll::Ready(value) = poll_once(&mut fut) {
+                return value;
+            }
+        }
+        panic!("{timeout_msg}");
+    }
+
+    /// Polls exactly `n_pending` times expecting `Pending`, then once more
+    /// expecting `Ready`, returning the output.
+    ///
+    /// This makes timing expectations explicit and catches off-by-one timing
+    /// bugs in state machines.
+    ///
+    /// # Panics
+    ///
+    /// Panics (using `message_if_not_pending`) if any of the first `n_pending`
+    /// polls returns `Ready`, or if the final poll is still `Pending`.
+    fn unwrap_ready_after(self, n_pending: usize, message_if_not_pending: &str) -> Self::Output
+    where
+        Self::Output: Debug,
+    {
+        let mut fut = std::pin::pin!(self);
+        for i in 0..n_pending {
+            match poll_once(&mut fut) {
+                Poll::Pending => {}
+                Poll::Ready(value) => panic!(
+                    "{message_if_not_pending}: got Ready({value:?}) after {} polls, expected Pending",
+                    i + 1
+                ),
+            }
+        }
+
+        match poll_once(&mut fut) {
+            Poll::Ready(value) => value,
+            Poll::Pending => panic!("expected Ready after {} polls, but got Pending", n_pending + 1),
+        }
+    }
+
+    /// Polls `n` times, asserting each poll returns `Pending`, then drops the future.
+    ///
+    /// # Panics
+    ///
+    /// Panics (using `message`) if any poll returns `Ready`.
+    fn unwrap_pending_for(self, n: usize, message: &str) {
+        let mut fut = std::pin::pin!(self);
+        for _ in 0..n {
+            assert!(poll_once(&mut fut).is_pending(), "{message}");
+        }
+    }
+}
+
+impl<F: Future> FutureTestExt for F {}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::pin::Pin;
+
+    use super::*;
+
+    /// A future returning a scripted sequence of polls, defaulting to `Pending`
+    /// once the script is exhausted.
+    struct ScriptedFuture {
+        steps: VecDeque<Poll<u32>>,
+    }
+
+    impl ScriptedFuture {
+        fn new(steps: Vec<Poll<u32>>) -> Self {
+            Self {
+                steps: VecDeque::from(steps),
+            }
+        }
+    }
+
+    impl Future for ScriptedFuture {
+        type Output = u32;
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<u32> {
+            self.steps.pop_front().unwrap_or(Poll::Pending)
+        }
+    }
+
+    #[test]
+    fn poll_once_returns_ready_value() {
+        let mut fut = ScriptedFuture::new(vec![Poll::Ready(5)]);
+        assert_eq!(poll_once(&mut fut), Poll::Ready(5));
+    }
+
+    #[test]
+    fn unwrap_ready_returns_value() {
+        assert_eq!(ScriptedFuture::new(vec![Poll::Ready(42)]).unwrap_ready(), 42);
+    }
+
+    #[test]
+    fn unwrap_ready_works_on_non_unpin_future() {
+        // `async {}` futures are `!Unpin`; `unwrap_ready` pins internally.
+        assert_eq!(async { 11_u32 }.unwrap_ready(), 11);
+    }
+
+    #[test]
+    #[should_panic(expected = "Ready after one poll")]
+    fn unwrap_ready_panics_when_pending() {
+        std::future::pending::<()>().unwrap_ready();
+    }
+
+    #[test]
+    fn unwrap_pending_passes_when_pending() {
+        ScriptedFuture::new(vec![Poll::Pending]).unwrap_pending();
+    }
+
+    #[test]
+    #[should_panic(expected = "Pending after one poll")]
+    fn unwrap_pending_panics_when_ready() {
+        ScriptedFuture::new(vec![Poll::Ready(3)]).unwrap_pending();
+    }
+
+    #[test]
+    fn unwrap_ready_within_drives_to_completion() {
+        let fut = ScriptedFuture::new(vec![Poll::Pending, Poll::Pending, Poll::Ready(7)]);
+        assert_eq!(fut.unwrap_ready_within(10, "never finished"), 7);
+    }
+
+    #[test]
+    #[should_panic(expected = "never finished")]
+    fn unwrap_ready_within_panics_on_timeout() {
+        let fut = ScriptedFuture::new(vec![Poll::Pending, Poll::Pending]);
+        let _ = fut.unwrap_ready_within(2, "never finished");
+    }
+
+    #[test]
+    fn unwrap_ready_after_matches_schedule() {
+        let fut = ScriptedFuture::new(vec![Poll::Pending, Poll::Pending, Poll::Ready(9)]);
+        assert_eq!(fut.unwrap_ready_after(2, "should be pending"), 9);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected Pending")]
+    fn unwrap_ready_after_panics_when_early_ready() {
+        let fut = ScriptedFuture::new(vec![Poll::Ready(1)]);
+        let _ = fut.unwrap_ready_after(2, "expected Pending");
+    }
+
+    #[test]
+    #[should_panic(expected = "but got Pending")]
+    fn unwrap_ready_after_panics_when_never_ready() {
+        let fut = ScriptedFuture::new(vec![Poll::Pending, Poll::Pending]);
+        let _ = fut.unwrap_ready_after(1, "should be pending");
+    }
+
+    #[test]
+    fn unwrap_pending_for_passes() {
+        ScriptedFuture::new(vec![Poll::Pending, Poll::Pending]).unwrap_pending_for(2, "should stay pending");
+    }
+
+    #[test]
+    #[should_panic(expected = "should stay pending")]
+    fn unwrap_pending_for_panics_on_ready() {
+        ScriptedFuture::new(vec![Poll::Ready(0)]).unwrap_pending_for(1, "should stay pending");
+    }
+}

--- a/crates/testing_aids/src/poll.rs
+++ b/crates/testing_aids/src/poll.rs
@@ -15,6 +15,12 @@ use std::task::{Context, Poll, Waker};
 
 /// Polls a future exactly once with a no-op waker.
 ///
+/// The future must be [`Unpin`], because it is polled through a mutable
+/// reference the caller keeps across polls. Futures produced by `async fn` and
+/// `async {}` blocks are `!Unpin`, so either pin them first (for example with
+/// [`std::pin::pin!`]) or use the [`FutureTestExt`] methods, which take the
+/// future by value and pin it internally.
+///
 /// Use this when a test needs to inspect external state between polls, or poll
 /// the same future from several places. For the common
 /// "drive to a known outcome" case, prefer [`FutureTestExt`].
@@ -199,6 +205,14 @@ mod tests {
         assert_eq!(poll_once(&mut fut), Poll::Pending);
         assert_eq!(poll_once(&mut fut), Poll::Ready(5));
         assert_eq!(polls.get(), 2, "each call must poll the future exactly once");
+    }
+
+    #[test]
+    fn poll_once_accepts_a_pinned_async_block() {
+        // `async {}` futures are `!Unpin`; pinning first satisfies `poll_once`,
+        // as its doc comment instructs.
+        let mut fut = std::pin::pin!(async { 3_u32 });
+        assert_eq!(poll_once(&mut fut), Poll::Ready(3));
     }
 
     #[test]


### PR DESCRIPTION
Ports the manual future-polling test helpers from the ox-sdk `oxidizer_futures_test` crate into this repo's `testing_aids` crate, and applies them in two places as a proof of concept.

## What is added

`testing_aids::poll` (re-exported from the crate root):

- `poll_once(&mut fut)` — polls an `Unpin` future exactly once with a noop waker. For tests that need to inspect external state between polls.
- `FutureTestExt` — a blanket-implemented extension trait with consuming assertions:
  - `unwrap_ready()` — poll once, return the output, panic if `Pending`
  - `unwrap_pending()` — poll once, assert `Pending`, drop
  - `unwrap_ready_within(max_polls, msg)` — poll up to N times, return the first `Ready`
  - `unwrap_ready_after(n_pending, msg)` — assert exactly N `Pending` polls then `Ready`, which catches off-by-one timing bugs in state machines
  - `unwrap_pending_for(n, msg)` — assert N consecutive `Pending` polls

Every `FutureTestExt` method takes the future **by value** and pins it internally, so they work directly on `!Unpin` futures such as `async` blocks with no caller-side `pin!`.

## Proof of concept

- `bytesbuf_io/src/testing/pending.rs` — four `*_returns_pending_on_first_poll` tests each drop a `pin!` + `Waker::noop()` + `Context::from_waker` + `matches!` block down to a single call.
- `cachet/src/telemetry/cache.rs` — `nested_with_request_id_restores_outer_id` had two nested hand-built poll harnesses; both collapse to `.unwrap_ready()`.

Net effect on the two call sites: 59 lines removed, 33 added.

## Effects

- Tests that drive a future by hand no longer repeat waker and pinning setup, so the assertion is what the reader sees. The same tests now depend on a shared helper rather than on locally visible `std::task` calls.
- `unwrap_ready_after` and `unwrap_pending_for` make poll-count expectations explicit, which turns a silent change in polling behaviour into a failure. Tests that state a poll count are correspondingly tighter and will need updating if the polling schedule legitimately changes.
- The helpers panic rather than return `Result`, which keeps call sites to one line and confines them to test code.
- `testing_aids` grows a fifth module and no new dependencies.
- The port duplicates code that also exists in ox-sdk. The two copies can drift; `oxidizer_futures_test` remains the upstream reference.

## Related

I filed a proposal to add this into future_tests crate https://github.com/rust-lang/futures-rs/issues/3018, but haven't gotten any reaction yet.