### PR TITLE
docs(ohno): document how error text is rendered

### DIFF
--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -46,8 +46,7 @@ fn open_file(path: impl AsRef<Path>) -> Result<String, ConfigError> {
 
 Derive macro for automatically implementing error traits.
 
-When applied to a struct or enum containing an [`OhnoCore`][__link5] field,
-this macro automatically implements [`std::error::Error`][__link6], [`std::fmt::Display`][__link7], [`std::fmt::Debug`][__link8], and [`From`][__link9] conversions.
+When applied to a struct containing an [`OhnoCore`][__link5] field, this macro automatically implements [`std::error::Error`][__link6], [`std::fmt::Display`][__link7], [`std::fmt::Debug`][__link8], and [`From`][__link9] conversions.
 
  > 
  > **Note**: `From<std::convert::Infallible>` is implemented by default and calls via [`unreachable!`][__link10] macro.
@@ -143,8 +142,9 @@ that it needs either a cause or a template.
 
 ### Enrichment and backtraces
 
-The message is only the first line of what `Display` writes. Each enrichment entry follows it
-on its own line, marked with `>` and tagged with the place it was added:
+The message is only the first part of what `Display` writes — with a template and a cause it is
+already two lines. Each enrichment entry follows it on its own line, marked with `>` and tagged
+with the place it was added:
 
 ```rust
 use std::io;
@@ -167,7 +167,7 @@ println!("{error}");
 //         > failed to load the service configuration (at src/config.rs:6)
 ```
 
-A captured backtrace comes last, after any enrichment:
+A captured backtrace comes last for that level, after that level’s enrichment:
 
 ```text
 no such file: /etc/app.toml
@@ -182,12 +182,15 @@ Backtrace:
    ...
 ```
 
-A backtrace is captured only when `RUST_BACKTRACE` asks for one. Use
-[`ErrorExt::message()`][__link12] to read the message on its own.
+Capture is the standard library’s decision: a backtrace is taken only when `RUST_LIB_BACKTRACE`
+asks for one, or when `RUST_BACKTRACE` does and `RUST_LIB_BACKTRACE` is unset. Use
+[`ErrorExt::message()`][__link12] to read the message without the backtrace.
 
 Every error owns its [`OhnoCore`][__link13], and every core renders its own backtrace, so a chain of
 wrappers that all use the default rendering prints the message once and one backtrace block per
-level:
+level. The levels are written in turn, innermost first — a wrapper’s own enrichment and
+backtrace follow the complete rendering of the level it wraps, so an outer enrichment entry
+appears *after* the inner level’s `Backtrace:` block, not alongside the other enrichment:
 
 ```text
 no such file: /etc/app.toml
@@ -457,7 +460,7 @@ uniformly via [`Labeled::label`][__link25].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbytrpabsE8xobjqG9axpJ2FMbPtKXWLOg3e8bzFvTXkcI6oFhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbNR5mLV9Kcl8bZv6w7esxE5UbZsOYl4G8UygbmNzvN7_GkWxhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
  [__link0]: https://doc.rust-lang.org/stable/std/?search=fmt::Display
  [__link1]: https://doc.rust-lang.org/stable/std/?search=fmt::Debug
  [__link10]: https://doc.rust-lang.org/stable/std/macro.unreachable.html

--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -92,13 +92,13 @@ pub struct NetworkError {
 ## How error text is rendered
 
 Without a `#[display("...")]` attribute, the text an error renders depends on whether it has a
-source.
+cause — an error or a string handed to `caused_by`.
 
-**With a source**, the source’s message is printed as it stands: no type name, and no
+**With a cause**, the cause’s message is printed as it stands: no type name, and no
 `caused by:` line, so the wrapper leaves no trace in the message line. Enrichment and a
 backtrace, described below, are still written after it.
-[`source()`][__link11] still returns the concrete error, so a caller that
-walks the chain still finds it.
+A cause that is an error also stays in the [`source()`][__link11] chain, so a
+caller that walks the chain still finds it.
 
 ```rust
 use std::io;
@@ -126,7 +126,7 @@ Wrapping therefore adds nothing to the text. A wrapper that should say what it w
 “failed to load the configuration”, say — has to be given a template; see
 [Overriding error text](#overriding-error-text).
 
-**Without a source**, there is no message to pass through, so the type’s own name is printed:
+**Without a cause**, there is no message to pass through, so the type’s own name is printed:
 
 ```rust
 #[ohno::error]
@@ -139,7 +139,7 @@ println!("{error}");
 ```
 
 That is a symbol, not an explanation, so an error that renders as its own bare name is a sign
-that it needs either a source or a template.
+that it needs either a cause or a template.
 
 ### Enrichment and backtraces
 
@@ -186,7 +186,8 @@ A backtrace is captured only when `RUST_BACKTRACE` asks for one. Use
 [`ErrorExt::message()`][__link12] to read the message on its own.
 
 Every error owns its [`OhnoCore`][__link13], and every core renders its own backtrace, so a chain of
-wrappers prints the message once and one backtrace block per level:
+wrappers that all use the default rendering prints the message once and one backtrace block per
+level:
 
 ```text
 no such file: /etc/app.toml
@@ -456,7 +457,7 @@ uniformly via [`Labeled::label`][__link25].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbF7t022SddTAbMru5KrO1GBsbj6WlvWEqJMgbKR_mg0kL5sxhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbytrpabsE8xobjqG9axpJ2FMbPtKXWLOg3e8bzFvTXkcI6oFhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
  [__link0]: https://doc.rust-lang.org/stable/std/?search=fmt::Display
  [__link1]: https://doc.rust-lang.org/stable/std/?search=fmt::Debug
  [__link10]: https://doc.rust-lang.org/stable/std/macro.unreachable.html

--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -182,11 +182,12 @@ Backtrace:
    ...
 ```
 
-Capture is the standard library’s decision: a backtrace is taken only when `RUST_LIB_BACKTRACE`
-asks for one, or when `RUST_BACKTRACE` does and `RUST_LIB_BACKTRACE` is unset. Use
-[`ErrorExt::message()`][__link12] to read the message without the backtrace.
+Whether a backtrace is captured at all is the standard library’s decision — see its
+[environment variables][__link12].
+Use [`ErrorExt::message()`][__link13] to read the message without this level’s own
+backtrace.
 
-Every error owns its [`OhnoCore`][__link13], and every core renders its own backtrace, so a chain of
+Every error owns its [`OhnoCore`][__link14], and every core renders its own backtrace, so a chain of
 wrappers that all use the default rendering prints the message once and one backtrace block per
 level. The levels are written in turn, innermost first — a wrapper’s own enrichment and
 backtrace follow the complete rendering of the level it wraps, so an outer enrichment entry
@@ -209,7 +210,7 @@ several layers deep.
 
 The `#[display("...")]` attribute replaces the rendered message with a template of its own,
 while still printing the cause after it. A cause that is an error also stays in the
-[`source()`][__link14] chain; a cause given as a string is printed the same way
+[`source()`][__link15] chain; a cause given as a string is printed the same way
 but does not join the chain, exactly as under the default rendering.
 
 ```rust
@@ -340,15 +341,15 @@ let my_err: MyError = io_err.into(); // Works automatically
 
 ## Error Enrichment
 
-The [`#[enrich_err("message")]`][__link15] attribute macro adds error enrichment with file and line info to function errors.
+The [`#[enrich_err("message")]`][__link16] attribute macro adds error enrichment with file and line info to function errors.
 
-Functions annotated with [`#[enrich_err("message")]`][__link16] automatically wrap any returned `Result`. If
+Functions annotated with [`#[enrich_err("message")]`][__link17] automatically wrap any returned `Result`. If
 the function returns an error, the macro injects a message, including file and line information, into the error chain.
 
 **Requirements:**
 
 * The function must return a type that implements the `map_err` method (such as `Result` or `Poll`)
-* The error type must implement the [`Enrichable`][__link17] trait (automatically implemented for all ohno error types)
+* The error type must implement the [`Enrichable`][__link18] trait (automatically implemented for all ohno error types)
 
 **Supported syntax patterns:**
 
@@ -404,10 +405,10 @@ fn open_file(path: &str) -> Result<String, MyError> {
 
 ## AppError
 
-For applications that need a simple, catch-all error type, use [`AppError`][__link18]. It
+For applications that need a simple, catch-all error type, use [`AppError`][__link19]. It
 automatically captures backtraces and can wrap any error type.
 
-To avoid accidental usage in libraries, [`AppError`][__link19] is only available when the `app-err`
+To avoid accidental usage in libraries, [`AppError`][__link20] is only available when the `app-err`
 feature is enabled.
 
 Example usage:
@@ -423,7 +424,7 @@ fn process() -> Result<(), AppError> {
 
 ## Error Labeling
 
-[`ErrorLabel`][__link20] is a low-cardinality string label for errors, intended for use as a metric
+[`ErrorLabel`][__link21] is a low-cardinality string label for errors, intended for use as a metric
 tag or structured log field. Labels must be chosen from a small, bounded set known at
 development time to avoid high-cardinality metric series.
 
@@ -437,7 +438,7 @@ let label = ErrorLabel::from_parts(["http", "client", "timeout"]);
 assert_eq!(label, "http.client.timeout");
 ```
 
-Use [`ErrorLabel::from_error_chain`][__link21] to walk an error’s [`source`][__link22]
+Use [`ErrorLabel::from_error_chain`][__link22] to walk an error’s [`source`][__link23]
 chain and build a dotted label from recognized errors:
 
 ```rust
@@ -451,8 +452,8 @@ let label = ErrorLabel::from_error_chain(&io_err, |e| {
 assert_eq!(label, "connection_refused");
 ```
 
-Types that carry an [`ErrorLabel`][__link23] can implement the [`Labeled`][__link24] trait to expose it
-uniformly via [`Labeled::label`][__link25].
+Types that carry an [`ErrorLabel`][__link24] can implement the [`Labeled`][__link25] trait to expose it
+uniformly via [`Labeled::label`][__link26].
 
 
 <hr/>
@@ -460,26 +461,27 @@ uniformly via [`Labeled::label`][__link25].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbNR5mLV9Kcl8bZv6w7esxE5UbZsOYl4G8UygbmNzvN7_GkWxhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbtHHEpUyBxrMbsYdoORGNXOkbIhF5Uyd5i_0bJY_4KBndhUFhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
  [__link0]: https://doc.rust-lang.org/stable/std/?search=fmt::Display
  [__link1]: https://doc.rust-lang.org/stable/std/?search=fmt::Debug
  [__link10]: https://doc.rust-lang.org/stable/std/macro.unreachable.html
  [__link11]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
- [__link12]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorExt::message
- [__link13]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
- [__link14]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
- [__link15]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
+ [__link12]: https://doc.rust-lang.org/std/backtrace/index.html#environment-variables
+ [__link13]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorExt::message
+ [__link14]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
+ [__link15]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
  [__link16]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
- [__link17]: https://docs.rs/ohno/0.4.0/ohno/?search=Enrichable
- [__link18]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
+ [__link17]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
+ [__link18]: https://docs.rs/ohno/0.4.0/ohno/?search=Enrichable
  [__link19]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
  [__link2]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorExt
- [__link20]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
- [__link21]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel::from_error_chain
- [__link22]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
- [__link23]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
- [__link24]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled
- [__link25]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled::label
+ [__link20]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
+ [__link21]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
+ [__link22]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel::from_error_chain
+ [__link23]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
+ [__link24]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
+ [__link25]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled
+ [__link26]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled::label
  [__link3]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
  [__link4]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
  [__link5]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore

--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -89,9 +89,120 @@ pub struct NetworkError {
 }
 ```
 
-## Display Error Override
+## How error text is rendered
 
-The `#[display("...")]` attribute customizes the main error message
+Without a `#[display("...")]` attribute, the text an error renders depends on whether it has a
+source.
+
+**With a source**, the source’s message is printed as it stands: no type name, and no
+`caused by:` line, so the wrapper leaves no trace in the output.
+[`source()`][__link11] still returns the concrete error, so a caller that
+walks the chain still finds it.
+
+```rust
+use std::io;
+
+#[ohno::error]
+pub struct ConfigError;
+
+fn read_config() -> Result<String, ConfigError> {
+    Err(ConfigError::caused_by(io::Error::new(
+        io::ErrorKind::NotFound,
+        "no such file: /etc/app.toml",
+    )))
+}
+
+let error = read_config().unwrap_err();
+
+println!("{error}");
+// Output: no such file: /etc/app.toml
+```
+
+A cause given as a string renders the same way, but it does not join the chain: it is a message
+rather than an error, so `source()` returns `None` for it.
+
+Wrapping therefore adds nothing to the text. A wrapper that should say what it was attempting —
+“failed to load the configuration”, say — has to be given a template; see
+[Overriding error text](#overriding-error-text).
+
+**Without a source**, there is no message to pass through, so the type’s own name is printed:
+
+```rust
+#[ohno::error]
+pub struct ConfigError;
+
+let error = ConfigError::new();
+
+println!("{error}");
+// Output: ConfigError
+```
+
+That is a symbol, not an explanation, so an error that renders as its own bare name is a sign
+that it needs either a source or a template.
+
+### Enrichment and backtraces
+
+The message is only the first line of what `Display` writes. Each enrichment entry follows it
+on its own line, marked with `>` and tagged with the place it was added:
+
+```rust
+use std::io;
+
+#[ohno::error]
+pub struct ConfigError;
+
+#[ohno::enrich_err("failed to load the service configuration")]
+fn read_config() -> Result<String, ConfigError> {
+    Err(ConfigError::caused_by(io::Error::new(
+        io::ErrorKind::NotFound,
+        "no such file: /etc/app.toml",
+    )))
+}
+
+let error = read_config().unwrap_err();
+
+println!("{error}");
+// Output: no such file: /etc/app.toml
+//         > failed to load the service configuration (at src/config.rs:6)
+```
+
+A captured backtrace comes last, after any enrichment:
+
+```text
+no such file: /etc/app.toml
+> failed to load the service configuration (at src/config.rs:6)
+
+Backtrace:
+   0: std::backtrace::Backtrace::capture
+   1: ohno::backtrace::Backtrace::capture
+   2: ohno::core::OhnoCore::from_source
+   3: my_app::config::ConfigError::caused_by
+   4: my_app::config::read_config
+   ...
+```
+
+A backtrace is captured only when `RUST_BACKTRACE` asks for one. Use
+[`ErrorExt::message()`][__link12] to read the message on its own.
+
+Every error owns its [`OhnoCore`][__link13], and every core renders its own backtrace, so a chain of
+wrappers prints the message once and one backtrace block per level:
+
+```text
+no such file: /etc/app.toml
+
+Backtrace:
+   ... frames from where ConfigError wrapped the io::Error ...
+
+Backtrace:
+   ... frames from where StartupError wrapped the ConfigError ...
+```
+
+This follows from each type holding its own core, and is worth knowing before a type is wrapped
+several layers deep.
+
+## Overriding error text
+
+The `#[display("...")]` attribute replaces the rendered message with a template of its own,
 while preserving the underlying error as a cause in the error chain.
 
 ```rust
@@ -109,9 +220,11 @@ let error = ConfigError::caused_by("/etc/config.toml", "file not found");
 // Output: "Failed to read config with path: /etc/config.toml\nCaused by:\n\tfile not found"
 ```
 
-The template string supports field interpolation using `{field_name}` syntax. The underlying
-error (if any) is automatically shown as “Caused by:” in the error chain. If the inner error
-has no source, only the custom message is displayed.
+The template string supports field interpolation using `{field_name}` syntax. Unlike the
+default rendering, the source is never printed on its own: the custom message always leads, and
+the underlying error (if any) follows as “Caused by:” in the error chain. If the error has no
+source, only the custom message is displayed — the type name is never used once a template is
+given.
 
 Fields of a tuple struct are interpolated by index, using `{0}`, `{1}`, and so on.
 
@@ -131,7 +244,7 @@ pub struct ConfigError {
 ```
 
 Positional arguments are implicitly scoped to `self`, so a field is referenced by its bare
-name. Unlike `thiserror`, neither the `self.` prefix nor the leading-dot form is accepted:
+name. Neither the `self.` prefix nor the leading-dot form is accepted:
 
 |Argument|Accepted|
 |--------|--------|
@@ -220,15 +333,15 @@ let my_err: MyError = io_err.into(); // Works automatically
 
 ## Error Enrichment
 
-The [`#[enrich_err("message")]`][__link11] attribute macro adds error enrichment with file and line info to function errors.
+The [`#[enrich_err("message")]`][__link14] attribute macro adds error enrichment with file and line info to function errors.
 
-Functions annotated with [`#[enrich_err("message")]`][__link12] automatically wrap any returned `Result`. If
+Functions annotated with [`#[enrich_err("message")]`][__link15] automatically wrap any returned `Result`. If
 the function returns an error, the macro injects a message, including file and line information, into the error chain.
 
 **Requirements:**
 
 * The function must return a type that implements the `map_err` method (such as `Result` or `Poll`)
-* The error type must implement the [`Enrichable`][__link13] trait (automatically implemented for all ohno error types)
+* The error type must implement the [`Enrichable`][__link16] trait (automatically implemented for all ohno error types)
 
 **Supported syntax patterns:**
 
@@ -284,10 +397,10 @@ fn open_file(path: &str) -> Result<String, MyError> {
 
 ## AppError
 
-For applications that need a simple, catch-all error type, use [`AppError`][__link14]. It
+For applications that need a simple, catch-all error type, use [`AppError`][__link17]. It
 automatically captures backtraces and can wrap any error type.
 
-To avoid accidental usage in libraries, [`AppError`][__link15] is only available when the `app-err`
+To avoid accidental usage in libraries, [`AppError`][__link18] is only available when the `app-err`
 feature is enabled.
 
 Example usage:
@@ -303,7 +416,7 @@ fn process() -> Result<(), AppError> {
 
 ## Error Labeling
 
-[`ErrorLabel`][__link16] is a low-cardinality string label for errors, intended for use as a metric
+[`ErrorLabel`][__link19] is a low-cardinality string label for errors, intended for use as a metric
 tag or structured log field. Labels must be chosen from a small, bounded set known at
 development time to avoid high-cardinality metric series.
 
@@ -317,7 +430,7 @@ let label = ErrorLabel::from_parts(["http", "client", "timeout"]);
 assert_eq!(label, "http.client.timeout");
 ```
 
-Use [`ErrorLabel::from_error_chain`][__link17] to walk an error’s [`source`][__link18]
+Use [`ErrorLabel::from_error_chain`][__link20] to walk an error’s [`source`][__link21]
 chain and build a dotted label from recognized errors:
 
 ```rust
@@ -331,8 +444,8 @@ let label = ErrorLabel::from_error_chain(&io_err, |e| {
 assert_eq!(label, "connection_refused");
 ```
 
-Types that carry an [`ErrorLabel`][__link19] can implement the [`Labeled`][__link20] trait to expose it
-uniformly via [`Labeled::label`][__link21].
+Types that carry an [`ErrorLabel`][__link22] can implement the [`Labeled`][__link23] trait to expose it
+uniformly via [`Labeled::label`][__link24].
 
 
 <hr/>
@@ -340,22 +453,25 @@ uniformly via [`Labeled::label`][__link21].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbv-Hzd015wccb3QHVUUNfzdYbgkSSUDnsKTUbn3uKf5ryHu1hZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbRFaOdtYzD6kbX0jbL0ZTwy4bz8BAwTIXEz0bF5vL5dCQJKFhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
  [__link0]: https://doc.rust-lang.org/stable/std/?search=fmt::Display
  [__link1]: https://doc.rust-lang.org/stable/std/?search=fmt::Debug
  [__link10]: https://doc.rust-lang.org/stable/std/macro.unreachable.html
- [__link11]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
- [__link12]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
- [__link13]: https://docs.rs/ohno/0.4.0/ohno/?search=Enrichable
- [__link14]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
- [__link15]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
- [__link16]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
- [__link17]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel::from_error_chain
- [__link18]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
+ [__link11]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
+ [__link12]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorExt::message
+ [__link13]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
+ [__link14]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
+ [__link15]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
+ [__link16]: https://docs.rs/ohno/0.4.0/ohno/?search=Enrichable
+ [__link17]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
+ [__link18]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
  [__link19]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
  [__link2]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorExt
- [__link20]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled
- [__link21]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled::label
+ [__link20]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel::from_error_chain
+ [__link21]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
+ [__link22]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
+ [__link23]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled
+ [__link24]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled::label
  [__link3]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
  [__link4]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
  [__link5]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore

--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -95,7 +95,8 @@ Without a `#[display("...")]` attribute, the text an error renders depends on wh
 source.
 
 **With a source**, the source’s message is printed as it stands: no type name, and no
-`caused by:` line, so the wrapper leaves no trace in the output.
+`caused by:` line, so the wrapper leaves no trace in the message line. Enrichment and a
+backtrace, described below, are still written after it.
 [`source()`][__link11] still returns the concrete error, so a caller that
 walks the chain still finds it.
 
@@ -217,14 +218,14 @@ pub struct ConfigError {
 // Usage
 let error = ConfigError::caused_by("/etc/config.toml", "file not found");
 
-// Output: "Failed to read config with path: /etc/config.toml\nCaused by:\n\tfile not found"
+// Output: "Failed to read config with path: /etc/config.toml\ncaused by: file not found"
 ```
 
 The template string supports field interpolation using `{field_name}` syntax. Unlike the
 default rendering, the source is never printed on its own: the custom message always leads, and
-the underlying error (if any) follows as “Caused by:” in the error chain. If the error has no
-source, only the custom message is displayed — the type name is never used once a template is
-given.
+the underlying error (if any) follows on the next line, after a `caused by:` label. If the
+error has no source, only the custom message is displayed — the type name is never used once a
+template is given.
 
 Fields of a tuple struct are interpolated by index, using `{0}`, `{1}`, and so on.
 
@@ -453,7 +454,7 @@ uniformly via [`Labeled::label`][__link24].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbRFaOdtYzD6kbX0jbL0ZTwy4bz8BAwTIXEz0bF5vL5dCQJKFhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbWLkNVCrfkmobfrGU4BhKp5kbplL20GaBRk4bv0uMqN1As6phZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
  [__link0]: https://doc.rust-lang.org/stable/std/?search=fmt::Display
  [__link1]: https://doc.rust-lang.org/stable/std/?search=fmt::Debug
  [__link10]: https://doc.rust-lang.org/stable/std/macro.unreachable.html

--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -204,7 +204,9 @@ several layers deep.
 ## Overriding error text
 
 The `#[display("...")]` attribute replaces the rendered message with a template of its own,
-while preserving the underlying error as a cause in the error chain.
+while still printing the cause after it. A cause that is an error also stays in the
+[`source()`][__link14] chain; a cause given as a string is printed the same way
+but does not join the chain, exactly as under the default rendering.
 
 ```rust
 use std::path::PathBuf;
@@ -222,10 +224,10 @@ let error = ConfigError::caused_by("/etc/config.toml", "file not found");
 ```
 
 The template string supports field interpolation using `{field_name}` syntax. Unlike the
-default rendering, the source is never printed on its own: the custom message always leads, and
-the underlying error (if any) follows on the next line, after a `caused by:` label. If the
-error has no source, only the custom message is displayed — the type name is never used once a
-template is given.
+default rendering, the cause is never printed on its own: the custom message always leads, and
+the cause (if any) follows on the next line, after a `caused by:` label. If the error has no
+cause, only the custom message is displayed — the type name is never used once a template is
+given.
 
 Fields of a tuple struct are interpolated by index, using `{0}`, `{1}`, and so on.
 
@@ -334,15 +336,15 @@ let my_err: MyError = io_err.into(); // Works automatically
 
 ## Error Enrichment
 
-The [`#[enrich_err("message")]`][__link14] attribute macro adds error enrichment with file and line info to function errors.
+The [`#[enrich_err("message")]`][__link15] attribute macro adds error enrichment with file and line info to function errors.
 
-Functions annotated with [`#[enrich_err("message")]`][__link15] automatically wrap any returned `Result`. If
+Functions annotated with [`#[enrich_err("message")]`][__link16] automatically wrap any returned `Result`. If
 the function returns an error, the macro injects a message, including file and line information, into the error chain.
 
 **Requirements:**
 
 * The function must return a type that implements the `map_err` method (such as `Result` or `Poll`)
-* The error type must implement the [`Enrichable`][__link16] trait (automatically implemented for all ohno error types)
+* The error type must implement the [`Enrichable`][__link17] trait (automatically implemented for all ohno error types)
 
 **Supported syntax patterns:**
 
@@ -398,10 +400,10 @@ fn open_file(path: &str) -> Result<String, MyError> {
 
 ## AppError
 
-For applications that need a simple, catch-all error type, use [`AppError`][__link17]. It
+For applications that need a simple, catch-all error type, use [`AppError`][__link18]. It
 automatically captures backtraces and can wrap any error type.
 
-To avoid accidental usage in libraries, [`AppError`][__link18] is only available when the `app-err`
+To avoid accidental usage in libraries, [`AppError`][__link19] is only available when the `app-err`
 feature is enabled.
 
 Example usage:
@@ -417,7 +419,7 @@ fn process() -> Result<(), AppError> {
 
 ## Error Labeling
 
-[`ErrorLabel`][__link19] is a low-cardinality string label for errors, intended for use as a metric
+[`ErrorLabel`][__link20] is a low-cardinality string label for errors, intended for use as a metric
 tag or structured log field. Labels must be chosen from a small, bounded set known at
 development time to avoid high-cardinality metric series.
 
@@ -431,7 +433,7 @@ let label = ErrorLabel::from_parts(["http", "client", "timeout"]);
 assert_eq!(label, "http.client.timeout");
 ```
 
-Use [`ErrorLabel::from_error_chain`][__link20] to walk an error’s [`source`][__link21]
+Use [`ErrorLabel::from_error_chain`][__link21] to walk an error’s [`source`][__link22]
 chain and build a dotted label from recognized errors:
 
 ```rust
@@ -445,8 +447,8 @@ let label = ErrorLabel::from_error_chain(&io_err, |e| {
 assert_eq!(label, "connection_refused");
 ```
 
-Types that carry an [`ErrorLabel`][__link22] can implement the [`Labeled`][__link23] trait to expose it
-uniformly via [`Labeled::label`][__link24].
+Types that carry an [`ErrorLabel`][__link23] can implement the [`Labeled`][__link24] trait to expose it
+uniformly via [`Labeled::label`][__link25].
 
 
 <hr/>
@@ -454,25 +456,26 @@ uniformly via [`Labeled::label`][__link24].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbWLkNVCrfkmobfrGU4BhKp5kbplL20GaBRk4bv0uMqN1As6phZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbF7t022SddTAbMru5KrO1GBsbj6WlvWEqJMgbKR_mg0kL5sxhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
  [__link0]: https://doc.rust-lang.org/stable/std/?search=fmt::Display
  [__link1]: https://doc.rust-lang.org/stable/std/?search=fmt::Debug
  [__link10]: https://doc.rust-lang.org/stable/std/macro.unreachable.html
  [__link11]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
  [__link12]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorExt::message
  [__link13]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
- [__link14]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
+ [__link14]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
  [__link15]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
- [__link16]: https://docs.rs/ohno/0.4.0/ohno/?search=Enrichable
- [__link17]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
+ [__link16]: https://docs.rs/ohno_macros/0.4.0/ohno_macros/?search=enrich_err
+ [__link17]: https://docs.rs/ohno/0.4.0/ohno/?search=Enrichable
  [__link18]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
- [__link19]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
+ [__link19]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
  [__link2]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorExt
- [__link20]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel::from_error_chain
- [__link21]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
- [__link22]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
- [__link23]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled
- [__link24]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled::label
+ [__link20]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
+ [__link21]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel::from_error_chain
+ [__link22]: https://doc.rust-lang.org/stable/std/?search=error::Error::source
+ [__link23]: https://docs.rs/ohno/0.4.0/ohno/?search=ErrorLabel
+ [__link24]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled
+ [__link25]: https://docs.rs/ohno/0.4.0/ohno/?search=Labeled::label
  [__link3]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore
  [__link4]: https://docs.rs/ohno/0.4.0/ohno/?search=AppError
  [__link5]: https://docs.rs/ohno/0.4.0/ohno/?search=OhnoCore

--- a/crates/ohno/README.md
+++ b/crates/ohno/README.md
@@ -185,7 +185,7 @@ Backtrace:
 Whether a backtrace is captured at all is the standard library’s decision — see its
 [environment variables][__link12].
 Use [`ErrorExt::message()`][__link13] to read the message without this level’s own
-backtrace.
+enrichment or backtrace.
 
 Every error owns its [`OhnoCore`][__link14], and every core renders its own backtrace, so a chain of
 wrappers that all use the default rendering prints the message once and one backtrace block per
@@ -461,7 +461,7 @@ uniformly via [`Labeled::label`][__link26].
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/ohno">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbtHHEpUyBxrMbsYdoORGNXOkbIhF5Uyd5i_0bJY_4KBndhUFhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbPt0s3Sb8yJUbtV_MElvrqIMbHWX1B21g8MIbor0e9qvU6hVhZIKCZG9obm9lMC40LjCCa29obm9fbWFjcm9zZTAuNC4w
  [__link0]: https://doc.rust-lang.org/stable/std/?search=fmt::Display
  [__link1]: https://doc.rust-lang.org/stable/std/?search=fmt::Debug
  [__link10]: https://doc.rust-lang.org/stable/std/macro.unreachable.html

--- a/crates/ohno/docs/COMPARISON.md
+++ b/crates/ohno/docs/COMPARISON.md
@@ -1,0 +1,84 @@
+<!-- Copyright (c) Microsoft Corporation. -->
+<!-- Licensed under the MIT License. -->
+
+# Coming from `thiserror`
+
+A translation guide for readers who know `thiserror` and are reading `ohno` for
+the first time. The crate documentation stands on its own and does not assume
+this file; everything here is a mapping, not a prerequisite.
+
+The two crates agree on the shape of the problem — derive the error traits,
+declare the message next to the type — so most of the move is mechanical. The
+part that is not mechanical is what an error renders when no message is
+declared, which is where the defaults differ most.
+
+## Attribute mapping
+
+| `thiserror` | `ohno` |
+| --- | --- |
+| `#[derive(Error)]` | `#[derive(ohno::Error)]`, or `#[ohno::error]` to have the core field inserted |
+| `#[error("...")]` | `#[display("...")]` |
+| `#[error(transparent)]` | the default: omit `#[display]` on a type that has a source |
+| `#[source]`, or a field named `source` | the `OhnoCore` field, marked `#[error]` or inserted by `#[ohno::error]` |
+| `#[from]` on a field | `#[from(Type1, Type2, ...)]` on the type |
+| `#[error("{0}")]`, `#[error("{path}")]` | the same placeholders |
+| `#[error("{}", self.path.display())]` | `#[display("{}", path.display())]` — the `self.` prefix is implicit, and rejected if written |
+
+## The message is optional
+
+`thiserror` requires a display attribute on every type and variant, and refuses
+to compile without one. `ohno` treats it as an override: a type with no
+`#[display]` still implements `Display`, and renders one of two defaults.
+
+**With a source**, the source's message is printed as it stands — no type name,
+and no `caused by:` line. This is what `#[error(transparent)]` is written for in
+`thiserror`, except that it is the default here rather than an opt-in, and it
+carries none of that attribute's restrictions: the type may hold other fields,
+and no attribute has to be spelled to get it.
+
+**Without a source**, the type's own name is printed, so a caller sees
+`Error: ConfigError` rather than a message. `thiserror` has no equivalent,
+because it will not compile a type that declares no message.
+
+The two defaults sit one source apart, which is worth knowing when porting a
+`#[error(transparent)]` wrapper: in `thiserror` such a wrapper cannot exist
+without its single inner error, while the `ohno` equivalent can be constructed
+empty, and then renders as its own bare name.
+
+See "How error text is rendered" in the crate documentation for the full account
+with examples.
+
+## A string cause is not a source
+
+`ohno` constructors accept either an error value or a string. Both render
+identically, but only an error value joins the chain — for a string cause,
+`source()` returns `None`. `thiserror` has no counterpart, since a source there
+is always a typed field.
+
+## `Display` carries more than the message
+
+In `thiserror`, `format!("{e}")` is the message and nothing else. In `ohno` it is
+the message, then any enrichment entries added along the way, then the backtrace
+if one was captured:
+
+```text
+no such file: /etc/app.toml
+> failed to load the service configuration (at src/config.rs:6)
+
+Backtrace:
+   0: std::backtrace::Backtrace::capture
+   ...
+```
+
+Code that logs `{e}` and expects a single line therefore needs review when
+porting. `ErrorExt::message()` returns the message on its own.
+
+Because every `ohno` error owns its own `OhnoCore`, and every core renders its
+own backtrace, a chain of wrappers prints the message once and one backtrace
+block per level.
+
+## Structs only
+
+`ohno` derives on structs; an enum is rejected. A `thiserror` enum ports to one
+struct per variant, or to a struct holding an enum field that the `#[display]`
+template reads.

--- a/crates/ohno/docs/COMPARISON.md
+++ b/crates/ohno/docs/COMPARISON.md
@@ -30,36 +30,39 @@ declared, which is where the defaults differ most.
 to compile without one. `ohno` treats it as an override: a type with no
 `#[display]` still implements `Display`, and renders one of two defaults.
 
-**With a source**, the source's message is printed as it stands — no type name,
+**With a cause**, the cause's message is printed as it stands — no type name,
 and no `caused by:` line. This is what `#[error(transparent)]` is written for in
 `thiserror`, except that it is the default here rather than an opt-in, and it
 carries none of that attribute's restrictions: the type may hold other fields,
 and no attribute has to be spelled to get it.
 
-**Without a source**, the type's own name is printed, so a caller sees
-`Error: ConfigError` rather than a message. `thiserror` has no equivalent,
-because it will not compile a type that declares no message.
+**Without a cause**, the type's own name is printed, so a log line reads
+`ConfigError` rather than a message. (`Error: ` in front of it, as `main`
+printing a `Result` produces, comes from the caller — `ohno` never writes a
+prefix.) `thiserror` has no equivalent, because it will not compile a type that
+declares no message.
 
-The two defaults sit one source apart, which is worth knowing when porting a
+The two defaults sit one cause apart, which is worth knowing when porting a
 `#[error(transparent)]` wrapper: in `thiserror` such a wrapper cannot exist
 without its single inner error, while the `ohno` equivalent can be constructed
 empty, and then renders as its own bare name.
 
-See "How error text is rendered" in the crate documentation for the full account
-with examples.
+See [How error text is rendered](../README.md#how-error-text-is-rendered) for the
+full account with examples.
 
 ## A string cause is not a source
 
 `ohno` constructors accept either an error value or a string. Both render
 identically, but only an error value joins the chain — for a string cause,
-`source()` returns `None`. `thiserror` has no counterpart, since a source there
-is always a typed field.
+`source()` returns `None`. That is why the defaults above are stated in terms of
+a *cause* rather than a *source*: `source()` does not predict what is rendered.
+`thiserror` has no counterpart, since a source there is always a typed field.
 
 ## `Display` carries more than the message
 
-In `thiserror`, `format!("{e}")` is the message and nothing else. In `ohno` it is
-the message, then any enrichment entries added along the way, then the backtrace
-if one was captured:
+In `thiserror`, `format!("{e}")` is the message and nothing else. In `ohno` it is,
+for each level of the chain: the message, then that level's enrichment entries,
+then that level's backtrace if one was captured:
 
 ```text
 no such file: /etc/app.toml
@@ -71,11 +74,16 @@ Backtrace:
 ```
 
 Code that logs `{e}` and expects a single line therefore needs review when
-porting. `ErrorExt::message()` returns the message on its own.
+porting. `ErrorExt::message()` drops the enrichment and the backtrace, but it is
+not a single-line guarantee either: with a `#[display]` template and a cause it
+returns `<message>\ncaused by: <cause>`.
 
 Because every `ohno` error owns its own `OhnoCore`, and every core renders its
 own backtrace, a chain of wrappers prints the message once and one backtrace
-block per level.
+block per level. The ordering above holds *per level*, not across the chain: the
+levels are written innermost first, so a wrapper's enrichment entries appear
+after the inner level's `Backtrace:` block rather than grouped with the inner
+level's entries.
 
 ## Structs only
 

--- a/crates/ohno/docs/COMPARISON.md
+++ b/crates/ohno/docs/COMPARISON.md
@@ -74,9 +74,11 @@ Backtrace:
 ```
 
 Code that logs `{e}` and expects a single line therefore needs review when
-porting. `ErrorExt::message()` drops the enrichment and the backtrace, but it is
-not a single-line guarantee either: with a `#[display]` template and a cause it
-returns `<message>\ncaused by: <cause>`.
+porting. `ErrorExt::message()` drops this level's own enrichment and backtrace,
+but it is not a single-line guarantee: with a `#[display]` template and a cause
+it returns `<message>\ncaused by: <cause>`, and on a transparent wrapper it
+renders the cause's full `Display` — which brings that level's enrichment and
+backtrace back with it.
 
 Because every `ohno` error owns its own `OhnoCore`, and every core renders its
 own backtrace, a chain of wrappers prints the message once and one backtrace

--- a/crates/ohno/examples/display_error_complex.rs
+++ b/crates/ohno/examples/display_error_complex.rs
@@ -3,8 +3,7 @@
 
 //! Prints:
 //! Operation 'update' failed with code 404
-//! Caused by:
-//!         Not found
+//! caused by: Not found
 
 #[derive(Debug)]
 struct ErrorCode(u32);

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -185,7 +185,7 @@
 //! Whether a backtrace is captured at all is the standard library's decision — see its
 //! [environment variables](https://doc.rust-lang.org/std/backtrace/index.html#environment-variables).
 //! Use [`ErrorExt::message()`](ErrorExt::message) to read the message without this level's own
-//! backtrace.
+//! enrichment or backtrace.
 //!
 //! Every error owns its [`OhnoCore`], and every core renders its own backtrace, so a chain of
 //! wrappers that all use the default rendering prints the message once and one backtrace block per

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -42,8 +42,7 @@
 //!
 //! Derive macro for automatically implementing error traits.
 //!
-//! When applied to a struct or enum containing an [`OhnoCore`] field,
-//! this macro automatically implements [`std::error::Error`], [`std::fmt::Display`], [`std::fmt::Debug`], and [`From`] conversions.
+//! When applied to a struct containing an [`OhnoCore`] field, this macro automatically implements [`std::error::Error`], [`std::fmt::Display`], [`std::fmt::Debug`], and [`From`] conversions.
 //!
 //! > **Note**: `From<std::convert::Infallible>` is implemented by default and calls via [`unreachable!`] macro.
 //!
@@ -112,7 +111,8 @@
 //!
 //! println!("{error}");
 //! // Output: no such file: /etc/app.toml
-//! # assert!(error.to_string().starts_with("no such file: /etc/app.toml"));
+//! # use ohno::ErrorExt;
+//! # assert_eq!(error.message(), "no such file: /etc/app.toml");
 //! ```
 //!
 //! A cause given as a string renders the same way, but it does not join the chain: it is a message
@@ -132,7 +132,8 @@
 //!
 //! println!("{error}");
 //! // Output: ConfigError
-//! # assert!(error.to_string().starts_with("ConfigError"));
+//! # use ohno::ErrorExt;
+//! # assert_eq!(error.message(), "ConfigError");
 //! ```
 //!
 //! That is a symbol, not an explanation, so an error that renders as its own bare name is a sign
@@ -140,8 +141,9 @@
 //!
 //! ## Enrichment and backtraces
 //!
-//! The message is only the first line of what `Display` writes. Each enrichment entry follows it
-//! on its own line, marked with `>` and tagged with the place it was added:
+//! The message is only the first part of what `Display` writes — with a template and a cause it is
+//! already two lines. Each enrichment entry follows it on its own line, marked with `>` and tagged
+//! with the place it was added:
 //!
 //! ```rust
 //! use std::io;
@@ -165,7 +167,7 @@
 //! # assert!(error.to_string().contains("> failed to load the service configuration (at "));
 //! ```
 //!
-//! A captured backtrace comes last, after any enrichment:
+//! A captured backtrace comes last for that level, after that level's enrichment:
 //!
 //! ```text
 //! no such file: /etc/app.toml
@@ -180,12 +182,15 @@
 //!    ...
 //! ```
 //!
-//! A backtrace is captured only when `RUST_BACKTRACE` asks for one. Use
-//! [`ErrorExt::message()`](ErrorExt::message) to read the message on its own.
+//! Capture is the standard library's decision: a backtrace is taken only when `RUST_LIB_BACKTRACE`
+//! asks for one, or when `RUST_BACKTRACE` does and `RUST_LIB_BACKTRACE` is unset. Use
+//! [`ErrorExt::message()`](ErrorExt::message) to read the message without the backtrace.
 //!
 //! Every error owns its [`OhnoCore`], and every core renders its own backtrace, so a chain of
 //! wrappers that all use the default rendering prints the message once and one backtrace block per
-//! level:
+//! level. The levels are written in turn, innermost first — a wrapper's own enrichment and
+//! backtrace follow the complete rendering of the level it wraps, so an outer enrichment entry
+//! appears *after* the inner level's `Backtrace:` block, not alongside the other enrichment:
 //!
 //! ```text
 //! no such file: /etc/app.toml
@@ -220,6 +225,8 @@
 //! let error = ConfigError::caused_by("/etc/config.toml", "file not found");
 //!
 //! // Output: "Failed to read config with path: /etc/config.toml\ncaused by: file not found"
+//! # use ohno::ErrorExt;
+//! # assert_eq!(error.message(), "Failed to read config with path: /etc/config.toml\ncaused by: file not found");
 //! ```
 //!
 //! The template string supports field interpolation using `{field_name}` syntax. Unlike the

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -84,9 +84,123 @@
 //! }
 //! ```
 //!
-//! # Display Error Override
+//! # How error text is rendered
 //!
-//! The `#[display("...")]` attribute customizes the main error message
+//! Without a `#[display("...")]` attribute, the text an error renders depends on whether it has a
+//! source.
+//!
+//! **With a source**, the source's message is printed as it stands: no type name, and no
+//! `caused by:` line, so the wrapper leaves no trace in the output.
+//! [`source()`](std::error::Error::source) still returns the concrete error, so a caller that
+//! walks the chain still finds it.
+//!
+//! ```rust
+//! use std::io;
+//!
+//! #[ohno::error]
+//! pub struct ConfigError;
+//!
+//! fn read_config() -> Result<String, ConfigError> {
+//!     Err(ConfigError::caused_by(io::Error::new(
+//!         io::ErrorKind::NotFound,
+//!         "no such file: /etc/app.toml",
+//!     )))
+//! }
+//!
+//! let error = read_config().unwrap_err();
+//!
+//! println!("{error}");
+//! // Output: no such file: /etc/app.toml
+//! # assert!(error.to_string().starts_with("no such file: /etc/app.toml"));
+//! ```
+//!
+//! A cause given as a string renders the same way, but it does not join the chain: it is a message
+//! rather than an error, so `source()` returns `None` for it.
+//!
+//! Wrapping therefore adds nothing to the text. A wrapper that should say what it was attempting —
+//! "failed to load the configuration", say — has to be given a template; see
+//! [Overriding error text](#overriding-error-text).
+//!
+//! **Without a source**, there is no message to pass through, so the type's own name is printed:
+//!
+//! ```rust
+//! #[ohno::error]
+//! pub struct ConfigError;
+//!
+//! let error = ConfigError::new();
+//!
+//! println!("{error}");
+//! // Output: ConfigError
+//! # assert!(error.to_string().starts_with("ConfigError"));
+//! ```
+//!
+//! That is a symbol, not an explanation, so an error that renders as its own bare name is a sign
+//! that it needs either a source or a template.
+//!
+//! ## Enrichment and backtraces
+//!
+//! The message is only the first line of what `Display` writes. Each enrichment entry follows it
+//! on its own line, marked with `>` and tagged with the place it was added:
+//!
+//! ```rust
+//! use std::io;
+//!
+//! #[ohno::error]
+//! pub struct ConfigError;
+//!
+//! #[ohno::enrich_err("failed to load the service configuration")]
+//! fn read_config() -> Result<String, ConfigError> {
+//!     Err(ConfigError::caused_by(io::Error::new(
+//!         io::ErrorKind::NotFound,
+//!         "no such file: /etc/app.toml",
+//!     )))
+//! }
+//!
+//! let error = read_config().unwrap_err();
+//!
+//! println!("{error}");
+//! // Output: no such file: /etc/app.toml
+//! //         > failed to load the service configuration (at src/config.rs:6)
+//! # assert!(error.to_string().contains("> failed to load the service configuration (at "));
+//! ```
+//!
+//! A captured backtrace comes last, after any enrichment:
+//!
+//! ```text
+//! no such file: /etc/app.toml
+//! > failed to load the service configuration (at src/config.rs:6)
+//!
+//! Backtrace:
+//!    0: std::backtrace::Backtrace::capture
+//!    1: ohno::backtrace::Backtrace::capture
+//!    2: ohno::core::OhnoCore::from_source
+//!    3: my_app::config::ConfigError::caused_by
+//!    4: my_app::config::read_config
+//!    ...
+//! ```
+//!
+//! A backtrace is captured only when `RUST_BACKTRACE` asks for one. Use
+//! [`ErrorExt::message()`](ErrorExt::message) to read the message on its own.
+//!
+//! Every error owns its [`OhnoCore`], and every core renders its own backtrace, so a chain of
+//! wrappers prints the message once and one backtrace block per level:
+//!
+//! ```text
+//! no such file: /etc/app.toml
+//!
+//! Backtrace:
+//!    ... frames from where ConfigError wrapped the io::Error ...
+//!
+//! Backtrace:
+//!    ... frames from where StartupError wrapped the ConfigError ...
+//! ```
+//!
+//! This follows from each type holding its own core, and is worth knowing before a type is wrapped
+//! several layers deep.
+//!
+//! # Overriding error text
+//!
+//! The `#[display("...")]` attribute replaces the rendered message with a template of its own,
 //! while preserving the underlying error as a cause in the error chain.
 //!
 //! ```rust
@@ -104,9 +218,11 @@
 //! // Output: "Failed to read config with path: /etc/config.toml\nCaused by:\n\tfile not found"
 //! ```
 //!
-//! The template string supports field interpolation using `{field_name}` syntax. The underlying
-//! error (if any) is automatically shown as "Caused by:" in the error chain. If the inner error
-//! has no source, only the custom message is displayed.
+//! The template string supports field interpolation using `{field_name}` syntax. Unlike the
+//! default rendering, the source is never printed on its own: the custom message always leads, and
+//! the underlying error (if any) follows as "Caused by:" in the error chain. If the error has no
+//! source, only the custom message is displayed — the type name is never used once a template is
+//! given.
 //!
 //! Fields of a tuple struct are interpolated by index, using `{0}`, `{1}`, and so on.
 //!
@@ -126,7 +242,7 @@
 //! ```
 //!
 //! Positional arguments are implicitly scoped to `self`, so a field is referenced by its bare
-//! name. Unlike `thiserror`, neither the `self.` prefix nor the leading-dot form is accepted:
+//! name. Neither the `self.` prefix nor the leading-dot form is accepted:
 //!
 //! | Argument | Accepted |
 //! | --- | --- |

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -90,7 +90,8 @@
 //! source.
 //!
 //! **With a source**, the source's message is printed as it stands: no type name, and no
-//! `caused by:` line, so the wrapper leaves no trace in the output.
+//! `caused by:` line, so the wrapper leaves no trace in the message line. Enrichment and a
+//! backtrace, described below, are still written after it.
 //! [`source()`](std::error::Error::source) still returns the concrete error, so a caller that
 //! walks the chain still finds it.
 //!
@@ -215,14 +216,14 @@
 //! // Usage
 //! let error = ConfigError::caused_by("/etc/config.toml", "file not found");
 //!
-//! // Output: "Failed to read config with path: /etc/config.toml\nCaused by:\n\tfile not found"
+//! // Output: "Failed to read config with path: /etc/config.toml\ncaused by: file not found"
 //! ```
 //!
 //! The template string supports field interpolation using `{field_name}` syntax. Unlike the
 //! default rendering, the source is never printed on its own: the custom message always leads, and
-//! the underlying error (if any) follows as "Caused by:" in the error chain. If the error has no
-//! source, only the custom message is displayed — the type name is never used once a template is
-//! given.
+//! the underlying error (if any) follows on the next line, after a `caused by:` label. If the
+//! error has no source, only the custom message is displayed — the type name is never used once a
+//! template is given.
 //!
 //! Fields of a tuple struct are interpolated by index, using `{0}`, `{1}`, and so on.
 //!

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -182,9 +182,10 @@
 //!    ...
 //! ```
 //!
-//! Capture is the standard library's decision: a backtrace is taken only when `RUST_LIB_BACKTRACE`
-//! asks for one, or when `RUST_BACKTRACE` does and `RUST_LIB_BACKTRACE` is unset. Use
-//! [`ErrorExt::message()`](ErrorExt::message) to read the message without the backtrace.
+//! Whether a backtrace is captured at all is the standard library's decision — see its
+//! [environment variables](https://doc.rust-lang.org/std/backtrace/index.html#environment-variables).
+//! Use [`ErrorExt::message()`](ErrorExt::message) to read the message without this level's own
+//! backtrace.
 //!
 //! Every error owns its [`OhnoCore`], and every core renders its own backtrace, so a chain of
 //! wrappers that all use the default rendering prints the message once and one backtrace block per

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -202,7 +202,9 @@
 //! # Overriding error text
 //!
 //! The `#[display("...")]` attribute replaces the rendered message with a template of its own,
-//! while preserving the underlying error as a cause in the error chain.
+//! while still printing the cause after it. A cause that is an error also stays in the
+//! [`source()`](std::error::Error::source) chain; a cause given as a string is printed the same way
+//! but does not join the chain, exactly as under the default rendering.
 //!
 //! ```rust
 //! use std::path::PathBuf;
@@ -220,10 +222,10 @@
 //! ```
 //!
 //! The template string supports field interpolation using `{field_name}` syntax. Unlike the
-//! default rendering, the source is never printed on its own: the custom message always leads, and
-//! the underlying error (if any) follows on the next line, after a `caused by:` label. If the
-//! error has no source, only the custom message is displayed — the type name is never used once a
-//! template is given.
+//! default rendering, the cause is never printed on its own: the custom message always leads, and
+//! the cause (if any) follows on the next line, after a `caused by:` label. If the error has no
+//! cause, only the custom message is displayed — the type name is never used once a template is
+//! given.
 //!
 //! Fields of a tuple struct are interpolated by index, using `{0}`, `{1}`, and so on.
 //!

--- a/crates/ohno/src/lib.rs
+++ b/crates/ohno/src/lib.rs
@@ -87,13 +87,13 @@
 //! # How error text is rendered
 //!
 //! Without a `#[display("...")]` attribute, the text an error renders depends on whether it has a
-//! source.
+//! cause — an error or a string handed to `caused_by`.
 //!
-//! **With a source**, the source's message is printed as it stands: no type name, and no
+//! **With a cause**, the cause's message is printed as it stands: no type name, and no
 //! `caused by:` line, so the wrapper leaves no trace in the message line. Enrichment and a
 //! backtrace, described below, are still written after it.
-//! [`source()`](std::error::Error::source) still returns the concrete error, so a caller that
-//! walks the chain still finds it.
+//! A cause that is an error also stays in the [`source()`](std::error::Error::source) chain, so a
+//! caller that walks the chain still finds it.
 //!
 //! ```rust
 //! use std::io;
@@ -122,7 +122,7 @@
 //! "failed to load the configuration", say — has to be given a template; see
 //! [Overriding error text](#overriding-error-text).
 //!
-//! **Without a source**, there is no message to pass through, so the type's own name is printed:
+//! **Without a cause**, there is no message to pass through, so the type's own name is printed:
 //!
 //! ```rust
 //! #[ohno::error]
@@ -136,7 +136,7 @@
 //! ```
 //!
 //! That is a symbol, not an explanation, so an error that renders as its own bare name is a sign
-//! that it needs either a source or a template.
+//! that it needs either a cause or a template.
 //!
 //! ## Enrichment and backtraces
 //!
@@ -184,7 +184,8 @@
 //! [`ErrorExt::message()`](ErrorExt::message) to read the message on its own.
 //!
 //! Every error owns its [`OhnoCore`], and every core renders its own backtrace, so a chain of
-//! wrappers prints the message once and one backtrace block per level:
+//! wrappers that all use the default rendering prints the message once and one backtrace block per
+//! level:
 //!
 //! ```text
 //! no such file: /etc/app.toml


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

## What this changes

Fixes AB#7675161. The `ohno` crate documentation describes only `#[display("...")]`. It does not say what an error renders when that attribute is absent, which is the common case. One sentence implies the type name is always the default message. That is true only for an error with no source.

## Details

- Replace the `Display Error Override` section with two sections. `How error text is rendered` covers the default. `Overriding error text` covers `#[display("...")]`. The default is documented first.
- Document the with-source default. The source message is printed as it stands, with no type name and no `caused by:` line. `source()` still returns the concrete error.
- Document the sourceless default. The type name is printed.
- Document that a cause given as a string renders like an error cause, but does not join the chain. `source()` returns `None` for it.
- Add an `Enrichment and backtraces` subsection. It shows an `#[enrich_err]` entry rendering under the message, then a captured backtrace.
- State that a chain of wrappers prints the message once and one backtrace block per level. Every error owns an `OhnoCore`, and every core renders its own backtrace.
- Correct the override text. Under a template the source is never printed alone, and the type name is never used.
- Add `crates/ohno/docs/COMPARISON.md`, a `thiserror` translation guide. It maps the attributes and names the places a port does not translate one for one.
- Remove the two `thiserror` references from the crate documentation, so the rendered documentation names no other crate.

## Effects

- Documentation only. No public API change, no behavior change, no new dependency.
- Three doctests are added. They assert the documented output on every build.
- `crates/ohno/README.md` is regenerated from `lib.rs` by `cargo doc2readme`. Its heading order changes.
- The `Display Error Override` heading is replaced by two headings. An external link to `#display-error-override` breaks. No link inside this repository uses that anchor.
- `docs/**/*.md` is in the workspace include allowlist. `COMPARISON.md` therefore ships in the published crate.
- `COMPARISON.md` states the behavior of `thiserror`, which this repository does not build. It can go stale without CI reporting it.
- The backtrace and enrichment output blocks are illustrative text. No test asserts their exact layout.
- The bug also asked for a `#[no_constructors]` recommendation for transparent wrappers. It is not added. That attribute is constructor guidance, and the `Automatic Constructors` section already documents it.

## Validation

- The rendered output in the documentation was copied from real runs, not written from memory. Scratch binaries confirmed the enrichment line format `> <message> (at <file>:<line>)`, and confirmed that a two-level wrapper prints two `Backtrace:` blocks under `RUST_BACKTRACE=1`.
- The string-cause claim was verified by running both forms. An error cause returns `Some` from `source()`. A string cause returns `None`. Both print the same text.