### PR TITLE
perf(multitude): improve steady-state allocation throughput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "multitude"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "alloc_tracker",
  "allocator-api2 0.2.21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ matchit = { version = "0.9.2", default-features = false }
 mimalloc = { version = "0.1.52", default-features = false }
 mockall = { version = "0.14.0", default-features = false }
 moka = { version = "0.12.14", default-features = false }
-multitude = { path = "crates/multitude", default-features = false, version = "0.8.0" }
+multitude = { path = "crates/multitude", default-features = false, version = "0.8.1" }
 multitude_macros = { path = "crates/multitude_macros", default-features = false, version = "0.1.1" }
 multitude_macros_impl = { path = "crates/multitude_macros_impl", default-features = false, version = "0.1.1" }
 mutants = { version = "0.0.3", default-features = false }

--- a/crates/multitude/Cargo.toml
+++ b/crates/multitude/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "multitude"
-version = "0.8.0"
+version = "0.8.1"
 description = "Fast and flexible arena allocator."
 readme = "README.md"
 keywords = ["arena", "memory", "allocator", "bump"]

--- a/crates/multitude/README.md
+++ b/crates/multitude/README.md
@@ -476,118 +476,118 @@ including a custom DST with a trait-object tail.
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/multitude">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbsPDWt438bisbkMh3Rx2B2aMbx5_CJ_u4DrMbgrz6oBHPzfdhZIaCaGJ5dGVtdWNrZjEuMjUuMIJlYnl0ZXNmMS4xMi4wgmhieXRlc2J1ZmUwLjguMIJpbXVsdGl0dWRlZTAuOC4wgmVzZXJkZWcxLjAuMjI4gmh6ZXJvY29weWYwLjguNTI
- [__link0]: https://docs.rs/multitude/0.8.0/multitude/?search=Alloc
- [__link1]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link10]: https://docs.rs/multitude/0.8.0/multitude/?search=vec::Vec
- [__link100]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::bytemuck
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbsPDWt438bisbkMh3Rx2B2aMbx5_CJ_u4DrMbgrz6oBHPzfdhZIaCaGJ5dGVtdWNrZjEuMjUuMIJlYnl0ZXNmMS4xMi4wgmhieXRlc2J1ZmUwLjguMIJpbXVsdGl0dWRlZTAuOC4xgmVzZXJkZWcxLjAuMjI4gmh6ZXJvY29weWYwLjguNTI
+ [__link0]: https://docs.rs/multitude/0.8.1/multitude/?search=Alloc
+ [__link1]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link10]: https://docs.rs/multitude/0.8.1/multitude/?search=vec::Vec
+ [__link100]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::bytemuck
  [__link101]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
- [__link102]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link103]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
+ [__link102]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link103]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
  [__link104]: https://docs.rs/bytes/1.12.0/bytes/?search=Bytes
  [__link105]: https://docs.rs/bytesbuf/0.8.0/bytesbuf/?search=mem::Memory
- [__link106]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena
+ [__link106]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena
  [__link107]: https://docs.rs/bytesbuf/0.8.0/bytesbuf/?search=BytesBuf
- [__link108]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena
+ [__link108]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena
  [__link109]: https://crates.io/crates/hashbrown
- [__link11]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::format
- [__link110]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_hash_map
- [__link111]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_hash_map_with_capacity
- [__link112]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_set
- [__link113]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_set_with_capacity
+ [__link11]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::format
+ [__link110]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_hash_map
+ [__link111]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_hash_map_with_capacity
+ [__link112]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_set
+ [__link113]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_set_with_capacity
  [__link12]: https://github.com/microsoft/oxidizer/blob/main/crates/multitude/docs/BUMPALO.md
  [__link13]: https://crates.io/crates/bumpalo
  [__link14]: https://github.com/microsoft/oxidizer/blob/main/crates/multitude/docs/PERF.md
- [__link15]: https://docs.rs/multitude/0.8.0/multitude/?search=Alloc
- [__link16]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link17]: https://docs.rs/multitude/0.8.0/multitude/?search=Rc
- [__link18]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link19]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc
- [__link2]: https://docs.rs/multitude/0.8.0/multitude/?search=Rc
- [__link20]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_box
- [__link21]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_rc
- [__link22]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_arc
- [__link23]: https://docs.rs/multitude/0.8.0/multitude/?search=Alloc
- [__link24]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link25]: https://docs.rs/multitude/0.8.0/multitude/?search=Rc
- [__link26]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
+ [__link15]: https://docs.rs/multitude/0.8.1/multitude/?search=Alloc
+ [__link16]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link17]: https://docs.rs/multitude/0.8.1/multitude/?search=Rc
+ [__link18]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link19]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc
+ [__link2]: https://docs.rs/multitude/0.8.1/multitude/?search=Rc
+ [__link20]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_box
+ [__link21]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_rc
+ [__link22]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_arc
+ [__link23]: https://docs.rs/multitude/0.8.1/multitude/?search=Alloc
+ [__link24]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link25]: https://docs.rs/multitude/0.8.1/multitude/?search=Rc
+ [__link26]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
  [__link27]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html
  [__link28]: https://doc.rust-lang.org/stable/std/marker/trait.Sync.html
- [__link29]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link3]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link30]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
+ [__link29]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link3]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link30]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
  [__link31]: https://doc.rust-lang.org/stable/alloc/?search=boxed::Box
- [__link32]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena
+ [__link32]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena
  [__link33]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html
- [__link34]: https://docs.rs/multitude/0.8.0/multitude/?search=Alloc
- [__link35]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link36]: https://docs.rs/multitude/0.8.0/multitude/?search=vec::Vec
- [__link37]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::String
- [__link38]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::Utf16String
+ [__link34]: https://docs.rs/multitude/0.8.1/multitude/?search=Alloc
+ [__link35]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link36]: https://docs.rs/multitude/0.8.1/multitude/?search=vec::Vec
+ [__link37]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::String
+ [__link38]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::Utf16String
  [__link39]: https://crates.io/crates/allocator-api2
- [__link4]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link40]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::String
- [__link41]: https://docs.rs/multitude/0.8.0/multitude/?search=vec::Vec
- [__link42]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::String::into_boxed_str
- [__link43]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link44]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link45]: https://docs.rs/multitude/0.8.0/multitude/?search=vec::Vec::into_boxed_slice
- [__link46]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link47]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link48]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link49]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link5]: https://docs.rs/multitude/0.8.0/multitude/?search=Rc
- [__link50]: https://docs.rs/multitude/0.8.0/multitude/?search=vec::Vec::leak
- [__link51]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena
+ [__link4]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link40]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::String
+ [__link41]: https://docs.rs/multitude/0.8.1/multitude/?search=vec::Vec
+ [__link42]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::String::into_boxed_str
+ [__link43]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link44]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link45]: https://docs.rs/multitude/0.8.1/multitude/?search=vec::Vec::into_boxed_slice
+ [__link46]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link47]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link48]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link49]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link5]: https://docs.rs/multitude/0.8.1/multitude/?search=Rc
+ [__link50]: https://docs.rs/multitude/0.8.1/multitude/?search=vec::Vec::leak
+ [__link51]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena
  [__link52]: https://crates.io/crates/hashbrown
- [__link53]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_hash_map
- [__link54]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_hash_map_with_capacity
- [__link55]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_set
- [__link56]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_set_with_capacity
- [__link57]: https://docs.rs/multitude/0.8.0/multitude/strings/index.html
- [__link58]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
- [__link59]: https://docs.rs/multitude/0.8.0/multitude/?search=Rc
- [__link6]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link60]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link61]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena
- [__link62]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::String
- [__link63]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::Utf16String
- [__link64]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::format
- [__link65]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::format_utf16
- [__link66]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::String
- [__link67]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::String::into_boxed_str
- [__link68]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link69]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::Utf16String
- [__link7]: https://docs.rs/multitude/0.8.0/multitude/?search=Alloc
- [__link70]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::Utf16String::into_boxed_utf16_str
- [__link71]: https://docs.rs/multitude/0.8.0/multitude/?search=de::DeserializeIn
- [__link72]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena
+ [__link53]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_hash_map
+ [__link54]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_hash_map_with_capacity
+ [__link55]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_set
+ [__link56]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_set_with_capacity
+ [__link57]: https://docs.rs/multitude/0.8.1/multitude/strings/index.html
+ [__link58]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
+ [__link59]: https://docs.rs/multitude/0.8.1/multitude/?search=Rc
+ [__link6]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link60]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link61]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena
+ [__link62]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::String
+ [__link63]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::Utf16String
+ [__link64]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::format
+ [__link65]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::format_utf16
+ [__link66]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::String
+ [__link67]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::String::into_boxed_str
+ [__link68]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link69]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::Utf16String
+ [__link7]: https://docs.rs/multitude/0.8.1/multitude/?search=Alloc
+ [__link70]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::Utf16String::into_boxed_utf16_str
+ [__link71]: https://docs.rs/multitude/0.8.1/multitude/?search=de::DeserializeIn
+ [__link72]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena
  [__link73]: https://docs.rs/serde/1.0.228/serde/?search=Deserialize
- [__link74]: https://docs.rs/multitude/0.8.0/multitude/?search=de::DeserializeIn
- [__link75]: https://docs.rs/multitude/0.8.0/multitude/de/index.html
- [__link76]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena
- [__link77]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_dst_arc
- [__link78]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_dst_rc
- [__link79]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::alloc_dst_box
- [__link8]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::String
+ [__link74]: https://docs.rs/multitude/0.8.1/multitude/?search=de::DeserializeIn
+ [__link75]: https://docs.rs/multitude/0.8.1/multitude/de/index.html
+ [__link76]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena
+ [__link77]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_dst_arc
+ [__link78]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_dst_rc
+ [__link79]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::alloc_dst_box
+ [__link8]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::String
  [__link80]: https://doc.rust-lang.org/stable/core/?search=alloc::Layout
  [__link81]: https://crates.io/crates/dst-factory
- [__link82]: https://docs.rs/multitude/0.8.0/multitude/?search=Box
- [__link83]: https://docs.rs/multitude/0.8.0/multitude/?search=Rc
- [__link84]: https://docs.rs/multitude/0.8.0/multitude/?search=Arc
+ [__link82]: https://docs.rs/multitude/0.8.1/multitude/?search=Box
+ [__link83]: https://docs.rs/multitude/0.8.1/multitude/?search=Rc
+ [__link84]: https://docs.rs/multitude/0.8.1/multitude/?search=Arc
  [__link85]: `coerce!`
  [__link86]: `coerce!`
  [__link87]: https://doc.rust-lang.org/stable/std/?search=io::Write
- [__link88]: https://docs.rs/multitude/0.8.0/multitude/?search=vec::Vec
- [__link89]: https://docs.rs/multitude/0.8.0/multitude/?search=de::DeserializeIn
- [__link9]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::Utf16String
- [__link90]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::deserialize
- [__link91]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::deserialize_json
- [__link92]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::Utf16String
- [__link93]: https://docs.rs/multitude/0.8.0/multitude/?search=strings::format_utf16
+ [__link88]: https://docs.rs/multitude/0.8.1/multitude/?search=vec::Vec
+ [__link89]: https://docs.rs/multitude/0.8.1/multitude/?search=de::DeserializeIn
+ [__link9]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::Utf16String
+ [__link90]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::deserialize
+ [__link91]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::deserialize_json
+ [__link92]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::Utf16String
+ [__link93]: https://docs.rs/multitude/0.8.1/multitude/?search=strings::format_utf16
  [__link94]: https://crates.io/crates/widestring
- [__link95]: https://docs.rs/multitude/0.8.0/multitude/?search=zerocopy::ZerocopyView
+ [__link95]: https://docs.rs/multitude/0.8.1/multitude/?search=zerocopy::ZerocopyView
  [__link96]: https://docs.rs/zerocopy/0.8.52/zerocopy/?search=FromZeros
- [__link97]: https://docs.rs/multitude/0.8.0/multitude/?search=Arena::zerocopy
- [__link98]: https://docs.rs/multitude/0.8.0/multitude/?search=bytemuck::BytemuckView
+ [__link97]: https://docs.rs/multitude/0.8.1/multitude/?search=Arena::zerocopy
+ [__link98]: https://docs.rs/multitude/0.8.1/multitude/?search=bytemuck::BytemuckView
  [__link99]: https://docs.rs/bytemuck/1.25.0/bytemuck/?search=Zeroable

--- a/crates/multitude/benches/criterion_alloc.rs
+++ b/crates/multitude/benches/criterion_alloc.rs
@@ -15,10 +15,152 @@
 mod alloc_common;
 
 use core::mem::MaybeUninit;
+use std::alloc::System;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
 
 use alloc_common as common;
-use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use multitude::{Arc, Box, Rc};
+use alloc_tracker::{Allocator as TrackingAllocator, Session};
+use criterion::{Bencher, Criterion, criterion_group, criterion_main};
+use multitude::{Arc, Arena, Box, Rc};
+
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator<System> = TrackingAllocator::system();
+
+fn iter_with_setup<T>(bencher: &mut Bencher<'_>, mut setup: impl FnMut() -> T, mut routine: impl FnMut(&mut T)) {
+    bencher.iter_custom(|iters| {
+        let mut elapsed = Duration::ZERO;
+
+        for _ in 0..iters {
+            let mut input = setup();
+            let start = Instant::now();
+            routine(&mut input);
+            elapsed += start.elapsed();
+            drop(input);
+        }
+
+        elapsed
+    });
+}
+
+fn assert_allocation_free<T>(session: &Session, name: &str, mut input: T, routine: impl FnOnce(&mut T)) {
+    let operation = session.operation(name);
+    {
+        let _measurement = operation.measure_thread().iterations(1);
+        routine(&mut input);
+    }
+    drop(input);
+
+    let report = session.to_report();
+    let (_, metrics) = report
+        .operations()
+        .find(|(operation_name, _)| *operation_name == name)
+        .expect("allocation operation was registered immediately above");
+    assert_eq!(
+        metrics.total_allocations_count(),
+        0,
+        "{name} unexpectedly called the backing allocator"
+    );
+    assert_eq!(metrics.total_bytes_allocated(), 0, "{name} unexpectedly allocated backing bytes");
+}
+
+fn validate_allocation_contract(_: &mut Criterion) {
+    let session = Session::new().no_stdout().no_file();
+
+    assert_allocation_free(&session, "alloc/multitude", common::warm_arena_local(), |arena| {
+        common::alloc(arena);
+    });
+    assert_allocation_free(&session, "alloc/bumpalo", common::warm_bump(), |bump| {
+        common::bumpalo_alloc(bump);
+    });
+
+    assert_allocation_free(&session, "alloc_str/multitude", common::setup_arena_words(), |state| {
+        let (arena, words) = state;
+        common::alloc_str(arena, words);
+    });
+    assert_allocation_free(&session, "alloc_str/bumpalo", common::setup_bump_words(), |state| {
+        let (bump, words) = state;
+        common::bumpalo_alloc_str(bump, words);
+    });
+
+    assert_allocation_free(
+        &session,
+        "alloc_slice_copy/multitude",
+        common::setup_arena_slices(common::N),
+        |state| {
+            let (arena, slices) = state;
+            common::alloc_slice_copy(arena, slices);
+        },
+    );
+    assert_allocation_free(&session, "alloc_slice_copy/bumpalo", common::setup_bump_slices(), |state| {
+        let (bump, slices) = state;
+        common::bumpalo_alloc_slice_copy(bump, slices);
+    });
+    assert_allocation_free(
+        &session,
+        "alloc_slice_clone/multitude",
+        common::setup_arena_slices(common::N),
+        |state| {
+            let (arena, slices) = state;
+            common::alloc_slice_clone(arena, slices);
+        },
+    );
+    assert_allocation_free(&session, "alloc_slice_clone/bumpalo", common::setup_bump_slices(), |state| {
+        let (bump, slices) = state;
+        common::bumpalo_alloc_slice_clone(bump, slices);
+    });
+    assert_allocation_free(&session, "alloc_slice_fill_with/multitude", common::warm_arena_local(), |arena| {
+        common::alloc_slice_fill_with(arena);
+    });
+    assert_allocation_free(&session, "alloc_slice_fill_with/bumpalo", common::warm_bump(), |bump| {
+        common::bumpalo_alloc_slice_fill_with(bump);
+    });
+    assert_allocation_free(&session, "alloc_slice_fill_iter/multitude", common::warm_arena_local(), |arena| {
+        common::alloc_slice_fill_iter(arena);
+    });
+    assert_allocation_free(&session, "alloc_slice_fill_iter/bumpalo", common::warm_bump(), |bump| {
+        common::bumpalo_alloc_slice_fill_iter(bump);
+    });
+
+    assert_allocation_free(&session, "string_new/multitude", common::setup_arena_words(), |state| {
+        let (arena, words) = state;
+        _ = black_box(common::alloc_string(arena, words));
+    });
+    assert_allocation_free(&session, "string_new/bumpalo", common::setup_bump_words(), |state| {
+        let (bump, words) = state;
+        _ = black_box(common::bumpalo_string_new_in(bump, words));
+    });
+    assert_allocation_free(
+        &session,
+        "string_capacity/multitude",
+        common::setup_arena_words_with_len(),
+        |state| {
+            let (arena, words, len) = state;
+            _ = black_box(common::alloc_string_with_capacity(arena, words, *len));
+        },
+    );
+    assert_allocation_free(&session, "string_capacity/bumpalo", common::setup_bump_words_with_len(), |state| {
+        let (bump, words, len) = state;
+        _ = black_box(common::bumpalo_string_with_capacity_in(bump, words, *len));
+    });
+
+    assert_allocation_free(&session, "vec_new/multitude", common::setup_arena_ints(), |state| {
+        let (arena, ints) = state;
+        _ = black_box(common::alloc_vec(arena, ints));
+    });
+    assert_allocation_free(&session, "vec_new/bumpalo", common::setup_bump_ints(), |state| {
+        let (bump, ints) = state;
+        _ = black_box(common::bumpalo_vec_new_in(bump, ints));
+    });
+    assert_allocation_free(&session, "vec_capacity/multitude", common::setup_arena_ints(), |state| {
+        let (arena, ints) = state;
+        _ = black_box(common::alloc_vec_with_capacity(arena, ints));
+    });
+    assert_allocation_free(&session, "vec_capacity/bumpalo", common::setup_bump_ints(), |state| {
+        let (bump, ints) = state;
+        _ = black_box(common::bumpalo_vec_with_capacity_in(bump, ints));
+    });
+}
 
 fn bench_arena_lifecycle(c: &mut Criterion) {
     let mut group = c.benchmark_group("criterion_alloc/arena_lifecycle");
@@ -30,13 +172,13 @@ fn bench_arena_lifecycle(c: &mut Criterion) {
 macro_rules! arena_collect_bench {
     ($group:ident, $name:literal, $ty:ty, $count:expr, $hot:path) => {
         $group.bench_function($name, |b| {
-            b.iter_batched(
+            iter_with_setup(
+                b,
                 || common::setup_arena_out::<$ty>($count),
-                |(arena, mut out)| {
-                    $hot(&arena, &mut out);
-                    (arena, out)
+                |state: &mut (Arena, Vec<$ty>)| {
+                    let (arena, out) = state;
+                    $hot(arena, out);
                 },
-                BatchSize::SmallInput,
             );
         });
     };
@@ -46,44 +188,16 @@ fn bench_alloc_u64(c: &mut Criterion) {
     let mut group = c.benchmark_group("criterion_alloc/alloc_u64");
 
     group.bench_function("alloc", |b| {
-        b.iter_batched(
-            common::warm_arena_local,
-            |arena| {
-                common::alloc(&arena);
-                arena
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_arena_local, |arena| common::alloc(arena));
     });
     group.bench_function("bumpalo_alloc", |b| {
-        b.iter_batched(
-            common::warm_bump,
-            |bump| {
-                common::bumpalo_alloc(&bump);
-                bump
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_bump, |bump| common::bumpalo_alloc(bump));
     });
     group.bench_function("alloc_with", |b| {
-        b.iter_batched(
-            common::warm_arena_local,
-            |arena| {
-                common::alloc_with(&arena);
-                arena
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_arena_local, |arena| common::alloc_with(arena));
     });
     group.bench_function("bumpalo_alloc_with", |b| {
-        b.iter_batched(
-            common::warm_bump,
-            |bump| {
-                common::bumpalo_alloc_with(&bump);
-                bump
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_bump, |bump| common::bumpalo_alloc_with(bump));
     });
 
     arena_collect_bench!(group, "alloc_box", Box<u64>, common::N, common::alloc_box);
@@ -129,13 +243,13 @@ fn bench_alloc_u64(c: &mut Criterion) {
 macro_rules! arena_words_collect_bench {
     ($group:ident, $name:literal, $ty:ty, $hot:path) => {
         $group.bench_function($name, |b| {
-            b.iter_batched(
+            iter_with_setup(
+                b,
                 common::setup_arena_words_out::<$ty>,
-                |(arena, words, mut out)| {
-                    $hot(&arena, &words, &mut out);
-                    (arena, words, out)
+                |state: &mut (Arena, Vec<String>, Vec<$ty>)| {
+                    let (arena, words, out) = state;
+                    $hot(arena, words, out);
                 },
-                BatchSize::SmallInput,
             );
         });
     };
@@ -145,24 +259,16 @@ fn bench_alloc_str(c: &mut Criterion) {
     let mut group = c.benchmark_group("criterion_alloc/alloc_str");
 
     group.bench_function("alloc_str", |b| {
-        b.iter_batched(
-            common::setup_arena_words,
-            |(arena, words)| {
-                common::alloc_str(&arena, &words);
-                (arena, words)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_arena_words, |state| {
+            let (arena, words) = state;
+            common::alloc_str(arena, words);
+        });
     });
     group.bench_function("bumpalo_alloc_str", |b| {
-        b.iter_batched(
-            common::setup_bump_words,
-            |(bump, words)| {
-                common::bumpalo_alloc_str(&bump, &words);
-                (bump, words)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_bump_words, |state| {
+            let (bump, words) = state;
+            common::bumpalo_alloc_str(bump, words);
+        });
     });
     arena_words_collect_bench!(group, "alloc_str_box", Box<str>, common::alloc_str_box);
     arena_words_collect_bench!(group, "alloc_str_arc", Arc<str>, common::alloc_str_arc);
@@ -173,13 +279,13 @@ fn bench_alloc_str(c: &mut Criterion) {
 macro_rules! arena_slice_input_bench {
     ($group:ident, $name:literal, $count:expr, $hot:path) => {
         $group.bench_function($name, |b| {
-            b.iter_batched(
+            iter_with_setup(
+                b,
                 || common::setup_arena_slices($count),
-                |(arena, slices)| {
-                    $hot(&arena, &slices);
-                    (arena, slices)
+                |state| {
+                    let (arena, slices) = state;
+                    $hot(arena, slices);
                 },
-                BatchSize::SmallInput,
             );
         });
     };
@@ -188,13 +294,13 @@ macro_rules! arena_slice_input_bench {
 macro_rules! arena_slice_collect_bench {
     ($group:ident, $name:literal, $ty:ty, $count:expr, $hot:path) => {
         $group.bench_function($name, |b| {
-            b.iter_batched(
+            iter_with_setup(
+                b,
                 || common::setup_arena_slices_out::<$ty>($count),
-                |(arena, slices, mut out)| {
-                    $hot(&arena, &slices, &mut out);
-                    (arena, slices, out)
+                |state: &mut (Arena, Vec<[u64; common::SLICE_LEN]>, Vec<$ty>)| {
+                    let (arena, slices, out) = state;
+                    $hot(arena, slices, out);
                 },
-                BatchSize::SmallInput,
             );
         });
     };
@@ -211,65 +317,29 @@ fn bench_alloc_slice(c: &mut Criterion) {
 
     arena_slice_input_bench!(group, "alloc_slice_copy", common::N, common::alloc_slice_copy);
     group.bench_function("bumpalo_alloc_slice_copy", |b| {
-        b.iter_batched(
-            common::setup_bump_slices,
-            |(bump, slices)| {
-                common::bumpalo_alloc_slice_copy(&bump, &slices);
-                (bump, slices)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_bump_slices, |state| {
+            let (bump, slices) = state;
+            common::bumpalo_alloc_slice_copy(bump, slices);
+        });
     });
     arena_slice_input_bench!(group, "alloc_slice_clone", common::N, common::alloc_slice_clone);
     group.bench_function("bumpalo_alloc_slice_clone", |b| {
-        b.iter_batched(
-            common::setup_bump_slices,
-            |(bump, slices)| {
-                common::bumpalo_alloc_slice_clone(&bump, &slices);
-                (bump, slices)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_bump_slices, |state| {
+            let (bump, slices) = state;
+            common::bumpalo_alloc_slice_clone(bump, slices);
+        });
     });
     group.bench_function("alloc_slice_fill_with", |b| {
-        b.iter_batched(
-            common::warm_arena_local,
-            |arena| {
-                common::alloc_slice_fill_with(&arena);
-                arena
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_arena_local, |arena| common::alloc_slice_fill_with(arena));
     });
     group.bench_function("bumpalo_alloc_slice_fill_with", |b| {
-        b.iter_batched(
-            common::warm_bump,
-            |bump| {
-                common::bumpalo_alloc_slice_fill_with(&bump);
-                bump
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_bump, |bump| common::bumpalo_alloc_slice_fill_with(bump));
     });
     group.bench_function("alloc_slice_fill_iter", |b| {
-        b.iter_batched(
-            common::warm_arena_local,
-            |arena| {
-                common::alloc_slice_fill_iter(&arena);
-                arena
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_arena_local, |arena| common::alloc_slice_fill_iter(arena));
     });
     group.bench_function("bumpalo_alloc_slice_fill_iter", |b| {
-        b.iter_batched(
-            common::warm_bump,
-            |bump| {
-                common::bumpalo_alloc_slice_fill_iter(&bump);
-                bump
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_bump, |bump| common::bumpalo_alloc_slice_fill_iter(bump));
     });
 
     arena_slice_collect_bench!(
@@ -408,44 +478,28 @@ fn bench_string_builder(c: &mut Criterion) {
     let mut group = c.benchmark_group("criterion_alloc/string_builder");
 
     group.bench_function("alloc_string", |b| {
-        b.iter_batched(
-            common::setup_arena_words,
-            |(arena, words)| {
-                let pointer = common::alloc_string(&arena, &words);
-                (pointer, arena, words)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_arena_words, |state| {
+            let (arena, words) = state;
+            _ = black_box(common::alloc_string(arena, words));
+        });
     });
     group.bench_function("bumpalo_string_new_in", |b| {
-        b.iter_batched(
-            common::setup_bump_words,
-            |(bump, words)| {
-                let pointer = common::bumpalo_string_new_in(&bump, &words);
-                (pointer, bump, words)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_bump_words, |state| {
+            let (bump, words) = state;
+            _ = black_box(common::bumpalo_string_new_in(bump, words));
+        });
     });
     group.bench_function("alloc_string_with_capacity", |b| {
-        b.iter_batched(
-            common::setup_arena_words_with_len,
-            |(arena, words, len)| {
-                let pointer = common::alloc_string_with_capacity(&arena, &words, len);
-                (pointer, arena, words)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_arena_words_with_len, |state| {
+            let (arena, words, len) = state;
+            _ = black_box(common::alloc_string_with_capacity(arena, words, *len));
+        });
     });
     group.bench_function("bumpalo_string_with_capacity_in", |b| {
-        b.iter_batched(
-            common::setup_bump_words_with_len,
-            |(bump, words, len)| {
-                let pointer = common::bumpalo_string_with_capacity_in(&bump, &words, len);
-                (pointer, bump, words)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_bump_words_with_len, |state| {
+            let (bump, words, len) = state;
+            _ = black_box(common::bumpalo_string_with_capacity_in(bump, words, *len));
+        });
     });
     group.finish();
 }
@@ -454,44 +508,28 @@ fn bench_vec_builder(c: &mut Criterion) {
     let mut group = c.benchmark_group("criterion_alloc/vec_builder");
 
     group.bench_function("alloc_vec", |b| {
-        b.iter_batched(
-            common::setup_arena_ints,
-            |(arena, ints)| {
-                let pointer = common::alloc_vec(&arena, &ints);
-                (pointer, arena, ints)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_arena_ints, |state| {
+            let (arena, ints) = state;
+            _ = black_box(common::alloc_vec(arena, ints));
+        });
     });
     group.bench_function("bumpalo_vec_new_in", |b| {
-        b.iter_batched(
-            common::setup_bump_ints,
-            |(bump, ints)| {
-                let pointer = common::bumpalo_vec_new_in(&bump, &ints);
-                (pointer, bump, ints)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_bump_ints, |state| {
+            let (bump, ints) = state;
+            _ = black_box(common::bumpalo_vec_new_in(bump, ints));
+        });
     });
     group.bench_function("alloc_vec_with_capacity", |b| {
-        b.iter_batched(
-            common::setup_arena_ints,
-            |(arena, ints)| {
-                let pointer = common::alloc_vec_with_capacity(&arena, &ints);
-                (pointer, arena, ints)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_arena_ints, |state| {
+            let (arena, ints) = state;
+            _ = black_box(common::alloc_vec_with_capacity(arena, ints));
+        });
     });
     group.bench_function("bumpalo_vec_with_capacity_in", |b| {
-        b.iter_batched(
-            common::setup_bump_ints,
-            |(bump, ints)| {
-                let pointer = common::bumpalo_vec_with_capacity_in(&bump, &ints);
-                (pointer, bump, ints)
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::setup_bump_ints, |state| {
+            let (bump, ints) = state;
+            _ = black_box(common::bumpalo_vec_with_capacity_in(bump, ints));
+        });
     });
     group.finish();
 }
@@ -500,40 +538,22 @@ fn bench_allocator_grow(c: &mut Criterion) {
     let mut group = c.benchmark_group("criterion_alloc/allocator_grow");
 
     group.bench_function("in_place", |b| {
-        b.iter_batched(
-            common::warm_arena_local,
-            |arena| {
-                common::allocator_grow_in_place(&arena);
-                arena
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_arena_local, |arena| common::allocator_grow_in_place(arena));
     });
     group.bench_function("zeroed_in_place", |b| {
-        b.iter_batched(
-            common::warm_arena_local,
-            |arena| {
-                common::allocator_grow_zeroed_in_place(&arena);
-                arena
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_arena_local, |arena| {
+            common::allocator_grow_zeroed_in_place(arena);
+        });
     });
     group.bench_function("shrink_in_place", |b| {
-        b.iter_batched(
-            common::warm_arena_local,
-            |arena| {
-                common::allocator_shrink_in_place(&arena);
-                arena
-            },
-            BatchSize::SmallInput,
-        );
+        iter_with_setup(b, common::warm_arena_local, |arena| common::allocator_shrink_in_place(arena));
     });
     group.finish();
 }
 
 criterion_group!(
     benches,
+    validate_allocation_contract,
     bench_arena_lifecycle,
     bench_alloc_u64,
     bench_alloc_str,

--- a/crates/multitude/benches/criterion_alloc_cg/linux.rs
+++ b/crates/multitude/benches/criterion_alloc_cg/linux.rs
@@ -30,10 +30,9 @@ fn arena_lifecycle_bumpalo_new() {
 macro_rules! arena_only {
     ($name:ident, $setup:expr, $hot:path) => {
         #[library_benchmark]
-        #[bench::run($setup)]
-        fn $name(arena: Arena) -> Arena {
-            $hot(&arena);
-            arena
+        #[bench::run(&mut $setup)]
+        fn $name(arena: &mut Arena) {
+            $hot(arena);
         }
     };
 }
@@ -65,10 +64,9 @@ arena_only!(
 macro_rules! bump_only {
     ($name:ident, $hot:path) => {
         #[library_benchmark]
-        #[bench::run(common::warm_bump())]
-        fn $name(bump: bumpalo::Bump) -> bumpalo::Bump {
-            $hot(&bump);
-            bump
+        #[bench::run(&mut common::warm_bump())]
+        fn $name(bump: &mut bumpalo::Bump) {
+            $hot(bump);
         }
     };
 }
@@ -81,11 +79,10 @@ bump_only!(alloc_slice_bumpalo_alloc_slice_fill_iter, common::bumpalo_alloc_slic
 macro_rules! arena_collect {
     ($name:ident, $ty:ty, $count:expr, $hot:path) => {
         #[library_benchmark]
-        #[bench::run(common::setup_arena_out($count))]
-        fn $name(state: (Arena, Vec<$ty>)) -> (Arena, Vec<$ty>) {
-            let (arena, mut out) = state;
-            $hot(&arena, &mut out);
-            (arena, out)
+        #[bench::run(&mut common::setup_arena_out($count))]
+        fn $name(state: &mut (Arena, Vec<$ty>)) {
+            let (arena, out) = state;
+            $hot(arena, out);
         }
     };
 }
@@ -124,21 +121,19 @@ arena_collect!(alloc_u64_alloc_uninit_rc, Rc<MaybeUninit<u64>>, common::N, commo
 arena_collect!(alloc_u64_alloc_zeroed_rc, Rc<MaybeUninit<u64>>, common::N, common::alloc_zeroed_rc);
 
 #[library_benchmark]
-#[bench::run(common::setup_arena_words())]
-fn alloc_str_alloc_str(state: (Arena, Vec<String>)) -> (Arena, Vec<String>) {
+#[bench::run(&mut common::setup_arena_words())]
+fn alloc_str_alloc_str(state: &mut (Arena, Vec<String>)) {
     let (arena, words) = state;
-    common::alloc_str(&arena, &words);
-    (arena, words)
+    common::alloc_str(arena, words);
 }
 
 macro_rules! arena_words_collect {
     ($name:ident, $ty:ty, $hot:path) => {
         #[library_benchmark]
-        #[bench::run(common::setup_arena_words_out())]
-        fn $name(state: (Arena, Vec<String>, Vec<$ty>)) -> (Arena, Vec<String>, Vec<$ty>) {
-            let (arena, words, mut out) = state;
-            $hot(&arena, &words, &mut out);
-            (arena, words, out)
+        #[bench::run(&mut common::setup_arena_words_out())]
+        fn $name(state: &mut (Arena, Vec<String>, Vec<$ty>)) {
+            let (arena, words, out) = state;
+            $hot(arena, words, out);
         }
     };
 }
@@ -148,21 +143,19 @@ arena_words_collect!(alloc_str_alloc_str_arc, Arc<str>, common::alloc_str_arc);
 arena_words_collect!(alloc_str_alloc_str_rc, Rc<str>, common::alloc_str_rc);
 
 #[library_benchmark]
-#[bench::run(common::setup_bump_words())]
-fn alloc_str_bumpalo_alloc_str(state: (bumpalo::Bump, Vec<String>)) -> (bumpalo::Bump, Vec<String>) {
+#[bench::run(&mut common::setup_bump_words())]
+fn alloc_str_bumpalo_alloc_str(state: &mut (bumpalo::Bump, Vec<String>)) {
     let (bump, words) = state;
-    common::bumpalo_alloc_str(&bump, &words);
-    (bump, words)
+    common::bumpalo_alloc_str(bump, words);
 }
 
 macro_rules! arena_slice_input {
     ($name:ident, $count:expr, $hot:path) => {
         #[library_benchmark]
-        #[bench::run(common::setup_arena_slices($count))]
-        fn $name(state: (Arena, Vec<[u64; common::SLICE_LEN]>)) -> (Arena, Vec<[u64; common::SLICE_LEN]>) {
+        #[bench::run(&mut common::setup_arena_slices($count))]
+        fn $name(state: &mut (Arena, Vec<[u64; common::SLICE_LEN]>)) {
             let (arena, slices) = state;
-            $hot(&arena, &slices);
-            (arena, slices)
+            $hot(arena, slices);
         }
     };
 }
@@ -173,11 +166,10 @@ arena_slice_input!(alloc_slice_alloc_slice_clone, common::N, common::alloc_slice
 macro_rules! arena_slice_collect {
     ($name:ident, $ty:ty, $count:expr, $hot:path) => {
         #[library_benchmark]
-        #[bench::run(common::setup_arena_slices_out($count))]
-        fn $name(state: (Arena, Vec<[u64; common::SLICE_LEN]>, Vec<$ty>)) -> (Arena, Vec<[u64; common::SLICE_LEN]>, Vec<$ty>) {
-            let (arena, slices, mut out) = state;
-            $hot(&arena, &slices, &mut out);
-            (arena, slices, out)
+        #[bench::run(&mut common::setup_arena_slices_out($count))]
+        fn $name(state: &mut (Arena, Vec<[u64; common::SLICE_LEN]>, Vec<$ty>)) {
+            let (arena, slices, out) = state;
+            $hot(arena, slices, out);
         }
     };
 }
@@ -294,87 +286,73 @@ arena_collect!(
 );
 
 #[library_benchmark]
-#[bench::run(common::setup_bump_slices())]
-fn alloc_slice_bumpalo_alloc_slice_copy(
-    state: (bumpalo::Bump, Vec<[u64; common::SLICE_LEN]>),
-) -> (bumpalo::Bump, Vec<[u64; common::SLICE_LEN]>) {
+#[bench::run(&mut common::setup_bump_slices())]
+fn alloc_slice_bumpalo_alloc_slice_copy(state: &mut (bumpalo::Bump, Vec<[u64; common::SLICE_LEN]>)) {
     let (bump, slices) = state;
-    common::bumpalo_alloc_slice_copy(&bump, &slices);
-    (bump, slices)
+    common::bumpalo_alloc_slice_copy(bump, slices);
 }
 
 #[library_benchmark]
-#[bench::run(common::setup_bump_slices())]
-fn alloc_slice_bumpalo_alloc_slice_clone(
-    state: (bumpalo::Bump, Vec<[u64; common::SLICE_LEN]>),
-) -> (bumpalo::Bump, Vec<[u64; common::SLICE_LEN]>) {
+#[bench::run(&mut common::setup_bump_slices())]
+fn alloc_slice_bumpalo_alloc_slice_clone(state: &mut (bumpalo::Bump, Vec<[u64; common::SLICE_LEN]>)) {
     let (bump, slices) = state;
-    common::bumpalo_alloc_slice_clone(&bump, &slices);
-    (bump, slices)
+    common::bumpalo_alloc_slice_clone(bump, slices);
 }
 
 #[library_benchmark]
-#[bench::run(common::setup_arena_words())]
-fn string_builder_alloc_string(state: (Arena, Vec<String>)) -> (*const str, Arena, Vec<String>) {
+#[bench::run(&mut common::setup_arena_words())]
+fn string_builder_alloc_string(state: &mut (Arena, Vec<String>)) {
     let (arena, words) = state;
-    let pointer = common::alloc_string(&arena, &words);
-    (pointer, arena, words)
+    _ = common::alloc_string(arena, words);
 }
 
 #[library_benchmark]
-#[bench::run(common::setup_arena_words_with_len())]
-fn string_builder_alloc_string_with_capacity(state: (Arena, Vec<String>, usize)) -> (*const str, Arena, Vec<String>) {
+#[bench::run(&mut common::setup_arena_words_with_len())]
+fn string_builder_alloc_string_with_capacity(state: &mut (Arena, Vec<String>, usize)) {
     let (arena, words, len) = state;
-    let pointer = common::alloc_string_with_capacity(&arena, &words, len);
-    (pointer, arena, words)
+    _ = common::alloc_string_with_capacity(arena, words, *len);
 }
 
 #[library_benchmark]
-#[bench::run(common::setup_bump_words())]
-fn string_builder_bumpalo_string_new_in(state: (bumpalo::Bump, Vec<String>)) -> (*const str, bumpalo::Bump, Vec<String>) {
+#[bench::run(&mut common::setup_bump_words())]
+fn string_builder_bumpalo_string_new_in(state: &mut (bumpalo::Bump, Vec<String>)) {
     let (bump, words) = state;
-    let pointer = common::bumpalo_string_new_in(&bump, &words);
-    (pointer, bump, words)
+    _ = common::bumpalo_string_new_in(bump, words);
 }
 
 #[library_benchmark]
-#[bench::run(common::setup_bump_words_with_len())]
-fn string_builder_bumpalo_string_with_capacity_in(state: (bumpalo::Bump, Vec<String>, usize)) -> (*const str, bumpalo::Bump, Vec<String>) {
+#[bench::run(&mut common::setup_bump_words_with_len())]
+fn string_builder_bumpalo_string_with_capacity_in(state: &mut (bumpalo::Bump, Vec<String>, usize)) {
     let (bump, words, len) = state;
-    let pointer = common::bumpalo_string_with_capacity_in(&bump, &words, len);
-    (pointer, bump, words)
+    _ = common::bumpalo_string_with_capacity_in(bump, words, *len);
 }
 
 #[library_benchmark]
-#[bench::run(common::setup_arena_ints())]
-fn vec_builder_alloc_vec(state: (Arena, Vec<i32>)) -> (*const [i32], Arena, Vec<i32>) {
+#[bench::run(&mut common::setup_arena_ints())]
+fn vec_builder_alloc_vec(state: &mut (Arena, Vec<i32>)) {
     let (arena, ints) = state;
-    let pointer = common::alloc_vec(&arena, &ints);
-    (pointer, arena, ints)
+    _ = common::alloc_vec(arena, ints);
 }
 
 #[library_benchmark]
-#[bench::run(common::setup_arena_ints())]
-fn vec_builder_alloc_vec_with_capacity(state: (Arena, Vec<i32>)) -> (*const [i32], Arena, Vec<i32>) {
+#[bench::run(&mut common::setup_arena_ints())]
+fn vec_builder_alloc_vec_with_capacity(state: &mut (Arena, Vec<i32>)) {
     let (arena, ints) = state;
-    let pointer = common::alloc_vec_with_capacity(&arena, &ints);
-    (pointer, arena, ints)
+    _ = common::alloc_vec_with_capacity(arena, ints);
 }
 
 #[library_benchmark]
-#[bench::run(common::setup_bump_ints())]
-fn vec_builder_bumpalo_vec_new_in(state: (bumpalo::Bump, Vec<i32>)) -> (*const [i32], bumpalo::Bump, Vec<i32>) {
+#[bench::run(&mut common::setup_bump_ints())]
+fn vec_builder_bumpalo_vec_new_in(state: &mut (bumpalo::Bump, Vec<i32>)) {
     let (bump, ints) = state;
-    let pointer = common::bumpalo_vec_new_in(&bump, &ints);
-    (pointer, bump, ints)
+    _ = common::bumpalo_vec_new_in(bump, ints);
 }
 
 #[library_benchmark]
-#[bench::run(common::setup_bump_ints())]
-fn vec_builder_bumpalo_vec_with_capacity_in(state: (bumpalo::Bump, Vec<i32>)) -> (*const [i32], bumpalo::Bump, Vec<i32>) {
+#[bench::run(&mut common::setup_bump_ints())]
+fn vec_builder_bumpalo_vec_with_capacity_in(state: &mut (bumpalo::Bump, Vec<i32>)) {
     let (bump, ints) = state;
-    let pointer = common::bumpalo_vec_with_capacity_in(&bump, &ints);
-    (pointer, bump, ints)
+    _ = common::bumpalo_vec_with_capacity_in(bump, ints);
 }
 
 library_benchmark_group!(

--- a/crates/multitude/benches/multitude_teardown.rs
+++ b/crates/multitude/benches/multitude_teardown.rs
@@ -8,23 +8,97 @@
 
 #![allow(clippy::unwrap_used, reason = "benchmark code")]
 
-use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use std::alloc::System;
+use std::time::{Duration, Instant};
+
+use alloc_tracker::{Allocator as TrackingAllocator, Session};
+use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 
 #[path = "multitude_teardown/shared.rs"]
 mod shared;
 
-use shared::{LARGE, MEDIUM, SMALL, bumpalo_state, free_standard, multitude_state, reset_bumpalo, reset_multitude, standard_state};
+use shared::{
+    LARGE, MEDIUM, SMALL, bumpalo_state, free_standard, multitude_state, reset_allocate_bumpalo, reset_allocate_multitude, reset_bumpalo,
+    reset_multitude, standard_state,
+};
+
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator<System> = TrackingAllocator::system();
+
+const INPUTS_PER_BATCH: u64 = 16;
+
+fn iter_with_setup<T>(bencher: &mut Bencher<'_>, mut setup: impl FnMut() -> T, mut routine: impl FnMut(&mut T)) {
+    bencher.iter_custom(|iters| {
+        let mut remaining = iters;
+        let mut elapsed = Duration::ZERO;
+
+        while remaining != 0 {
+            let batch_len = remaining.min(INPUTS_PER_BATCH);
+            let mut inputs = (0..batch_len).map(|_| setup()).collect::<Vec<_>>();
+            let start = Instant::now();
+            for input in &mut inputs {
+                routine(input);
+            }
+            elapsed += start.elapsed();
+            drop(inputs);
+            remaining -= batch_len;
+        }
+
+        elapsed
+    });
+}
+
+fn assert_allocation_free<T>(name: &str, mut input: T, routine: impl FnOnce(&mut T)) {
+    let session = Session::new().no_stdout().no_file();
+    let operation = session.operation(name);
+    {
+        let _measurement = operation.measure_thread().iterations(1);
+        routine(&mut input);
+    }
+    drop(input);
+
+    let report = session.to_report();
+    let (_, metrics) = report
+        .operations()
+        .find(|(operation_name, _)| *operation_name == name)
+        .expect("allocation operation was registered immediately above");
+    assert_eq!(
+        metrics.total_allocations_count(),
+        0,
+        "{name} unexpectedly called the backing allocator"
+    );
+    assert_eq!(metrics.total_bytes_allocated(), 0, "{name} unexpectedly allocated backing bytes");
+}
 
 fn bench_count<const N: usize>(criterion: &mut Criterion, name: &str) {
+    assert_allocation_free(&format!("{name}/multitude_reset"), multitude_state::<N>(), reset_multitude);
+    assert_allocation_free(&format!("{name}/bumpalo_reset"), bumpalo_state::<N>(), reset_bumpalo);
+    assert_allocation_free(
+        &format!("{name}/multitude_reset_allocate"),
+        multitude_state::<N>(),
+        reset_allocate_multitude,
+    );
+    assert_allocation_free(
+        &format!("{name}/bumpalo_reset_allocate"),
+        bumpalo_state::<N>(),
+        reset_allocate_bumpalo,
+    );
+
     let mut group = criterion.benchmark_group(format!("multitude_teardown/{name}"));
     group.bench_function("standard", |bencher| {
-        bencher.iter_batched_ref(standard_state::<N>, free_standard, BatchSize::SmallInput);
+        iter_with_setup(bencher, standard_state::<N>, free_standard);
     });
     group.bench_function("multitude", |bencher| {
-        bencher.iter_batched_ref(multitude_state::<N>, reset_multitude, BatchSize::SmallInput);
+        iter_with_setup(bencher, multitude_state::<N>, reset_multitude);
     });
     group.bench_function("bumpalo", |bencher| {
-        bencher.iter_batched_ref(bumpalo_state::<N>, reset_bumpalo, BatchSize::SmallInput);
+        iter_with_setup(bencher, bumpalo_state::<N>, reset_bumpalo);
+    });
+    group.bench_function("multitude_reset_allocate", |bencher| {
+        iter_with_setup(bencher, multitude_state::<N>, reset_allocate_multitude);
+    });
+    group.bench_function("bumpalo_reset_allocate", |bencher| {
+        iter_with_setup(bencher, bumpalo_state::<N>, reset_allocate_bumpalo);
     });
     group.finish();
 }

--- a/crates/multitude/benches/multitude_teardown/shared.rs
+++ b/crates/multitude/benches/multitude_teardown/shared.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use core::hint::black_box;
+
 use multitude::{Alloc, Arena};
 
 pub(crate) const SMALL: usize = 1;
@@ -50,4 +52,16 @@ pub(crate) fn reset_multitude(arena: &mut Arena) {
 #[inline(never)]
 pub(crate) fn reset_bumpalo(bump: &mut bumpalo::Bump) {
     bump.reset();
+}
+
+#[inline(never)]
+pub(crate) fn reset_allocate_multitude(arena: &mut Arena) {
+    arena.reset();
+    let _ = black_box(Alloc::leak(arena.alloc_with(|| payload(0))));
+}
+
+#[inline(never)]
+pub(crate) fn reset_allocate_bumpalo(bump: &mut bumpalo::Bump) {
+    bump.reset();
+    let _ = black_box(bump.alloc_with(|| payload(0)));
 }

--- a/crates/multitude/benches/multitude_teardown_cg.rs
+++ b/crates/multitude/benches/multitude_teardown_cg.rs
@@ -29,11 +29,12 @@ mod linux {
     use gungraun::{library_benchmark, library_benchmark_group};
 
     use crate::shared::{
-        LARGE, MEDIUM, SMALL, StandardState, bumpalo_state, free_standard, multitude_state, reset_bumpalo, reset_multitude, standard_state,
+        LARGE, MEDIUM, SMALL, StandardState, bumpalo_state, free_standard, multitude_state, reset_allocate_bumpalo,
+        reset_allocate_multitude, reset_bumpalo, reset_multitude, standard_state,
     };
 
     macro_rules! benchmark_count {
-        ($standard:ident, $multitude:ident, $bumpalo:ident, $count:ident) => {
+        ($standard:ident, $multitude:ident, $bumpalo:ident, $multitude_reset_allocate:ident, $bumpalo_reset_allocate:ident, $count:ident) => {
             #[library_benchmark]
             #[bench::run(&mut standard_state::<$count>())]
             fn $standard(state: &mut StandardState<$count>) {
@@ -51,24 +52,72 @@ mod linux {
             fn $bumpalo(bump: &mut bumpalo::Bump) {
                 reset_bumpalo(bump);
             }
+
+            #[library_benchmark]
+            #[bench::run(&mut multitude_state::<$count>())]
+            fn $multitude_reset_allocate(arena: &mut multitude::Arena) {
+                reset_allocate_multitude(arena);
+            }
+
+            #[library_benchmark]
+            #[bench::run(&mut bumpalo_state::<$count>())]
+            fn $bumpalo_reset_allocate(bump: &mut bumpalo::Bump) {
+                reset_allocate_bumpalo(bump);
+            }
         };
     }
 
-    benchmark_count!(free_1_standard, free_1_multitude, free_1_bumpalo, SMALL);
-    benchmark_count!(free_32_standard, free_32_multitude, free_32_bumpalo, MEDIUM);
-    benchmark_count!(free_1000_standard, free_1000_multitude, free_1000_bumpalo, LARGE);
+    benchmark_count!(
+        free_1_standard,
+        free_1_multitude,
+        free_1_bumpalo,
+        free_1_multitude_reset_allocate,
+        free_1_bumpalo_reset_allocate,
+        SMALL
+    );
+    benchmark_count!(
+        free_32_standard,
+        free_32_multitude,
+        free_32_bumpalo,
+        free_32_multitude_reset_allocate,
+        free_32_bumpalo_reset_allocate,
+        MEDIUM
+    );
+    benchmark_count!(
+        free_1000_standard,
+        free_1000_multitude,
+        free_1000_bumpalo,
+        free_1000_multitude_reset_allocate,
+        free_1000_bumpalo_reset_allocate,
+        LARGE
+    );
 
     library_benchmark_group!(
         name = free_1;
-        benchmarks = free_1_standard, free_1_multitude, free_1_bumpalo
+        benchmarks =
+            free_1_standard,
+            free_1_multitude,
+            free_1_bumpalo,
+            free_1_multitude_reset_allocate,
+            free_1_bumpalo_reset_allocate
     );
     library_benchmark_group!(
         name = free_32;
-        benchmarks = free_32_standard, free_32_multitude, free_32_bumpalo
+        benchmarks =
+            free_32_standard,
+            free_32_multitude,
+            free_32_bumpalo,
+            free_32_multitude_reset_allocate,
+            free_32_bumpalo_reset_allocate
     );
     library_benchmark_group!(
         name = free_1000;
-        benchmarks = free_1000_standard, free_1000_multitude, free_1000_bumpalo
+        benchmarks =
+            free_1000_standard,
+            free_1000_multitude,
+            free_1000_bumpalo,
+            free_1000_multitude_reset_allocate,
+            free_1000_bumpalo_reset_allocate
     );
 }
 

--- a/crates/multitude/docs/DESIGN.md
+++ b/crates/multitude/docs/DESIGN.md
@@ -225,15 +225,32 @@ after the arena is gone.
 smart pointer is pinned until reset even after its `Arc`s drop. This is the
 deliberate, acknowledged cost of letting one current chunk serve both
 styles; the arena tracks a single "did this chunk hand out a reference?"
-flag so that only genuinely mixed chunks pay it.
+flag so that only genuinely mixed chunks pay it. Local reservations sample
+that flag after bounds checks but before committing the bump cursor, and write
+it only for the false-to-true transition. This keeps the steady-state path free
+of repeated marker stores and avoids a marker load after the cursor store.
+The marker transition and chunk-exhaustion edges are laid out as cold blocks,
+leaving the marked, in-capacity path as straight-line fall-through code.
 
 **Reset is a cursor rewind.** `Arena::reset` takes `&mut self`, which
 statically guarantees no `Alloc` (which borrows `&self`) is live. It runs
 **no** destructors — every `Alloc` already ran its own on drop, and
-smart-pointer values remain owned by their still-live handles. It simply
-reconciles the current chunk's refcount surplus (below) and returns chunk
-bytes to the cache (or leaves chunks alive if escaped handles still hold
-them).
+smart-pointer values remain owned by their still-live handles. A current chunk
+that handed out no smart pointer is retained with its pre-credited refcount and
+rewound in place. Otherwise reset reconciles the current chunk's refcount
+surplus (below) and detaches it, returning its bytes to the cache when the last
+escaped handle releases it. Reset similarly releases only the list-owned
+reference to each older retired chunk; an outstanding smart owner keeps that
+chunk alive until the owner releases it.
+
+The marker is cleared even when reset retains the current chunk: the next
+generation may use that chunk exclusively for smart pointers and must still
+qualify for early reclamation. Leaving a stale mark would silently pin it.
+Encoding an additional "rewound but previously local" state would remove a
+small part of the first-allocation boundary, but the measured path already
+executes fewer instructions than Bumpalo and the extra lifecycle state is not
+justified by the remaining wall-clock delta in
+[`PERF.md`](PERF.md#reset-plus-the-next-allocation).
 
 `ArenaStats` keeps its lifetime counters and live gauges across this boundary,
 while its explicitly named `*_since_reset` counters start a new generation

--- a/crates/multitude/docs/PERF.md
+++ b/crates/multitude/docs/PERF.md
@@ -13,8 +13,9 @@ published here; run them with `cargo bench` in this crate.
 ## How these numbers were produced
 
 Criterion medians use 30 samples, a 1 s warm-up, and a 2 s measurement.
-Each scenario runs in its own warmed process, with the implementations being compared measured adjacently to limit host-load and frequency drift.
-Serde and teardown timings are the median of 3 independently warmed runs, with variant order alternated between runs.
+Benchmark processes were pinned to logical CPU 4.
+Each comparison group runs in a freshly warmed process. Compared implementations are invoked adjacently to limit host-load and frequency drift.
+Differential allocation, Serde, and teardown timings are the median of 3 independently warmed paired runs. Compared variants run in the same process, with group order alternated between rounds.
 
 ## Arena vs. the system allocator
 
@@ -22,7 +23,7 @@ One pass allocates a mixed working set — 1,000 `u64` values, 1,000 32-byte sli
 
 | Workload | Multitude arena | System allocator (mimalloc) | Δ vs system allocator | Speedup |
 |---|---:|---:|---:|---:|
-| Allocate and release 3,000 mixed objects | 10.23 µs | 27.01 µs | -62.1% | 2.64× |
+| Allocate and release 3,000 mixed objects | 10.23 µs | 30.65 µs | -66.6% | 3.00× |
 
 ## Multitude vs. Bumpalo, head-to-head
 
@@ -30,16 +31,16 @@ Identical workloads run against `multitude` and [`bumpalo`](https://crates.io/cr
 
 | Workload | Multitude | Bumpalo | Δ |
 |---|---:|---:|---:|
-| Sized value (`alloc`) | 2.42 µs | 1.56 µs | +54.7% |
-| String copy (`alloc_str`) | 4.08 µs | 4.11 µs | -0.8% |
-| Slice copy (`alloc_slice_copy`) | 4.35 µs | 4.18 µs | +4.1% |
-| Slice clone (`alloc_slice_clone`) | 4.58 µs | 4.59 µs | -0.4% |
-| Slice from closure (`alloc_slice_fill_with`) | 2.88 µs | 2.42 µs | +19.2% |
-| Slice from iterator (`alloc_slice_fill_iter`) | 2.93 µs | 2.46 µs | +18.8% |
-| Growable string (`alloc_string`) | 3.44 µs | 4.32 µs | -20.4% |
-| Growable string, preallocated (`alloc_string_with_capacity`) | 3.94 µs | 3.87 µs | +1.8% |
-| Growable vector (`alloc_vec`) | 1.15 µs | 1.33 µs | -13.7% |
-| Growable vector, preallocated (`alloc_vec_with_capacity`) | 1.13 µs | 1.16 µs | -2.3% |
+| Sized value (`alloc`) | 1.41 µs | 1.42 µs | -0.9% |
+| String copy (`alloc_str`) | 3.28 µs | 4.08 µs | -19.5% |
+| Slice copy (`alloc_slice_copy`) | 3.31 µs | 3.41 µs | -3.0% |
+| Slice clone (`alloc_slice_clone`) | 2.91 µs | 3.21 µs | -9.3% |
+| Slice from closure (`alloc_slice_fill_with`) | 1.93 µs | 1.89 µs | +1.9% |
+| Slice from iterator (`alloc_slice_fill_iter`) | 1.93 µs | 1.96 µs | -1.2% |
+| Growable string (`alloc_string`) | 2.99 µs | 4.34 µs | -31.1% |
+| Growable string, preallocated (`alloc_string_with_capacity`) | 3.05 µs | 3.66 µs | -16.6% |
+| Growable vector (`alloc_vec`) | 1.04 µs | 1.18 µs | -12.0% |
+| Growable vector, preallocated (`alloc_vec_with_capacity`) | 1.05 µs | 1.01 µs | +3.8% |
 
 ## Allocation teardown
 
@@ -47,15 +48,25 @@ Setup is outside the measured region: each implementation starts with the same n
 
 | Allocations | Implementation | Time | Δ vs standard allocator |
 |---:|---|---:|---:|
-| 1 | Standard allocator | 14 ns | +0.0% |
-| 1 | Multitude | 34 ns | +147.2% |
-| 1 | Bumpalo | 14 ns | -0.3% |
-| 32 | Standard allocator | 428 ns | +0.0% |
-| 32 | Multitude | 33 ns | -92.3% |
-| 32 | Bumpalo | 14 ns | -96.7% |
-| 1000 | Standard allocator | 14.67 µs | +0.0% |
-| 1000 | Multitude | 35 ns | -99.8% |
-| 1000 | Bumpalo | 16 ns | -99.9% |
+| 1 | Standard allocator | 5 ns | +0.0% |
+| 1 | Multitude | 3 ns | -38.7% |
+| 1 | Bumpalo | 6 ns | +38.2% |
+| 32 | Standard allocator | 411 ns | +0.0% |
+| 32 | Multitude | 3 ns | -99.3% |
+| 32 | Bumpalo | 6 ns | -98.6% |
+| 1000 | Standard allocator | 13.17 µs | +0.0% |
+| 1000 | Multitude | 4 ns | -100.0% |
+| 1000 | Bumpalo | 8 ns | -99.9% |
+
+### Reset plus the next allocation
+
+This extends the pure-reset diagnostic through the first 64-byte allocation of the next generation. Both allocators start with the same warmed state, and backing-allocation assertions enforce that the measured boundary only rewinds and reuses existing storage.
+
+| Previous allocations | Multitude | Bumpalo | Δ |
+|---:|---:|---:|---:|
+| 1 | 8 ns | 6 ns | +34.3% |
+| 32 | 8 ns | 7 ns | +25.4% |
+| 1000 | 10 ns | 9 ns | +9.9% |
 
 ## Serde deserialization
 
@@ -63,8 +74,8 @@ The arena and standard paths deserialize the same JSON document into equivalent 
 
 | Workload | Arena | Standard `serde_json` | Δ |
 |---|---:|---:|---:|
-| Typed record | 461 ns | 482 ns | -4.3% |
-| Dynamic value | 634 ns | 646 ns | -1.9% |
+| Typed record | 436 ns | 456 ns | -4.5% |
+| Dynamic value | 621 ns | 661 ns | -6.0% |
 
 ### Reused-allocator lifecycle
 
@@ -74,9 +85,9 @@ This is the shape of a server that reuses one allocator per request: deserialize
 
 | Implementation | Time | Δ vs standard Serde |
 |---|---:|---:|
-| Standard Serde | 461 ns | +0.0% |
-| Multitude | 440 ns | -4.6% |
-| Bumpalo (manual seed) | 440 ns | -4.5% |
+| Standard Serde | 436 ns | +0.0% |
+| Multitude | 423 ns | -3.0% |
+| Bumpalo (manual seed) | 382 ns | -12.5% |
 
 #### 32-record batch
 
@@ -84,9 +95,9 @@ The same complete lifecycle for 32 independent JSON documents in one reusable al
 
 | Implementation | Time | Δ vs standard Serde |
 |---|---:|---:|
-| Standard Serde | 20.00 µs | +0.0% |
-| Multitude | 13.38 µs | -33.1% |
-| Bumpalo (manual seed) | 14.60 µs | -27.0% |
+| Standard Serde | 18.76 µs | +0.0% |
+| Multitude | 12.67 µs | -32.4% |
+| Bumpalo (manual seed) | 12.68 µs | -32.4% |
 
 ## Record-batch decoding
 
@@ -94,11 +105,11 @@ A synthetic batch of 16 wide records, decoded either into standard collections o
 
 | Workload | Standard | Arena | Δ |
 |---|---:|---:|---:|
-| Decode a batch of wide records | 59.94 µs | 45.55 µs | -24.0% |
-| String fields, no escapes | 61.37 µs | 45.98 µs | -25.1% |
-| String fields, escaped | 82.39 µs | 67.17 µs | -18.5% |
-| Retain one record in eight | 61.11 µs | 45.58 µs | -25.4% |
-| Malformed input (error path) | 61.25 µs | 45.89 µs | -25.1% |
+| Decode a batch of wide records | 54.07 µs | 40.48 µs | -25.1% |
+| String fields, no escapes | 55.88 µs | 40.43 µs | -27.6% |
+| String fields, escaped | 76.42 µs | 60.97 µs | -20.2% |
+| Retain one record in eight | 54.73 µs | 41.46 µs | -24.2% |
+| Malformed input (error path) | 56.20 µs | 40.70 µs | -27.6% |
 
 ### Reset-per-refresh workload
 
@@ -106,8 +117,8 @@ The most end-to-end scenario in this report: each iteration parses 1,000 escaped
 
 | Implementation | Time | Δ vs standard collections |
 |---|---:|---:|
-| Standard collections | 5.33 ms | +0.0% |
-| Arena, `Vec` output, reset per refresh | 4.26 ms | -20.0% |
-| Arena, per-record output, reset per refresh | 4.23 ms | -20.7% |
-| Arena, raw-value scan, per-record output | 3.56 ms | -33.1% |
-| Arena, raw-value scan, indexed selection | 3.53 ms | -33.7% |
+| Standard collections | 5.12 ms | +0.0% |
+| Arena, `Vec` output, reset per refresh | 3.93 ms | -23.2% |
+| Arena, per-record output, reset per refresh | 3.88 ms | -24.1% |
+| Arena, raw-value scan, per-record output | 3.35 ms | -34.6% |
+| Arena, raw-value scan, indexed selection | 3.33 ms | -35.0% |

--- a/crates/multitude/docs/TODO.md
+++ b/crates/multitude/docs/TODO.md
@@ -7,72 +7,10 @@ shipped architecture is documented in [`DESIGN.md`](./DESIGN.md).
 
 ## Contents
 
-### Performance
-- [P1](#p1) — Encode allocation-resident slice lengths with a variable-width integer
-- [P2](#p2) — Make the growable-collection freeze prefix opt-in
-
 ### Features
 - [F1](#f1) — Provide an owning `IntoIterator` for `Box<[T]>`
 - [F2](#f2) — Add guaranteed in-place initialization (`alloc_*_emplace`)
 - [F3](#f3) — Add `ArenaSnapshot<T>` for single-owner immutable graphs
-
-## Performance
-
-<a id="p1"></a>
-### P1 — Encode allocation-resident slice lengths with a variable-width integer
-
-**Area:** chunk layout · **Priority:** Low · **Effort:** Medium
-
-Consider storing the length of arrays in the chunk using a variable integer encoding instead
-of always storing a usize. This would save RAM and CPU cache space, at the cost of a bit of computation
-whenever getting the length.
-
-**Done when:** slice-like allocations store their length in a variable-width
-encoding, the decode cost on the resolution path is benchmarked against the
-current fixed-width read, and the memory saving is measured on a
-representative small-slice workload.
-
----
-
-<a id="p2"></a>
-### P2 — Make the growable-collection freeze prefix opt-in
-
-**Area:** `vec`, `strings` · **Priority:** Medium · **Effort:** Medium
-
-Every growable buffer currently reserves the `Arc<[T]>` freeze prefix
-(`[strong][len]`) unconditionally, so `into_arc` / `into_boxed_slice` are
-zero-copy (see `vec/freeze.rs`, `internal::constants::buffer_freezable`,
-`ArenaBuf::freeze_prefix`). That costs a few prefix bytes (and the
-`arc_block_align` rounding) on every buffer — even ones that are never
-frozen.
-
-Let the caller choose, at construction time, whether to reserve the prefix,
-based on how they intend to use the collection: buffers that won't be frozen
-skip the prefix and pack tighter, while freeze-bound buffers keep O(1)
-`into_arc` / `into_boxed_slice`.
-
-Two shapes (same underlying "buffer may or may not carry the prefix" work,
-which already exists via the `freeze_prefix` flag and the const
-`buffer_freezable` gate):
-
-- **Runtime flag on the builders** (`alloc_vec*` / `alloc_string*` /
-  `alloc_utf16_string*`): record the choice in `ArenaBuf` next to the
-  existing `freeze_prefix` flag and branch in `Vec::try_grow_to`. Smallest
-  API; one branch in the cold growth path; freeze falls back to the O(n)
-  copy when the prefix is absent (the `can_freeze_in_place` check already
-  handles this).
-- **Zero-cost marker type parameter on `Vec`**: a sealed marker selecting
-  prefix-vs-no-prefix, with `into_arc` / `into_boxed_slice` O(1) only on the
-  freeze-ready variant. No runtime branch and a compile-time freeze
-  guarantee; cost is generic noise in signatures, mitigated by defaulting to
-  today's behavior plus type aliases.
-
-`String` / `Utf16String` wrap `Vec`, so the choice propagates for free.
-
-**Done when:** one of the two shapes is implemented, a buffer constructed
-without the prefix demonstrably occupies fewer bytes, freeze on a
-prefix-less buffer still succeeds via the copy fallback, and the default
-construction path keeps today's zero-copy freeze behavior.
 
 ## Features
 

--- a/crates/multitude/scripts/perf_report.rs
+++ b/crates/multitude/scripts/perf_report.rs
@@ -22,6 +22,7 @@ ohno = { path = "../../ohno", features = ["app-err"] }
 //!   `scripts/perf_report.rs`                                       — full run (30 samples, 2s measurement)
 //!   `scripts/perf_report.rs --fast`                                — quick run (10 samples, 1s)
 //!   `scripts/perf_report.rs --samples 50 --measurement-time 3`     — custom criterion settings
+//!   `scripts/perf_report.rs --comparison-repetitions 5`            — repeat paired comparisons
 //!   `scripts/perf_report.rs --cpu 4`                               — pin benchmark processes to CPU 4
 //!
 //! The group tables below select which benchmark variants are measured and
@@ -63,10 +64,10 @@ struct Args {
     #[arg(long)]
     cpu: Option<u32>,
 
-    /// Number of independently warmed runs for each Serde and teardown variant
-    /// (default: 3).
-    #[arg(long, default_value_t = 3)]
-    serde_repetitions: u32,
+    /// Number of independently warmed runs for each differential allocation,
+    /// Serde, and teardown group (default: 3).
+    #[arg(long, alias = "serde-repetitions", default_value_t = 3)]
+    comparison_repetitions: u32,
 }
 
 /// `(criterion_group, published_variants_in_report_order)`.
@@ -116,9 +117,36 @@ const ALLOC_GROUPS: &[Group] = &[
 ];
 
 const TEARDOWN_GROUPS: &[Group] = &[
-    ("multitude_teardown/free_1", &["standard", "multitude", "bumpalo"]),
-    ("multitude_teardown/free_32", &["standard", "multitude", "bumpalo"]),
-    ("multitude_teardown/free_1000", &["standard", "multitude", "bumpalo"]),
+    (
+        "multitude_teardown/free_1",
+        &[
+            "standard",
+            "multitude",
+            "bumpalo",
+            "multitude_reset_allocate",
+            "bumpalo_reset_allocate",
+        ],
+    ),
+    (
+        "multitude_teardown/free_32",
+        &[
+            "standard",
+            "multitude",
+            "bumpalo",
+            "multitude_reset_allocate",
+            "bumpalo_reset_allocate",
+        ],
+    ),
+    (
+        "multitude_teardown/free_1000",
+        &[
+            "standard",
+            "multitude",
+            "bumpalo",
+            "multitude_reset_allocate",
+            "bumpalo_reset_allocate",
+        ],
+    ),
 ];
 
 const SERDE_GROUPS: &[Group] = &[
@@ -445,7 +473,7 @@ fn fmt_speedup(candidate: Option<f64>, baseline: Option<f64>) -> String {
 
 fn build_report(
     crit: &[(String, f64)],
-    serde_repetitions: u32,
+    comparison_repetitions: u32,
     criterion_samples: u32,
     criterion_warmup_secs: u32,
     criterion_measurement_secs: u32,
@@ -479,16 +507,17 @@ fn build_report(
         let _ = writeln!(out, "Benchmark processes were pinned to logical CPU {cpu}.");
     }
     out.push_str(
-        "Each scenario runs in its own warmed process, with the implementations \
-         being compared measured adjacently to limit host-load and frequency drift.\n",
+        "Each comparison group runs in a freshly warmed process. Compared implementations \
+         are invoked adjacently to limit host-load and frequency drift.\n",
     );
-    if serde_repetitions == 1 {
-        out.push_str("Serde and teardown timings come from one independently warmed run.\n\n");
+    if comparison_repetitions == 1 {
+        out.push_str("Differential allocation, Serde, and teardown timings come from one independently warmed paired run.\n\n");
     } else {
         let _ = writeln!(
             out,
-            "Serde and teardown timings are the median of {serde_repetitions} independently \
-             warmed runs, with variant order alternated between runs.\n"
+            "Differential allocation, Serde, and teardown timings are the median of \
+             {comparison_repetitions} independently warmed paired runs. Compared \
+             variants run in the same process, with group order alternated between rounds.\n"
         );
     }
 
@@ -573,6 +602,32 @@ fn build_report(
                 fmt_delta(time, standard_time),
             );
         }
+    }
+    out.push('\n');
+
+    out.push_str("### Reset plus the next allocation\n\n");
+    out.push_str(
+        "This extends the pure-reset diagnostic through the first 64-byte \
+         allocation of the next generation. Both allocators start with the \
+         same warmed state, and backing-allocation assertions enforce that the \
+         measured boundary only rewinds and reuses existing storage.\n\n",
+    );
+    out.push_str("| Previous allocations | Multitude | Bumpalo | Δ |\n");
+    out.push_str("|---:|---:|---:|---:|\n");
+    for (count, group) in [
+        (1, "multitude_teardown/free_1"),
+        (32, "multitude_teardown/free_32"),
+        (1_000, "multitude_teardown/free_1000"),
+    ] {
+        let multitude = lookup_time(crit, &format!("{group}/multitude_reset_allocate"));
+        let bumpalo = lookup_time(crit, &format!("{group}/bumpalo_reset_allocate"));
+        let _ = writeln!(
+            out,
+            "| {count} | {} | {} | {} |",
+            fmt_ns(multitude),
+            fmt_ns(bumpalo),
+            fmt_delta(multitude, bumpalo),
+        );
     }
     out.push('\n');
 
@@ -755,11 +810,12 @@ fn run_groups(
     Ok(combined)
 }
 
-/// Run every benchmark variant independently, alternating order between rounds.
+/// Run every benchmark group in an independent process, alternating group order
+/// between rounds.
 ///
-/// This is reserved for cross-implementation lifecycle benchmarks whose setup
-/// has materially different global allocator effects. Alternating order and
-/// reporting the median across rounds reduces host-load and frequency bias.
+/// Keeping compared variants in one process makes their CPU state adjacent;
+/// alternating group order and reporting the median across rounds reduces
+/// longer-term host-load and frequency bias.
 fn run_repeated_variants(
     cwd: &Path,
     bench: &str,
@@ -771,27 +827,25 @@ fn run_repeated_variants(
 ) -> Result<String, AppError> {
     let mut combined = String::new();
     for round in 0..repetitions {
-        for (group, variants) in groups {
-            let indices: Vec<usize> = if round.is_multiple_of(2) {
-                (0..variants.len()).collect()
-            } else {
-                (0..variants.len()).rev().collect()
-            };
-            for index in indices {
-                let variant = variants[index];
-                let filter = format!("^{group}/{variant}$");
-                let mut args = Vec::with_capacity(common_args.len() + 1);
-                args.push(filter.as_str());
-                args.extend_from_slice(common_args);
-                combined.push_str(&run_bench(
-                    cwd,
-                    bench,
-                    features,
-                    &args,
-                    &format!("{bench} ({group}/{variant}, round {}/{repetitions})", round + 1),
-                    cpu,
-                )?);
-            }
+        let indices: Vec<usize> = if round.is_multiple_of(2) {
+            (0..groups.len()).collect()
+        } else {
+            (0..groups.len()).rev().collect()
+        };
+        for index in indices {
+            let (group, variants) = groups[index];
+            let filter = group_filter(group, variants);
+            let mut args = Vec::with_capacity(common_args.len() + 1);
+            args.push(filter.as_str());
+            args.extend_from_slice(common_args);
+            combined.push_str(&run_bench(
+                cwd,
+                bench,
+                features,
+                &args,
+                &format!("{bench} ({group}, round {}/{repetitions})", round + 1),
+                cpu,
+            )?);
         }
     }
     Ok(combined)
@@ -836,14 +890,22 @@ fn run(args: &Args) -> Result<(), AppError> {
         &crit_args,
         args.cpu,
     )?;
-    let alloc_log = run_groups(&crate_dir, "criterion_alloc", &[], ALLOC_GROUPS, &crit_args, args.cpu)?;
+    let alloc_log = run_repeated_variants(
+        &crate_dir,
+        "criterion_alloc",
+        &[],
+        ALLOC_GROUPS,
+        &crit_args,
+        args.comparison_repetitions,
+        args.cpu,
+    )?;
     let teardown_log = run_repeated_variants(
         &crate_dir,
         "multitude_teardown",
         &[],
         TEARDOWN_GROUPS,
         &crit_args,
-        args.serde_repetitions,
+        args.comparison_repetitions,
         args.cpu,
     )?;
     let serde_log = run_repeated_variants(
@@ -852,7 +914,7 @@ fn run(args: &Args) -> Result<(), AppError> {
         &["serde_json"],
         SERDE_GROUPS,
         &crit_args,
-        args.serde_repetitions,
+        args.comparison_repetitions,
         args.cpu,
     )?;
     let record_batch_log = run_groups(
@@ -874,7 +936,7 @@ fn run(args: &Args) -> Result<(), AppError> {
 
     let report = build_report(
         &crit,
-        args.serde_repetitions,
+        args.comparison_repetitions,
         samples,
         warmup_secs,
         measurement_secs,

--- a/crates/multitude/src/arena/alloc_slice_ref.rs
+++ b/crates/multitude/src/arena/alloc_slice_ref.rs
@@ -62,6 +62,20 @@ fn empty_slice<'a, T>() -> &'a mut [T] {
     unsafe { core::slice::from_raw_parts_mut(NonNull::<T>::dangling().as_ptr(), 0) }
 }
 
+/// Adopts a fully initialized slice while preserving a length already known by
+/// the caller.
+///
+/// # Safety
+///
+/// `slot` must contain exactly `len` initialized elements that the returned
+/// [`Alloc`] may exclusively own.
+unsafe fn adopt_slice_with_len<T>(slot: &mut [T], len: usize) -> Alloc<'_, [T]> {
+    debug_assert_eq!(slot.len(), len);
+    let ptr = slot.as_mut_ptr();
+    // SAFETY: guaranteed by the caller.
+    unsafe { Alloc::from_mut(core::slice::from_raw_parts_mut(ptr, len)) }
+}
+
 /// Records the caller invariant that `len` is non-zero.
 #[inline(always)]
 #[cfg_attr(test, mutants::skip)]
@@ -281,11 +295,11 @@ impl<A: Allocator + Clone> Arena<A> {
     /// into a fresh arena slot and takes ownership of it in an [`Alloc`].
     #[inline(always)]
     fn impl_alloc_slice_copy<T: Copy>(&self, src: &[T]) -> Result<Alloc<'_, [T]>, AllocError> {
+        let len = src.len();
         let slot = self.alloc_slice_copy_raw::<T>(src)?;
-        // SAFETY: `alloc_slice_copy_raw` returns the unique `&mut [T]` for a
-        // freshly-written arena slice that the arena hands out exactly once and
-        // never drops itself, so `Alloc` may adopt it and own its destructor.
-        Ok(unsafe { Alloc::from_mut(slot) })
+        // SAFETY: `alloc_slice_copy_raw` initialized exactly `src.len()`
+        // elements in the unique arena slot returned.
+        Ok(unsafe { adopt_slice_with_len(slot, len) })
     }
 
     /// Raw allocation path shared by `alloc_slice_copy` and
@@ -348,11 +362,11 @@ impl<A: Allocator + Clone> Arena<A> {
     /// into a fresh arena slot and takes ownership of it in an [`Alloc`].
     #[inline(always)]
     fn impl_alloc_slice_clone<T: Clone>(&self, src: &[T]) -> Result<Alloc<'_, [T]>, AllocError> {
+        let len = src.len();
         let slot = self.alloc_slice_clone_raw::<T>(src)?;
-        // SAFETY: `alloc_slice_clone_raw` returns the unique `&mut [T]` for a
-        // freshly-written arena slice that the arena hands out exactly once and
-        // never drops itself, so `Alloc` may adopt it and own its destructor.
-        Ok(unsafe { Alloc::from_mut(slot) })
+        // SAFETY: `alloc_slice_clone_raw` initialized exactly `src.len()`
+        // elements in the unique arena slot returned.
+        Ok(unsafe { adopt_slice_with_len(slot, len) })
     }
 
     /// Closure-free fast path for `alloc_slice_clone` /
@@ -412,11 +426,9 @@ impl<A: Allocator + Clone> Arena<A> {
     #[inline(always)]
     fn impl_alloc_slice_fill_with<T, F: FnMut(usize) -> T>(&self, len: usize, f: F) -> Result<Alloc<'_, [T]>, AllocError> {
         let slot = self.alloc_slice_fill_with_raw::<T, F>(len, f)?;
-        // SAFETY: `alloc_slice_fill_with_raw` returns the unique `&mut [T]` for
-        // a freshly-written arena slice that the arena hands out exactly once
-        // and never drops itself, so `Alloc` may adopt it and own its
-        // destructor.
-        Ok(unsafe { Alloc::from_mut(slot) })
+        // SAFETY: `alloc_slice_fill_with_raw` initialized exactly `len`
+        // elements in the unique arena slot returned.
+        Ok(unsafe { adopt_slice_with_len(slot, len) })
     }
 
     /// Closure-bearing fast path for `alloc_slice_fill_with` /
@@ -473,23 +485,21 @@ impl<A: Allocator + Clone> Arena<A> {
     /// arena slot from `iter` and takes ownership of it in an [`Alloc`].
     #[inline(always)]
     fn impl_alloc_slice_fill_iter<T, I: ExactSizeIterator<Item = T>>(&self, iter: I) -> Result<Alloc<'_, [T]>, AllocError> {
-        let slot = self.alloc_slice_fill_iter_raw::<T, I>(iter)?;
-        // SAFETY: `alloc_slice_fill_iter_raw` returns the unique `&mut [T]` for
-        // a freshly-written arena slice that the arena hands out exactly once
-        // and never drops itself, so `Alloc` may adopt it and own its
-        // destructor.
-        Ok(unsafe { Alloc::from_mut(slot) })
+        reject_over_aligned::<T>()?;
+        let len = iter.len();
+        let slot = self.alloc_slice_fill_iter_raw::<T, I>(iter, len)?;
+        // SAFETY: `alloc_slice_fill_iter_raw` initialized exactly `len`
+        // elements in the unique arena slot returned.
+        Ok(unsafe { adopt_slice_with_len(slot, len) })
     }
 
     /// Iterator-bearing fast path for `alloc_slice_fill_iter` /
     /// `try_alloc_slice_fill_iter`. The iterator length is sampled once
-    /// via [`ExactSizeIterator::len`] before reservation. Keeping the refill
+    /// via [`ExactSizeIterator::len`] before this helper. Keeping the refill
     /// continuation out of line avoids materializing iterator state on the
     /// common path. The iterator is consumed only on success arms that return.
     #[inline(always)]
-    fn alloc_slice_fill_iter_raw<T, I: ExactSizeIterator<Item = T>>(&self, iter: I) -> Result<&mut [T], AllocError> {
-        reject_over_aligned::<T>()?;
-        let len = iter.len();
+    fn alloc_slice_fill_iter_raw<T, I: Iterator<Item = T>>(&self, iter: I, len: usize) -> Result<&mut [T], AllocError> {
         if len == 0 {
             // Drop the iterator without consuming it: the contract is
             // "fill `len` slots from the iterator", so a zero-length
@@ -550,7 +560,7 @@ mod tests {
         let arena = Arena::new();
         let _prime = arena.alloc(0_u8);
 
-        let slice = arena.alloc_slice_fill_iter_raw([1_u8, 2, 3].into_iter()).unwrap();
+        let slice = arena.alloc_slice_fill_iter_raw([1_u8, 2, 3].into_iter(), 3).unwrap();
 
         assert_eq!(slice, [1, 2, 3]);
     }

--- a/crates/multitude/src/arena/mod.rs
+++ b/crates/multitude/src/arena/mod.rs
@@ -365,7 +365,12 @@ impl<A: Allocator + Clone> Arena<A> {
         // outstanding handles). Fold in the currently-active chunk's free
         // tail so the reported value also reflects the slack that would
         // become wasted if the next alloc forced a refill right now.
-        let current_free = u64::from(self.current.borrow().wasted_tail_for_stats());
+        let current_is_active = self.current_has_reference.get() || self.local_shared_count.get() != 0;
+        let current_free = if current_is_active {
+            u64::from(self.current.borrow().wasted_tail_for_stats())
+        } else {
+            0
+        };
         ArenaStats {
             total_bytes_allocated: self.provider.bytes_allocated(),
             peak_bytes_allocated: self.provider.peak_bytes_allocated(),
@@ -397,8 +402,11 @@ impl<A: Allocator + Clone> Arena<A> {
 
     /// Reset the arena for a new allocation phase.
     ///
-    /// The current and retired chunks return their bytes to the chunk cache,
-    /// unless outstanding smart pointers keep them alive.
+    /// Retired chunks return their bytes to the chunk cache unless outstanding
+    /// smart pointers keep them alive. A current chunk used only for
+    /// arena-lifetime allocations is retained and rewound in place; a current
+    /// chunk that handed out owning pointers is detached so those owners keep
+    /// their prior-generation values alive.
     ///
     /// Given that this takes `&mut self`, the borrow checker ensures no
     /// outstanding [`Alloc`](crate::Alloc) handles can still be live — each one
@@ -406,8 +414,8 @@ impl<A: Allocator + Clone> Arena<A> {
     /// dropped, so all reference destructors have already run by the time
     /// `reset` is callable. Outstanding `Arc`/`Rc`/`Box` handles allocated before
     /// the reset keep their backing chunks alive independently. `reset` itself
-    /// runs no destructors; it is purely a bulk cursor rewind. After reset the
-    /// next allocation installs a fresh chunk.
+    /// runs no destructors; it is purely a bulk cursor rewind and
+    /// ownership-state transition.
     ///
     /// # Example
     ///
@@ -421,30 +429,55 @@ impl<A: Allocator + Clone> Arena<A> {
     /// assert_eq!(*arena.alloc(8), 8);
     /// ```
     pub fn reset(&mut self) {
+        if self.local_shared_count.get() != 0 {
+            self.reset_slow();
+            return;
+        }
+        if !self.retired_local.is_empty() {
+            self.reset_slow();
+            return;
+        }
+
+        // The common local-only generation has no retired chunks to release
+        // and no owning pointers to detach.
+        let _ = self.current.borrow().rewind();
+        self.current_has_reference.set(false);
+        self.record_reset();
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn reset_slow(&mut self) {
         self.retired_local.clear();
         let local = self.local_shared_count.replace(0);
-        let displaced = self.current.replace_mut(ChunkMutator::<A>::empty());
-        // Return the unused pre-credited surplus and the mutator's +1 with
-        // one atomic operation. No reference destructors run here (the
-        // `Alloc` handles already ran them).
-        let refund = (LARGE_SHARED_REF_SURPLUS - local) as usize;
-        // SAFETY: `local` counts every surplus reference handed out from the
-        // current chunk, so the remainder is exactly the unused pre-credit.
-        unsafe { displaced.release_with_refund(refund) };
+        if local == 0 {
+            // No owning pointer escaped from the current chunk. The exclusive
+            // arena borrow also proves every arena-lifetime handle is gone, so
+            // retaining the pre-credited mutator and rewinding it is safe.
+            let _ = self.current.borrow().rewind();
+        } else {
+            let displaced = self.current.replace_mut(ChunkMutator::<A>::empty());
+            // Return the unused pre-credited surplus and the mutator's +1 with
+            // one atomic operation. No reference destructors run here (the
+            // `Alloc` handles already ran them).
+            let refund = (LARGE_SHARED_REF_SURPLUS - local) as usize;
+            // SAFETY: `local` counts every surplus reference handed out from
+            // the current chunk, so the remainder is exactly the unused
+            // pre-credit.
+            unsafe { displaced.release_with_refund(refund) };
+        }
         self.current_has_reference.set(false);
+        self.record_reset();
+    }
+
+    #[inline]
+    fn record_reset(&self) {
         #[cfg(feature = "stats")]
         {
             self.provider.reset_generation_stats();
             self.relocations_since_reset.set(0);
             self.resets.set(self.resets.get() + 1);
         }
-    }
-
-    /// Records that the current chunk has handed out an arena-lifetime
-    /// reference, so it will be pinned (not reclaimed early) when rotated out.
-    #[inline(always)]
-    fn mark_reference_handout(&self) {
-        self.current_has_reference.set(true);
     }
 
     /// Returns a [`ZerocopyView`](crate::zerocopy::ZerocopyView)

--- a/crates/multitude/src/arena/reserve.rs
+++ b/crates/multitude/src/arena/reserve.rs
@@ -23,8 +23,7 @@ impl<A: Allocator + Clone> Arena<A> {
     #[inline(always)]
     #[cfg_attr(test, mutants::skip)] // body→None ⇒ refill spin (OOM)
     pub(in crate::arena) fn try_reserve_local<T>(&self) -> Option<Uninit<'_, T>> {
-        let ticket = self.current().try_alloc_uninit::<T>()?;
-        self.mark_reference_handout();
+        let ticket = self.current().try_alloc_uninit_local::<T>(&self.current_has_reference)?;
         // SAFETY: reference handouts retain the chunk until an exclusive arena
         // operation, which cannot overlap this borrow.
         Some(unsafe { ticket.rebind() })
@@ -35,8 +34,7 @@ impl<A: Allocator + Clone> Arena<A> {
     #[inline(always)]
     #[cfg_attr(test, mutants::skip)] // see `try_reserve_local`
     pub(crate) fn try_reserve_local_slice<T>(&self, len: usize) -> Option<Uninit<'_, [T]>> {
-        let ticket = self.current().try_alloc_uninit_slice::<T>(len)?;
-        self.mark_reference_handout();
+        let ticket = self.current().try_alloc_uninit_slice_local::<T>(len, &self.current_has_reference)?;
         // SAFETY: reference handouts retain the chunk for this borrow.
         Some(unsafe { ticket.rebind() })
     }
@@ -54,8 +52,10 @@ impl<A: Allocator + Clone> Arena<A> {
     #[cfg_attr(test, mutants::skip)] // see `try_reserve_local`
     pub(in crate::arena) fn try_reserve_local_slice_with_size<T>(&self, len: usize, size: usize) -> Option<Uninit<'_, [T]>> {
         // SAFETY: required by this function's contract.
-        let ticket = unsafe { self.current().try_alloc_uninit_slice_with_size::<T>(len, size) }?;
-        self.mark_reference_handout();
+        let ticket = unsafe {
+            self.current()
+                .try_alloc_uninit_slice_with_size_local::<T>(len, size, &self.current_has_reference)
+        }?;
         // SAFETY: reference handouts retain the chunk for this borrow.
         Some(unsafe { ticket.rebind() })
     }
@@ -67,13 +67,14 @@ impl<A: Allocator + Clone> Arena<A> {
     /// paths).
     ///
     /// As with the other reference reservations no chunk refcount is taken
-    /// here: the chunk is pinned via `mark_reference_handout` and the
+    /// here: the chunk is pinned via the local-reference marker and the
     /// refcount is acquired only at freeze time.
     #[inline(always)]
     #[cfg_attr(test, mutants::skip)] // see `try_reserve_local`
     pub(crate) fn try_reserve_freezable_slice<T>(&self, len: usize) -> Option<Uninit<'_, [T]>> {
-        let ticket = self.current().try_alloc_freezable_slice::<T>(len)?;
-        self.mark_reference_handout();
+        let ticket = self
+            .current()
+            .try_alloc_freezable_slice_local::<T>(len, &self.current_has_reference)?;
         // SAFETY: reference handouts retain the chunk for this borrow.
         Some(unsafe { ticket.rebind() })
     }
@@ -83,8 +84,7 @@ impl<A: Allocator + Clone> Arena<A> {
     #[inline(always)]
     #[cfg_attr(test, mutants::skip)] // see `try_reserve_local`
     pub(in crate::arena) fn try_reserve_local_bytes(&self, len: usize) -> Option<Uninit<'_, [u8]>> {
-        let ticket = self.current().try_alloc_bytes(len)?;
-        self.mark_reference_handout();
+        let ticket = self.current().try_alloc_bytes_local(len, &self.current_has_reference)?;
         // SAFETY: reference handouts retain the chunk for this borrow.
         Some(unsafe { ticket.rebind() })
     }

--- a/crates/multitude/src/arena/retired_local.rs
+++ b/crates/multitude/src/arena/retired_local.rs
@@ -54,6 +54,12 @@ impl<A: Allocator + Clone> RetiredLocalChunks<A> {
         }
     }
 
+    #[inline]
+    #[cfg_attr(test, mutants::skip)] // `false` only selects the equivalent slow reset path
+    pub(in crate::arena) fn is_empty(&self) -> bool {
+        self.head.get().is_null()
+    }
+
     /// Retire `mutator`'s chunk by linking its header onto the list head.
     /// Empty mutators are a no-op (nothing to retire).
     ///

--- a/crates/multitude/src/internal/chunk_mutator.rs
+++ b/crates/multitude/src/internal/chunk_mutator.rs
@@ -19,6 +19,18 @@ use super::uninit::Uninit;
 
 type ByteAllocation<'a, A> = (Uninit<'a, [u8]>, NonNull<Chunk<A>>);
 
+/// This transition occurs at most once per local generation. Marking it cold
+/// keeps the already-set branch as the steady-state fall-through.
+#[cold]
+fn set_reference_marker(marker: &Cell<bool>) {
+    marker.set(true);
+}
+
+/// Branch-layout hint for the uncommon chunk-exhaustion path. The workspace
+/// Rust 1.93 MSRV predates `core::hint::cold_path`.
+#[cold]
+fn allocation_miss() {}
+
 /// Owns one strong reference to a chunk and tracks the bump cursor.
 ///
 /// Hot-path layout stores only `chunk`, `bump`, and `end`; cold paths
@@ -137,6 +149,19 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
         self.chunk
     }
 
+    /// Rewinds the bump cursor to the start of the owned chunk.
+    ///
+    /// Returns `false` for the empty sentinel mutator.
+    #[inline]
+    pub(crate) fn rewind(&self) -> bool {
+        let Some(chunk) = self.chunk else {
+            return false;
+        };
+        // SAFETY: this mutator owns a strong reference to `chunk`.
+        self.bump.set(unsafe { Chunk::<A>::payload_ptr(chunk) });
+        true
+    }
+
     /// Reserves `size` bytes aligned to `align`. Returns an `InChunk<u8>`
     /// pointing at the start, or `None` if the chunk has insufficient
     /// room or the request would overflow.
@@ -150,6 +175,25 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
     // Always rejecting requests would make caller refill loops infinite.
     #[cfg_attr(test, mutants::skip)]
     pub(crate) fn try_alloc(&self, size: usize, align: usize) -> Option<InChunk<u8>> {
+        self.try_alloc_before_commit(size, align, || {})
+    }
+
+    /// Local-reference form of [`Self::try_alloc`].
+    #[inline]
+    #[cfg_attr(test, mutants::skip)] // see `try_alloc`
+    fn try_alloc_local(&self, size: usize, align: usize, marker: &Cell<bool>) -> Option<InChunk<u8>> {
+        self.try_alloc_before_commit(size, align, || {
+            if !marker.get() {
+                set_reference_marker(marker);
+            }
+        })
+    }
+
+    /// Shared allocation core with a success-only action immediately before the
+    /// bump cursor is committed.
+    #[inline]
+    #[cfg_attr(test, mutants::skip)] // see `try_alloc`
+    fn try_alloc_before_commit(&self, size: usize, align: usize, before_commit: impl FnOnce()) -> Option<InChunk<u8>> {
         debug_assert!(align.is_power_of_two(), "align must be a power of two");
         debug_assert!(size.checked_add(align).is_some(), "size + align overflows usize");
         let cur = self.bump.get();
@@ -171,6 +215,7 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
         // `size.max(1)` probes that byte without changing the ZST bump.
         let probe_end = aligned_addr.checked_add(size.max(1))?;
         if probe_end > limit_addr {
+            allocation_miss();
             return None;
         }
         // SAFETY: `probe_end <= limit_addr`, so both `aligned_ptr`
@@ -181,6 +226,7 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
         // `aligned_ptr + size` also lands within the chunk payload; `byte_add`
         // on the bump cursor preserves chunk-wide provenance.
         let new_bump = unsafe { aligned_ptr.byte_add(size) };
+        before_commit();
         self.bump.set(new_bump);
         Some(InChunk::from_raw(aligned_ptr))
     }
@@ -190,6 +236,14 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
     #[cfg_attr(test, mutants::skip)] // see `try_alloc`: body→None ⇒ refill spin
     pub(crate) fn try_alloc_uninit<T>(&self) -> Option<Uninit<'_, T>> {
         let bytes = self.try_alloc(mem::size_of::<T>(), mem::align_of::<T>())?;
+        Some(Uninit::new(bytes.cast::<T>()))
+    }
+
+    /// Local-reference form of [`Self::try_alloc_uninit`].
+    #[inline]
+    #[cfg_attr(test, mutants::skip)] // see `try_alloc`
+    pub(crate) fn try_alloc_uninit_local<T>(&self, marker: &Cell<bool>) -> Option<Uninit<'_, T>> {
+        let bytes = self.try_alloc_local(mem::size_of::<T>(), mem::align_of::<T>(), marker)?;
         Some(Uninit::new(bytes.cast::<T>()))
     }
 
@@ -209,17 +263,37 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
     /// Byte-slice fast path: skips the alignment mask, `checked_mul`,
     /// and ZST branch. Only valid for `T = u8` (align 1, size 1).
     #[inline]
+    #[cfg_attr(test, mutants::skip)] // body→None ⇒ refill spin
     pub(crate) fn try_alloc_bytes(&self, len: usize) -> Option<Uninit<'_, [u8]>> {
+        self.try_alloc_bytes_before_commit(len, || {})
+    }
+
+    /// Local-reference form of [`Self::try_alloc_bytes`].
+    #[inline]
+    #[cfg_attr(test, mutants::skip)] // body→None ⇒ refill spin
+    pub(crate) fn try_alloc_bytes_local(&self, len: usize, marker: &Cell<bool>) -> Option<Uninit<'_, [u8]>> {
+        self.try_alloc_bytes_before_commit(len, || {
+            if !marker.get() {
+                set_reference_marker(marker);
+            }
+        })
+    }
+
+    #[inline]
+    #[cfg_attr(test, mutants::skip)] // body→None ⇒ refill spin
+    fn try_alloc_bytes_before_commit(&self, len: usize, before_commit: impl FnOnce()) -> Option<Uninit<'_, [u8]>> {
         let cur = self.bump.get();
         let cur_addr = cur.as_ptr() as usize;
         let limit_addr = self.end.get().as_ptr() as usize;
         hint_chunk_cur_addr_nonnull(cur_addr);
         let end_addr = cur_addr.checked_add(len)?;
         if end_addr > limit_addr {
+            allocation_miss();
             return None;
         }
         // SAFETY: `end_addr <= limit_addr`.
         let new_bump = unsafe { cur.byte_add(len) };
+        before_commit();
         self.bump.set(new_bump);
         Some(Uninit::new(InChunk::from_raw(cur).into_slice::<u8>(len)))
     }
@@ -243,15 +317,28 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
         Some(Uninit::new(bytes.into_slice::<T>(len)))
     }
 
-    /// Like [`Self::try_alloc_uninit_slice`] with a precomputed byte size.
+    /// Local-reference form of [`Self::try_alloc_uninit_slice`].
+    #[cfg_attr(test, mutants::skip)] // see `try_alloc`
+    pub(crate) fn try_alloc_uninit_slice_local<T>(&self, len: usize, marker: &Cell<bool>) -> Option<Uninit<'_, [T]>> {
+        let size = mem::size_of::<T>().checked_mul(len)?;
+        let bytes = self.try_alloc_local(size, mem::align_of::<T>(), marker)?;
+        Some(Uninit::new(bytes.into_slice::<T>(len)))
+    }
+
+    /// Local-reference slice reservation with a precomputed byte size.
     ///
     /// # Safety
     ///
     /// `size` must equal `size_of::<T>() * len` without overflow.
-    #[cfg_attr(test, mutants::skip)] // see `try_alloc`: body→None ⇒ refill spin
-    pub(crate) unsafe fn try_alloc_uninit_slice_with_size<T>(&self, len: usize, size: usize) -> Option<Uninit<'_, [T]>> {
+    #[cfg_attr(test, mutants::skip)] // see `try_alloc`
+    pub(crate) unsafe fn try_alloc_uninit_slice_with_size_local<T>(
+        &self,
+        len: usize,
+        size: usize,
+        marker: &Cell<bool>,
+    ) -> Option<Uninit<'_, [T]>> {
         debug_assert_eq!(size, mem::size_of::<T>().wrapping_mul(len));
-        let bytes = self.try_alloc(size, mem::align_of::<T>())?;
+        let bytes = self.try_alloc_local(size, mem::align_of::<T>(), marker)?;
         Some(Uninit::new(bytes.into_slice::<T>(len)))
     }
 
@@ -303,10 +390,38 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
         value_align: usize,
         meta_bytes: usize,
     ) -> Option<NonNull<u8>> {
+        self.try_alloc_smart_prefixed_before_commit::<S>(payload_bytes, value_align, meta_bytes, || {})
+    }
+
+    #[inline]
+    #[cfg_attr(test, mutants::skip)] // see `try_alloc`
+    fn try_alloc_smart_prefixed_local<S: super::thin_dst::Strong>(
+        &self,
+        payload_bytes: usize,
+        value_align: usize,
+        meta_bytes: usize,
+        marker: &Cell<bool>,
+    ) -> Option<NonNull<u8>> {
+        self.try_alloc_smart_prefixed_before_commit::<S>(payload_bytes, value_align, meta_bytes, || {
+            if !marker.get() {
+                set_reference_marker(marker);
+            }
+        })
+    }
+
+    #[inline]
+    #[cfg_attr(test, mutants::skip)] // see `try_alloc`
+    fn try_alloc_smart_prefixed_before_commit<S: super::thin_dst::Strong>(
+        &self,
+        payload_bytes: usize,
+        value_align: usize,
+        meta_bytes: usize,
+        before_commit: impl FnOnce(),
+    ) -> Option<NonNull<u8>> {
         use super::thin_dst::strong_prefix_bytes_for;
         let prefix = strong_prefix_bytes_for(value_align, meta_bytes);
         let total = prefix.checked_add(payload_bytes.max(1))?;
-        let base = self.try_alloc(total, S::block_align(value_align))?;
+        let base = self.try_alloc_before_commit(total, S::block_align(value_align), before_commit)?;
         // SAFETY: `base` is aligned to `S::block_align(value_align)`, so the
         // leading strong-count write is valid for the policy; `base + prefix`
         // is `value_align`-aligned and stays within the reservation.
@@ -401,6 +516,21 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
         let payload_bytes = mem::size_of::<T>().checked_mul(len)?;
         // SAFETY: `payload_bytes == size_of::<T>() * len` (just checked).
         unsafe { self.try_alloc_freezable_slice_with_size::<T>(len, payload_bytes) }
+    }
+
+    /// Local-reference form of [`Self::try_alloc_freezable_slice`].
+    #[inline]
+    #[cfg_attr(test, mutants::skip)] // see `try_alloc`
+    pub(crate) fn try_alloc_freezable_slice_local<T>(&self, len: usize, marker: &Cell<bool>) -> Option<Uninit<'_, [T]>> {
+        let payload_bytes = mem::size_of::<T>().checked_mul(len)?;
+        debug_assert_eq!(payload_bytes, mem::size_of::<T>().wrapping_mul(len));
+        let value_ptr = self.try_alloc_smart_prefixed_local::<super::thin_dst::AtomicStrong>(
+            payload_bytes,
+            mem::align_of::<T>(),
+            mem::size_of::<usize>(),
+            marker,
+        )?;
+        Some(Uninit::new(InChunk::from_raw(value_ptr).into_slice::<T>(len)))
     }
 
     /// DST form of [`Self::try_alloc_arc_value`]. The caller writes metadata
@@ -554,8 +684,9 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
     ///
     /// # Safety
     ///
-    /// The caller must transfer ownership of exactly `refund` unused
-    /// pre-credited references in addition to the mutator's owned `+1`.
+    /// For a non-empty mutator, the caller must transfer ownership of exactly
+    /// `refund` unused pre-credited references in addition to the mutator's
+    /// owned `+1`. An empty mutator is a no-op.
     #[inline]
     pub(crate) unsafe fn release_with_refund(self, refund: usize) {
         let Some(chunk) = self.chunk else {
@@ -655,6 +786,33 @@ mod tests {
     fn free_bytes_on_empty_mutator_is_zero() {
         let m = empty_mutator();
         assert_eq!(m.free_bytes(), 0);
+    }
+
+    #[test]
+    fn rewind_on_empty_mutator_is_false() {
+        let m = empty_mutator();
+        assert!(!m.rewind());
+    }
+
+    #[test]
+    fn release_with_refund_on_empty_mutator_is_noop() {
+        let m = empty_mutator();
+        // SAFETY: an empty mutator has no references to release and is
+        // documented as a no-op.
+        unsafe { m.release_with_refund(0) };
+    }
+
+    #[test]
+    fn rewind_restores_full_chunk_capacity() {
+        let arena = crate::Arena::builder().with_capacity(1024).build();
+        let _ = arena.alloc(0_u8);
+        let m = arena.current();
+        let after_prime = m.free_bytes();
+        let _ = m.try_alloc_bytes(16).unwrap();
+        assert_eq!(m.free_bytes(), after_prime - 16);
+
+        assert!(m.rewind());
+        assert!(m.free_bytes() > after_prime);
     }
 
     #[test]

--- a/crates/multitude/src/internal/uninit.rs
+++ b/crates/multitude/src/internal/uninit.rs
@@ -13,6 +13,26 @@ use core::{mem, str};
 
 use super::in_chunk::InChunk;
 
+const FIXED_COPY_BYTES: usize = 64;
+
+/// Copies one cache-line-sized region without a dynamic `memcpy` dispatch.
+///
+/// # Safety
+///
+/// `dst` and `src` must be valid for [`FIXED_COPY_BYTES`] non-overlapping
+/// bytes.
+//
+// Keeping this out of line is deliberate: when LLVM inlined the fixed copy
+// beside the dynamic fallback, it merged both paths back into libc `memcpy`.
+// The isolated fixed-size body compiles to inline vector moves.
+#[inline(never)]
+unsafe fn copy_fixed_bytes_nonoverlapping(src: *const u8, dst: *mut u8) {
+    // SAFETY: the caller guarantees both regions cover `FIXED_COPY_BYTES`.
+    unsafe {
+        ptr::copy_nonoverlapping(src.cast::<[u8; FIXED_COPY_BYTES]>(), dst.cast::<[u8; FIXED_COPY_BYTES]>(), 1);
+    }
+}
+
 /// Copies bytes into non-overlapping storage, inlining common short lengths
 /// instead of dispatching to dynamic `memcpy`.
 ///
@@ -157,7 +177,9 @@ impl<'a, T> Uninit<'a, [T]> {
         // provenance (no narrow `&mut [T]` retag).
         unsafe {
             let dst = slice_ptr.as_ptr().cast::<T>();
-            if const { mem::size_of::<T>() == 1 } {
+            if mem::size_of_val(src) == FIXED_COPY_BYTES {
+                copy_fixed_bytes_nonoverlapping(src.as_ptr().cast(), dst.cast());
+            } else if const { mem::size_of::<T>() == 1 } {
                 copy_bytes_nonoverlapping(src.as_ptr().cast(), dst.cast(), len);
             } else {
                 ptr::copy_nonoverlapping(src.as_ptr(), dst, len);
@@ -177,12 +199,52 @@ impl<'a, T> Uninit<'a, [T]> {
     where
         T: Clone,
     {
-        debug_assert_eq!(
-            src.len(),
-            self.ptr.as_non_null().len(),
-            "init_clone_from_slice: source length must match reservation"
-        );
-        self.init_with(|i| src[i].clone())
+        let slice_ptr = self.ptr.as_non_null();
+        let len = slice_ptr.len();
+        debug_assert_eq!(src.len(), len, "init_clone_from_slice: source length must match reservation");
+        // Keep fixed clone sites visible to LLVM. A conventional iterator
+        // loop made it coalesce each short trivial slice into an out-of-line
+        // `memcpy`; this shape instead produced inline vector copies in
+        // disassembly while the guard preserves panic cleanup.
+        // SAFETY: `dst` has `len` uninitialized `T` slots, `src` has the same
+        // length, and the guard drops exactly the initialized prefix on panic.
+        unsafe {
+            let dst = slice_ptr.as_ptr().cast::<T>();
+            let mut guard = InitGuard { dst, initialized: 0 };
+            while len - guard.initialized >= 8 {
+                let index = guard.initialized;
+                dst.add(index).write((*src.as_ptr().add(index)).clone());
+                guard.initialized += 1;
+                let index = guard.initialized;
+                dst.add(index).write((*src.as_ptr().add(index)).clone());
+                guard.initialized += 1;
+                let index = guard.initialized;
+                dst.add(index).write((*src.as_ptr().add(index)).clone());
+                guard.initialized += 1;
+                let index = guard.initialized;
+                dst.add(index).write((*src.as_ptr().add(index)).clone());
+                guard.initialized += 1;
+                let index = guard.initialized;
+                dst.add(index).write((*src.as_ptr().add(index)).clone());
+                guard.initialized += 1;
+                let index = guard.initialized;
+                dst.add(index).write((*src.as_ptr().add(index)).clone());
+                guard.initialized += 1;
+                let index = guard.initialized;
+                dst.add(index).write((*src.as_ptr().add(index)).clone());
+                guard.initialized += 1;
+                let index = guard.initialized;
+                dst.add(index).write((*src.as_ptr().add(index)).clone());
+                guard.initialized += 1;
+            }
+            for value in &src[guard.initialized..] {
+                let index = guard.initialized;
+                dst.add(index).write(value.clone());
+                guard.initialized += 1;
+            }
+            mem::forget(guard);
+            core::slice::from_raw_parts_mut(dst, len)
+        }
     }
 
     /// Initializes the reserved slice by calling `f(i)` for each index

--- a/crates/multitude/tests/alloc_ref.rs
+++ b/crates/multitude/tests/alloc_ref.rs
@@ -98,18 +98,47 @@ fn alloc_slice_copy_mutable() {
 #[test]
 fn alloc_slice_clone_works() {
     let arena = Arena::new();
-    let originals = [
-        std::string::String::from("a"),
-        std::string::String::from("b"),
-        std::string::String::from("c"),
-    ];
+    let originals: [std::string::String; 9] = std::array::from_fn(|i| i.to_string());
     let mut s = arena.alloc_slice_clone(&originals);
-    assert_eq!(s.len(), 3);
-    assert_eq!(s[0], "a");
+    assert_eq!(s.len(), 9);
+    assert_eq!(s[0], "0");
+    assert_eq!(s[8], "8");
     s[0].push('!');
-    assert_eq!(s[0], "a!");
+    assert_eq!(s[0], "0!");
     // Originals untouched.
-    assert_eq!(originals[0], "a");
+    assert_eq!(originals[0], "0");
+}
+
+#[test]
+fn alloc_slice_clone_clones_each_unrolled_source_once() {
+    #[derive(Debug)]
+    struct CloneOnce {
+        value: usize,
+        cloned: std::rc::Rc<std::cell::Cell<bool>>,
+    }
+
+    impl Clone for CloneOnce {
+        fn clone(&self) -> Self {
+            assert!(!self.cloned.replace(true), "source element cloned more than once");
+            Self {
+                value: self.value,
+                cloned: std::rc::Rc::clone(&self.cloned),
+            }
+        }
+    }
+
+    let arena = Arena::new();
+    let originals: [CloneOnce; 9] = std::array::from_fn(|value| CloneOnce {
+        value,
+        cloned: std::rc::Rc::new(std::cell::Cell::new(false)),
+    });
+
+    let cloned = arena.alloc_slice_clone(&originals);
+
+    for (index, value) in cloned.iter().enumerate() {
+        assert_eq!(value.value, index);
+    }
+    assert!(originals.iter().all(|value| value.cloned.get()));
 }
 
 #[test]
@@ -254,9 +283,9 @@ fn alloc_charges_stats() {
 /// across the active `current_*` chunks plus any chunks that have
 /// been retired from a `current_*` slot but not yet cached or
 /// destroyed. It must be zero on a fresh arena (no chunks held at
-/// all), and return to zero after `reset` releases every chunk back
-/// to the cache / underlying allocator (which leaves the arena with
-/// the empty-mutator sentinels, contributing 0 slack each).
+/// all), and return to zero after `reset` clears retired chunks and
+/// marks a retained, rewound current chunk inactive for the new
+/// generation.
 #[cfg(feature = "stats")]
 #[test]
 fn wasted_tail_bytes_is_live_and_returns_to_zero_after_reset() {
@@ -273,14 +302,13 @@ fn wasted_tail_bytes_is_live_and_returns_to_zero_after_reset() {
         "active chunk's free tail must contribute to wasted_tail_bytes",
     );
     arena.reset();
-    // After reset every chunk has been released (either cached or
-    // destroyed). `current_*` are reset to empty-mutator sentinels
-    // which contribute 0 slack.
+    // After reset every retired chunk has been released. The current chunk is
+    // retained and rewound but remains inactive until the next allocation, so
+    // it contributes no live-generation slack.
     assert_eq!(
         arena.stats().wasted_tail_bytes,
         0,
-        "reset returned every chunk and reinstalled the empty sentinel; \
-         wasted-tail must be zero again",
+        "reset must clear prior-generation wasted-tail accounting",
     );
 }
 
@@ -357,8 +385,8 @@ fn wasted_tail_bytes_is_held_by_outstanding_arc() {
 /// current chunk is full, the old mutator is pushed
 /// into `retired_local` (which keeps a `+1` for the duration of the
 /// `&Arena` borrow). The wasted tail of every retired chunk must be
-/// counted; `reset` releases every retired chunk back to the cache
-/// and the counter must return cleanly to zero.
+/// counted; `reset` releases every retired chunk back to the cache,
+/// rewinds the current chunk, and returns the counter cleanly to zero.
 #[cfg(feature = "stats")]
 #[test]
 fn wasted_tail_grows_on_local_refill_and_clears_on_reset() {
@@ -410,8 +438,7 @@ fn wasted_tail_grows_on_local_refill_and_clears_on_reset() {
     assert_eq!(
         arena.stats().wasted_tail_bytes,
         0,
-        "reset must release every chunk and reinstall the empty sentinels, \
-         taking the gauge back to zero",
+        "reset must release retired chunks and mark the rewound current inactive",
     );
 }
 
@@ -445,28 +472,25 @@ fn wasted_tail_returns_to_exactly_baseline_across_full_cycle() {
     }
 }
 
-/// Cache-reuse must not leak: a chunk that's cached on reset, then
-/// re-acquired in the next epoch, then re-retired must contribute its
-/// new wasted tail (not the stale stashed value from the previous
-/// epoch, and not double-counted).
+/// Reuse must not leak: retired chunks cached on reset and a retained current
+/// chunk must contribute only their current generation's wasted tail.
 #[cfg(feature = "stats")]
 #[test]
 fn wasted_tail_correct_after_cache_reuse_cycles() {
     let mut arena = Arena::new();
     let mut acquired_chunks_total = 0u64;
     for _ in 0..8 {
-        // Force at least one full chunk's worth of allocs so we cycle
-        // through `current` AND populate the cache on reset.
+        // Force enough allocs to cycle through `current`; reset caches retired
+        // chunks and rewinds the final current chunk.
         for _ in 0..64 {
             let _ = arena.alloc(0);
         }
         let stats = arena.stats();
         acquired_chunks_total = stats.normal_chunks_allocated;
         arena.reset();
-        // After every reset the counter must be 0 — even though the
-        // chunk's `wasted_at_retire` field still holds the previous
-        // value, the subtract at cache-push consumed it exactly once,
-        // and the next epoch's retire will re-set + re-add.
+        // After every reset the counter must be 0. Cache publication consumes
+        // retired waste exactly once and the retained current is inactive
+        // until the next allocation.
         assert_eq!(arena.stats().wasted_tail_bytes, 0, "cache reuse leaked into wasted-tail counter");
     }
     // Sanity: we actually exercised real allocations, not a no-op.

--- a/crates/multitude/tests/arena.rs
+++ b/crates/multitude/tests/arena.rs
@@ -216,8 +216,8 @@ fn arena_stats_report_cache_reuse_and_resets() {
 
     arena.reset();
     let reset = arena.stats();
-    assert_eq!(reset.cached_chunks, 1);
-    assert_eq!(reset.cached_bytes, 64 * 1024);
+    assert_eq!(reset.cached_chunks, 0);
+    assert_eq!(reset.cached_bytes, 0);
     assert_eq!(reset.resets, 1);
     assert_eq!(reset.normal_chunks_allocated_since_reset, 0);
     assert_eq!(reset.oversized_chunks_allocated_since_reset, 0);
@@ -228,8 +228,8 @@ fn arena_stats_report_cache_reuse_and_resets() {
     let value = arena.alloc(2_u64);
     drop(value);
     let reused = arena.stats();
-    assert_eq!(reused.normal_chunks_reused, 2);
-    assert_eq!(reused.normal_chunks_reused_since_reset, 1);
+    assert_eq!(reused.normal_chunks_reused, 1);
+    assert_eq!(reused.normal_chunks_reused_since_reset, 0);
 }
 
 #[cfg(feature = "stats")]
@@ -444,7 +444,6 @@ mod reset {
 
     use multitude::{Arc, Arena};
 
-    #[expect(unused_imports, reason = "common helpers are feature-dependent")]
     use crate::common;
 
     #[test]
@@ -501,11 +500,10 @@ mod reset {
 
     #[cfg(feature = "stats")]
     #[test]
-    fn reset_returns_chunks_to_cache_and_avoids_fresh_alloc() {
-        // Seed the high-water mark to the largest class up front so the
-        // chunk that backs our single allocation isn't evicted from the
-        // cache when it returns (the high-water filter requires
-        // `cap >= class_to_bytes(high_water)`).
+    fn reset_retains_local_current_and_avoids_fresh_alloc() {
+        // Use the largest class so a regression that returns the current
+        // chunk would leave it visible in the cache instead of evicting it
+        // through the high-water filter.
         let mut arena = Arena::builder().with_capacity(64 * 1024).build();
         let _ = arena.alloc(0_u64);
 
@@ -516,13 +514,44 @@ mod reset {
 
         let stats_after_reset = arena.stats();
         assert_eq!(stats_after_reset.normal_chunks_allocated, stats_before.normal_chunks_allocated);
+        assert_eq!(stats_after_reset.cached_chunks, 0, "the rewound current chunk stays installed");
 
         let _ = arena.alloc(1_u64);
         let stats_after_realloc = arena.stats();
         assert_eq!(
             stats_after_realloc.normal_chunks_allocated, stats_before.normal_chunks_allocated,
-            "reset should not allocate a fresh chunk; cache reuse expected"
+            "reset should retain the current chunk instead of allocating a fresh one"
         );
+        assert_eq!(
+            stats_after_realloc.normal_chunks_reused, stats_before.normal_chunks_reused,
+            "allocating after reset must not need a cache pop"
+        );
+    }
+
+    #[test]
+    fn reset_preserves_smart_owner_from_retired_mixed_chunk() {
+        let allocator = common::SendTrackingAllocator::new();
+        let mut arena = Arena::builder_in(allocator.clone()).with_capacity(512).build();
+
+        drop(arena.alloc(0_u8));
+        let escaped = arena.alloc_arc(0xABCD_u32);
+        drop(arena.alloc([0_u8; 1024]));
+        assert_eq!(allocator.live_chunks(), 2, "the larger allocation must rotate the mixed chunk");
+
+        arena.reset();
+
+        assert_eq!(*escaped, 0xABCD);
+        assert_eq!(
+            allocator.live_chunks(),
+            2,
+            "reset must release only the retired list's reference while the Arc is live"
+        );
+
+        drop(arena);
+        assert_eq!(*escaped, 0xABCD);
+        assert_eq!(allocator.live_chunks(), 1);
+        drop(escaped);
+        assert_eq!(allocator.live_chunks(), 0);
     }
 
     #[cfg(feature = "stats")]
@@ -542,13 +571,13 @@ mod reset {
     }
 
     #[test]
-    fn reset_clears_byte_budget_for_cached_chunks() {
+    fn reset_reuses_current_chunk_with_tight_byte_budget() {
         // Tight budget: only one chunk worth.
         let mut arena: Arena = Arena::builder().byte_budget(8 * 1024).build();
 
         let _ = arena.alloc(0_u8); // forces fresh chunk allocation
         arena.reset();
-        // Should be able to allocate again from the cached chunk without
+        // Should be able to allocate again from the retained chunk without
         // tripping the budget.
         let _ = arena.alloc(1_u8);
     }
@@ -559,7 +588,7 @@ mod reset {
         // Allocate a couple of near-max_normal_alloc buffers to put the
         // (class-7, 64 KiB) starter chunk into use. `MaybeUninit<[u8;
         // 4000]>` skips per-byte init; a couple of them is enough to
-        // exercise the reset→cache→reuse path without a long alloc loop.
+        // exercise the reset-and-rewind path without a long alloc loop.
         let mut arena: Arena = Arena::builder().max_normal_alloc(4 * 1024).with_capacity(64 * 1024).build();
         for _ in 0..2 {
             let _ = arena.alloc(core::mem::MaybeUninit::<[u8; 4000]>::uninit());
@@ -1256,6 +1285,13 @@ mod fast_path_correctness {
     }
 
     #[test]
+    fn alloc_slice_copy_cache_line_preserves_contents() {
+        let arena = Arena::new();
+        let src = [0_u64, 1, 2, 3, 4, 5, 6, 7];
+        assert_eq!(&*arena.alloc_slice_copy(src), &src);
+    }
+
+    #[test]
     fn alloc_u128_is_aligned() {
         let arena = Arena::new();
         for _ in 0..100 {
@@ -1613,6 +1649,25 @@ mod fast_path_correctness {
         fn drop(&mut self) {
             let _ = DROP_COUNTER.fetch_add(1, Ordering::SeqCst);
         }
+    }
+
+    #[test]
+    fn slice_clone_panic_drops_unrolled_and_tail_prefix() {
+        let _lock = DROP_TEST_LOCK.lock().unwrap();
+        DROP_COUNTER.store(0, Ordering::SeqCst);
+        let src: Vec<_> = (0..11).map(|id| PanicOnClone { id, panic_at: 9 }).collect();
+        let arena = Arena::new();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = arena.alloc_slice_clone(&src);
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(
+            DROP_COUNTER.load(Ordering::SeqCst),
+            9,
+            "all successful clones from the eight-wide block and tail must be dropped"
+        );
     }
 }
 
@@ -2968,7 +3023,7 @@ mod oversized_routing {
         assert_eq!(v.capacity(), v.len(), "Vec strictly below max_normal_alloc must reclaim tail");
     }
 
-    // The cache floor preserves reusable saturated-class chunks after reset.
+    // The saturated current chunk remains reusable after reset.
     #[test]
     fn local_cache_floor_advances_so_post_reset_alloc_reuses_chunk() {
         let mut arena = Arena::new();
@@ -2980,7 +3035,7 @@ mod oversized_routing {
         }
         let before_reset = arena.stats().normal_chunks_allocated;
         arena.reset();
-        // Reset caches only chunks at or above the saturated floor.
+        // Reset retains and rewinds the saturated current chunk.
         let _ = arena.alloc(0_u8);
         let after_reset = arena.stats().normal_chunks_allocated;
         assert!(


### PR DESCRIPTION
## Summary

- make Criterion and Callgrind comparisons measure identical, warmed, allocation-free Multitude and Bumpalo hot paths
- optimize arena reset, reference marking, fixed copies, clone initialization, and known-length iterator allocation
- add repeatable same-process reporting and reset regressions, update the performance report, and bump `multitude` to 0.8.1

The updated report has Multitude ahead on scalar allocation, slice copy/clone, iterator fill, and growable string/vector scenarios; the two remaining scenarios are within 4% of Bumpalo.

## Validation

- `cargo clippy -p multitude --profile dev --all-targets --all-features --locked`
- `cargo test -p multitude --locked --all-features --test arena reset::reset_preserves_smart_owner_from_retired_mixed_chunk`
- package formatting, README generation, and spellcheck
