### PR TITLE
perf(ci): cut the PR Miri step from 3h16m to about 1h15m

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,7 +357,15 @@ jobs:
         run: cargo +${{ env.RUST_NIGHTLY }} careful nextest run --all-features --workspace ${{ needs.delta.outputs.exclude_not_affected }} --color always --target ${{ matrix.target }}
       - name: Miri (stacked borrows)
         if: success() || failure()
-        run: cargo +${{ env.RUST_NIGHTLY }} miri test --all-features --workspace ${{ needs.delta.outputs.exclude_not_affected }} --lib --tests
+        # The `*_macros_impl` crates are proc-macro implementation crates: they
+        # manipulate token streams and contain no `unsafe`, so Miri has no
+        # aliasing or provenance violations to find in them. Their tests are
+        # snapshot comparisons of generated token streams, and any `unsafe` they
+        # *emit* is executed -- and therefore checked by Miri -- in the consuming
+        # crate's own tests, which are still covered here. Interpreting them
+        # anyway cost ~52 min of the ~3h16m step (multitude_macros_impl alone ran
+        # 30 tests in 45 min), so they are excluded to keep PR feedback usable.
+        run: cargo +${{ env.RUST_NIGHTLY }} miri test --all-features --workspace ${{ needs.delta.outputs.exclude_not_affected }} --exclude data_privacy_macros_impl --exclude fundle_macros_impl --exclude internity_macros_impl --exclude multitude_macros_impl --exclude templated_uri_macros_impl --exclude thread_aware_macros_impl --lib --tests
 
   model-checking:
     if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.delta.outputs.skip != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,15 +357,28 @@ jobs:
         run: cargo +${{ env.RUST_NIGHTLY }} careful nextest run --all-features --workspace ${{ needs.delta.outputs.exclude_not_affected }} --color always --target ${{ matrix.target }}
       - name: Miri (stacked borrows)
         if: success() || failure()
-        # The `*_macros_impl` crates are proc-macro implementation crates: they
-        # manipulate token streams and contain no `unsafe`, so Miri has no
-        # aliasing or provenance violations to find in them. Their tests are
-        # snapshot comparisons of generated token streams, and any `unsafe` they
-        # *emit* is executed -- and therefore checked by Miri -- in the consuming
-        # crate's own tests, which are still covered here. Interpreting them
-        # anyway cost ~52 min of the ~3h16m step (multitude_macros_impl alone ran
-        # 30 tests in 45 min), so they are excluded to keep PR feedback usable.
-        run: cargo +${{ env.RUST_NIGHTLY }} miri test --all-features --workspace ${{ needs.delta.outputs.exclude_not_affected }} --exclude data_privacy_macros_impl --exclude fundle_macros_impl --exclude internity_macros_impl --exclude multitude_macros_impl --exclude templated_uri_macros_impl --exclude thread_aware_macros_impl --lib --tests
+        # Excluded crates generate code rather than run it, so Miri has no
+        # aliasing or provenance violations to find in them:
+        #
+        #   * the `*_macros_impl` crates are proc-macro implementations whose
+        #     tests are snapshot comparisons of generated token streams;
+        #   * `routerama_build` is a build-time generator. Its only runtime
+        #     component, the `trie` module, is used by `routerama` (which depends
+        #     on it with `default-features = false`) and is therefore still
+        #     interpreted by Miri through `routerama`'s own tests.
+        #
+        # Any `unsafe` these crates *emit* -- for example `data_privacy_macros_impl`
+        # emitting `str::from_utf8_unchecked` -- is executed, and so checked, in
+        # the consuming crate's tests, which remain in this run.
+        #
+        # Interpreting them anyway cost ~75 min of the ~3h16m step
+        # (`multitude_macros_impl` alone ran 30 tests in 45 min).
+        #
+        # Note `rest_over_grpc` is deliberately NOT excluded: its build half is
+        # already `#[cfg_attr(miri, ignore)]`, and the tests that do run cover the
+        # runtime transcoding path over `bytes`/`hyper`, which is exactly the kind
+        # of buffer handling Miri needs to check.
+        run: cargo +${{ env.RUST_NIGHTLY }} miri test --all-features --workspace ${{ needs.delta.outputs.exclude_not_affected }} --exclude data_privacy_macros_impl --exclude fundle_macros_impl --exclude internity_macros_impl --exclude multitude_macros_impl --exclude routerama_build --exclude templated_uri_macros_impl --exclude thread_aware_macros_impl --lib --tests
 
   model-checking:
     if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.delta.outputs.skip != 'true'

--- a/crates/internity/tests/basic.rs
+++ b/crates/internity/tests/basic.rs
@@ -595,6 +595,14 @@ fn freeze_races_writer_and_stays_prefix_consistent() {
     use std::collections::BTreeSet;
     use std::sync::mpsc;
 
+    // The properties under test are structural -- a freeze snapshot must be a
+    // prefix, never a cross-shard tear -- so they hold at any size, provided the
+    // count still spans several shards. The polling loop below re-freezes and
+    // walks the whole lexicon on every iteration, so the cost grows faster than
+    // linearly under Miri; 256 keeps multi-shard coverage at a fraction of it.
+    #[cfg(miri)]
+    const COUNT: usize = 256;
+    #[cfg(not(miri))]
     const COUNT: usize = 4096;
     const MID: usize = COUNT / 2;
 

--- a/crates/routerama/tests/dynamic_parity.rs
+++ b/crates/routerama/tests/dynamic_parity.rs
@@ -301,11 +301,11 @@ fn dynamic_agrees_with_static_over_a_generated_path_space() {
     // but under Miri it re-interprets the same few resolver code paths tens of
     // thousands of times for no additional aliasing coverage, so cap the depth.
     #[cfg(miri)]
-    let (max_depth, min_checked) = (2, 800);
+    let max_depth = 2;
     #[cfg(not(miri))]
-    let (max_depth, min_checked) = (4, 50_000);
+    let max_depth = 4;
 
-    let mut checked = 0_u64;
+    let mut checked = 0_usize;
     for method in methods {
         for depth in 0..=max_depth {
             let mut indices = vec![0_usize; depth];
@@ -364,7 +364,19 @@ fn dynamic_agrees_with_static_over_a_generated_path_space() {
             }
         }
     }
-    assert!(checked > min_checked, "expected a large path space, checked {checked}");
+    // Each method walks one path per index combination of every length up to
+    // `max_depth`, and each path is checked once per verb, so the size of the
+    // sweep follows from the arrays above. Asserting the exact figure rather
+    // than a hand-tuned floor keeps the guard correct if those arrays are edited
+    // later, and catches an early exit in the odometer above that a floor misses.
+    let paths: usize = std::iter::successors(Some(1_usize), |combinations| Some(combinations * segments.len()))
+        .take(max_depth + 1)
+        .sum();
+    assert_eq!(
+        checked,
+        paths * methods.len() * verbs.len(),
+        "generated path space was not enumerated in full"
+    );
 }
 
 fn exotic_resolver() -> ExoticRouteResolver {

--- a/crates/routerama/tests/dynamic_parity.rs
+++ b/crates/routerama/tests/dynamic_parity.rs
@@ -296,9 +296,18 @@ fn dynamic_agrees_with_static_over_a_generated_path_space() {
     let methods = ["GET", "POST", "DELETE"];
     let verbs = ["", ":archive", ":other"];
 
+    // The path space grows as `segments.len() ^ depth`, so depth 4 enumerates
+    // 7_381 paths and ~66_000 request checks. That breadth is worth it natively,
+    // but under Miri it re-interprets the same few resolver code paths tens of
+    // thousands of times for no additional aliasing coverage, so cap the depth.
+    #[cfg(miri)]
+    let (max_depth, min_checked) = (2, 800);
+    #[cfg(not(miri))]
+    let (max_depth, min_checked) = (4, 50_000);
+
     let mut checked = 0_u64;
     for method in methods {
-        for depth in 0..=4 {
+        for depth in 0..=max_depth {
             let mut indices = vec![0_usize; depth];
             loop {
                 let mut path = String::new();
@@ -355,7 +364,7 @@ fn dynamic_agrees_with_static_over_a_generated_path_space() {
             }
         }
     }
-    assert!(checked > 50_000, "expected a large path space, checked {checked}");
+    assert!(checked > min_checked, "expected a large path space, checked {checked}");
 }
 
 fn exotic_resolver() -> ExoticRouteResolver {


### PR DESCRIPTION
## Problem

The `Miri (stacked borrows)` step in `extended-analysis` took **3h16m** (07:39 → 10:55) on [run 32003005645](https://github.com/microsoft/oxidizer/actions/runs/32003005645/job/95315406903), on each of the four OS matrix legs. Every other step in that job totals about 10 minutes.

For reference, the same workspace runs 6700 tests in **65s** natively under `cargo nextest`. Nothing here is inherently slow — the cost is Miri interpreting specific work.

Parsing the job log shows the time is highly concentrated: of 252 test targets, five accounted for 75% of the step, and the long tail of 240 targets shared about 1300s.

| secs | crate | target | tests |
|-----:|-------|--------|------:|
| 2695 | `multitude_macros_impl` | lib unittests | 30 |
| 2009 | `internity` | `tests/basic.rs` | 52 |
| 1815 | `rest_over_grpc` | lib unittests | 171 (+77 ignored) |
| 1631 | `routerama` | `tests/dynamic_parity.rs` | 8 |
| 1385 | `routerama_build` | lib unittests | 135 |

## Changes

Each change removes time that was buying no additional checking, and none of them weaken a native run.

**1. Exclude code-generating crates from the PR Miri run.** The six `*_macros_impl` crates plus `routerama_build` generate code rather than run it; they contain no `unsafe`, and their tests compare generated token streams. Any `unsafe` they *emit* (for example `data_privacy_macros_impl` emitting `str::from_utf8_unchecked`) is executed, and therefore checked, in the consuming crate's tests, which remain in the run. `routerama_build`'s one runtime module, `trie`, likewise keeps full coverage: `routerama` depends on it with `default-features = false` and drives `trie::{build_trie, Trie, Leaf, Node, VarPlan}` from its resolver, walk and match paths.

**2. Bound two combinatorial test loops under Miri.** Both do repetitive work that adds breadth natively but no aliasing coverage under Miri.

`routerama::dynamic_parity` enumerates a path space growing as `segments.len() ^ depth`; depth 4 is 7381 paths and ~66 000 request checks against the same handful of resolver paths. Capped at depth 2 under Miri (819 checks, still covering every route shape, capture and verb form).

`internity::freeze_races_writer_and_stays_prefix_consistent` interned 4096 strings while a second thread repeatedly froze and walked the whole lexicon, so cost grew faster than linearly. Its assertions — a snapshot is always a prefix, never a cross-shard tear — are structural and hold at any size spanning several shards, so 256 is used under Miri.

## Effects

| change | before | after |
|---|---:|---:|
| 6 × `*_macros_impl` excluded | 3129s | 0 |
| `routerama_build` excluded | 1385s | 0 |
| `routerama` `dynamic_parity` | 1631s | 24s |
| `internity` `basic` | 2009s | 305s |

- The step should drop from about 3h16m to about 1h15m, a reduction of roughly 62%, on each of the four matrix legs.
- Native test runs are unchanged and keep their full breadth: 52 and 8 tests pass in 0.58s and 0.44s.
- Miri no longer checks the excluded crates on PRs. The nightly Miri workflows (tree-borrows, strict-provenance, race-coverage) are untouched and still run the full workspace.
- `dynamic_parity` and the `internity` freeze test explore a smaller space under Miri, so a violation reachable only at greater depth or higher string counts would not be caught on a PR.

## Considered and rejected

`rest_over_grpc` is the largest remaining target at 1815s and was deliberately left in. Its build half is already `#[cfg_attr(miri, ignore)]` — those are the 77 ignored tests in the run above — so the 171 tests that actually execute are the runtime transcoding path in `transcode/`, `stream.rs` and `http_response.rs`, layered over `bytes` and `hyper`. That is exactly the buffer handling Miri exists to check, so excluding it would trade real coverage for speed.

## Validation

- `cargo miri test -p routerama --test dynamic_parity` → 8/8 pass in 24s (was 1631s)
- `cargo miri test -p internity --test basic` → 48/48 pass in 305s (was 2009s)
- `cargo test` native → 52/52 and 8/8 pass
- Both `cfg(miri)` branches type-check under `RUSTFLAGS=--cfg miri`
- `cargo clippy --tests -D warnings` clean for both crates
- rustfmt clean against `rustfmt.toml` and `unstable-rustfmt.toml`
- All seven excluded package names resolve in `cargo metadata`

Miri timings were measured on Windows; `internity` gates four thread tests behind `cfg(not(all(miri, windows)))`, so its Linux CI figure will be somewhat above 305s.
