### PR TITLE
fix(rallocator): preserve allocation effects in release tests

### DIFF
--- a/crates/rallocator/tests/global_allocator.rs
+++ b/crates/rallocator/tests/global_allocator.rs
@@ -239,6 +239,7 @@ unsafe fn allocate_forged_payload(layout: Layout) {
         words.write(OLD_BUMP_MARKER);
         words.add(1).write(!OLD_BUMP_MARKER);
         words.add(2).write(1);
+        std::hint::black_box(address);
         dealloc(address, layout);
     }
 }

--- a/crates/rallocator/tests/heap.rs
+++ b/crates/rallocator/tests/heap.rs
@@ -235,6 +235,7 @@ fn general_usage_reports_cached_medium_spans() {
     let layout = Layout::from_size_align(128 * 1024, 16).unwrap();
     with_hint(Hint::new().with_heap(&heap), || unsafe {
         let address = alloc(layout);
+        std::hint::black_box(address);
         dealloc(address, layout);
     });
 

--- a/crates/rallocator/tests/telemetry.rs
+++ b/crates/rallocator/tests/telemetry.rs
@@ -107,7 +107,7 @@ fn collection_includes_every_participating_thread_log() {
     let threads: Vec<_> = (0..4)
         .map(|value| {
             std::thread::spawn(move || {
-                drop(Box::new(value));
+                drop(std::hint::black_box(Box::new(value)));
             })
         })
         .collect();


### PR DESCRIPTION
## Root cause
Commit 9afbe27 (#638) introduced three `rallocator` tests whose allocations had no observable effect under optimization. In the release profile, LLVM elided those allocations, so the tests deterministically failed on both Windows and Linux. The Cargo test task then exited 100; the missing Clippy SARIF and SBoM directories were downstream post-job symptoms, not the initiating failure. The previous green and first failing runs used the same 1ES Rust task/template versions, so this is not a shared-tooling migration.

## Fix
Use `std::hint::black_box` at the three allocation sites so release builds must execute the allocator operations the tests are intended to observe. Assertions and checks remain unchanged.

## Validation
- `cargo test --locked -p rallocator --release --all-features`
- `cargo clippy --locked -p rallocator --all-targets --all-features --release -- -D warnings`
- `cargo fmt -p rallocator -- --check`

Bug: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7740542
Failing build: https://o365exchange.visualstudio.com/O365%20Core/_build/results?buildId=39443989&view=results
First failing build: https://o365exchange.visualstudio.com/O365%20Core/_build/results?buildId=39412685&view=results