### PR TITLE
fix: declare dependency features where the API is used

### DIFF
--- a/crates/bytesbuf/Cargo.toml
+++ b/crates/bytesbuf/Cargo.toml
@@ -64,7 +64,11 @@ gungraun = { workspace = true, features = ["default"] }
 libc = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-windows-sys = { workspace = true }
+# `windows-sys` enables no Win32 modules by default; each module used must be listed.
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_System_SystemInformation",
+] }
 
 [[bench]]
 name = "buf"

--- a/crates/bytesbuf_io/Cargo.toml
+++ b/crates/bytesbuf_io/Cargo.toml
@@ -36,7 +36,7 @@ trait-variant = { workspace = true }
 
 [dev-dependencies]
 bytesbuf = { path = "../bytesbuf", features = ["test-util"] }
-futures = { workspace = true }
+futures = { workspace = true, features = ["executor"] }
 mutants = { workspace = true }
 new_zealand = { workspace = true }
 testing_aids = { path = "../testing_aids" }

--- a/crates/fetch/Cargo.toml
+++ b/crates/fetch/Cargo.toml
@@ -144,6 +144,7 @@ argh = { workspace = true }
 criterion = { workspace = true }
 ctor = { workspace = true }
 fastrand.workspace = true
+futures = { workspace = true, features = ["executor", "std"] }
 hyper-util = { workspace = true, features = ["tokio", "http1", "http2", "client-legacy"] }
 insta = { workspace = true }
 mutants = { workspace = true }
@@ -162,7 +163,7 @@ rustls = { workspace = true, features = [
 ], default-features = false }
 rustls-platform-verifier = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 static_assertions = { workspace = true }
 tokio = { workspace = true, features = [
     "macros",
@@ -170,6 +171,7 @@ tokio = { workspace = true, features = [
     "rt",
     "net",
 ] }
+tracing = { workspace = true, features = ["std"] }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 wiremock = { workspace = true }

--- a/crates/http_extensions/Cargo.toml
+++ b/crates/http_extensions/Cargo.toml
@@ -63,7 +63,7 @@ json = ["dep:serde_core", "dep:serde_json"]
 test-util = ["tick/test-util"]
 
 [dependencies]
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["std"] }
 bytesbuf = { workspace = true, features = ["bytes-compat", "std"] }
 futures = { workspace = true, features = ["std"] }
 http = { workspace = true }

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -70,7 +70,7 @@ ptr_meta = { workspace = true }
 serde = { workspace = true, features = ["alloc"], optional = true }
 serde_json = { workspace = true, features = ["alloc", "raw_value"], optional = true }
 widestring = { workspace = true, features = ["alloc"], optional = true }
-zerocopy = { workspace = true, optional = true }
+zerocopy = { workspace = true, features = ["derive"], optional = true }
 
 # Loom is only used under `--cfg loom` for the model-checked tests.
 # `target.'cfg(loom)'` is matched by Cargo when `RUSTFLAGS="--cfg loom"` is set.

--- a/crates/ohno_macros/Cargo.toml
+++ b/crates/ohno_macros/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { workspace = true }
+proc-macro2 = { workspace = true, features = ["proc-macro"] }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full", "derive", "printing", "parsing", "extra-traits", "proc-macro"] }
 

--- a/crates/seatbelt/Cargo.toml
+++ b/crates/seatbelt/Cargo.toml
@@ -90,7 +90,7 @@ opentelemetry-stdout = { workspace = true, default-features = false, features = 
 opentelemetry_sdk = { workspace = true, default-features = false, features = ["metrics", "testing", "experimental_metrics_custom_reader"] }
 rstest = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 static_assertions = { workspace = true }
 testing_aids = { path = "../testing_aids" }
 tick = { path = "../tick", features = ["test-util", "tokio"] }

--- a/crates/tick/Cargo.toml
+++ b/crates/tick/Cargo.toml
@@ -64,7 +64,7 @@ jiff = { workspace = true, default-features = true }
 mutants = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_core = { workspace = true, features = ["std"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 static_assertions = { workspace = true }
 time = { workspace = true, features = ["formatting", "local-offset", "macros"] }
 tokio = { workspace = true, features = ["time", "rt", "macros", "rt-multi-thread"] }


### PR DESCRIPTION
[Copilot speaking]

## Motivation

Cargo unifies dependency features across the whole graph. A crate that uses feature-gated API from a dependency will therefore compile even when it never declares the feature that gates it, provided some *other* crate in the graph happens to enable it. The dependency edge is silently incomplete, and the build breaks the moment the unrelated supplier changes its own feature choices.

The workspace root declares external dependencies with `default-features = false`, which makes this failure mode readily available: nothing is enabled unless somebody asks for it, and "somebody" is frequently the wrong crate.

`bytesbuf` was the clearest case. Its Windows-only test helper calls `GlobalMemoryStatusEx` and `GetLastError`, but the `windows-sys` dev-dependency declared no features at all. Both required Win32 modules were supplied entirely by `criterion → walkdir → same-file → winapi-util`:

```
windows-sys feature "Win32_System_SystemInformation"
  └── winapi-util          <-- sole supplier; bytesbuf contributes nothing
windows-sys feature "Win32_Foundation"
  └── winapi-util          <-- sole supplier
```

Dropping or changing the benchmark harness would have broken the Windows test build for reasons visible nowhere near the code that failed.

An audit of every dependency declaration in the workspace found the pattern was not isolated.

## Changes

Ten dependency declarations now name the features whose API the declaring crate actually uses, so each edge stands on its own:

| Crate | Dependency | Features | Gated API in use |
|---|---|---|---|
| `bytesbuf` | `windows-sys` (dev) | `Win32_Foundation`, `Win32_System_SystemInformation` | `GlobalMemoryStatusEx`, `MEMORYSTATUSEX`, `GetLastError` |
| `bytesbuf_io` | `futures` (dev) | `executor` | `futures::executor::block_on` |
| `fetch` | `futures` (dev) | `executor`, `std` | `futures::executor::block_on` |
| `fetch` | `serde_json` (dev) | `std` | `serde_json` value/error API |
| `http_extensions` | `bytes` | `std` | `std::io` integration |
| `multitude` | `zerocopy` | `derive` | `#[derive(FromBytes, IntoBytes, ...)]` |
| `ohno_macros` | `proc-macro2` | `proc-macro` | conversions to/from `proc_macro` types |
| `seatbelt` | `serde_json` (dev) | `std` | `serde_json` value/error API |
| `tick` | `serde_json` (dev) | `std` | `serde_json` value/error API |

`fetch`'s `tracing` dependency moves rather than gains a feature. Its only `std`-gated use is `tracing::subscriber::set_default` inside `#[cfg(test)]` modules, so `std` belongs in `[dev-dependencies]`. Declaring it under `[dependencies]` would have propagated `tracing/std` to every downstream consumer of the published crate to serve a test-only need.

Each entry was verified against the resolved feature graph, confirming the declaring crate is now a direct contributor of the feature rather than a passenger:

```
cargo tree -p <crate> --all-features -e features -i <dep>
```

The remaining declarations examined during the audit resolve extra features through the graph but do not depend on them: the crates either use only ungated API, or propagate the feature conditionally through their own `[features]` table.

`Cargo.lock` is unchanged. These features were already enabled in every build; the change is which crate is responsible for asking.

## Note on detection

`cargo hack --feature-powerset` does not surface this class of defect. It varies the features of workspace crates, while the incomplete declarations concern features of external dependencies, which stay fixed across the powerset. A build that omits the unrelated supplier is the only thing that exposes them.
