### PR TITLE
fix(rest_over_grpc_examples): rename the duplicate `tower_service` example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,11 @@ jobs:
         run: cargo hack build --each-feature --workspace ${{ needs.delta.outputs.exclude_not_affected }} --verbose --locked --color always
       - name: Tests
         if: success() || failure()
-        run: cargo nextest run --verbose --workspace ${{ needs.delta.outputs.exclude_not_affected }} --all-features
+        # --no-tests=pass: the crate selection here is narrowed by `delta` to the
+        # affected crates, so a PR that only touches crates without test targets
+        # (docs, examples) legitimately selects zero tests. Without this, nextest
+        # treats that as an error and exits 4.
+        run: cargo nextest run --verbose --workspace ${{ needs.delta.outputs.exclude_not_affected }} --all-features --no-tests=pass
       - name: Docs
         if: success() || failure()
         env:
@@ -354,7 +358,8 @@ jobs:
           cargo +${{ env.RUST_NIGHTLY }} udeps --locked --all-features --all-targets --workspace ${{ needs.delta.outputs.exclude_not_affected }} --color always
       - name: Careful
         if: success() || failure()
-        run: cargo +${{ env.RUST_NIGHTLY }} careful nextest run --all-features --workspace ${{ needs.delta.outputs.exclude_not_affected }} --color always --target ${{ matrix.target }}
+        # --no-tests=pass: see the `testing` job's Tests step.
+        run: cargo +${{ env.RUST_NIGHTLY }} careful nextest run --all-features --workspace ${{ needs.delta.outputs.exclude_not_affected }} --color always --target ${{ matrix.target }} --no-tests=pass
       - name: Miri (stacked borrows)
         if: success() || failure()
         run: cargo +${{ env.RUST_NIGHTLY }} miri test --all-features --workspace ${{ needs.delta.outputs.exclude_not_affected }} --lib --tests

--- a/crates/rest_over_grpc_examples/Cargo.toml
+++ b/crates/rest_over_grpc_examples/Cargo.toml
@@ -69,8 +69,8 @@ workspace = true
 # --- serving-layer examples ---
 
 [[example]]
-name = "tower_service"
-path = "examples/serving/tower_service.rs"
+name = "generated_tower_service"
+path = "examples/serving/generated_tower_service.rs"
 
 [[example]]
 name = "axum_app"

--- a/crates/rest_over_grpc_examples/README.md
+++ b/crates/rest_over_grpc_examples/README.md
@@ -22,7 +22,7 @@ See [`build.rs`](build.rs) for generation and
 |---|---|
 | Call a generated transcoder directly | [`basic_transcode`](examples/transcoding/basic_transcode.rs) |
 | Add custom routes and fallback behavior | [`custom_fallback`](examples/transcoding/custom_fallback.rs) |
-| Mount a generated service in Tower | [`tower_service`](examples/serving/tower_service.rs) |
+| Mount a generated service in Tower | [`generated_tower_service`](examples/serving/generated_tower_service.rs) |
 | Mount it in Axum and return neutral responses from handlers | [`axum_app`](examples/serving/axum_app.rs) |
 | Observe server-streamed response frames | [`streaming_response`](examples/serving/streaming_response.rs) |
 | Enforce custom content-type and body-size policy | [`custom_body_handling`](examples/serving/custom_body_handling.rs) |

--- a/crates/rest_over_grpc_examples/examples/serving/generated_tower_service.rs
+++ b/crates/rest_over_grpc_examples/examples/serving/generated_tower_service.rs
@@ -13,7 +13,7 @@
 //! Run with:
 //!
 //! ```text
-//! cargo run -p rest_over_grpc_examples --example tower_service
+//! cargo run -p rest_over_grpc_examples --example generated_tower_service
 //! ```
 
 use bytes::Bytes;

--- a/crates/rest_over_grpc_examples/src/lib.rs
+++ b/crates/rest_over_grpc_examples/src/lib.rs
@@ -28,7 +28,8 @@
 //! layer they exercise:
 //!
 //! - `examples/serving/` — getting requests on and off the network
-//!   (`tower_service`, `axum_app`, `streaming_response`, `custom_body_handling`).
+//!   (`generated_tower_service`, `axum_app`, `streaming_response`,
+//!   `custom_body_handling`).
 //! - `examples/transcoding/` — calling the transcoder (`basic_transcode`,
 //!   `custom_fallback`).
 //! - `examples/handling/` — supplying the service logic (`direct_service`,


### PR DESCRIPTION
Two packages declared an example target named `tower_service`: `rest_over_grpc` (autoexample, `required-features = ["tower"]`) and `rest_over_grpc_examples` (explicit `[[example]]`). Cargo warned about an output filename collision on both `tower_service.exe` and its `.pdb`, then built the two targets concurrently into that one path.

On Windows the resulting `link.exe` race is fatal — `anvil-examples` failed with `LNK1104: cannot open file ...\examples\tower_service.exe` on an unrelated PR. On Linux and macOS the same race silently overwrote the binary, so only the Windows leg surfaced it. Cargo also warns the collision "may become a hard error in the future" (rust-lang/cargo#6313).

Rename the target in `rest_over_grpc_examples` (`publish = false`) to `generated_tower_service`, which also states what distinguishes it: it serves the generated tonic-bridged `Transcoder`, whereas the `rest_over_grpc` example wraps a hand-written one. The published crate's example name is unchanged.

`cargo build --workspace --examples --all-features --locked` now completes with no filename-collision warning anywhere in the workspace.

---

## Also: unblock CI for test-less affected sets

The first commit made this PR the first one whose affected crate set is a single crate with no test targets, which exposed a pre-existing CI bug. `delta` reported `Modified 1 / Affected 1`, so the `testing` job's `Tests` step ran effectively as `-p rest_over_grpc_examples`. That crate has no test targets, so:

```
Starting 0 tests across 1 binary
Summary [0.000s] 0 tests run: 0 passed, 0 skipped
error: no tests to run
(hint: use `--no-tests` to customize)
```

`cargo nextest run` exits 4 and all four `testing` legs fail, even though nothing is wrong. The condition predates the rename — `rest_over_grpc_examples` had no test targets on `main` either, so any docs- or examples-only PR would hit this.

The second commit passes `--no-tests=pass` on the two nextest runs whose crate selection is delta-narrowed (`testing` → `Tests`, `extended-analysis` → `Careful`), so an empty selection is a pass rather than an error.

The `Serde negative contract` run is deliberately left alone: it pins `-p internity -E 'binary(compile_fail)'` with no delta narrowing, so zero tests there really would mean the filter had stopped matching, and should still fail.

Verified on the pinned nextest 0.9.137: the command above exits 4, and exits 0 with `--no-tests=pass`.