### PR TITLE
fix(release): show planned version in release decision prompt

### DIFF
--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -600,6 +600,9 @@ function Get-ManualSemverReviewFindings {
             PackageName                = $entry.Name
             CurrentVersion             = $entry.CurrentVersion
             InReleaseSet               = $true
+            PlannedCurrentVersion      = $entry.CurrentVersion
+            EffectiveChangeType        = $entry.EffectiveChangeType
+            EffectiveTargetVersion     = $entry.EffectiveTargetVersion
             ChangedFileCount           = $changedFileCount
             DependencyChains           = @()
             WorkspaceDependencyChains  = Get-InWorkspaceDependencyChains -Packages $WorkspaceBaseline -TargetFolder $entry.Folder
@@ -656,6 +659,9 @@ function Get-ManualSemverReviewFindings {
                 PackageName                = $dependentEntry.Name
                 CurrentVersion             = $dependentEntry.CurrentVersion
                 InReleaseSet               = $true
+                PlannedCurrentVersion      = $dependentEntry.CurrentVersion
+                EffectiveChangeType        = $dependentEntry.EffectiveChangeType
+                EffectiveTargetVersion     = $dependentEntry.EffectiveTargetVersion
                 ChangedFileCount           = $changedFileCount
                 DependencyChains           = @()
                 WorkspaceDependencyChains  = Get-InWorkspaceDependencyChains -Packages $WorkspaceBaseline -TargetFolder $dependentFolder
@@ -1299,7 +1305,29 @@ function Format-PackageMenu {
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine("  1. $viewDiffLabel")
     if ($inReleaseSet) {
-        [void]$sb.AppendLine('  2. Keep the release level already in the plan')
+        $plannedCurrentVersion = if ($null -ne $Finding.PSObject.Properties['PlannedCurrentVersion']) {
+            [string]$Finding.PlannedCurrentVersion
+        } else {
+            ''
+        }
+        $plannedChangeType = if ($null -ne $Finding.PSObject.Properties['EffectiveChangeType']) {
+            [string]$Finding.EffectiveChangeType
+        } else {
+            ''
+        }
+        $plannedTargetVersion = if ($null -ne $Finding.PSObject.Properties['EffectiveTargetVersion']) {
+            [string]$Finding.EffectiveTargetVersion
+        } else {
+            ''
+        }
+        $plannedHint = if (-not [string]::IsNullOrWhiteSpace($plannedChangeType) -and
+            -not [string]::IsNullOrWhiteSpace($plannedCurrentVersion) -and
+            -not [string]::IsNullOrWhiteSpace($plannedTargetVersion)) {
+            " ($($plannedChangeType): $plannedCurrentVersion -> $plannedTargetVersion)"
+        } else {
+            ''
+        }
+        [void]$sb.AppendLine("  2. Keep the release level already in the plan$plannedHint")
     } else {
         [void]$sb.AppendLine('  2. No material changes - release only if another package requires it')
     }

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -1120,6 +1120,10 @@ function New-ResolvedReleaseSetFromBaseRef {
 #                       with below-breaking change type); $false otherwise.
 #                       The caller uses this to distinguish "needs review for
 #                       elevation" from "needs review for primary release".
+#   PlannedCurrentVersion    - release plan's starting version, or $null when
+#                              the package is not yet in the release set
+#   EffectiveChangeType      - release level already in the plan, or $null
+#   EffectiveTargetVersion   - target version already in the plan, or $null
 #   ChangedFileCount  - number of files changed under crates/<folder>/ since baseline
 #   DependencyChains  - @( @('released_package', 'mid_package', 'this_dep'), ... )
 #                       - chains rooted in release-set members (or, in
@@ -1267,6 +1271,9 @@ function Get-UnreleasedModifiedDependencies {
                             PackageName                = $depPackage.Name
                             CurrentVersion             = $depPackage.Version
                             InReleaseSet               = $isInReleaseSet
+                            PlannedCurrentVersion      = if ($isInReleaseSet) { $depEntry.CurrentVersion } else { $null }
+                            EffectiveChangeType        = if ($isInReleaseSet) { $depEntry.EffectiveChangeType } else { $null }
+                            EffectiveTargetVersion     = if ($isInReleaseSet) { $depEntry.EffectiveTargetVersion } else { $null }
                             ChangedFileCount           = $modifiedMap[$depFolder]
                             DependencyChains           = @(, $depChain)
                             RequiresManualSemverReview = [bool]$depPackage.IsProcMacroOnly
@@ -1313,11 +1320,15 @@ function Get-UnreleasedModifiedDependencies {
         if ($findings.Contains($folder)) { continue }
         if (-not (& $shouldSurface $folder)) { continue }
         $pkg = $byFolder[$folder]
+        $entry = $ResolvedReleaseSet[$folder]
         $findings[$folder] = [pscustomobject]@{
             Folder                     = $folder
             PackageName                = $pkg.Name
             CurrentVersion             = $pkg.Version
-            InReleaseSet               = $ResolvedReleaseSet.ContainsKey($folder)
+            InReleaseSet               = $null -ne $entry
+            PlannedCurrentVersion      = if ($null -ne $entry) { $entry.CurrentVersion } else { $null }
+            EffectiveChangeType        = if ($null -ne $entry) { $entry.EffectiveChangeType } else { $null }
+            EffectiveTargetVersion     = if ($null -ne $entry) { $entry.EffectiveTargetVersion } else { $null }
             ChangedFileCount           = $modifiedMap[$folder]
             DependencyChains           = @()
             RequiresManualSemverReview = [bool]$pkg.IsProcMacroOnly

--- a/scripts/tests/Pester/unit/release-crate/PromptFlow.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-crate/PromptFlow.Tests.ps1
@@ -60,12 +60,20 @@ Describe 'Format-PackageMenu' {
             param(
                 [string]$Folder = 'ohno',
                 [object[]]$Chains = @(@('a', 'ohno')),
-                [string]$CurrentVersion = '1.2.3'
+                [string]$CurrentVersion = '1.2.3',
+                [bool]$InReleaseSet = $false,
+                [string]$PlannedCurrentVersion = $null,
+                [string]$EffectiveChangeType = $null,
+                [string]$EffectiveTargetVersion = $null
             )
             return [pscustomobject]@{
                 Folder                    = $Folder
                 PackageName               = $Folder
                 CurrentVersion            = $CurrentVersion
+                InReleaseSet              = $InReleaseSet
+                PlannedCurrentVersion     = $PlannedCurrentVersion
+                EffectiveChangeType       = $EffectiveChangeType
+                EffectiveTargetVersion    = $EffectiveTargetVersion
                 ChangedFileCount          = 1
                 # DependencyChains stays release-set-rooted for the PR comment
                 # and non-interactive bail-out paths; the menu reads only
@@ -84,11 +92,13 @@ Describe 'Format-PackageMenu' {
 
     Context 'manual proc-macro SemVer review' {
         It 'renders the same menu as an ordinary package already in the release plan' {
-            $ordinary = NewFinding -Folder 'macros' -CurrentVersion '1.2.3'
-            $ordinary | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
+            $ordinary = NewFinding -Folder 'macros' -CurrentVersion '1.2.3' `
+                -InReleaseSet $true -PlannedCurrentVersion '1.2.3' `
+                -EffectiveChangeType 'patch' -EffectiveTargetVersion '1.2.4'
 
-            $finding = NewFinding -Folder 'macros' -CurrentVersion '1.2.3'
-            $finding | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
+            $finding = NewFinding -Folder 'macros' -CurrentVersion '1.2.3' `
+                -InReleaseSet $true -PlannedCurrentVersion '1.2.3' `
+                -EffectiveChangeType 'patch' -EffectiveTargetVersion '1.2.4'
             $finding | Add-Member -NotePropertyName RequiresManualSemverReview -NotePropertyValue $true
             $finding | Add-Member -NotePropertyName ManualSemverReviewKind -NotePropertyValue 'proc-macro'
             $finding | Add-Member -NotePropertyName ManualSemverReviewSources -NotePropertyValue @()
@@ -97,16 +107,18 @@ Describe 'Format-PackageMenu' {
 
             $out | Should -Be (Format-PackageMenu -Finding $ordinary -RemainingCount 0)
             $out | Should -Match 'Detected package with unreleased modifications: macros'
-            $out | Should -Match '2\. Keep the release level already in the plan'
+            $out | Should -Match '2\. Keep the release level already in the plan \(patch: 1\.2\.3 -> 1\.2\.4\)'
             $out | Should -Not -Match 'Manual SemVer|cargo-semver-checks|proc-macro'
         }
 
         It 'renders the same menu for a mandatory downstream review as for an ordinary package' {
-            $ordinary = NewFinding -Folder 'facade' -CurrentVersion '1.2.3'
-            $ordinary | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
+            $ordinary = NewFinding -Folder 'facade' -CurrentVersion '1.2.3' `
+                -InReleaseSet $true -PlannedCurrentVersion '1.2.3' `
+                -EffectiveChangeType 'non-breaking' -EffectiveTargetVersion '1.3.0'
 
-            $finding = NewFinding -Folder 'facade' -CurrentVersion '1.2.3'
-            $finding | Add-Member -NotePropertyName InReleaseSet -NotePropertyValue $true
+            $finding = NewFinding -Folder 'facade' -CurrentVersion '1.2.3' `
+                -InReleaseSet $true -PlannedCurrentVersion '1.2.3' `
+                -EffectiveChangeType 'non-breaking' -EffectiveTargetVersion '1.3.0'
             $finding | Add-Member -NotePropertyName RequiresManualSemverReview -NotePropertyValue $true
             $finding | Add-Member -NotePropertyName ManualSemverReviewKind -NotePropertyValue 'proc-macro-dependent'
             $finding | Add-Member -NotePropertyName ManualSemverReviewSources -NotePropertyValue @('macros')
@@ -117,6 +129,33 @@ Describe 'Format-PackageMenu' {
             $out | Should -Match 'Detected package with unreleased modifications: facade'
             $out | Should -Not -Match 'Manual SemVer|cargo-semver-checks|proc-macro'
         }
+    }
+
+    It 'shows the planned release level and target version in option 2' {
+        $finding = NewFinding -Folder 'anyspawn' -CurrentVersion '0.6.0' `
+            -InReleaseSet $true -PlannedCurrentVersion '0.6.0' `
+            -EffectiveChangeType 'patch' -EffectiveTargetVersion '0.6.1'
+
+        $out = Format-PackageMenu -Finding $finding -RemainingCount 30
+
+        $out | Should -Match '2\. Keep the release level already in the plan \(patch: 0\.6\.0 -> 0\.6\.1\)'
+    }
+
+    It 'keeps the legacy option 2 wording when a hand-crafted finding lacks plan details' {
+        $finding = [pscustomobject]@{
+            Folder                    = 'ohno'
+            PackageName               = 'ohno'
+            CurrentVersion            = '1.2.3'
+            InReleaseSet              = $true
+            ChangedFileCount          = 1
+            DependencyChains          = @()
+            WorkspaceDependencyChains = @()
+        }
+
+        $out = Format-PackageMenu -Finding $finding -RemainingCount 0
+        $option2 = $out -split "`r?`n" | Where-Object { $_ -match '^\s*2\. ' } | Select-Object -First 1
+
+        $option2.Trim() | Should -Be '2. Keep the release level already in the plan'
     }
 
     Context 'no-changes (-All-mode) finding' {
@@ -385,6 +424,48 @@ Describe 'Format-PackageMenu' {
             $out | Should -Match 'Direct dependent in this workspace: b\b'
             $out | Should -Not -Match 'release_set_root'
         }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Get-UnreleasedModifiedDependencies (planned release details)
+# ---------------------------------------------------------------------------
+
+Describe 'Get-UnreleasedModifiedDependencies: planned release details' {
+
+    It 'carries the effective release level and version into in-plan findings' {
+        Mock -CommandName Get-WorkspacePackages -MockWith {
+            @([pscustomobject]@{
+                Folder          = 'anyspawn'
+                Name            = 'anyspawn'
+                Version         = '0.6.0'
+                Published       = $true
+                Deps            = @()
+                IsProcMacroOnly = $false
+            })
+        }
+        Mock -CommandName Get-InWorkspaceDependencyChains -MockWith { @() }
+
+        $resolved = @{
+            anyspawn = [pscustomobject]@{
+                Folder                 = 'anyspawn'
+                Name                   = 'anyspawn'
+                CurrentVersion         = '0.6.0'
+                EffectiveChangeType    = 'patch'
+                EffectiveTargetVersion = '0.6.1'
+                Source                 = 'cascade'
+            }
+        }
+
+        $finding = @(Get-UnreleasedModifiedDependencies `
+            -RepoRoot $TestDrive `
+            -ResolvedReleaseSet $resolved `
+            -ModifiedSnapshot @{ anyspawn = 1 })[0]
+
+        $finding.InReleaseSet          | Should -BeTrue
+        $finding.PlannedCurrentVersion | Should -Be '0.6.0'
+        $finding.EffectiveChangeType   | Should -Be 'patch'
+        $finding.EffectiveTargetVersion | Should -Be '0.6.1'
     }
 }
 


### PR DESCRIPTION
## Summary

Show the existing release plan’s change type and version transition in option 2 of the package release decision prompt.

Before:

```text
2. Keep the release level already in the plan
```

After:

```
2. Keep the release level already in the plan (patch: 0.1.0 -> 0.1.1)
```

This lets users understand the effect of keeping the planned release level before making a decision.

Fixes AB#7705528
