### PR TITLE
fix(release): close two fail-open gaps in the exposure cascade

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -237,31 +237,45 @@ is floored at `breaking`. The planner repeats this check to a fixpoint so
 the result propagates through chains such as `bytesbuf` → `bytesbuf_io` →
 another facade.
 
-Two kinds of edge are considered, and they treat missing evidence
-differently:
+Two kinds of path are considered. They treat missing evidence
+differently, and a crate that holds both is judged on each in turn rather
+than on whichever one is found first:
 
 - **Direct dependency edges** fail closed. Absent metadata, a malformed
   entry, or a wildcard root all count as possible exposure, because an
   unknown must not ship a break as compatible.
 
-- **Indirect edges to a transitive dependency** require positive allowlist
+- **Indirect paths to a transitive dependency** require positive allowlist
   evidence: either a literal root naming the dependency under the crate root
   it defines (`[lib] name = "..."` when set, otherwise its package name), or
   a wildcard root that may expand to it. A `package = "..."` alias cannot apply
   here -- only a crate that *declares* a dependency can rename it, and an
-  indirect dependent declares no edge to the target at all. This exists
+  indirect path crosses no edge to the target to carry a rename. This exists
   because `cargo-check-external-types` attributes a
   re-exported type to the crate that *defines* it: `fetch_azure`
   allowlists `typespec_client_core::*` for a trait `azure_core`
-  re-exports, while depending only on `azure_core`. Such an edge is
+  re-exports, while depending only on `azure_core`. Such a path is
   invisible to a direct-dependency scan.
 
   Here absent or malformed metadata is *not* read as exposure. Failing
-  closed on an indirect edge would match every transitive dependency of
+  closed on an indirect path would match every transitive dependency of
   every crate that declares no allowlist, forcing unrelated crates to
   breaking. Nothing is missed: a crate with no allowlist that really does
   expose the type still fails closed on its direct edge to whichever
   intermediate carries it, and the fixpoint propagates that upward.
+
+Both are tested because the roots they accept differ. A crate that imports
+the target directly under a `package = "..."` rename, and *also* reaches it
+through a conduit that re-exports its types, legitimately carries the
+target's own crate root — earned on the indirect path, and one the renamed
+direct edge could never supply. Judging it on the direct edge alone reports
+"not exposed" and leaves it on the patch floor while its public API is the
+target's types.
+
+The indirect test therefore asks whether a path exists through *some other
+package*, not merely whether the crate is reachable from the target.
+Plain reachability would count the direct edge itself and readmit the
+renamed root that the direct predicate deliberately rejected.
 
 The policy must remain validated by `cargo-check-external-types`: an
 extra allowlist entry can cause an unnecessary breaking bump, while

--- a/scripts/lib/release-flow.ps1
+++ b/scripts/lib/release-flow.ps1
@@ -211,6 +211,58 @@ function Parse-ReleaseTokens {
     return $results.ToArray()
 }
 
+# BFS over a workspace baseline collecting every transitive dependent of a
+# cargo package (identified by its underscore-normalized cargo name), in the
+# two shapes the cascade needs:
+#
+#   PublishedFolders    - folders of the published dependents only. What joins
+#                         a release set.
+#   DependentCargoNames - cargo names of ALL dependents, published or not.
+#                         Used to decide whether a crate reaches the target
+#                         through some *other* package, which requires seeing
+#                         unpublished conduits too.
+#
+# The target itself appears in neither: it is seeded into the visited set so
+# the walk terminates, but it is not its own dependent.
+#
+# Operates against an in-memory baseline snapshot rather than disk, so it
+# produces deterministic answers even after disk state changes.
+function Get-TransitiveDependentClosureFromBaseline {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Baseline,
+        [Parameter(Mandatory = $true)][string]$TargetCargoName
+    )
+
+    $toVisit = [System.Collections.Generic.Queue[string]]::new()
+    $toVisit.Enqueue($TargetCargoName)
+    $visited = [System.Collections.Generic.HashSet[string]]::new()
+    [void]$visited.Add($TargetCargoName)
+
+    $dependents = New-Object 'System.Collections.Generic.List[string]'
+    $dependentNames = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal)
+    while ($toVisit.Count -gt 0) {
+        $current = $toVisit.Dequeue()
+        foreach ($candidate in $Baseline) {
+            $candidateNorm = $candidate.Name.Replace('-', '_')
+            if ($visited.Contains($candidateNorm)) { continue }
+            if ($candidate.Deps -contains $current) {
+                [void]$visited.Add($candidateNorm)
+                [void]$dependentNames.Add($candidateNorm)
+                $toVisit.Enqueue($candidateNorm)
+                if ($candidate.Published) {
+                    $dependents.Add($candidate.Folder)
+                }
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        PublishedFolders    = @($dependents)
+        DependentCargoNames = $dependentNames
+    }
+}
+
 # BFS over a workspace baseline to find all published transitive dependents of
 # a cargo package (identified by its underscore-normalized cargo name). Mirrors
 # Get-AllTransitiveDependents but operates against an in-memory baseline
@@ -225,28 +277,8 @@ function Get-TransitivePublishedDependentsFromBaseline {
         [Parameter(Mandatory = $true)][string]$TargetCargoName
     )
 
-    $toVisit = [System.Collections.Generic.Queue[string]]::new()
-    $toVisit.Enqueue($TargetCargoName)
-    $visited = [System.Collections.Generic.HashSet[string]]::new()
-    [void]$visited.Add($TargetCargoName)
-
-    $dependents = New-Object 'System.Collections.Generic.List[string]'
-    while ($toVisit.Count -gt 0) {
-        $current = $toVisit.Dequeue()
-        foreach ($candidate in $Baseline) {
-            $candidateNorm = $candidate.Name.Replace('-', '_')
-            if ($visited.Contains($candidateNorm)) { continue }
-            if ($candidate.Deps -contains $current) {
-                [void]$visited.Add($candidateNorm)
-                $toVisit.Enqueue($candidateNorm)
-                if ($candidate.Published) {
-                    $dependents.Add($candidate.Folder)
-                }
-            }
-        }
-    }
-
-    return @($dependents)
+    return @((Get-TransitiveDependentClosureFromBaseline `
+                -Baseline $Baseline -TargetCargoName $TargetCargoName).PublishedFolders)
 }
 
 # Raises a resolved release-set entry's EffectiveChangeType to at least
@@ -394,25 +426,78 @@ function Test-EntryPlansBreakingRelease {
     return Test-IsBreakingChange -oldVersion $Entry.CurrentVersion -ChangeType $plannedChangeType
 }
 
+# Returns $true when a package reaches $TargetCargoName through some package
+# other than the target itself -- that is, when a path of length two or more
+# exists, independently of any direct edge.
+#
+# The cascade needs this separately from plain reachability because the two
+# exposure predicates accept different allowlist roots, and which roots are
+# legitimate depends on how the crate reaches the target rather than on whether
+# a direct edge happens to exist. A crate holding both kinds of path may
+# legitimately name the target's own crate root, earned on the indirect path,
+# even though the direct edge renames the target and so cannot supply it.
+#
+# $DependentCargoNames is the closure of everything that transitively depends
+# on the target, so a dependency listed there is a package the target's types
+# can travel through.
+function Test-PackageReachesTargetIndirectly {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
+        [Parameter(Mandatory = $true)][string]$TargetCargoName,
+        # AllowEmptyCollection: a target with no dependents at all yields an
+        # empty set, which PowerShell would otherwise reject as a missing
+        # mandatory argument.
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()]
+        [System.Collections.Generic.HashSet[string]]$DependentCargoNames
+    )
+
+    foreach ($dep in @($Dependent.Deps)) {
+        # Belt and braces: the target seeds the BFS visited set, so it is never
+        # added to its own dependent closure and the Contains test below would
+        # reject it anyway. Skipping it explicitly keeps "some package other
+        # than the target" true by construction rather than by a property of a
+        # different function.
+        if ($dep -eq $TargetCargoName) { continue }
+        if ($DependentCargoNames.Contains($dep)) { return $true }
+    }
+
+    return $false
+}
+
 # Returns the baseline packages that must inherit a breaking bump from
 # $TargetPackage: those already in the release set that reach it and name its
 # types in their own public API.
 #
-# Two kinds of edge qualify:
+# Two kinds of edge qualify, and they are tested independently rather than as
+# alternatives, because one crate can hold both:
 #
 #   * A DIRECT dependency that may expose the target. "May" is the operative
 #     word: an absent or malformed allowlist fails closed here, because an
 #     unknown must not ship a break as compatible.
-#   * An INDIRECT dependency whose allowlist explicitly names the target.
+#   * An INDIRECT path whose allowlist explicitly names the target.
 #     cargo-check-external-types attributes a re-exported type to its defining
 #     crate, so a crate reaching `a::T` through `b` allowlists `a` while
 #     depending only on `b`. Requiring a direct edge missed these entirely.
 #     The root matched here is the target's own crate root (its [lib] name),
-#     not a rename alias: renames live on edges, and an indirect dependent
-#     declares no edge to the target to rename.
+#     not a rename alias: renames live on edges, and an indirect path crosses
+#     no edge to the target that could rename it.
 #     This branch demands positive evidence rather than failing closed, so it
 #     cannot drag in transitive dependents that merely lack metadata -- those
 #     are already covered by their own direct edges, walked up by the fixpoint.
+#
+# Testing only one of the two would lose a mixed topology: a crate that imports
+# the target directly under a rename *and* also reaches it through a conduit
+# that re-exports its types. The direct predicate deliberately refuses the
+# target's global crate root on a renamed edge -- the rename shadows it, so an
+# allowlist entry carrying that root cannot have been earned there and would
+# be a false match. But the indirect path can earn exactly that root, so
+# judging such a crate solely on its direct edge reports "not exposed" and
+# leaves it on the patch floor while its API is the target's types.
+#
+# The indirect test therefore keys off a path that exists independently of the
+# direct edge, not merely off reachability: plain reachability counts the
+# direct edge itself, which would readmit the renamed root the direct
+# predicate just rejected and reintroduce that false match.
 #
 # Proc-macro-only dependents are excluded because they have no rustdoc API to
 # expose anything through; they reach the release set via the manual-review
@@ -426,10 +511,10 @@ function Get-PublishedDependentsExposingTarget {
         # [ordered], which is not a Hashtable -- PowerShell would satisfy a
         # [hashtable] annotation by silently substituting a converted copy.
         [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Resolved,
-        # Optional memo of target cargo name -> reachable published dependent
-        # folders. The baseline is fixed for the duration of a resolve, so the
-        # BFS answer is stable; the fixpoint would otherwise recompute it for
-        # every breaking source on every pass.
+        # Optional memo of target cargo name -> dependent closure. The baseline
+        # is fixed for the duration of a resolve, so the BFS answer is stable;
+        # the fixpoint would otherwise recompute it for every breaking source on
+        # every pass.
         [System.Collections.IDictionary]$TransitiveDependentCache
     )
 
@@ -437,31 +522,53 @@ function Get-PublishedDependentsExposingTarget {
     $targetCargoName = $TargetPackage.Name.Replace('-', '_')
 
     if ($null -ne $TransitiveDependentCache -and $TransitiveDependentCache.Contains($targetCargoName)) {
-        $reachable = $TransitiveDependentCache[$targetCargoName]
+        $closure = $TransitiveDependentCache[$targetCargoName]
     } else {
-        $reachable = [System.Collections.Generic.HashSet[string]]::new(
-            [string[]]@(Get-TransitivePublishedDependentsFromBaseline `
-                    -Baseline $WorkspaceBaseline -TargetCargoName $targetCargoName),
-            [System.StringComparer]::Ordinal)
+        $closure = Get-TransitiveDependentClosureFromBaseline `
+            -Baseline $WorkspaceBaseline -TargetCargoName $targetCargoName
         if ($null -ne $TransitiveDependentCache) {
-            $TransitiveDependentCache[$targetCargoName] = $reachable
+            $TransitiveDependentCache[$targetCargoName] = $closure
         }
     }
+
+    $dependentNames = $closure.DependentCargoNames
 
     return @($WorkspaceBaseline | Where-Object {
             $_.Published -and
             -not $_.IsProcMacroOnly -and
             $Resolved.Contains($_.Folder) -and
-            $(
-                if ($_.Deps -contains $targetCargoName) {
-                    Test-PackageExposesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name
-                } else {
-                    $reachable.Contains($_.Folder) -and
-                    (Test-PackageAllowlistNamesTarget -Dependent $_ -TargetPackageName $TargetPackage.Name `
-                        -TargetCrateRoot $TargetPackage.CrateRoot)
-                }
-            )
+            (Test-PackageExposesTargetOnAnyEdge -Dependent $_ -TargetPackage $TargetPackage `
+                -TargetCargoName $targetCargoName -DependentCargoNames $dependentNames)
         })
+}
+
+# Returns $true when either qualifying exposure relationship holds between a
+# candidate and the target. Split out of Get-PublishedDependentsExposingTarget's
+# filter so each edge is evaluated on its own terms, and so neither nested
+# pipeline shadows the enclosing $_.
+function Test-PackageExposesTargetOnAnyEdge {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
+        [Parameter(Mandatory = $true)][pscustomobject]$TargetPackage,
+        [Parameter(Mandatory = $true)][string]$TargetCargoName,
+        # AllowEmptyCollection: see Test-PackageReachesTargetIndirectly.
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()]
+        [System.Collections.Generic.HashSet[string]]$DependentCargoNames
+    )
+
+    if (($Dependent.Deps -contains $TargetCargoName) -and
+        (Test-PackageExposesTarget -Dependent $Dependent -TargetPackageName $TargetPackage.Name)) {
+        return $true
+    }
+
+    if ((Test-PackageReachesTargetIndirectly -Dependent $Dependent `
+                -TargetCargoName $TargetCargoName -DependentCargoNames $DependentCargoNames) -and
+        (Test-PackageAllowlistNamesTarget -Dependent $Dependent -TargetPackageName $TargetPackage.Name `
+                -TargetCrateRoot $TargetPackage.CrateRoot)) {
+        return $true
+    }
+
+    return $false
 }
 
 # Raises one dependent entry to 'breaking' because it exposes an incompatibly

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -732,11 +732,13 @@ function Get-WorkspacePackages {
 # crate-root parameter.
 #
 # A third diversion exists but is not this function's problem: the same
-# `[lib] name` seen from a crate that does NOT declare the edge. A re-exported
-# type is attributed to its defining crate, so a dependent several hops away
-# names it without depending on it -- and having no edge, it has no DepAliases
-# entry for it either. Test-PackageAllowlistNamesTarget handles that case,
-# building its roots from the target's own record instead.
+# `[lib] name` carried by an allowlist entry earned on an INDIRECT path. A
+# re-exported type is attributed to its defining crate, so a dependent several
+# hops away names it under that root -- and having crossed no edge to the
+# target, no alias applies to it. Test-PackageAllowlistNamesTarget handles that
+# case, building its roots from the target's own record instead. A crate can
+# hold both kinds of path at once, so the two are evaluated independently
+# rather than as alternatives; see Get-PublishedDependentsExposingTarget.
 #
 # The real package name below is a known over-acceptance, not a considered
 # exception to that rule: a rename shadows the package name exactly as it
@@ -844,15 +846,18 @@ function Test-PackageExposesTarget {
 # closed.
 #
 # This function answers "does this crate claim to name the target's types?" for
-# an INDIRECT dependency. cargo-check-external-types attributes a re-exported
+# an INDIRECT path. cargo-check-external-types attributes a re-exported
 # type to its DEFINING crate, so a crate that reaches `a::T` through `b`
 # allowlists `a` while depending only on `b` (fetch_azure documents exactly this
-# for typespec_client_core). Such an edge is invisible to a direct-dependency
+# for typespec_client_core). Such a path is invisible to a direct-dependency
 # scan, so it needs its own check.
 #
-# Because there is no declared edge, the name the allowlist carries comes from
-# the target itself -- its crate root -- and never from a rename, which only a
-# crate that declares the dependency can apply. Hence -TargetCrateRoot.
+# Because the path crosses no edge to the target, the name the allowlist
+# carries comes from the target itself -- its crate root -- and never from a
+# rename, which only a crate that declares the dependency can apply. Hence
+# -TargetCrateRoot. That holds even when the same crate separately declares a
+# direct edge: the two paths are judged independently, since a crate can hold
+# both and earn a root on one that the other cannot supply.
 #
 # It must not inherit the fail-closed branches, because "no allowlist" would
 # then match every transitive dependency in the graph and force unrelated
@@ -866,8 +871,8 @@ function Test-PackageAllowlistNamesTarget {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Dependent,
         [Parameter(Mandatory = $true)][string]$TargetPackageName,
-        # Matters most on this path: a crate reached indirectly declares no edge
-        # to the target, so it has no DepAliases entry for it. The target's own
+        # Matters most on this path: a crate reached indirectly crosses no edge
+        # to the target, so no DepAliases entry applies to it. The target's own
         # crate root is the only place the diverted name can come from.
         [string]$TargetCrateRoot
     )
@@ -876,13 +881,18 @@ function Test-PackageAllowlistNamesTarget {
         return $false
     }
 
-    # This predicate is called only when no dependency edge to the target
-    # exists. DepAliases is therefore irrelevant: production can populate an
-    # alias only while processing a declared edge, which would take the direct
-    # branch instead. When the target's crate root is known it is exclusive:
-    # `[lib] name` replaces the package name as the usable Rust root. The
-    # package name remains only as compatibility for older synthetic records
-    # that predate CrateRoot.
+    # This predicate judges an INDIRECT path, which crosses no edge to the
+    # target. DepAliases is therefore not consulted even when the dependent
+    # also declares a direct edge: an alias applies only to the edge that
+    # declares it, and a type arriving re-exported through a conduit is
+    # attributed to the target's own crate root regardless of what any direct
+    # edge renames it to. The direct edge is judged separately, by
+    # Test-PackageExposesTarget, against its own aliases.
+    #
+    # When the target's crate root is known it is exclusive: `[lib] name`
+    # replaces the package name as the usable Rust root. The package name
+    # remains only as compatibility for older synthetic records that predate
+    # CrateRoot.
     if (-not [string]::IsNullOrWhiteSpace($TargetCrateRoot)) {
         $acceptedRoots = @($TargetCrateRoot.Replace('-', '_'))
     } else {

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -570,12 +570,17 @@ function Get-CrateRequiredChangeType {
 #   Name                  - cargo package name
 #   Folder                - folder name under crates/ (used as the script's PackageName argument)
 #   Published             - $true if the package is published to crates.io
-#   Deps                  - array of normalized dependency names (kind 'normal' or 'build', not 'dev')
+#   Deps                  - array of normalized names of the WORKSPACE MEMBERS this package
+#                           depends on (kind 'normal' or 'build', not 'dev'). Membership is
+#                           decided by the dependency's resolved path, not its name, so a
+#                           registry crate or an out-of-workspace path dependency is excluded
+#                           even when it shares a member's package name.
 #   DepAliases            - hashtable mapping a normalized dependency name to additional
 #                           normalized crate roots observed for it -- a `package = "..."`
 #                           alias, or the dependency's own `[lib] name`. An entry does not say
 #                           whether a separate unrenamed declaration also exists, so this is
-#                           not a complete or exclusive set of reachable roots.
+#                           not a complete or exclusive set of reachable roots. Covers the same
+#                           workspace-member dependencies as Deps.
 #   CrateRoot             - the package's own normalized crate root (its `[lib] name` when it
 #                           sets one, else its normalized package name), or $null when the
 #                           package has no library target at all. This is the name a crate's
@@ -613,6 +618,26 @@ function Get-WorkspacePackages {
         $crateRootByPackage[$package.name.Replace('-', '_')] = ([string]$libTarget.name).Replace('-', '_')
     }
 
+    # Manifest directories of the packages this function returns, used to decide
+    # whether a dependency is a workspace edge.
+    #
+    # Cargo reports a dependency's package name but nothing that distinguishes a
+    # workspace member from a registry crate or a path dependency outside the
+    # workspace. Every consumer of Deps asks a workspace-reachability question --
+    # which crates can carry a released package's types to their own public API --
+    # so matching on the text name alone lets an unrelated external crate stand in
+    # for a workspace conduit and fabricate a path that does not exist.
+    #
+    # Identity therefore comes from the resolved path, not the name.
+    $memberDirs = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($package in $metadata.packages) {
+        $memberDir = [System.IO.Path]::GetFullPath((Split-Path $package.manifest_path -Parent))
+        if ($memberDir.StartsWith($cratesDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+            [void]$memberDirs.Add($memberDir.TrimEnd([System.IO.Path]::DirectorySeparatorChar))
+        }
+    }
+
     foreach ($package in $metadata.packages) {
         $manifestDir = [System.IO.Path]::GetFullPath((Split-Path $package.manifest_path -Parent))
         if (-not $manifestDir.StartsWith($cratesDir, [System.StringComparison]::OrdinalIgnoreCase)) {
@@ -623,6 +648,23 @@ function Get-WorkspacePackages {
         $depAliases = @{}
         foreach ($dep in $package.dependencies) {
             if ($dep.kind -eq 'dev') {
+                continue
+            }
+
+            # A dependency joins the workspace graph only when its `path`
+            # resolves to a member directory. `path` is absent for a registry
+            # dependency and points outside crates/ for a non-member path
+            # dependency; in neither case can the edge carry a workspace
+            # package's types, so it must not participate in reachability --
+            # nor contribute an alias, which would let an external crate's
+            # rename supply an allowlist root for a same-named member.
+            $depPathProp = $dep.PSObject.Properties['path']
+            if (-not $depPathProp -or [string]::IsNullOrWhiteSpace($depPathProp.Value)) {
+                continue
+            }
+            $depDir = [System.IO.Path]::GetFullPath([string]$depPathProp.Value).
+                TrimEnd([System.IO.Path]::DirectorySeparatorChar)
+            if (-not $memberDirs.Contains($depDir)) {
                 continue
             }
 

--- a/scripts/lib/releasing.ps1
+++ b/scripts/lib/releasing.ps1
@@ -665,7 +665,24 @@ function Get-WorkspacePackages {
             $externalTypes = $pkgMeta.Value.PSObject.Properties['cargo_check_external_types']
             if ($externalTypes -and $null -ne $externalTypes.Value) {
                 $allowed = $externalTypes.Value.PSObject.Properties['allowed_external_types']
-                if ($allowed -and $null -ne $allowed.Value) {
+                # Only a genuine array is a declared policy. The schema demands
+                # one, so any other shape is malformed metadata -- and leaving
+                # $allowedTypes as $null routes it to the absent-metadata branch
+                # in Test-PackageExposesTarget, which fails closed.
+                #
+                # Wrapping instead would be a fail-OPEN: `@("std::*")` turns the
+                # malformed scalar `allowed_external_types = "std::*"` into a
+                # well-formed one-entry allowlist that matches nothing, so the
+                # crate reads as provably exposing nothing. `[package.metadata]`
+                # is arbitrary TOML that cargo passes through unvalidated, so
+                # such a value reaches the planner intact.
+                #
+                # A string is itself IEnumerable (over its characters), so it
+                # must be excluded explicitly or it would read as an array of
+                # single-character entries.
+                if ($allowed -and $null -ne $allowed.Value -and
+                    $allowed.Value -is [System.Collections.IEnumerable] -and
+                    $allowed.Value -isnot [string]) {
                     $allowedTypes = @($allowed.Value)
                 }
             }

--- a/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
+++ b/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
@@ -257,10 +257,32 @@ function Write-PackageCargoToml {
 function Format-DependencyLine {
     param([Parameter(Mandatory = $true)][hashtable]$Dep)
 
+    # A dep marked External lives outside crates/, so it is not a workspace
+    # member and cannot use workspace inheritance. Used by tests that need a
+    # non-member dependency sharing a member's package name.
+    if ($Dep.ContainsKey('External') -and $Dep.External) {
+        if ($Dep.ContainsKey('Rename') -and -not [string]::IsNullOrWhiteSpace($Dep.Rename)) {
+            return "$($Dep.Rename) = { package = `"$($Dep.Name)`", path = `"../../external/$($Dep.Name)`" }"
+        }
+        return "$($Dep.Name) = { path = `"../../external/$($Dep.Name)`" }"
+    }
+
     if ($Dep.ContainsKey('Rename') -and -not [string]::IsNullOrWhiteSpace($Dep.Rename)) {
         return "$($Dep.Rename) = { package = `"$($Dep.Name)`", path = `"../$($Dep.Name)`" }"
     }
     return "$($Dep.Name).workspace = true"
+}
+
+# Returns the spec's non-member packages, or an empty array when it declares none.
+# A spec may be a hashtable or a psd1-loaded object, so membership is probed
+# rather than assumed.
+function Get-SpecExternalPackages {
+    param([Parameter(Mandatory = $true)]$Spec)
+
+    if ($Spec -isnot [hashtable]) { return @() }
+    if (-not $Spec.ContainsKey('ExternalPackages')) { return @() }
+    if ($null -eq $Spec.ExternalPackages) { return @() }
+    return @($Spec.ExternalPackages)
 }
 
 function Write-RootCargoToml {
@@ -274,6 +296,12 @@ function Write-RootCargoToml {
         'resolver = "2"'
         'members = ["crates/*"]'
     )
+    # Non-member packages sit under external/, which is inside the workspace
+    # directory, so cargo would otherwise reject them as unlisted members.
+    $externals = @(Get-SpecExternalPackages -Spec $Spec)
+    if ($externals.Count -gt 0) {
+        $lines += 'exclude = ["external"]'
+    }
     # Optional [workspace.package] inheritance block. Tests that exercise
     # `publish.workspace = true` / `version.workspace = true` need the
     # workspace root to define a default; expose this via Spec.WorkspacePackage.
@@ -347,6 +375,19 @@ function New-SyntheticWorkspace {
         Write-PackageCargoToml -Package $package -Path (Join-Path $packageDir 'Cargo.toml')
         Set-Content -Path (Join-Path $srcDir 'lib.rs') -Value "// $($package.Name)" -NoNewline
         Set-Content -Path (Join-Path $packageDir 'CHANGELOG.md') -Value "# Changelog`n`n## [Unreleased]" -NoNewline
+    }
+
+    # Packages under external/, deliberately outside `members = ["crates/*"]`
+    # and named in the root `exclude` list so cargo treats them as their own
+    # thing rather than as unlisted members. They exist so a member can declare
+    # a path dependency that is NOT a workspace member -- the only shape that
+    # tells name matching apart from identity matching.
+    foreach ($external in @(Get-SpecExternalPackages -Spec $Spec)) {
+        $externalDir = Join-Path $Path "external\$($external.Name)"
+        $externalSrc = Join-Path $externalDir 'src'
+        New-Item -ItemType Directory -Path $externalSrc -Force | Out-Null
+        Write-PackageCargoToml -Package $external -Path (Join-Path $externalDir 'Cargo.toml')
+        Set-Content -Path (Join-Path $externalSrc 'lib.rs') -Value "// $($external.Name)" -NoNewline
     }
 
     Initialize-GitRepo -Path $Path

--- a/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
+++ b/scripts/tests/Pester/_common/New-SyntheticWorkspace.ps1
@@ -187,6 +187,16 @@ function Write-PackageCargoToml {
         $entries = ($Package.AllowedExternalTypes | ForEach-Object { "`"$_`"" }) -join ', '
         $lines += "allowed_external_types = [$entries]"
     }
+    # Emits the value verbatim, bypassing the array wrapping above, so a test
+    # can build the malformed shapes cargo accepts. `[package.metadata]` is
+    # arbitrary TOML that cargo passes through unvalidated, so a scalar reaches
+    # the planner exactly as written here.
+    elseif ($Package.ContainsKey('RawAllowedExternalTypes') -and
+        -not [string]::IsNullOrWhiteSpace($Package.RawAllowedExternalTypes)) {
+        $lines += ''
+        $lines += '[package.metadata.cargo_check_external_types]'
+        $lines += "allowed_external_types = $($Package.RawAllowedExternalTypes)"
+    }
     if ($Package.ContainsKey('ProcMacro') -and $Package.ProcMacro) {
         $lines += ''
         $lines += '[lib]'

--- a/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
+++ b/scripts/tests/Pester/unit/release-packages/ResolveReleaseSet.Tests.ps1
@@ -27,10 +27,10 @@ BeforeAll {
             [bool]     $IsProcMacroOnly = $false,
             [hashtable] $DepAliases = @{},
             # The crate's rustdoc name -- its [lib] name, which defaults to the
-            # normalized package name. Allowlists of INDIRECT dependents are
-            # rooted at this, never at a rename alias: a rename only exists on
-            # an edge the renaming crate declares, and an indirect dependent
-            # declares no such edge.
+            # normalized package name. Allowlist entries earned on an INDIRECT
+            # path are rooted at this, never at a rename alias: a rename exists
+            # only on an edge the renaming crate declares, and an indirect path
+            # crosses no such edge to the target.
             [string]   $CrateRoot = $null,
             [AllowNull()][string[]] $AllowedExternalTypes = @()
         )
@@ -1047,6 +1047,89 @@ Describe 'Resolve-ReleaseSet exposure cascade over re-exported types' {
             -GetRequiredChangeType (New-StubClassifier)
 
         ($resolved | Where-Object { $_.Folder -eq 'facade' }).EffectiveChangeType | Should -Be 'breaking'
+    }
+
+    Context 'a crate holding both a direct and an indirect path' {
+        # The two exposure predicates accept different allowlist roots, so a
+        # crate that reaches the target both ways has to be judged on both.
+        # Testing only the direct edge loses the roots the indirect path earns.
+
+        It 'raises a dependent whose renamed direct edge cannot supply the root its indirect path does' {
+            # facade imports defining directly, but under `package = "..."`, so
+            # on that edge the crate is nameable only as aliased_dep and the
+            # direct predicate rightly refuses def_v1. facade also reaches
+            # defining through relay, which re-exports its types -- and that
+            # path attributes them to defining's own crate root, def_v1. The
+            # allowlist entry is therefore legitimate, and facade's public API
+            # really is defining's types.
+            $baseline = @(
+                New-BaselinePackage -Folder 'defining' -Version '1.0.0' -CrateRoot 'def_v1' `
+                    -AllowedExternalTypes @()
+                New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                    -DepAliases @{ 'defining' = @('def_v1') } `
+                    -AllowedExternalTypes @('def_v1::*')
+                New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('defining', 'relay') `
+                    -DepAliases @{ 'defining' = @('aliased_dep') } `
+                    -AllowedExternalTypes @('def_v1::Handle')
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType (New-StubClassifier)
+
+            ($resolved | Where-Object { $_.Folder -eq 'facade' }).EffectiveChangeType |
+                Should -Be 'breaking' -Because 'the indirect path earns the root the renamed direct edge cannot'
+        }
+
+        It 'does not raise a dependent whose only path to the target is the renamed direct edge' {
+            # Identical to the case above except that nothing re-exports
+            # defining, so lonely has no second path. Its allowlist entry
+            # cannot have been earned: importing the crate as aliased_dep makes
+            # def_v1::Handle unwritable, so the entry names some unrelated
+            # crate that merely collides with defining's root.
+            #
+            # This is why the indirect test keys off a path that exists
+            # independently of the direct edge rather than plain reachability:
+            # reachability counts the direct edge itself and would readmit the
+            # root the direct predicate just rejected.
+            $baseline = @(
+                New-BaselinePackage -Folder 'defining' -Version '1.0.0' -CrateRoot 'def_v1' `
+                    -AllowedExternalTypes @()
+                New-BaselinePackage -Folder 'lonely' -Version '1.0.0' -Deps @('defining') `
+                    -DepAliases @{ 'defining' = @('aliased_dep') } `
+                    -AllowedExternalTypes @('def_v1::Handle')
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType (New-StubClassifier)
+
+            ($resolved | Where-Object { $_.Folder -eq 'lonely' }).EffectiveChangeType |
+                Should -Not -Be 'breaking' -Because 'a renamed edge makes that root unwritable, so the entry is a collision'
+        }
+
+        It 'still requires positive evidence on the indirect path' {
+            # facade holds both paths but claims to name nothing foreign, so
+            # neither predicate has anything to match. Evaluating both edges
+            # must not degrade into "any crate that reaches the target".
+            $baseline = @(
+                New-BaselinePackage -Folder 'defining' -Version '1.0.0' -CrateRoot 'def_v1' `
+                    -AllowedExternalTypes @()
+                New-BaselinePackage -Folder 'relay' -Version '1.0.0' -Deps @('defining') `
+                    -DepAliases @{ 'defining' = @('def_v1') } `
+                    -AllowedExternalTypes @('def_v1::*')
+                New-BaselinePackage -Folder 'facade' -Version '1.0.0' -Deps @('defining', 'relay') `
+                    -DepAliases @{ 'defining' = @('aliased_dep') } `
+                    -AllowedExternalTypes @()
+            )
+            $parsed = Parse-ReleaseTokens -Tokens @('defining@breaking')
+
+            $resolved = Resolve-ReleaseSet -ParsedTokens $parsed -WorkspaceBaseline $baseline `
+                -GetRequiredChangeType (New-StubClassifier)
+
+            ($resolved | Where-Object { $_.Folder -eq 'facade' }).EffectiveChangeType |
+                Should -Not -Be 'breaking'
+        }
     }
 
     Context 'the indirect edge demands positive evidence' {

--- a/scripts/tests/Pester/unit/releasing/GitFs.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/GitFs.Tests.ps1
@@ -373,6 +373,82 @@ Describe 'Get-WorkspacePackages: publish-syntax variants via cargo metadata' {
     }
 }
 
+Describe 'Get-WorkspacePackages: allowed_external_types container shapes' {
+
+    # `allowed_external_types` must be an array. `[package.metadata]` is
+    # arbitrary TOML that cargo passes through unvalidated, so a malformed
+    # shape reaches the planner intact and has to be rejected here.
+    #
+    # The rejection must produce $null, not an empty array: downstream,
+    # Test-PackageExposesTarget reads $null as "no policy declared" and fails
+    # closed, while @() is a positive claim of no foreign types and fails open.
+
+    It 'reads a well-formed array allowlist' {
+        Reset-ReleaseScriptCaches
+        $spec = @{
+            Packages = @(
+                @{ Name = 'pkg'; Version = '0.1.0'; AllowedExternalTypes = @('std::io::Error') }
+            )
+        }
+        $ws = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'aet-array')
+
+        $pkg = Get-WorkspacePackages -repoRoot $ws.Path | Where-Object { $_.Name -eq 'pkg' }
+        @($pkg.AllowedExternalTypes) | Should -Be @('std::io::Error')
+    }
+
+    It 'rejects a scalar allowlist rather than wrapping it into a valid-looking one' {
+        # Wrapping would turn the malformed `allowed_external_types = "std::*"`
+        # into a well-formed single-entry allowlist that matches no target, so
+        # the crate would read as provably not exposing anything -- a fail-open
+        # that ships a breaking dependency inside a compatible version.
+        Reset-ReleaseScriptCaches
+        $spec = @{
+            Packages = @(
+                @{ Name = 'pkg'; Version = '0.1.0'; RawAllowedExternalTypes = '"std::*"' }
+            )
+        }
+        $ws = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'aet-scalar')
+
+        $pkg = Get-WorkspacePackages -repoRoot $ws.Path | Where-Object { $_.Name -eq 'pkg' }
+        $pkg.AllowedExternalTypes | Should -BeNullOrEmpty -Because 'a scalar is not a declared policy'
+        Test-PackageExposesTarget -Dependent $pkg -TargetPackageName 'bytesbuf' |
+            Should -BeTrue -Because 'malformed metadata must fail closed'
+    }
+
+    It 'rejects a table allowlist' {
+        Reset-ReleaseScriptCaches
+        $spec = @{
+            Packages = @(
+                @{ Name = 'pkg'; Version = '0.1.0'; RawAllowedExternalTypes = '{ std = "*" }' }
+            )
+        }
+        $ws = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'aet-table')
+
+        $pkg = Get-WorkspacePackages -repoRoot $ws.Path | Where-Object { $_.Name -eq 'pkg' }
+        $pkg.AllowedExternalTypes | Should -BeNullOrEmpty
+        Test-PackageExposesTarget -Dependent $pkg -TargetPackageName 'bytesbuf' | Should -BeTrue
+    }
+
+    It 'preserves an empty array as the positive claim it is' {
+        # `[]` is the one shape that legitimately means "my public API names
+        # nothing foreign", so it must survive as an empty allowlist rather
+        # than collapsing to $null and being read as absent metadata.
+        Reset-ReleaseScriptCaches
+        $spec = @{
+            Packages = @(
+                @{ Name = 'pkg'; Version = '0.1.0'; RawAllowedExternalTypes = '[]' }
+            )
+        }
+        $ws = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'aet-empty')
+
+        $pkg = Get-WorkspacePackages -repoRoot $ws.Path | Where-Object { $_.Name -eq 'pkg' }
+        ($null -ne $pkg.AllowedExternalTypes) | Should -BeTrue -Because 'an empty array is a declared policy, not absent metadata'
+        @($pkg.AllowedExternalTypes).Count | Should -Be 0
+        Test-PackageExposesTarget -Dependent $pkg -TargetPackageName 'bytesbuf' |
+            Should -BeFalse -Because 'an empty allowlist claims no foreign types'
+    }
+}
+
 Describe 'Get-WorkspacePackages' {
     BeforeAll {
         Reset-ReleaseScriptCaches

--- a/scripts/tests/Pester/unit/releasing/GitFs.Tests.ps1
+++ b/scripts/tests/Pester/unit/releasing/GitFs.Tests.ps1
@@ -477,6 +477,56 @@ Describe 'Get-WorkspacePackages' {
     }
 }
 
+Describe 'Get-WorkspacePackages: dependency identity vs dependency name' {
+    BeforeAll {
+        Reset-ReleaseScriptCaches
+        # `relay` exists twice: as a workspace member that depends on `target`,
+        # and as an unrelated non-member under external/. `borrower` depends on
+        # the non-member one, `member_user` on the member one. The two are
+        # indistinguishable by package name and differ only by resolved path.
+        $spec = @{
+            Packages = @(
+                @{ Name = 'target'; Version = '1.0.0' }
+                @{ Name = 'relay';  Version = '1.0.0'; Deps = @(@{ Name = 'target' }) }
+                @{ Name = 'member_user'; Version = '1.0.0'; Deps = @(@{ Name = 'relay' }) }
+                @{ Name = 'borrower'; Version = '1.0.0'; Deps = @(@{ Name = 'relay'; External = $true }) }
+            )
+            ExternalPackages = @(
+                @{ Name = 'relay'; Version = '9.9.9' }
+            )
+        }
+        $script:IdentityWs = New-SyntheticWorkspace -Spec $spec -Path (Join-Path $TestDrive 'dep-identity')
+        $script:IdentityPackages = Get-WorkspacePackages -repoRoot $script:IdentityWs.Path
+    }
+
+    It 'returns only the workspace members, not the non-member of the same name' {
+        @($script:IdentityPackages | Where-Object { $_.Name -eq 'relay' }).Count | Should -Be 1
+        $script:IdentityPackages.Count | Should -Be 4
+    }
+
+    It 'does not record a non-member path dependency as a workspace edge' {
+        $borrower = $script:IdentityPackages | Where-Object { $_.Name -eq 'borrower' }
+        # Text-name matching would put 'relay' here and fabricate a path from
+        # borrower to target through a package borrower never depends on.
+        $borrower.Deps | Should -Not -Contain 'relay'
+        @($borrower.Deps).Count | Should -Be 0
+    }
+
+    It 'still records the edge when the dependency really is the workspace member' {
+        $memberUser = $script:IdentityPackages | Where-Object { $_.Name -eq 'member_user' }
+        $memberUser.Deps | Should -Contain 'relay'
+    }
+
+    It 'does not place the non-member dependent in the target''s dependent closure' {
+        $dependents = Get-AllTransitiveDependents -packageName 'target' -repoRoot $script:IdentityWs.Path
+        # relay genuinely depends on target; member_user reaches it through relay.
+        $dependents | Should -Contain 'relay'
+        $dependents | Should -Contain 'member_user'
+        # borrower does not, and must not be dragged into a release for it.
+        $dependents | Should -Not -Contain 'borrower'
+    }
+}
+
 Describe 'Get-WorkspacePackages: proc-macro target classification' {
     BeforeAll {
         Reset-ReleaseScriptCaches


### PR DESCRIPTION
Closes #665. Follow-up to #646, which the two findings below came out of. Both are
fail-opens in the exposure cascade: cases where the planner reports "not exposed"
and leaves a crate on the patch floor while its public API really does carry the
bumped types.

Neither is reachable in the workspace as it stands today, which is why #646 was
merged ahead of them — see the issue for the reachability analysis.

## 1. Judge both exposure paths when a crate holds each

`Get-PublishedDependentsExposingTarget` picked its exposure predicate with an
`if`/`else` on whether a direct dependency edge existed, making the direct and
indirect tests mutually exclusive. A crate holding both paths was judged only on
the direct one.

That is a fail-open, because **the two predicates accept different allowlist roots
by design**:

| | roots built from | treats the target's own crate root |
|---|---|---|
| direct | the edge's `DepAliases` (rename-aware) | **rejects** it — a `package = "..."` rename shadows it |
| indirect | the target's own record | accepts it |

So a crate that imports the target under a rename *and* also reaches it through a
conduit re-exporting its types loses the root its indirect path legitimately
earned. Both edges are now evaluated independently, and the crate is raised if
either claims exposure.

The load-bearing subtlety: the indirect test asks whether a path reaches the
target **through some other package**, not whether the crate is merely reachable
from it. Plain reachability would count the direct edge itself and readmit exactly
the renamed root the direct predicate just rejected.

## 2. Fail closed on a malformed `allowed_external_types` container

`@($allowed.Value)` promoted a malformed scalar into a valid-looking one-entry
allowlist that matches nothing, yielding "not exposed". `[package.metadata]` is
arbitrary TOML that cargo passes through unvalidated, so this is reachable by a
typo.

This was the **only** malformed shape that failed open — a non-string container
already returned `True`, as did absent metadata. The value is now left `$null`,
reusing the existing absent-metadata branch, which fails closed.

Two shapes to be careful with:
- a string is itself `IEnumerable` (over its chars), so it must be excluded explicitly;
- `@()` must survive as a positive claim of "no external types" — collapsing it to
  `$null` would be a different fail-open.

## Verification

Every change was mutation-verified in both directions — a guard test that does not
exercise the condition it guards is worthless:

- reverting the `if`/`else` fails **exactly** the new mixed-path test;
- swapping path-independence for plain reachability fails **exactly** the control
  test, whose only path to the target is the renamed direct edge;
- restoring `@($allowed.Value)` fails **exactly** the scalar and table tests, while
  the array and empty-array tests keep passing, proving no over-rejection.

Suites: `unit\release-packages` **87/87**, `unit\releasing` **67/67**,
`integration\ExposureCascade-RealWorkspace` **14/14** (re-run after the rebase,
since it reads live manifests and `main` has moved).

Also included: contract corrections on `Test-PackageAllowlistNamesTarget`,
`Get-AcceptedExposureRoots` and the indirect-edge section of `docs/releasing.md`,
all of which described the old mutually-exclusive behaviour. The `releasing.ps1`
part of the first commit is comment-only.
