### PR TITLE
fix: declare optional dependencies as dev-dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,10 @@ Pull request titles must follow [Conventional Commits](https://www.conventionalc
 
 Doctests that reference items behind a Cargo feature must compile both with and without that feature; wrap their bodies in hidden `#[cfg(...)]` shims. See [docs/feature-gated-doctests.md](docs/feature-gated-doctests.md).
 
+## Optional Dependencies in Test Builds
+
+Feature-dependent code is gated behind `cfg(any(test, feature = "foo"))` so that a crate's test build compiles it without enumerating features. Features must therefore be additive. Because `cfg(test)` does not activate Cargo features, every optional dependency must also be declared as a non-optional dev-dependency, carrying whatever dependency features the feature activates. See [docs/optional-deps-in-test-builds.md](docs/optional-deps-in-test-builds.md).
+
 ## `no_std` Support
 
 `no_std` support is optional when deciding whether to adopt or expand it. Support for constrained targets must not justify disproportionate implementation complexity, such as extensive `cfg` branching or specialized fallbacks for platforms without pointer-width atomics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,25 @@ Feature-dependent code is gated behind `cfg(any(test, feature = "foo"))` so that
 
 Once a crate documents a `no_std` configuration as supported, that configuration is a real compatibility promise, not best-effort support. It must work correctly, be tested in CI, and be documented with its actual prerequisites and support boundary, including requirements such as `alloc`, pointer-width atomics, or specific target capabilities.
 
+### `no_std`-only code is exempt from coverage and mutation testing
+
+Code selected by the *absence* of `std` — `#[cfg(not(feature = "std"))]` and equivalents — is excluded from the coverage gate and from mutation testing. Neither harness is guaranteed to build a `no_std` configuration: mutation testing runs with default features, and in the coverage run's `--no-default-features` leg Cargo feature unification across the selected dependency graph can re-enable `std` anyway. Such code is therefore often absent from the measured build entirely, and holding it to a coverage or mutation obligation measures the harness rather than the code.
+
+Mark it with both exclusions:
+
+```rust
+#[cfg(not(feature = "std"))]
+#[cfg_attr(coverage_nightly, coverage(off))] // no_std-only path (AGENTS.md, "no_std Support").
+#[cfg_attr(test, mutants::skip)] // no_std-only path (AGENTS.md, "no_std Support").
+fn capture() -> Self {
+    Self::Disabled
+}
+```
+
+`coverage(off)` needs `#![cfg_attr(coverage_nightly, feature(coverage_attribute))]` in the crate root.
+
+Attach the exclusions to the `no_std` arm alone, splitting the item into per-configuration definitions where the two arms share one function. The `std` arm keeps its full coverage and mutation obligations. The exemption covers only code that a `no_std` build selects *instead of* a `std` build; ungated code that merely also compiles under `no_std` is tested normally.
+
 ## Required CI Checks
 
 The `required-checks` job in `.github/workflows/main.yml` is a "fan-in"

--- a/crates/anyspawn_azure/Cargo.toml
+++ b/crates/anyspawn_azure/Cargo.toml
@@ -54,6 +54,8 @@ anyspawn = { path = "../anyspawn", features = ["tokio"] }
 tick = { path = "../tick", features = ["tokio"] }
 
 # external
+async-trait = { workspace = true }
+azure_identity = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 # >>> anvil-managed: anvil-lints

--- a/crates/bytesbuf/Cargo.toml
+++ b/crates/bytesbuf/Cargo.toml
@@ -54,6 +54,8 @@ bytes = { workspace = true, features = ["std"] }
 criterion = { workspace = true }
 mutants = { workspace = true }
 new_zealand = { workspace = true }
+nm = { workspace = true }
+plurality = { path = "../plurality" }
 static_assertions = { workspace = true }
 testing_aids = { path = "../testing_aids" }
 

--- a/crates/bytesbuf_io/Cargo.toml
+++ b/crates/bytesbuf_io/Cargo.toml
@@ -37,6 +37,7 @@ trait-variant = { workspace = true }
 [dev-dependencies]
 bytesbuf = { path = "../bytesbuf", features = ["test-util"] }
 futures = { workspace = true }
+futures-core = { workspace = true }
 mutants = { workspace = true }
 new_zealand = { workspace = true }
 testing_aids = { path = "../testing_aids" }

--- a/crates/cachet/Cargo.toml
+++ b/crates/cachet/Cargo.toml
@@ -71,10 +71,12 @@ alloc_tracker = { workspace = true }
 benchmarking = { path = "../benchmarking" }
 bytesbuf = { path = "../bytesbuf" }
 cachet_memory = { path = "../cachet_memory" }
+cachet_service = { path = "../cachet_service" }
 cachet_tier = { path = "../cachet_tier", features = ["test-util"] }
 criterion = { workspace = true }
 ctor = { workspace = true }
 dashmap = { workspace = true }
+layered = { path = "../layered" }
 postcard = { workspace = true }
 recoverable = { path = "../recoverable" }
 seatbelt = { path = "../seatbelt", features = ["retry", "tower-service"] }

--- a/crates/data_privacy/Cargo.toml
+++ b/crates/data_privacy/Cargo.toml
@@ -47,8 +47,10 @@ derive_more = { workspace = true, features = ["constructor", "from"] }
 insta.workspace = true
 mutants.workspace = true
 once_cell = { workspace = true, features = ["std"] }
+rapidhash = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
+xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [[example]]
 name = "employees"

--- a/crates/data_privacy_core/Cargo.toml
+++ b/crates/data_privacy_core/Cargo.toml
@@ -33,6 +33,7 @@ serde_core = { workspace = true, optional = true, default-features = false, feat
 [dev-dependencies]
 insta.workspace = true
 mutants.workspace = true
+serde_core = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 
 # >>> anvil-managed: anvil-lints

--- a/crates/fetch_hyper/Cargo.toml
+++ b/crates/fetch_hyper/Cargo.toml
@@ -102,7 +102,7 @@ hyper-tls = { workspace = true, features = ["alpn"] }
 hyper-util = { workspace = true, features = ["client-legacy", "http1", "http2", "tokio"] }
 insta = { workspace = true }
 mutants = { workspace = true }
-native-tls = { workspace = true }
+native-tls = { workspace = true, features = ["alpn"] }
 ohno = { path = "../ohno", features = ["test-util"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "testing"], default-features = false }
 rustls = { workspace = true, features = ["tls12", "std", "aws-lc-rs"] }

--- a/crates/http_extensions/Cargo.toml
+++ b/crates/http_extensions/Cargo.toml
@@ -95,7 +95,7 @@ serde_core = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 static_assertions = { workspace = true }
 templated_uri = { path = "../templated_uri", features = ["uuid"] }
-tick = { path = "../tick", features = ["test-util", "tokio"] }
+tick = { path = "../tick", features = ["fmt", "test-util", "tokio"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net"] }
 uuid = { workspace = true }
 

--- a/crates/http_path_template/src/error.rs
+++ b/crates/http_path_template/src/error.rs
@@ -74,15 +74,17 @@ enum MaybeBacktrace {
 
 impl MaybeBacktrace {
     /// Captures a backtrace, allocating only if capture is actually enabled.
+    #[cfg(feature = "std")]
     fn capture() -> Self {
-        #[cfg(feature = "std")]
-        {
-            Self::from_backtrace(Backtrace::capture())
-        }
-        #[cfg(not(feature = "std"))]
-        {
-            Self::Disabled
-        }
+        Self::from_backtrace(Backtrace::capture())
+    }
+
+    /// Returns [`MaybeBacktrace::Disabled`]; backtrace capture is unavailable without `std`.
+    #[cfg(not(feature = "std"))]
+    #[cfg_attr(coverage_nightly, coverage(off))] // no_std-only path (AGENTS.md, "no_std Support").
+    #[cfg_attr(test, mutants::skip)] // no_std-only path (AGENTS.md, "no_std Support").
+    fn capture() -> Self {
+        Self::Disabled
     }
 
     /// Wraps a `std::backtrace::Backtrace`, boxing it only when it

--- a/crates/http_path_template/src/lib.rs
+++ b/crates/http_path_template/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![no_std]
 #![forbid(unsafe_code)]
 #![doc(html_logo_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/http_path_template/logo.png")]

--- a/crates/internity/Cargo.toml
+++ b/crates/internity/Cargo.toml
@@ -48,8 +48,11 @@ serde = { workspace = true, features = ["alloc"], optional = true }
 bolero = { workspace = true, features = ["std"] }
 criterion = { workspace = true }
 foldhash = { workspace = true }
+internity_macros = { path = "../internity_macros" }
 lasso = { workspace = true, features = ["multi-threaded"] }
 mutants = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true, features = ["alloc"] }
 serde_json = { workspace = true, features = ["std"] }
 string-interner = { workspace = true, features = ["backends", "inline-more", "std"] }
 string_cache = { workspace = true }

--- a/crates/layered/Cargo.toml
+++ b/crates/layered/Cargo.toml
@@ -41,6 +41,7 @@ criterion = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 mutants = { workspace = true }
 pin-project-lite = { workspace = true }
+plurality = { path = "../plurality" }
 static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower = { workspace = true, features = ["limit", "util"] }

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -94,8 +94,8 @@ hashbrown = { workspace = true, features = ["allocator-api2", "default-hasher"] 
 mimalloc = { workspace = true }
 multitude_macros = { path = "../multitude_macros" }
 mutants = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["raw_value"] }
+serde = { workspace = true, features = ["alloc", "derive"] }
+serde_json = { workspace = true, features = ["alloc", "raw_value"] }
 widestring = { workspace = true, features = ["alloc"] }
 zerocopy = { workspace = true }
 

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -86,11 +86,18 @@ bolero = { workspace = true, features = ["std"] }
 # because bolero-libfuzzer 0.13.0 references `bolero_engine::any::run`
 # but does not itself activate that feature on `bolero-engine`.
 bumpalo = { workspace = true, features = ["collections"] }
+bytemuck = { workspace = true, features = ["derive"] }
+bytes = { workspace = true }
+bytesbuf = { path = "../bytesbuf" }
 criterion = { workspace = true }
+hashbrown = { workspace = true, features = ["allocator-api2", "default-hasher"] }
 mimalloc = { workspace = true }
+multitude_macros = { path = "../multitude_macros" }
 mutants = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
+widestring = { workspace = true, features = ["alloc"] }
+zerocopy = { workspace = true }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { workspace = true }

--- a/crates/plurality/Cargo.toml
+++ b/crates/plurality/Cargo.toml
@@ -45,7 +45,7 @@ loom = { workspace = true }
 
 [dev-dependencies]
 alloc_tracker = { workspace = true }
-allocator-api2 = { workspace = true, features = ["alloc"] }
+allocator-api2 = { workspace = true, features = ["alloc", "std"] }
 bolero = { workspace = true, features = ["std"] }
 criterion = { workspace = true }
 infinity_pool = { workspace = true }

--- a/crates/rest_over_grpc/Cargo.toml
+++ b/crates/rest_over_grpc/Cargo.toml
@@ -123,7 +123,7 @@ protox = { workspace = true }
 quote = { workspace = true }
 routerama_build = { path = "../routerama_build" }
 serde = { workspace = true, features = ["std", "derive"] }
-serde_json = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std", "raw_value"] }
 syn = { workspace = true, features = ["full", "parsing"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
 tower-service = { workspace = true }

--- a/crates/rest_over_grpc/Cargo.toml
+++ b/crates/rest_over_grpc/Cargo.toml
@@ -107,15 +107,26 @@ smallvec = { workspace = true }
 tower-service = { workspace = true, optional = true }
 
 [dev-dependencies]
+axum-core = { workspace = true }
 futures = { workspace = true, features = ["std", "executor"] }
+heck = { workspace = true }
+http-body = { workspace = true }
+http-body-util = { workspace = true }
+http_path_template = { path = "../http_path_template" }
+layered = { path = "../layered" }
 mutants = { workspace = true }
 prettyplease = { workspace = true }
+proc-macro2 = { workspace = true }
+prost-reflect = { workspace = true }
 prost-types = { workspace = true }
 protox = { workspace = true }
+quote = { workspace = true }
+routerama_build = { path = "../routerama_build" }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
 syn = { workspace = true, features = ["full", "parsing"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
+tower-service = { workspace = true }
 
 [[example]]
 name = "tower_service"

--- a/crates/routerama/Cargo.toml
+++ b/crates/routerama/Cargo.toml
@@ -47,6 +47,7 @@ bolero = { workspace = true, features = ["std"] }
 # because bolero-libfuzzer references `bolero_engine::any::run` but does
 # not itself activate that feature on `bolero-engine`.
 criterion = { workspace = true }
+itoa = { workspace = true }
 matchit = { workspace = true }
 mutants = { workspace = true }
 path-tree = { workspace = true }

--- a/crates/routerama_build/Cargo.toml
+++ b/crates/routerama_build/Cargo.toml
@@ -43,6 +43,9 @@ unicode-ident = { workspace = true }
 criterion = { workspace = true }
 mutants = { workspace = true }
 prettyplease = { workspace = true }
+proc-macro-crate = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["full", "parsing"] }
 
 [lints]

--- a/crates/routerama_build/Cargo.toml
+++ b/crates/routerama_build/Cargo.toml
@@ -46,7 +46,7 @@ prettyplease = { workspace = true }
 proc-macro-crate = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["full", "parsing"] }
+syn = { workspace = true, features = ["clone-impls", "parsing", "proc-macro", "printing", "derive", "full", "visit"] }
 
 [lints]
 workspace = true

--- a/crates/seatbelt/src/breaker/engine/engine_telemetry.rs
+++ b/crates/seatbelt/src/breaker/engine/engine_telemetry.rs
@@ -111,6 +111,13 @@ impl<T: CircuitEngine> CircuitEngine for EngineTelemetry<T> {
 
 impl<T: CircuitEngine> EngineTelemetry<T> {
     /// Emits telemetry events for circuit state changes produced by `exit`.
+    #[cfg_attr(
+        not(any(feature = "metrics", feature = "logs", test)),
+        expect(
+            clippy::unused_self,
+            reason = "the body is entirely telemetry emission, which compiles away when neither `metrics` nor `logs` is enabled"
+        )
+    )]
     fn report_state_change(&self, exit_result: &ExitCircuitResult) {
         match exit_result {
             ExitCircuitResult::Opened(health) => {

--- a/crates/seatbelt/src/hedging/service.rs
+++ b/crates/seatbelt/src/hedging/service.rs
@@ -263,6 +263,13 @@ impl<In, Out> HedgingShared<In, Out> {
         }
     }
 
+    #[cfg_attr(
+        not(any(feature = "metrics", feature = "logs", test)),
+        expect(
+            clippy::unused_self,
+            reason = "the guard only carries telemetry state, which compiles away when neither `metrics` nor `logs` is enabled"
+        )
+    )]
     fn create_guard(&self, attempt: Attempt, hedging_delay: Duration) -> TelemetryGuard {
         TelemetryGuard::new(
             attempt,

--- a/crates/seatbelt_http/Cargo.toml
+++ b/crates/seatbelt_http/Cargo.toml
@@ -50,6 +50,7 @@ http_extensions = { path = "../http_extensions", features = ["test-util"] }
 layered = { path = "../layered" }
 mutants = { workspace = true }
 ohno = { path = "../ohno" }
+templated_uri = { path = "../templated_uri" }
 tick = { path = "../tick", features = ["test-util"] }
 
 # >>> anvil-managed: anvil-lints

--- a/docs/optional-deps-in-test-builds.md
+++ b/docs/optional-deps-in-test-builds.md
@@ -58,15 +58,22 @@ not weaken the feature gate for them.
 
 ## Dependency features are also mirrored
 
-A feature can activate features of a dependency as well as the dependency
-itself. The dev-dependency carries those features, otherwise the gated code
-compiles against a smaller API surface than a feature build gives it:
+Reproducing the dependency by name is not enough. The dev-dependency also
+carries every feature that a feature build would give it, otherwise the gated
+code compiles against a smaller API surface than the feature build provides.
+
+Two sources contribute. The `[dependencies]` entry declares features directly,
+and the `[features]` table activates further ones through `dep/feature` entries:
 
 ```toml
 [features]
-test-util = ["bytesbuf/test-util"]
+codegen = ["dep:syn", "bytesbuf/test-util"]
+
+[dependencies]
+syn = { workspace = true, optional = true, features = ["full", "parsing"] }
 
 [dev-dependencies]
+syn = { workspace = true, features = ["full", "parsing"] }
 bytesbuf = { path = "../bytesbuf", features = ["test-util"] }
 ```
 

--- a/docs/optional-deps-in-test-builds.md
+++ b/docs/optional-deps-in-test-builds.md
@@ -1,0 +1,106 @@
+# Optional dependencies in test builds
+
+Feature-dependent code is gated behind `cfg(any(test, feature = "foo"))` rather
+than `cfg(feature = "foo")`, so that a crate's own test build compiles the
+feature-dependent code without the test target having to enumerate features.
+
+```rust
+#[cfg(any(test, feature = "dynamic-service"))]
+mod dynamic;
+
+#[cfg(any(test, feature = "dynamic-service"))]
+pub use dynamic::{DynamicService, DynamicServiceExt};
+```
+
+`cfg(test)` and Cargo features are resolved by different mechanisms. A test
+build turns on `cfg(test)`, which pulls the gated code into the compilation. It
+does not turn the feature on, so nothing the feature would have activated is
+activated. The manifest has to supply that separately.
+
+## Features are additive
+
+The pattern depends on features being additive: enabling one never removes or
+changes behaviour that was available without it, and enabling all of them at
+once is a valid configuration.
+
+Mutually exclusive features are an invalid pattern. Two features that cannot be
+enabled together cannot both be on in a test build, and a consumer combining two
+unrelated dependents of the crate would break through no fault of their own.
+
+## Optional dependencies are also dev-dependencies
+
+A feature commonly activates an optional dependency. That dependency is not
+linked in a test build, so the gated code fails to resolve it. Every optional
+dependency is therefore also declared as a non-optional dev-dependency:
+
+```toml
+[dependencies]
+tower-service = { workspace = true, optional = true }
+
+[dev-dependencies]
+tower-service = { workspace = true }
+```
+
+Where the dependency is another member of this workspace, the dev-dependency is
+path-only — no version, no `workspace = true` — so that publish ordering
+resolves correctly:
+
+```toml
+[dependencies]
+plurality = { workspace = true, optional = true }
+
+[dev-dependencies]
+plurality = { path = "../plurality" }
+```
+
+Downstream consumers never build a dependency's dev-dependencies, so this does
+not weaken the feature gate for them.
+
+## Dependency features are also mirrored
+
+A feature can activate features of a dependency as well as the dependency
+itself. The dev-dependency carries those features, otherwise the gated code
+compiles against a smaller API surface than a feature build gives it:
+
+```toml
+[features]
+test-util = ["bytesbuf/test-util"]
+
+[dev-dependencies]
+bytesbuf = { path = "../bytesbuf", features = ["test-util"] }
+```
+
+A feature that implies another feature of the same crate is not reproduced this
+way, because no manifest entry can turn on a crate's own feature for its test
+build. Code reached through such an implication is gated on the implied feature
+as well.
+
+## The test build is a superset
+
+A path dev-dependency enables its target's default features, whereas the
+matching `[dependencies]` entry inherits `default-features = false` from the
+workspace. A test build therefore sees at least as much of each dependency as
+any feature build does, and compiling under `cfg(test)` does not prove that the
+same code compiles under the feature.
+
+`just anvil-cargo-hack` checks the feature powerset of each library and is the
+authority on whether feature-gated code compiles in a real feature build.
+
+## Detecting a missing dev-dependency
+
+A missing dev-dependency surfaces as gated code failing to resolve its
+dependency:
+
+```text
+error[E0432]: unresolved import `plurality`
+error[E0433]: cannot find module or crate `plurality` in this scope
+```
+
+Building test targets with default features surfaces it:
+
+```powershell
+cargo check -p <crate> --tests
+```
+
+Commands that pass `--all-features` enable the feature and link the optional
+dependency, so they do not exercise this.


### PR DESCRIPTION
[Copilot speaking]

## Motivation

Feature-dependent code in this workspace is gated behind `cfg(any(test, feature = "foo"))` rather than `cfg(feature = "foo")`, so that a crate's own test build compiles the feature-dependent code without the test target having to enumerate features.

`cfg(test)` and Cargo features are resolved by different mechanisms. A test build turns on `cfg(test)`, which pulls the gated code into the compilation, but it does not turn the feature on, so nothing the feature would have activated is activated:

```
  cfg(test)  ──────────────► gated code compiled in
  feature    ──── OFF ─────► optional dependency NOT linked
                             dependency features NOT enabled
                                        │
                                        ▼
                       error[E0432]: unresolved import
```

`layered` demonstrated the failure: `cargo check -p layered --tests` failed with E0432/E0433 because `mod dynamic` is gated on the `dynamic-service` feature while `plurality` was declared only as an optional dependency. Every check in CI that builds test targets passes `--all-features`, which enables the feature, links the optional dependency, and hides the problem.

Auditing the workspace found the same latent gap in 12 crates, plus a related class in 7 more: a dev-dependency present but carrying fewer features than a feature build would give it, which lets gated code compile against a smaller API surface than it really has.

## Changes

Every optional dependency is now also declared as a non-optional dev-dependency, so it is present in test builds. Same-workspace members are referenced path-only so that publish ordering still resolves; external crates inherit from the workspace.

Every dev-dependency that mirrors a regular dependency now carries the features a feature build gives that dependency, drawn from both the `[dependencies]` declaration and the `dep/feature` entries in the `[features]` table.

`cargo check -p layered --tests` now succeeds. Feature resolution for non-test builds is unaffected: the workspace uses resolver 2, which excludes dev-dependencies from feature unification when test targets are not being built, and `Cargo.lock` is unchanged.

The convention is documented in `docs/optional-deps-in-test-builds.md` and referenced from `AGENTS.md`. It covers the requirement that features be additive, the mirroring of both dependencies and their features, the limitation that a feature implying another feature of the same crate cannot be reproduced this way, and that `cargo hack --feature-powerset` rather than the test build is the authority on whether feature-gated code compiles in a real feature build.

This invariant currently has no automated enforcement — every existing check passes `--all-features`, which is exactly what masks it. A manifest-level check would fit naturally in `cargo-anvil`, which is where the workspace's checks are generated from.
