### PR TITLE
docs(ohno): document transparent sources and how to model multiple failures

### DIFF
--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -139,6 +139,134 @@ name. Unlike `thiserror`, neither the `self.` prefix nor the leading-dot form is
 |`self.path.display()`|no, the `self.` prefix is implicit|
 |`.path.display()`|no, not a valid expression|
 
+### Without `#[display]`
+
+When no `#[display]` override is given, the rendered message depends on whether the error
+has a source.
+
+**With a source, the source’s message is printed verbatim** — no type name, and no
+`caused by:` line — while [`source()`][__link11] still returns the concrete
+error. This is the direct equivalent of `thiserror`’s `#[error(transparent)]`, and it is what
+makes the abstract-wrapper shape described in
+[Modelling Multiple Failure Conditions](#modelling-multiple-failure-conditions) viable.
+
+```rust
+#[ohno::error]
+pub struct StorageError;
+
+let error = StorageError::caused_by("disk is full");
+
+// The wrapper contributes no text of its own.
+assert_eq!(error.to_string(), "disk is full");
+```
+
+**Without a source, the bare type name is printed.** The two cases are one `#[from]` apart, so
+a wrapper that is accidentally constructed without a source renders as `Error: StorageError`
+rather than a message:
+
+```rust
+#[ohno::error]
+pub struct StorageError;
+
+let error = StorageError::new();
+
+assert_eq!(error.to_string(), "StorageError");
+```
+
+Apply [`#[no_constructors]`](#automatic-constructors) to every transparent wrapper to make
+sourceless construction unrepresentable, rather than relying on review to catch it.
+
+One further caveat: because each ohno error carries its own [`OhnoCore`][__link12], a chain of
+transparent wrappers emits one backtrace block per level when backtrace capture is enabled.
+A two-level wrapper prints two blocks under `RUST_BACKTRACE=1`. This is inherent to
+per-type cores rather than a property of the transparent shape itself.
+
+## Modelling Multiple Failure Conditions
+
+`#[derive(Error)]` rejects enums, because [`OhnoCore`][__link13] has to live somewhere and a per-variant
+core would be meaningless. This is the first question most people arriving from `thiserror`
+have, since its headline pattern is an enum with one variant per failure condition.
+
+There are two workable shapes. The deciding question is: **does anything actually branch on
+the category?**
+
+### Abstract wrapper — nothing branches on the category
+
+Prefer this shape. A fieldless error type with `#[from(..)]` over concrete per-condition error
+types, relying on the transparent passthrough described
+[above](#without-display) so the wrapper adds no text of its own:
+
+```rust
+use ohno::ErrorExt as _;
+
+#[ohno::error]
+pub struct ParseError;
+
+#[ohno::error]
+pub struct TimeoutError;
+
+#[ohno::error]
+#[derive(Default)]
+#[from(ParseError, TimeoutError)]
+pub struct RequestError;
+
+let error: RequestError = ParseError::caused_by("unexpected token").into();
+
+// The wrapper is transparent: the leaf's message is what users see.
+assert_eq!(error.to_string(), "unexpected token");
+
+// A caller that does need to discriminate can still recover the concrete type.
+assert!(error.find_source::<ParseError>().is_some());
+assert!(error.find_source::<TimeoutError>().is_none());
+```
+
+### Kind field — production code branches on the category
+
+One struct carrying a plain kind enum, a `#[display("{kind}")]` override, and a `kind()`
+accessor:
+
+```rust
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RequestErrorKind {
+    Parse,
+    Timeout,
+}
+
+impl fmt::Display for RequestErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse => f.write_str("request could not be parsed"),
+            Self::Timeout => f.write_str("request timed out"),
+        }
+    }
+}
+
+#[ohno::error]
+#[display("{kind}")]
+pub struct RequestError {
+    kind: RequestErrorKind,
+}
+
+impl RequestError {
+    #[must_use]
+    pub fn kind(&self) -> RequestErrorKind {
+        self.kind
+    }
+}
+
+let error = RequestError::new(RequestErrorKind::Timeout);
+
+assert_eq!(error.kind(), RequestErrorKind::Timeout);
+assert_eq!(error.to_string(), "request timed out");
+```
+
+Adopting ohno across nine crates, the abstract wrapper was the right shape almost everywhere,
+and the kind field was used exactly once — in the single case where production code actually
+branched on the category. Reach for the kind field only when that is true; matching on a
+category nothing consumes just adds a public enum to maintain.
+
 ## Automatic Constructors
 
 By default, `#[derive(Error)]` automatically generates `new()` and `caused_by()` constructor methods:
@@ -220,15 +348,15 @@ let my_err: MyError = io_err.into(); // Works automatically
 
 ## Error Enrichment
 
-The [`#[enrich_err("message")]`][__link11] attribute macro adds error enrichment with file and line info to function errors.
+The [`#[enrich_err("message")]`][__link14] attribute macro adds error enrichment with file and line info to function errors.
 
-Functions annotated with [`#[enrich_err("message")]`][__link12] automatically wrap any returned `Result`. If
+Functions annotated with [`#[enrich_err("message")]`][__link15] automatically wrap any returned `Result`. If
 the function returns an error, the macro injects a message, including file and line information, into the error chain.
 
 **Requirements:**
 
 * The function must return a type that implements the `map_err` method (such as `Result` or `Poll`)
-* The error type must implement the [`Enrichable`][__link13] trait (automatically implemented for all ohno error types)
+* The error type must implement the [`Enrichable`][__link16] trait (automatically implemented for all ohno error types)
 
 **Supported syntax patterns:**
 
@@ -284,10 +412,10 @@ fn open_file(path: &str) -> Result<String, MyError> {
 
 ## AppError
 
-For applications that need a simple, catch-all error type, use [`AppError`][__link14]. It
+For applications that need a simple, catch-all error type, use [`AppError`][__link17]. It
 automatically captures backtraces and can wrap any error type.
 
-To avoid accidental usage in libraries, [`AppError`][__link15] is only available when the `app-err`
+To avoid accidental usage in libraries, [`AppError`][__link18] is only available when the `app-err`
 feature is enabled.
 
 Example usage:
@@ -303,7 +431,7 @@ fn process() -> Result<(), AppError> {
 
 ## Error Labeling
 
-[`ErrorLabel`][__link16] is a low-cardinality string label for errors, intended for use as a metric
+[`ErrorLabel`][__link19] is a low-cardinality string label for errors, intended for use as a metric
 tag or structured log field. Labels must be chosen from a small, bounded set known at
 development time to avoid high-cardinality metric series.
 
@@ -317,7 +445,7 @@ let label = ErrorLabel::from_parts(["http", "client", "timeout"]);
 assert_eq!(label, "http.client.timeout");
 ```
 
-Use [`ErrorLabel::from_error_chain`][__link17] to walk an error’s [`source`][__link18]
+Use [`ErrorLabel::from_error_chain`][__link20] to walk an error’s [`source`][__link21]
 chain and build a dotted label from recognized errors:
 
 ```rust
@@ -331,8 +459,8 @@ let label = ErrorLabel::from_error_chain(&io_err, |e| {
 assert_eq!(label, "connection_refused");
 ```
 
-Types that carry an [`ErrorLabel`][__link19] can implement the [`Labeled`][__link20] trait to expose it
-uniformly via [`Labeled::label`][__link21].
+Types that carry an [`ErrorLabel`][__link22] can implement the [`Labeled`][__link23] trait to expose it
+uniformly via [`Labeled::label`][__link24].
 
 
 <hr/>
@@ -340,22 +468,25 @@ uniformly via [`Labeled::label`][__link21].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbv-Hzd015wccb3QHVUUNfzdYbgkSSUDnsKTUbn3uKf5ryHu1hZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbxrtgMzSQtLobG_YdBTen9vQbiTdbxoFbwvsb-UfheR5PhZFhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
  [__link0]: https://doc.rust-lang.org/stable/std/?search=fmt::Display
  [__link1]: https://doc.rust-lang.org/stable/std/?search=fmt::Debug
  [__link10]: https://doc.rust-lang.org/stable/std/macro.unreachable.html
- [__link11]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
- [__link12]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
- [__link13]: https://docs.rs/ohno/0.4.0/ohno/?search=Enrichable
- [__link14]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
- [__link15]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
- [__link16]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
- [__link17]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel::from_error_chain
- [__link18]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
+ [__link11]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
+ [__link12]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
+ [__link13]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
+ [__link14]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
+ [__link15]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
+ [__link16]: https://docs.rs/ohno/0.4.0/ohno/?search=Enrichable
+ [__link17]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
+ [__link18]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
  [__link19]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
  [__link2]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorExt
- [__link20]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled
- [__link21]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled::label
+ [__link20]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel::from_error_chain
+ [__link21]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
+ [__link22]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
+ [__link23]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled
+ [__link24]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled::label
  [__link3]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
  [__link4]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
  [__link5]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore

--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -148,16 +148,18 @@ has a source.
 `caused by:` line — while [`source()`][__link11] still returns the concrete
 error. This is the direct equivalent of `thiserror`’s `#[error(transparent)]`, and it is what
 makes the abstract-wrapper shape described in
-[Modelling Multiple Failure Conditions](#modelling-multiple-failure-conditions) viable.
+[Modeling Multiple Failure Conditions](#modeling-multiple-failure-conditions) viable.
 
 ```rust
+use ohno::assert_error_message;
+
 #[ohno::error]
 pub struct StorageError;
 
 let error = StorageError::caused_by("disk is full");
 
 // The wrapper contributes no text of its own.
-assert_eq!(error.to_string(), "disk is full");
+assert_error_message!(error, "disk is full");
 ```
 
 **Without a source, the bare type name is printed.** The two cases are one `#[from]` apart, so
@@ -165,23 +167,25 @@ a wrapper that is accidentally constructed without a source renders as `Error: S
 rather than a message:
 
 ```rust
+use ohno::assert_error_message;
+
 #[ohno::error]
 pub struct StorageError;
 
 let error = StorageError::new();
 
-assert_eq!(error.to_string(), "StorageError");
+assert_error_message!(error, "StorageError");
 ```
 
-Apply [`#[no_constructors]`](#automatic-constructors) to every transparent wrapper to make
-sourceless construction unrepresentable, rather than relying on review to catch it.
+Apply [`#[no_constructors]`](#automatic-constructors) to every transparent wrapper so that a
+wrapper with no source cannot be built at all, rather than relying on review to catch it.
 
 One further caveat: because each ohno error carries its own [`OhnoCore`][__link12], a chain of
 transparent wrappers emits one backtrace block per level when backtrace capture is enabled.
 A two-level wrapper prints two blocks under `RUST_BACKTRACE=1`. This is inherent to
 per-type cores rather than a property of the transparent shape itself.
 
-## Modelling Multiple Failure Conditions
+## Modeling Multiple Failure Conditions
 
 `#[derive(Error)]` rejects enums, because [`OhnoCore`][__link13] has to live somewhere and a per-variant
 core would be meaningless. This is the first question most people arriving from `thiserror`
@@ -197,7 +201,7 @@ types, relying on the transparent passthrough described
 [above](#without-display) so the wrapper adds no text of its own:
 
 ```rust
-use ohno::ErrorExt as _;
+use ohno::{ErrorExt as _, assert_error_message};
 
 #[ohno::error]
 pub struct ParseError;
@@ -213,7 +217,7 @@ pub struct RequestError;
 let error: RequestError = ParseError::caused_by("unexpected token").into();
 
 // The wrapper is transparent: the leaf's message is what users see.
-assert_eq!(error.to_string(), "unexpected token");
+assert_error_message!(error, "unexpected token");
 
 // A caller that does need to discriminate can still recover the concrete type.
 assert!(error.find_source::<ParseError>().is_some());
@@ -227,6 +231,8 @@ accessor:
 
 ```rust
 use std::fmt;
+
+use ohno::assert_error_message;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RequestErrorKind {
@@ -259,7 +265,7 @@ impl RequestError {
 let error = RequestError::new(RequestErrorKind::Timeout);
 
 assert_eq!(error.kind(), RequestErrorKind::Timeout);
-assert_eq!(error.to_string(), "request timed out");
+assert_error_message!(error, "request timed out");
 ```
 
 Adopting ohno across nine crates, the abstract wrapper was the right shape almost everywhere,
@@ -468,7 +474,7 @@ uniformly via [`Labeled::label`][__link24].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbxrtgMzSQtLobG_YdBTen9vQbiTdbxoFbwvsb-UfheR5PhZFhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQb6AB-xE0kPw0bH5ofcQampBgbM4OxvEk7l6UbbJqe5GnscZxhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
  [__link0]: https://doc.rust-lang.org/stable/std/?search=fmt::Display
  [__link1]: https://doc.rust-lang.org/stable/std/?search=fmt::Debug
  [__link10]: https://doc.rust-lang.org/stable/std/macro.unreachable.html

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -134,6 +134,134 @@
 //! | `self.path.display()` | no, the `self.` prefix is implicit |
 //! | `.path.display()` | no, not a valid expression |
 //!
+//! ## Without `#[display]`
+//!
+//! When no `#[display]` override is given, the rendered message depends on whether the error
+//! has a source.
+//!
+//! **With a source, the source's message is printed verbatim** — no type name, and no
+//! `caused by:` line — while [`source()`](std::error::Error::source) still returns the concrete
+//! error. This is the direct equivalent of `thiserror`'s `#[error(transparent)]`, and it is what
+//! makes the abstract-wrapper shape described in
+//! [Modelling Multiple Failure Conditions](#modelling-multiple-failure-conditions) viable.
+//!
+//! ```rust
+//! #[ohno::error]
+//! pub struct StorageError;
+//!
+//! let error = StorageError::caused_by("disk is full");
+//!
+//! // The wrapper contributes no text of its own.
+//! assert_eq!(error.to_string(), "disk is full");
+//! ```
+//!
+//! **Without a source, the bare type name is printed.** The two cases are one `#[from]` apart, so
+//! a wrapper that is accidentally constructed without a source renders as `Error: StorageError`
+//! rather than a message:
+//!
+//! ```rust
+//! #[ohno::error]
+//! pub struct StorageError;
+//!
+//! let error = StorageError::new();
+//!
+//! assert_eq!(error.to_string(), "StorageError");
+//! ```
+//!
+//! Apply [`#[no_constructors]`](#automatic-constructors) to every transparent wrapper to make
+//! sourceless construction unrepresentable, rather than relying on review to catch it.
+//!
+//! One further caveat: because each ohno error carries its own [`OhnoCore`], a chain of
+//! transparent wrappers emits one backtrace block per level when backtrace capture is enabled.
+//! A two-level wrapper prints two blocks under `RUST_BACKTRACE=1`. This is inherent to
+//! per-type cores rather than a property of the transparent shape itself.
+//!
+//! # Modelling Multiple Failure Conditions
+//!
+//! `#[derive(Error)]` rejects enums, because [`OhnoCore`] has to live somewhere and a per-variant
+//! core would be meaningless. This is the first question most people arriving from `thiserror`
+//! have, since its headline pattern is an enum with one variant per failure condition.
+//!
+//! There are two workable shapes. The deciding question is: **does anything actually branch on
+//! the category?**
+//!
+//! ## Abstract wrapper — nothing branches on the category
+//!
+//! Prefer this shape. A fieldless error type with `#[from(..)]` over concrete per-condition error
+//! types, relying on the transparent passthrough described
+//! [above](#without-display) so the wrapper adds no text of its own:
+//!
+//! ```rust
+//! use ohno::ErrorExt as _;
+//!
+//! #[ohno::error]
+//! pub struct ParseError;
+//!
+//! #[ohno::error]
+//! pub struct TimeoutError;
+//!
+//! #[ohno::error]
+//! #[derive(Default)]
+//! #[from(ParseError, TimeoutError)]
+//! pub struct RequestError;
+//!
+//! let error: RequestError = ParseError::caused_by("unexpected token").into();
+//!
+//! // The wrapper is transparent: the leaf's message is what users see.
+//! assert_eq!(error.to_string(), "unexpected token");
+//!
+//! // A caller that does need to discriminate can still recover the concrete type.
+//! assert!(error.find_source::<ParseError>().is_some());
+//! assert!(error.find_source::<TimeoutError>().is_none());
+//! ```
+//!
+//! ## Kind field — production code branches on the category
+//!
+//! One struct carrying a plain kind enum, a `#[display("{kind}")]` override, and a `kind()`
+//! accessor:
+//!
+//! ```rust
+//! use std::fmt;
+//!
+//! #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+//! pub enum RequestErrorKind {
+//!     Parse,
+//!     Timeout,
+//! }
+//!
+//! impl fmt::Display for RequestErrorKind {
+//!     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//!         match self {
+//!             Self::Parse => f.write_str("request could not be parsed"),
+//!             Self::Timeout => f.write_str("request timed out"),
+//!         }
+//!     }
+//! }
+//!
+//! #[ohno::error]
+//! #[display("{kind}")]
+//! pub struct RequestError {
+//!     kind: RequestErrorKind,
+//! }
+//!
+//! impl RequestError {
+//!     #[must_use]
+//!     pub fn kind(&self) -> RequestErrorKind {
+//!         self.kind
+//!     }
+//! }
+//!
+//! let error = RequestError::new(RequestErrorKind::Timeout);
+//!
+//! assert_eq!(error.kind(), RequestErrorKind::Timeout);
+//! assert_eq!(error.to_string(), "request timed out");
+//! ```
+//!
+//! Adopting ohno across nine crates, the abstract wrapper was the right shape almost everywhere,
+//! and the kind field was used exactly once — in the single case where production code actually
+//! branched on the category. Reach for the kind field only when that is true; matching on a
+//! category nothing consumes just adds a public enum to maintain.
+//!
 //! # Automatic Constructors
 //!
 //! By default, `#[derive(Error)]` automatically generates `new()` and `caused_by()` constructor methods:

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -143,16 +143,22 @@
 //! `caused by:` line — while [`source()`](std::error::Error::source) still returns the concrete
 //! error. This is the direct equivalent of `thiserror`'s `#[error(transparent)]`, and it is what
 //! makes the abstract-wrapper shape described in
-//! [Modelling Multiple Failure Conditions](#modelling-multiple-failure-conditions) viable.
+//! [Modeling Multiple Failure Conditions](#modeling-multiple-failure-conditions) viable.
 //!
 //! ```rust
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
+//! use ohno::assert_error_message;
+//!
 //! #[ohno::error]
 //! pub struct StorageError;
 //!
 //! let error = StorageError::caused_by("disk is full");
 //!
 //! // The wrapper contributes no text of its own.
-//! assert_eq!(error.to_string(), "disk is full");
+//! assert_error_message!(error, "disk is full");
+//! # }
+//! # }
 //! ```
 //!
 //! **Without a source, the bare type name is printed.** The two cases are one `#[from]` apart, so
@@ -160,23 +166,29 @@
 //! rather than a message:
 //!
 //! ```rust
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
+//! use ohno::assert_error_message;
+//!
 //! #[ohno::error]
 //! pub struct StorageError;
 //!
 //! let error = StorageError::new();
 //!
-//! assert_eq!(error.to_string(), "StorageError");
+//! assert_error_message!(error, "StorageError");
+//! # }
+//! # }
 //! ```
 //!
-//! Apply [`#[no_constructors]`](#automatic-constructors) to every transparent wrapper to make
-//! sourceless construction unrepresentable, rather than relying on review to catch it.
+//! Apply [`#[no_constructors]`](#automatic-constructors) to every transparent wrapper so that a
+//! wrapper with no source cannot be built at all, rather than relying on review to catch it.
 //!
 //! One further caveat: because each ohno error carries its own [`OhnoCore`], a chain of
 //! transparent wrappers emits one backtrace block per level when backtrace capture is enabled.
 //! A two-level wrapper prints two blocks under `RUST_BACKTRACE=1`. This is inherent to
 //! per-type cores rather than a property of the transparent shape itself.
 //!
-//! # Modelling Multiple Failure Conditions
+//! # Modeling Multiple Failure Conditions
 //!
 //! `#[derive(Error)]` rejects enums, because [`OhnoCore`] has to live somewhere and a per-variant
 //! core would be meaningless. This is the first question most people arriving from `thiserror`
@@ -192,7 +204,9 @@
 //! [above](#without-display) so the wrapper adds no text of its own:
 //!
 //! ```rust
-//! use ohno::ErrorExt as _;
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
+//! use ohno::{ErrorExt as _, assert_error_message};
 //!
 //! #[ohno::error]
 //! pub struct ParseError;
@@ -208,11 +222,13 @@
 //! let error: RequestError = ParseError::caused_by("unexpected token").into();
 //!
 //! // The wrapper is transparent: the leaf's message is what users see.
-//! assert_eq!(error.to_string(), "unexpected token");
+//! assert_error_message!(error, "unexpected token");
 //!
 //! // A caller that does need to discriminate can still recover the concrete type.
 //! assert!(error.find_source::<ParseError>().is_some());
 //! assert!(error.find_source::<TimeoutError>().is_none());
+//! # }
+//! # }
 //! ```
 //!
 //! ## Kind field — production code branches on the category
@@ -221,7 +237,11 @@
 //! accessor:
 //!
 //! ```rust
+//! # fn main() {
+//! # #[cfg(feature = "test-util")] {
 //! use std::fmt;
+//!
+//! use ohno::assert_error_message;
 //!
 //! #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 //! pub enum RequestErrorKind {
@@ -254,7 +274,9 @@
 //! let error = RequestError::new(RequestErrorKind::Timeout);
 //!
 //! assert_eq!(error.kind(), RequestErrorKind::Timeout);
-//! assert_eq!(error.to_string(), "request timed out");
+//! assert_error_message!(error, "request timed out");
+//! # }
+//! # }
 //! ```
 //!
 //! Adopting ohno across nine crates, the abstract wrapper was the right shape almost everywhere,


### PR DESCRIPTION
&#x1F916; This description was written by an AI agent.

## Problem

Two documentation gaps, both hit immediately by anyone migrating from `thiserror`.

**Display without a `#[display]` override.** The docs stated only that the type
name is used as the default message. That describes the sourceless case and
gives the opposite impression for the case that matters more. With a source,
`Display` prints exactly the source's message — no type name, no `caused by:`
line — while `source()` still returns the concrete error
(`src/core.rs:225`). That is the direct equivalent of `thiserror`'s
`#[error(transparent)]`, and it is what makes the abstract-wrapper shape viable
at all. Nothing said so.

The sourceless case deserves a warning next to it, because the two are one
`#[from]` apart: a wrapper with no `#[display]` and no source renders as the bare
type name, so a user sees `Error: StorageError` rather than a message.

**Modelling multiple failure conditions.** `#[derive(Error)]` rejects enums,
which is understandable — `OhnoCore` has to live somewhere and a per-variant core
would be meaningless — but it is the first question a `thiserror` user asks,
since its headline pattern is an enum with one variant per failure condition.
Neither the README nor the rustdoc answered it. The two workable shapes existed
only as tribal knowledge; the kind-field shape was hinted at in the macro's own
rustdoc and used in `examples/from_attribute.rs`, but was never named as a
recommended pattern or contrasted with the alternative.

## Change

Adds two sections to the crate-level documentation.

`Without #[display]` documents both arms of the behaviour, cross-references
`#[error(transparent)]` for readers arriving from `thiserror`, warns about the
sourceless case, and points at `#[no_constructors]` as the way to make sourceless
construction unrepresentable. It also records the caveat that because each ohno
error carries its own `OhnoCore`, a chain of transparent wrappers emits one
backtrace block per level under `RUST_BACKTRACE=1`.

`Modelling Multiple Failure Conditions` covers both shapes and leads with the
question that decides between them — does anything actually branch on the
category? The abstract wrapper is presented first, as the one that is almost
always right; the kind field is documented as the exception for when production
code genuinely branches.

## Validation

```text
cargo test --doc -p ohno --all-features   40 passed, 0 failed
just package=ohno clippy                  clean
just package=ohno format                  no changes
```

Every added example is a runnable doctest that asserts the rendered output rather
than describing it, so the documented behaviour cannot drift from the
implementation. The assertions pin the three claims that were previously
undocumented or wrong:

```rust
assert_eq!(StorageError::caused_by("disk is full").to_string(), "disk is full");
assert_eq!(StorageError::new().to_string(), "StorageError");
assert!(error.find_source::<ParseError>().is_some());
```

`crates/ohno/README.md` is regenerated, since it is produced from these doc
comments by `just readme`.

## Reviewer notes

Running `just readme` locally also rewrote four unrelated READMEs
(`allocation_hints`, `rallocator`, `rallocator_telemetry`, `rallocator_wire`).
The only change in each was the `__cargo_doc2readme_dependencies_info` blob,
which is stale on `main` and unrelated to this work, so I reverted them. They are
worth regenerating separately.

Note that this required installing `cargo-doc2readme` 0.7.2 to match
`CARGO_DOC2README_VERSION` in `constants.env`; a newer 0.7.3 rewrites that blob in
every crate in the workspace.

The pre-existing doctest failure for the `AppError` example when the `app-err`
feature is off is unchanged by this pull request and reproduces on `main`.

Tracked by work items 7675160 and 7675161.
