### PR TITLE
fix(arty_executor): declare the foldhash std feature it uses

### DIFF
--- a/crates/arty_executor/Cargo.toml
+++ b/crates/arty_executor/Cargo.toml
@@ -25,8 +25,6 @@ test-util = ["dep:scopeguard"]
 
 [dependencies]
 events_once = { workspace = true }
-# The workspace declares foldhash with `default-features = false`. `foldhash::HashMap`
-# and `HashMapExt`, used in `wake_diagnostic`, live behind the `std` feature.
 foldhash = { workspace = true, features = ["std"] }
 infinity_pool = { workspace = true }
 nm = { workspace = true }

--- a/crates/arty_executor/Cargo.toml
+++ b/crates/arty_executor/Cargo.toml
@@ -25,7 +25,9 @@ test-util = ["dep:scopeguard"]
 
 [dependencies]
 events_once = { workspace = true }
-foldhash = { workspace = true }
+# The workspace declares foldhash with `default-features = false`. `foldhash::HashMap`
+# and `HashMapExt`, used in `wake_diagnostic`, live behind the `std` feature.
+foldhash = { workspace = true, features = ["std"] }
 infinity_pool = { workspace = true }
 nm = { workspace = true }
 pin-project = { workspace = true }

--- a/crates/arty_executor/src/wake.rs
+++ b/crates/arty_executor/src/wake.rs
@@ -105,7 +105,7 @@ impl WakeSignal {
         let fake_task_ref = unsafe { TaskRef::fake() };
 
         Self::new(
-            Arc::new(Mutex::new(VecDeque::with_capacity(0))),
+            Arc::new(Mutex::new(VecDeque::new())),
             Arc::new(AtomicBool::new(false)),
             Waker::noop().clone(),
             fake_task_ref,
@@ -367,7 +367,7 @@ mod tests {
         let fake_task_ref = unsafe { TaskRef::fake() };
 
         // Capacity is 0 so the queue is not allowed to allocate (== is never used).
-        let awakened_queue = Arc::new(Mutex::new(VecDeque::with_capacity(0)));
+        let awakened_queue = Arc::new(Mutex::new(VecDeque::new()));
         let probe_embedded_wake_signals = Arc::new(AtomicBool::new(false));
         let parent_waker = Arc::new(TestWaker::new());
 


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

## What this changes

`crates/arty_executor/Cargo.toml` now asks for foldhash's `std` feature on its own dependency.

## Why

`crates/arty_executor/src/wake_diagnostic.rs` imports `foldhash::HashMap` and `foldhash::HashMapExt`. Both are aliases over `std::collections`, so both live behind foldhash's `std` feature. The workspace declares `foldhash = { version = "0.2.0", default-features = false }`, and this crate took that declaration unchanged. Nothing in the crate enabled `std`.

The imports resolved anyway, because `nm_impl` 0.1.44 depended on foldhash with `features = ["std"]` and feature unification carried that into every graph containing `nm`. `nm_impl` 0.1.45 dropped the foldhash dependency. The activation went with it, and the crate stopped compiling wherever nothing else turns `std` on.

`cargo semver-checks` builds each crate in a throwaway example package, so it saw this first and reported it on an unrelated documentation PR (#698):

```
error[E0432]: unresolved imports `foldhash::HashMap`, `foldhash::HashMapExt`
 --> crates/arty_executor/src/wake_diagnostic.rs:9:16
```

The workspace itself is still green only because `Cargo.lock` pins `nm_impl` 0.1.44. The next lockfile update would break it here too.

## Effects

- `arty_executor` builds from its own manifest, without relying on a dependency of `nm_impl`.
- foldhash's `std` feature was already active in every workspace build, so no dependency is added and no build grows.
- No source file, public API or runtime behavior changes.

## Validation

- Reproduced the failure in an isolated example crate built with `cargo add --path crates/arty_executor --features test-util`, matching what `cargo semver-checks` constructs. Before this change `cargo tree --edges features --invert foldhash` shows `foldhash feature "std"` reached only through `nm_impl`; after it, `arty_executor` activates the feature itself.
- `cargo test --package arty_executor --all-features` on 1.93.1: 46 passed.
- `cargo clippy --package arty_executor --all-targets -D warnings` on 1.96.1: clean.
- `just anvil-cargo-sort`: clean.

Filed as AB#7795965.

---

🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

**Note on scope:** the `anvil-clippy` gate on this branch denied two pre-existing `VecDeque::with_capacity(0)` call sites in `crates/arty_executor/src/wake.rs` (lines 108 and 370, both test-only placeholder queues), failing `pr-fast` on linux, linux-arm and windows-arm. Clippy's own suggestion — `VecDeque::new()` — was applied verbatim at both sites. `new()` allocates nothing, so the intent of those placeholders is unchanged. This is the minimum needed to get CI green; nothing else in the crate was touched.