### PR TITLE
chore: reference the public nightly toolchain and rename the alignment-cap cfg

### DIFF
--- a/.github/prompts/clippy-nightly.prompt.md
+++ b/.github/prompts/clippy-nightly.prompt.md
@@ -1,8 +1,8 @@
 # Fixing Nightly Clippy Lints with MCP Tools
 
-You are a Rust developer working on a project that uses the `ms-nightly` toolchain and enforces strict Clippy lints.
+You are a Rust developer working on a project that uses the `nightly` toolchain and enforces strict Clippy lints.
 Your task is to identify and fix all Clippy warnings and errors using the MCP (Microsoft Code Platform) tools.
-For all requests, you shall use `ms-nightly` toolchain and MCP tools to ensure compatibility with the latest features and lints.
+For all requests, you shall use `nightly` toolchain and MCP tools to ensure compatibility with the latest features and lints.
 
 ## Instructions
 
@@ -16,7 +16,7 @@ For all requests, you shall use `ms-nightly` toolchain and MCP tools to ensure c
     - For each crate in your workspace, perform the following steps before moving to the next crate.
 
 2. **Run Clippy with Nightly Toolchain**
-    - Use the `ms-nightly` toolchain to run Clippy on the current crate. Use the `#cargo-clippy` tool for this, targeting only the specific crate.
+    - Use the `nightly` toolchain to run Clippy on the current crate. Use the `#cargo-clippy` tool for this, targeting only the specific crate.
 
 3. **Automatically Fix Lints with `fix`**
     - Use the `fix` parameter with `#cargo-clippy` to automatically apply suggested fixes for applicable lints in the current crate.
@@ -24,7 +24,7 @@ For all requests, you shall use `ms-nightly` toolchain and MCP tools to ensure c
 
 4. **Analyze Clippy Output**
     - Review the Clippy output for any remaining warnings or errors in the current crate.
-    - Pay special attention to lints that are only available on `ms-nightly`.
+    - Pay special attention to lints that are only available on `nightly`.
 
 5. **Manually Fix Remaining Lints**
     - For each remaining lint:
@@ -44,7 +44,7 @@ For all requests, you shall use `ms-nightly` toolchain and MCP tools to ensure c
 
 ## Tips
 
-- Always use the latest `ms-nightly` toolchain and MCP tools for best results.
+- Always use the latest `nightly` toolchain and MCP tools for best results.
 - Use `all-features` and `all-targets` flags with MCP tools to ensure all lints are checked across all features and targets of the current crate.
 - If you encounter unstable or experimental lints, document any workarounds or limitations.
   Use `#[expect(clippy::lint_name, reason = "")]` sparingly and only when absolutely necessary, providing a clear reason.

--- a/.github/prompts/clippy-nightly.prompt.md
+++ b/.github/prompts/clippy-nightly.prompt.md
@@ -1,7 +1,7 @@
 # Fixing Nightly Clippy Lints with MCP Tools
 
 You are a Rust developer working on a project that uses the `nightly` toolchain and enforces strict Clippy lints.
-Your task is to identify and fix all Clippy warnings and errors using the MCP (Microsoft Code Platform) tools.
+Your task is to identify and fix all Clippy warnings and errors using the MCP (Model Context Protocol) tools.
 For all requests, you shall use `nightly` toolchain and MCP tools to ensure compatibility with the latest features and lints.
 
 ## Instructions

--- a/.github/prompts/clippy-nightly.prompt.md
+++ b/.github/prompts/clippy-nightly.prompt.md
@@ -2,7 +2,13 @@
 
 You are a Rust developer working on a project that uses the `nightly` toolchain and enforces strict Clippy lints.
 Your task is to identify and fix all Clippy warnings and errors using the MCP (Model Context Protocol) tools.
-For all requests, you shall use `nightly` toolchain and MCP tools to ensure compatibility with the latest features and lints.
+For all requests, you shall use the nightly toolchain named by `RUST_NIGHTLY` in `constants.env` and MCP tools to ensure compatibility with the latest features and lints.
+Do not use a bare `nightly`: it floats, and no gate in this repo enforces it.
+
+Note that CI's Clippy gate runs the *stable* toolchain named by `RUST_LATEST`, not nightly.
+Nightly-only lints are therefore advisory - they surface problems ahead of the gating
+toolchain. Do not add `#[expect(...)]` for a warning only nightly emits; confirm it fires on
+`RUST_LATEST` first, or the expectation becomes unfulfilled once nightly moves on.
 
 ## Instructions
 
@@ -16,7 +22,7 @@ For all requests, you shall use `nightly` toolchain and MCP tools to ensure comp
     - For each crate in your workspace, perform the following steps before moving to the next crate.
 
 2. **Run Clippy with Nightly Toolchain**
-    - Use the `nightly` toolchain to run Clippy on the current crate. Use the `#cargo-clippy` tool for this, targeting only the specific crate.
+    - Use the toolchain named by `RUST_NIGHTLY` to run Clippy on the current crate. Use the `#cargo-clippy` tool for this, targeting only the specific crate.
 
 3. **Automatically Fix Lints with `fix`**
     - Use the `fix` parameter with `#cargo-clippy` to automatically apply suggested fixes for applicable lints in the current crate.
@@ -44,7 +50,7 @@ For all requests, you shall use `nightly` toolchain and MCP tools to ensure comp
 
 ## Tips
 
-- Always use the latest `nightly` toolchain and MCP tools for best results.
+- Always use the toolchain named by `RUST_NIGHTLY` in `constants.env` and MCP tools for best results.
 - Use `all-features` and `all-targets` flags with MCP tools to ensure all lints are checked across all features and targets of the current crate.
 - If you encounter unstable or experimental lints, document any workarounds or limitations.
   Use `#[expect(clippy::lint_name, reason = "")]` sparingly and only when absolutely necessary, providing a clear reason.

--- a/.vscode/settings.template.jsonc
+++ b/.vscode/settings.template.jsonc
@@ -58,12 +58,12 @@
     "rust-analyzer.cargo.allTargets": true,
     "rust-analyzer.check.allTargets": true,
 
-    // The (ms-)nightly toolchain has additional code formatting capabilities that are disabled
+    // The nightly toolchain has additional code formatting capabilities that are disabled
     // with the regular toolchain. This enables those capabilities.
     //
-    // Requires the ms-nightly toolchain to be installed. You may need to install it manually, as
-    // it may not be installed by default (`msrustup toolchain install ms-nightly`).
-    "rust-analyzer.rustfmt.extraArgs": ["+ms-nightly", "--config-path", "${workspaceFolder}/unstable-rustfmt.toml"],
+    // Requires the nightly toolchain to be installed. You may need to install it manually, as
+    // it may not be installed by default (`rustup toolchain install nightly`).
+    "rust-analyzer.rustfmt.extraArgs": ["+nightly", "--config-path", "${workspaceFolder}/unstable-rustfmt.toml"],
 
     // Clippy is extremely slow when used on our large workspace, so you may want to use
     // `check` instead to run regular `cargo check`. To run Clippy, invoke it manually from the

--- a/.vscode/settings.template.jsonc
+++ b/.vscode/settings.template.jsonc
@@ -62,9 +62,13 @@
     // with the regular toolchain. This enables those capabilities.
     //
     // The pinned nightly must match `RUST_NIGHTLY` in `constants.env`, which is what CI's
-    // format check runs; a different nightly can format the same file differently. Update
-    // both together. Install it with
-    // `rustup toolchain install nightly-2026-05-30 --component rustfmt`, or run `just install-tools`.
+    // format check runs; a different nightly can format the same file differently.
+    // `scripts/update_rust_toolchain.ps1` rewrites both, so a routine bump keeps them in step.
+    //
+    // Your own copy of this file does not move with a bump: after `RUST_NIGHTLY` changes,
+    // re-copy this line into `.vscode/settings.json` and install the new toolchain with
+    // `rustup toolchain install <RUST_NIGHTLY> --component rustfmt` (or re-run `just install-tools`),
+    // otherwise format-on-save fails on a toolchain you no longer have.
     "rust-analyzer.rustfmt.extraArgs": ["+nightly-2026-05-30", "--config-path", "${workspaceFolder}/unstable-rustfmt.toml"],
 
     // Clippy is extremely slow when used on our large workspace, so you may want to use

--- a/.vscode/settings.template.jsonc
+++ b/.vscode/settings.template.jsonc
@@ -61,9 +61,11 @@
     // The nightly toolchain has additional code formatting capabilities that are disabled
     // with the regular toolchain. This enables those capabilities.
     //
-    // Requires the nightly toolchain to be installed. You may need to install it manually, as
-    // it may not be installed by default (`rustup toolchain install nightly`).
-    "rust-analyzer.rustfmt.extraArgs": ["+nightly", "--config-path", "${workspaceFolder}/unstable-rustfmt.toml"],
+    // The pinned nightly must match `RUST_NIGHTLY` in `constants.env`, which is what CI's
+    // format check runs; a different nightly can format the same file differently. Update
+    // both together. Install it with
+    // `rustup toolchain install nightly-2026-05-30 --component rustfmt`, or run `just install-tools`.
+    "rust-analyzer.rustfmt.extraArgs": ["+nightly-2026-05-30", "--config-path", "${workspaceFolder}/unstable-rustfmt.toml"],
 
     // Clippy is extremely slow when used on our large workspace, so you may want to use
     // `check` instead to run regular `cargo check`. To run Clippy, invoke it manually from the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,7 +291,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(miri_race_coverage)',
     'cfg(miri_strict_provenance)',
     'cfg(miri_tree_borrows)',
-    'cfg(utc_backend)',
+    'cfg(align_capped_backend)',
 ] }
 # <<< anvil-managed: anvil-workspace-lints
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,6 +291,11 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(miri_race_coverage)',
     'cfg(miri_strict_provenance)',
     'cfg(miri_tree_borrows)',
+    # Set when the codegen backend cannot give a type the `#[repr(align(N))]` it asks for,
+    # which makes `multitude`'s over-aligned test types fail to compile. Nothing in-tree sets
+    # it; a build using such a backend passes `--cfg align_capped_backend` itself. It is
+    # all-or-nothing: it drops every over-aligned case (32 KiB, 64 KiB and 128 KiB), so a
+    # backend that supports some of them still loses that coverage.
     'cfg(align_capped_backend)',
 ] }
 # <<< anvil-managed: anvil-workspace-lints

--- a/crates/multitude/src/arena/alloc_growable.rs
+++ b/crates/multitude/src/arena/alloc_growable.rs
@@ -427,8 +427,7 @@ impl<A: Allocator + Clone> Arena<A> {
             return Err(FromUtf16Error::new());
         }
         let mut out = self.alloc_string_with_capacity(bytes.len() / 2);
-        let units = bytes.chunks_exact(2).map(|pair| {
-            let raw = [pair[0], pair[1]];
+        let units = bytes.as_chunks::<2>().0.iter().map(|&raw| {
             if big_endian {
                 u16::from_be_bytes(raw)
             } else {
@@ -449,8 +448,7 @@ impl<A: Allocator + Clone> Arena<A> {
     /// Fallible variant of [`Self::alloc_string_from_utf16_bytes_lossy`].
     fn try_alloc_string_from_utf16_bytes_lossy(&self, bytes: &[u8], big_endian: bool) -> Result<String<'_, A>, AllocError> {
         let mut out = self.try_alloc_string_with_capacity(bytes.len() / 2 + 1)?;
-        let units = bytes.chunks_exact(2).map(|pair| {
-            let raw = [pair[0], pair[1]];
+        let units = bytes.as_chunks::<2>().0.iter().map(|&raw| {
             if big_endian {
                 u16::from_be_bytes(raw)
             } else {

--- a/crates/multitude/tests/arena.rs
+++ b/crates/multitude/tests/arena.rs
@@ -2241,7 +2241,7 @@ mod coverage_arena_gaps {
     /// Used to drive over-alignment rejection in `_with` family functions
     /// without ever instantiating the value on the test stack frame
     /// (the over-alignment guard fires before the closure is invoked).
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[repr(align(32768))]
     #[derive(Clone, Copy)]
     struct HalfChunkAlign;
@@ -2250,7 +2250,7 @@ mod coverage_arena_gaps {
     /// `layout.align() >= CHUNK_ALIGN` guard in the slice-copy family.
     /// Same Windows-stack caveat as [`HalfChunkAlign`]: never lives on
     /// the test stack.
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[repr(align(65536))]
     #[derive(Clone, Copy)]
     struct ChunkAlign;
@@ -2304,7 +2304,7 @@ mod coverage_arena_gaps {
         assert_eq!(arc[69_999], 7);
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     #[should_panic(expected = "multitude: allocator returned AllocError")]
     fn alloc_arc_with_over_aligned_panics() {
@@ -2320,7 +2320,7 @@ mod coverage_arena_gaps {
         assert_eq!(r[69_999], 3);
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     #[should_panic(expected = "multitude: allocator returned AllocError")]
     fn alloc_with_over_aligned_panics() {
@@ -2328,7 +2328,7 @@ mod coverage_arena_gaps {
         let _ = arena.alloc_with(|| HalfChunkAlign);
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     #[should_panic(expected = "multitude: allocator returned AllocError")]
     fn alloc_box_with_over_aligned_panics() {
@@ -2338,7 +2338,7 @@ mod coverage_arena_gaps {
 
     // Over-alignment is rejected before initialization.
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     #[should_panic(expected = "multitude: allocator returned AllocError")]
     fn alloc_uninit_box_over_aligned_panics() {
@@ -2346,7 +2346,7 @@ mod coverage_arena_gaps {
         let _ = arena.alloc_uninit_box::<HalfChunkAlign>();
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     #[should_panic(expected = "multitude: allocator returned AllocError")]
     fn alloc_uninit_arc_over_aligned_panics() {
@@ -2354,7 +2354,7 @@ mod coverage_arena_gaps {
         let _ = arena.alloc_uninit_arc::<HalfChunkAlign>();
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     #[should_panic(expected = "multitude: allocator returned AllocError")]
     fn alloc_slice_copy_over_aligned_panics() {
@@ -2366,7 +2366,7 @@ mod coverage_arena_gaps {
         let _ = arena.alloc_slice_copy(src);
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_slice_no_drop_over_aligned_returns_err() {
         let arena = Arena::<Global>::new();
@@ -2379,7 +2379,7 @@ mod coverage_arena_gaps {
         assert!(res.is_err());
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_slice_copy_over_aligned_returns_err() {
         let arena = Arena::<Global>::new();
@@ -2388,7 +2388,7 @@ mod coverage_arena_gaps {
         assert!(res.is_err());
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_slice_copy_arc_over_aligned_returns_err() {
         let arena = Arena::<Global>::new();
@@ -2456,7 +2456,7 @@ mod coverage_arena_gaps {
         assert_eq!(arc[2047], 2047);
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_arc_with_over_aligned_returns_err() {
         let arena = Arena::<Global>::new();
@@ -6063,13 +6063,13 @@ mod public_surface_behavior {
     // including Windows, whose default 1 MiB stack can't accommodate the
     // 128 KiB-aligned frame the guarded body would otherwise require.
     //
-    // Skipped under the UTC codegen backend (`--cfg utc_backend`): UTC caps
-    // type alignment at 8192 bytes, well below the 128 KiB this test needs.
-    #[cfg(not(utc_backend))]
+    // Skipped on codegen backends that cap type alignment below the 128 KiB
+    // this test needs (`--cfg align_capped_backend`).
+    #[cfg(not(align_capped_backend))]
     #[repr(align(131072))]
     struct HugeAlign(#[expect(dead_code, reason = "field present to give the type a non-zero size")] u8);
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_with_rejects_excessive_alignment() {
         // try_alloc_with is the Alloc<T> entry point. CHUNK_ALIGN is 64 KiB;
@@ -6319,11 +6319,11 @@ mod public_surface_behavior {
     // `try_alloc_with_rejects_excessive_alignment`. The `MaybeUninit<T>` returned
     // by the uninit-family entry points never materializes a real `T` on the
     // stack, so the test compiles and runs safely on every platform.
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[repr(align(131072))]
     struct HugeAlignBox(#[expect(dead_code, reason = "field gives the type a non-zero size")] u8);
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_uninit_box_rejects_excessive_alignment() {
         let arena: Arena = Arena::new();
@@ -6768,7 +6768,7 @@ mod public_surface_behavior {
     }
 
     #[test]
-    #[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+    #[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
     // See note on `acquire_slice_slot_rejects_overaligned`: naming a
     // `T` with `align(131072)` aborts on Windows before the guard runs.
     fn try_alloc_slice_copy_rejects_overaligned() {
@@ -6791,7 +6791,7 @@ mod public_surface_behavior {
     }
 
     #[test]
-    #[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+    #[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
     // See note on `acquire_slice_slot_rejects_overaligned`: naming a
     // `T` with `align(131072)` aborts on Windows before the guard runs.
     fn try_alloc_slice_fill_with_rejects_overaligned() {
@@ -6898,23 +6898,23 @@ mod public_surface_behavior {
     // before the guard runs. The MaybeUninit/uninit-family tests only hold
     // the type *inside* `MaybeUninit`, so they're safe everywhere.
 
-    #[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+    #[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
     #[repr(align(32768))]
     #[derive(Clone, Copy)]
     struct HalfChunkAlignNoDrop(#[expect(dead_code, reason = "field gives the type a non-zero size")] u8);
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[repr(align(32768))]
     struct HalfChunkAlignDrop(#[expect(dead_code, reason = "field gives the type a non-zero size")] u8);
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[expect(clippy::empty_drop, reason = "Drop impl makes needs_drop::<T>() true for the test")]
     impl Drop for HalfChunkAlignDrop {
         fn drop(&mut self) {}
     }
 
     #[test]
-    #[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+    #[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
     fn try_alloc_arc_with_rejects_half_chunk_alignment() {
         let arena: Arena = Arena::new();
         let r: Result<multitude::Arc<HalfChunkAlignDrop>, _> = arena.try_alloc_arc_with(|| HalfChunkAlignDrop(0));
@@ -6922,14 +6922,14 @@ mod public_surface_behavior {
     }
 
     #[test]
-    #[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+    #[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
     fn try_alloc_box_with_rejects_half_chunk_alignment() {
         let arena: Arena = Arena::new();
         let r: Result<multitude::Box<HalfChunkAlignDrop>, _> = arena.try_alloc_box_with(|| HalfChunkAlignDrop(0));
         assert!(r.is_err());
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_uninit_box_rejects_half_chunk_alignment() {
         // Holding T inside MaybeUninit means no stack frame needs T's
@@ -6939,7 +6939,7 @@ mod public_surface_behavior {
         assert!(r.is_err());
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_uninit_arc_rejects_half_chunk_alignment() {
         let arena: Arena = Arena::new();
@@ -6948,7 +6948,7 @@ mod public_surface_behavior {
     }
 
     #[test]
-    #[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+    #[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
     fn try_alloc_slice_fill_with_arc_rejects_half_chunk_alignment() {
         let arena: Arena = Arena::new();
         let r = arena.try_alloc_slice_fill_with_arc::<HalfChunkAlignDrop, _>(1, |_| HalfChunkAlignDrop(0));
@@ -6956,14 +6956,14 @@ mod public_surface_behavior {
     }
 
     #[test]
-    #[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+    #[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
     fn try_alloc_slice_fill_with_box_rejects_half_chunk_alignment() {
         let arena: Arena = Arena::new();
         let r = arena.try_alloc_slice_fill_with_box::<HalfChunkAlignDrop, _>(1, |_| HalfChunkAlignDrop(0));
         assert!(r.is_err());
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_uninit_slice_arc_rejects_half_chunk_alignment() {
         let arena: Arena = Arena::new();
@@ -6971,7 +6971,7 @@ mod public_surface_behavior {
         assert!(r.is_err());
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_uninit_slice_box_rejects_half_chunk_alignment() {
         let arena: Arena = Arena::new();
@@ -6980,7 +6980,7 @@ mod public_surface_behavior {
     }
 
     #[test]
-    #[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+    #[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
     fn try_alloc_slice_copy_arc_allows_half_chunk_align_for_copy_t() {
         let arena: Arena = Arena::new();
         let data = [HalfChunkAlignNoDrop(0), HalfChunkAlignNoDrop(1)];
@@ -7583,19 +7583,19 @@ mod public_surface_behavior_3 {
         assert_eq!(DROPPED.load(Ordering::Relaxed), 4);
     }
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[repr(align(32768))]
     #[derive(Clone, Copy)]
     struct OverAligned32K;
 
     // SAFETY: zero-sized POD; no drop.
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     unsafe impl Send for OverAligned32K {}
     // SAFETY: zero-sized POD; no drop.
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     unsafe impl Sync for OverAligned32K {}
 
-    #[cfg(not(utc_backend))]
+    #[cfg(not(align_capped_backend))]
     #[test]
     fn try_alloc_slice_fill_with_arc_rejects_over_aligned() {
         let arena = Arena::new();

--- a/crates/multitude/tests/audit_repro.rs
+++ b/crates/multitude/tests/audit_repro.rs
@@ -156,7 +156,7 @@ fn arc_concurrent_assume_init_no_race() {
 ///
 /// We use a ZST with `#[repr(align(32768))]` so the type's alignment
 /// checks the cap without forcing a 32 KiB stack frame.
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 #[test]
 fn alloc_slice_ref_accepts_half_chunk_alignment_for_non_drop() {
     #[repr(align(32768))]

--- a/crates/multitude/tests/bytemuck_integration.rs
+++ b/crates/multitude/tests/bytemuck_integration.rs
@@ -153,7 +153,7 @@ fn try_alloc_slice_arc_ok() {
 //
 // Windows cannot materialize a 64 KiB-aligned value in its default stack;
 // non-slice variants check the same alignment guard there.
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 #[derive(Clone, Copy)]
 #[repr(C, align(65536))]
 struct OverAligned {
@@ -161,11 +161,11 @@ struct OverAligned {
 }
 
 // SAFETY: all-zeros is a valid OverAligned (it's just a u8 + padding).
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 unsafe impl Zeroable for OverAligned {}
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_box_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_box::<OverAligned>();
@@ -173,7 +173,7 @@ fn try_alloc_box_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_arc_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_arc::<OverAligned>();
@@ -181,7 +181,7 @@ fn try_alloc_arc_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_slice_box_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_slice_box::<OverAligned>(4);
@@ -189,7 +189,7 @@ fn try_alloc_slice_box_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_slice_arc_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_slice_arc::<OverAligned>(4);
@@ -197,7 +197,7 @@ fn try_alloc_slice_arc_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_box_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -205,7 +205,7 @@ fn alloc_box_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_arc_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -213,7 +213,7 @@ fn alloc_arc_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_box_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -221,7 +221,7 @@ fn alloc_slice_box_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_arc_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -258,7 +258,7 @@ fn try_alloc_ref_scalar_ok() {
 }
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_ref_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc::<OverAligned>();
@@ -266,7 +266,7 @@ fn try_alloc_ref_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_ref_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -304,7 +304,7 @@ fn try_alloc_slice_ref_ok() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 fn try_alloc_slice_ref_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.bytemuck().try_alloc_slice::<OverAligned>(4);
@@ -312,7 +312,7 @@ fn try_alloc_slice_ref_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_ref_panics_on_over_aligned() {
     let arena = Arena::new();

--- a/crates/multitude/tests/pin_support.rs
+++ b/crates/multitude/tests/pin_support.rs
@@ -68,7 +68,7 @@ fn alloc_arc_pin_with_cross_thread() {
     assert_eq!(addr_before, addr_thread, "Arc-pinned value must keep its address across threads");
 }
 
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 #[test]
 fn try_alloc_uninit_box_pin_rejects_over_alignment() {
     // Avoid constructing the 32 KiB-aligned value on the stack.

--- a/crates/multitude/tests/zerocopy_integration.rs
+++ b/crates/multitude/tests/zerocopy_integration.rs
@@ -123,7 +123,7 @@ fn try_alloc_slice_arc_ok() {
 
 // Windows cannot materialize a 64 KiB-aligned value in its default stack;
 // non-slice variants check the same alignment guard there.
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 #[derive(FromZeros)]
 #[repr(C, align(65536))]
 struct OverAligned {
@@ -131,7 +131,7 @@ struct OverAligned {
 }
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_box_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_box::<OverAligned>();
@@ -139,7 +139,7 @@ fn try_alloc_box_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_arc_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_arc::<OverAligned>();
@@ -147,7 +147,7 @@ fn try_alloc_arc_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_slice_box_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_slice_box::<OverAligned>(4);
@@ -155,7 +155,7 @@ fn try_alloc_slice_box_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_slice_arc_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_slice_arc::<OverAligned>(4);
@@ -163,7 +163,7 @@ fn try_alloc_slice_arc_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_box_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -171,7 +171,7 @@ fn alloc_box_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_arc_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -179,7 +179,7 @@ fn alloc_arc_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_box_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -187,7 +187,7 @@ fn alloc_slice_box_panics_on_over_aligned() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_arc_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -224,7 +224,7 @@ fn try_alloc_ref_scalar_ok() {
 }
 
 #[test]
-#[cfg(not(utc_backend))]
+#[cfg(not(align_capped_backend))]
 fn try_alloc_ref_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc::<OverAligned>();
@@ -232,7 +232,7 @@ fn try_alloc_ref_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_ref_panics_on_over_aligned() {
     let arena = Arena::new();
@@ -270,7 +270,7 @@ fn try_alloc_slice_ref_ok() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 fn try_alloc_slice_ref_over_aligned_returns_err() {
     let arena = Arena::new();
     let result = arena.zerocopy().try_alloc_slice::<OverAligned>(4);
@@ -278,7 +278,7 @@ fn try_alloc_slice_ref_over_aligned_returns_err() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(utc_backend)))]
+#[cfg(all(not(target_os = "windows"), not(align_capped_backend)))]
 #[should_panic = "arena allocation failed"]
 fn alloc_slice_ref_panics_on_over_aligned() {
     let arena = Arena::new();

--- a/scripts/tests/Pester/unit/toolchain/PinnedNightly.Tests.ps1
+++ b/scripts/tests/Pester/unit/toolchain/PinnedNightly.Tests.ps1
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\..\_common\TestHelpers.ps1')
+
+    $script:RepoRoot = Get-OxiRepoRoot
+    $script:ConstantsFile = Join-Path $script:RepoRoot 'constants.env'
+    $script:SettingsTemplate = Join-Path $script:RepoRoot '.vscode\settings.template.jsonc'
+}
+
+Describe 'Pinned nightly toolchain' {
+    It 'pins the same nightly in settings.template.jsonc as RUST_NIGHTLY in constants.env' {
+        $constantsNightly = (Get-Content $script:ConstantsFile | Select-String '^RUST_NIGHTLY=(.+)$').Matches.Groups[1].Value
+        $constantsNightly | Should -Match '^nightly-\d{4}-\d{2}-\d{2}$'
+
+        $pins = [regex]::Matches((Get-Content $script:SettingsTemplate -Raw), 'nightly-\d{4}-\d{2}-\d{2}')
+        $pins.Count | Should -BeGreaterThan 0 -Because 'the template pins rustfmt to a specific nightly'
+
+        foreach ($pin in $pins) {
+            $pin.Value | Should -Be $constantsNightly -Because 'scripts/update_rust_toolchain.ps1 must carry a RUST_NIGHTLY bump into the template'
+        }
+    }
+}

--- a/scripts/update_rust_toolchain.ps1
+++ b/scripts/update_rust_toolchain.ps1
@@ -15,6 +15,10 @@
 .PARAMETER ConstantsFile
     Path to the constants.env file. Defaults to ../constants.env relative to script location.
 
+.PARAMETER VsCodeSettingsTemplate
+    Path to .vscode/settings.template.jsonc, whose rustfmt toolchain is pinned to RUST_NIGHTLY.
+    Defaults to ../.vscode/settings.template.jsonc relative to script location.
+
 .PARAMETER DryRun
     If specified, shows what would be updated without actually modifying the files.
 
@@ -27,6 +31,7 @@
 
 param(
     [string]$ConstantsFile = (Join-Path $PSScriptRoot ".." "constants.env"),
+    [string]$VsCodeSettingsTemplate = (Join-Path $PSScriptRoot ".." ".vscode" "settings.template.jsonc"),
     [switch]$DryRun
 )
 
@@ -146,6 +151,24 @@ function Update-ConstantsEnv {
     return $content
 }
 
+function Update-PinnedNightly {
+    <#
+    .SYNOPSIS
+        Rewrites every `nightly-YYYY-MM-DD` literal in the given content to $NewNightly.
+
+    .DESCRIPTION
+        `.vscode/settings.template.jsonc` pins rustfmt to the same nightly as RUST_NIGHTLY so
+        the editor formats the way CI's format check does. That pin is a hand-copied literal,
+        so a RUST_NIGHTLY bump has to carry it along or the two silently diverge.
+    #>
+    param(
+        [string]$Content,
+        [string]$NewNightly
+    )
+
+    return $Content -replace 'nightly-\d{4}-\d{2}-\d{2}', $NewNightly
+}
+
 # Main script execution
 Write-Host "Fetching latest Rust versions..."
 Write-Host ""
@@ -222,4 +245,20 @@ if ($DryRun) {
 if ($constantsUpdates.Count -gt 0) {
     $newConstantsContent = Update-ConstantsEnv -FilePath $ConstantsFile -Updates $constantsUpdates
     Set-Content -Path $ConstantsFile -Value $newConstantsContent -NoNewline
+
+    if ($constantsUpdates.ContainsKey("RUST_NIGHTLY")) {
+        if (Test-Path $VsCodeSettingsTemplate) {
+            $templateContent = Get-Content $VsCodeSettingsTemplate -Raw
+            $newTemplateContent = Update-PinnedNightly -Content $templateContent -NewNightly $constantsUpdates["RUST_NIGHTLY"]
+
+            if ($newTemplateContent -ne $templateContent) {
+                Set-Content -Path $VsCodeSettingsTemplate -Value $newTemplateContent -NoNewline
+                Write-Host "Updated pinned nightly in '$VsCodeSettingsTemplate'."
+                Write-Host "Contributors must re-copy that line into their own .vscode/settings.json."
+            }
+        }
+        else {
+            Write-Host "Warning: '$VsCodeSettingsTemplate' not found; its pinned nightly was not updated."
+        }
+    }
 }


### PR DESCRIPTION
&#x1F916;

## Problem

The VS Code settings template and the Clippy prompt point contributors at a toolchain that public `rustup` cannot install, so following either verbatim fails on a clean clone.

Separately, the `multitude` test gate for over-aligned types is named after one particular codegen backend instead of the property that actually decides whether those tests can run, and the flag has no written contract anywhere in-tree.

## Change

- `.vscode/settings.template.jsonc` and `.github/prompts/clippy-nightly.prompt.md` now reference the public nightly toolchain. rustfmt is pinned to `+nightly-2026-05-30`, matching `RUST_NIGHTLY` in `constants.env`, which is what CI's format check runs.
- `scripts/update_rust_toolchain.ps1` rewrites that pin whenever it bumps `RUST_NIGHTLY`, so the two cannot drift apart, and `scripts/tests/Pester/unit/toolchain/PinnedNightly.Tests.ps1` asserts they agree regardless of who performs the bump. The template also tells contributors to re-copy the line and install the new toolchain afterwards, since their own `settings.json` does not move with a bump.
- The Clippy prompt names `RUST_NIGHTLY` rather than a floating `nightly`, and records that CI's Clippy gate is the stable `RUST_LATEST`, so nightly-only lints are advisory and should not be silenced with `#[expect(...)]` before confirming they fire on the gating toolchain.
- The test cfg is renamed to `align_capped_backend` across `Cargo.toml` and five `multitude` test files (65 occurrences), the comment in `crates/multitude/tests/arena.rs` states the constraint the gate encodes, and the `check-cfg` entry now documents the flag's contract: when to set it, that nothing in-tree sets it, and that it is all-or-nothing across the 32 KiB, 64 KiB and 128 KiB cases.

No test logic changes; the `check-cfg` declaration moves with the rename, so the gate behaves exactly as before.

## Drive-by: `chunks_exact` -> `as_chunks` in `alloc_growable.rs`

Unrelated to the above, but it blocks CI on this branch.

`clippy::chunks_exact_to_as_chunks` is newer than the pinned `RUST_LATEST` (1.96.1) and fires on the two UTF-16 byte-pairing sites in `crates/multitude/src/arena/alloc_growable.rs`, which `-D warnings` turns into an error. The lint is already latent on `main`; editing the workspace `Cargo.toml` invalidated the lint cache and re-linted the whole crate, which is why `pr-fast` fails here and not on branches opened earlier.

Both sites now use `as_chunks::<2>().0.iter()`. `as_chunks` discards the trailing odd byte exactly as `chunks_exact(2)` did, so the lossy constructors still append their own replacement character and behaviour is unchanged.

## Validation

- `cargo check -p multitude --tests --all-features` - clean.
- The same command with `RUSTFLAGS=--cfg align_capped_backend` - clean, no `unexpected_cfgs` warning.
- `cargo test -p multitude --all-features utf16` - 216 passed, 0 failed.
- `scripts/tests/Pester/Run-Tests.ps1 -Path unit` - 414 passed, 0 failed, 1 skipped. The new pin test was also confirmed to fail when the template pin is drifted by hand.

WI: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7783302