### PR TITLE
fix: silence newly-firing clippy lints from Rust 1.98

### DIFF
--- a/crates/bytesbuf_io/src/read_futures.rs
+++ b/crates/bytesbuf_io/src/read_futures.rs
@@ -137,6 +137,7 @@ where
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::convert::Infallible;
+    use std::future::ready;
     use std::pin::pin;
     use std::task::Waker;
 
@@ -322,16 +323,16 @@ mod tests {
     impl crate::Read for ErroringRead {
         type Error = TestError;
 
-        async fn read_at_most_into(&mut self, _len: usize, _into: BytesBuf) -> Result<(usize, BytesBuf), Self::Error> {
-            Err(TestError("read_at_most_into error".to_string()))
+        fn read_at_most_into(&mut self, _len: usize, _into: BytesBuf) -> impl Future<Output = Result<(usize, BytesBuf), Self::Error>> {
+            ready(Err(TestError("read_at_most_into error".to_string())))
         }
 
-        async fn read_more_into(&mut self, _into: BytesBuf) -> Result<(usize, BytesBuf), Self::Error> {
-            Err(TestError("read_more_into error".to_string()))
+        fn read_more_into(&mut self, _into: BytesBuf) -> impl Future<Output = Result<(usize, BytesBuf), Self::Error>> {
+            ready(Err(TestError("read_more_into error".to_string())))
         }
 
-        async fn read_any(&mut self) -> Result<BytesBuf, Self::Error> {
-            Err(TestError("read_any error".to_string()))
+        fn read_any(&mut self) -> impl Future<Output = Result<BytesBuf, Self::Error>> {
+            ready(Err(TestError("read_any error".to_string())))
         }
     }
 

--- a/crates/bytesbuf_io/src/testing/fake_read.rs
+++ b/crates/bytesbuf_io/src/testing/fake_read.rs
@@ -65,7 +65,11 @@ impl FakeRead {
     ///
     /// This call never fails.
     #[cfg_attr(test, mutants::skip)] // Mutations easily lead to infinite loops, not worth the effort.
-    #[expect(clippy::unused_async, reason = "API compatibility between trait and inherent fn")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "API compatibility between trait and inherent fn"
+    )]
     pub async fn read_at_most_into(&mut self, len: usize, mut into: BytesBuf) -> Result<(usize, BytesBuf), Infallible> {
         let bytes_to_read = len
             .min(self.contents.len())

--- a/crates/bytesbuf_io/src/testing/fake_write.rs
+++ b/crates/bytesbuf_io/src/testing/fake_write.rs
@@ -53,7 +53,11 @@ impl FakeWrite {
     /// # Errors
     ///
     /// This call never fails.
-    #[expect(clippy::unused_async, reason = "API compatibility between trait and inherent fn")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "API compatibility between trait and inherent fn"
+    )]
     pub async fn write(&mut self, data: BytesView) -> Result<(), Infallible> {
         self.contents.put_bytes(data);
         Ok(())

--- a/crates/bytesbuf_io/src/testing/mod.rs
+++ b/crates/bytesbuf_io/src/testing/mod.rs
@@ -3,6 +3,8 @@
 
 //! Utilities for testing code that uses `bytesbuf_io` abstractions.
 
+#![allow(unknown_lints, reason = "the pinned and latest Clippy versions expose different async lints")]
+
 mod fake_read;
 mod fake_write;
 mod null;

--- a/crates/bytesbuf_io/src/testing/null.rs
+++ b/crates/bytesbuf_io/src/testing/null.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use std::convert::Infallible;
+use std::future::ready;
 
 use bytesbuf::mem::testing::TransparentMemory;
 use bytesbuf::mem::{HasMemory, Memory, MemoryShared, OpaqueMemory};
@@ -42,6 +43,7 @@ impl Null {
     #[expect(
         clippy::needless_pass_by_ref_mut,
         clippy::unused_async,
+        clippy::unused_async_trait_impl,
         reason = "API compatibility between trait and inherent fn"
     )]
     pub async fn read_at_most_into(&mut self, _len: usize, into: BytesBuf) -> Result<(usize, BytesBuf), Infallible> {
@@ -57,6 +59,7 @@ impl Null {
     #[expect(
         clippy::needless_pass_by_ref_mut,
         clippy::unused_async,
+        clippy::unused_async_trait_impl,
         reason = "API compatibility between trait and inherent fn"
     )]
     pub async fn read_more_into(&mut self, into: BytesBuf) -> Result<(usize, BytesBuf), Infallible> {
@@ -72,6 +75,7 @@ impl Null {
     #[expect(
         clippy::needless_pass_by_ref_mut,
         clippy::unused_async,
+        clippy::unused_async_trait_impl,
         reason = "API compatibility between trait and inherent fn"
     )]
     pub async fn read_any(&mut self) -> Result<BytesBuf, Infallible> {
@@ -87,6 +91,7 @@ impl Null {
     #[expect(
         clippy::needless_pass_by_ref_mut,
         clippy::unused_async,
+        clippy::unused_async_trait_impl,
         reason = "API compatibility between trait and inherent fn"
     )]
     pub async fn write(&mut self, _sequence: BytesView) -> Result<(), Infallible> {
@@ -153,8 +158,8 @@ impl Write for Null {
     type Error = Infallible;
 
     #[cfg_attr(test, mutants::skip)] // Trivial forwarder.
-    async fn write(&mut self, _sequence: BytesView) -> Result<(), Infallible> {
-        Ok(())
+    fn write(&mut self, _sequence: BytesView) -> impl Future<Output = Result<(), Infallible>> {
+        ready(Ok(()))
     }
 }
 

--- a/crates/cachet/examples/error_handling.rs
+++ b/crates/cachet/examples/error_handling.rs
@@ -8,6 +8,7 @@
 //! - Attach recovery information with `with_recovery()`
 //! - Extract and handle typed errors from cache operations
 
+use std::future::ready;
 use std::io::{self, ErrorKind};
 
 use cachet::{Cache, CacheEntry, CacheTier, Error, InsertOutcome};
@@ -19,21 +20,23 @@ use tick::Clock;
 struct FailingCache;
 
 impl CacheTier<String, i32> for FailingCache {
-    async fn get(&self, _key: &String) -> Result<Option<CacheEntry<i32>>, Error> {
+    fn get(&self, _key: &String) -> impl Future<Output = Result<Option<CacheEntry<i32>>, Error>> + Send {
         // Wrap the IO error and attach recovery information
-        Err(Error::from_source(io::Error::new(ErrorKind::TimedOut, "connection timed out")).with_recovery(RecoveryInfo::retry()))
+        ready(Err(
+            Error::from_source(io::Error::new(ErrorKind::TimedOut, "connection timed out")).with_recovery(RecoveryInfo::retry())
+        ))
     }
 
-    async fn insert(&self, _key: String, _entry: CacheEntry<i32>) -> Result<InsertOutcome, Error> {
-        Ok(InsertOutcome::Accepted)
+    fn insert(&self, _key: String, _entry: CacheEntry<i32>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
+        ready(Ok(InsertOutcome::Accepted))
     }
 
-    async fn invalidate(&self, _key: &String) -> Result<(), Error> {
-        Ok(())
+    fn invalidate(&self, _key: &String) -> impl Future<Output = Result<(), Error>> + Send {
+        ready(Ok(()))
     }
 
-    async fn clear(&self) -> Result<(), Error> {
-        Ok(())
+    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
+        ready(Ok(()))
     }
 }
 

--- a/crates/cachet/examples/error_handling.rs
+++ b/crates/cachet/examples/error_handling.rs
@@ -8,7 +8,12 @@
 //! - Attach recovery information with `with_recovery()`
 //! - Extract and handle typed errors from cache operations
 
-use std::future::ready;
+#![allow(unknown_lints, reason = "the pinned and latest Clippy versions expose different async lints")]
+#![expect(
+    clippy::unused_async_trait_impl,
+    reason = "examples are written for a human reader, and a plain `async fn` shows the shape of a tier impl better than `impl Future` plus `std::future::ready`"
+)]
+
 use std::io::{self, ErrorKind};
 
 use cachet::{Cache, CacheEntry, CacheTier, Error, InsertOutcome};
@@ -20,23 +25,21 @@ use tick::Clock;
 struct FailingCache;
 
 impl CacheTier<String, i32> for FailingCache {
-    fn get(&self, _key: &String) -> impl Future<Output = Result<Option<CacheEntry<i32>>, Error>> + Send {
+    async fn get(&self, _key: &String) -> Result<Option<CacheEntry<i32>>, Error> {
         // Wrap the IO error and attach recovery information
-        ready(Err(
-            Error::from_source(io::Error::new(ErrorKind::TimedOut, "connection timed out")).with_recovery(RecoveryInfo::retry())
-        ))
+        Err(Error::from_source(io::Error::new(ErrorKind::TimedOut, "connection timed out")).with_recovery(RecoveryInfo::retry()))
     }
 
-    fn insert(&self, _key: String, _entry: CacheEntry<i32>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
-        ready(Ok(InsertOutcome::Accepted))
+    async fn insert(&self, _key: String, _entry: CacheEntry<i32>) -> Result<InsertOutcome, Error> {
+        Ok(InsertOutcome::Accepted)
     }
 
-    fn invalidate(&self, _key: &String) -> impl Future<Output = Result<(), Error>> + Send {
-        ready(Ok(()))
+    async fn invalidate(&self, _key: &String) -> Result<(), Error> {
+        Ok(())
     }
 
-    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
-        ready(Ok(()))
+    async fn clear(&self) -> Result<(), Error> {
+        Ok(())
     }
 }
 

--- a/crates/cachet/examples/multi_tier.rs
+++ b/crates/cachet/examples/multi_tier.rs
@@ -5,6 +5,7 @@
 //! Example: only promote "not found" results to avoid repeated backend queries.
 
 use std::fmt;
+use std::future::ready;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -31,25 +32,25 @@ impl fmt::Display for UserData {
 struct Database(Mutex<u32>);
 
 impl CacheTier<String, UserData> for Arc<Database> {
-    async fn get(&self, key: &String) -> Result<Option<CacheEntry<UserData>>, Error> {
+    fn get(&self, key: &String) -> impl Future<Output = Result<Option<CacheEntry<UserData>>, Error>> + Send {
         *self.0.lock() += 1;
         let data = match key.as_str() {
             "user:1" => UserData::Found("Alice".to_string()),
             _ => UserData::NotFound,
         };
-        Ok(Some(CacheEntry::new(data)))
+        ready(Ok(Some(CacheEntry::new(data))))
     }
 
-    async fn insert(&self, _: String, _: CacheEntry<UserData>) -> Result<InsertOutcome, Error> {
-        Ok(InsertOutcome::Accepted)
+    fn insert(&self, _: String, _: CacheEntry<UserData>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
+        ready(Ok(InsertOutcome::Accepted))
     }
 
-    async fn invalidate(&self, _: &String) -> Result<(), Error> {
-        Ok(())
+    fn invalidate(&self, _: &String) -> impl Future<Output = Result<(), Error>> + Send {
+        ready(Ok(()))
     }
 
-    async fn clear(&self) -> Result<(), Error> {
-        Ok(())
+    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
+        ready(Ok(()))
     }
 }
 

--- a/crates/cachet/examples/multi_tier.rs
+++ b/crates/cachet/examples/multi_tier.rs
@@ -4,8 +4,13 @@
 //! Multi-tier cache with conditional promotion policies.
 //! Example: only promote "not found" results to avoid repeated backend queries.
 
+#![allow(unknown_lints, reason = "the pinned and latest Clippy versions expose different async lints")]
+#![expect(
+    clippy::unused_async_trait_impl,
+    reason = "examples are written for a human reader, and a plain `async fn` shows the shape of a tier impl better than `impl Future` plus `std::future::ready`"
+)]
+
 use std::fmt;
-use std::future::ready;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -32,25 +37,25 @@ impl fmt::Display for UserData {
 struct Database(Mutex<u32>);
 
 impl CacheTier<String, UserData> for Arc<Database> {
-    fn get(&self, key: &String) -> impl Future<Output = Result<Option<CacheEntry<UserData>>, Error>> + Send {
+    async fn get(&self, key: &String) -> Result<Option<CacheEntry<UserData>>, Error> {
         *self.0.lock() += 1;
         let data = match key.as_str() {
             "user:1" => UserData::Found("Alice".to_string()),
             _ => UserData::NotFound,
         };
-        ready(Ok(Some(CacheEntry::new(data))))
+        Ok(Some(CacheEntry::new(data)))
     }
 
-    fn insert(&self, _: String, _: CacheEntry<UserData>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
-        ready(Ok(InsertOutcome::Accepted))
+    async fn insert(&self, _: String, _: CacheEntry<UserData>) -> Result<InsertOutcome, Error> {
+        Ok(InsertOutcome::Accepted)
     }
 
-    fn invalidate(&self, _: &String) -> impl Future<Output = Result<(), Error>> + Send {
-        ready(Ok(()))
+    async fn invalidate(&self, _: &String) -> Result<(), Error> {
+        Ok(())
     }
 
-    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
-        ready(Ok(()))
+    async fn clear(&self) -> Result<(), Error> {
+        Ok(())
     }
 }
 

--- a/crates/cachet/examples/refresh.rs
+++ b/crates/cachet/examples/refresh.rs
@@ -4,6 +4,7 @@
 //! Time-to-refresh: return stale data immediately, refresh in background.
 //! Keeps cache warm and avoids latency spikes from cache misses.
 
+use std::future::ready;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -25,16 +26,16 @@ impl CacheTier<String, String> for Database {
         Ok(Some(CacheEntry::new(format!("{key}_v{v}"))))
     }
 
-    async fn insert(&self, _: String, _: CacheEntry<String>) -> Result<InsertOutcome, Error> {
-        Ok(InsertOutcome::Accepted)
+    fn insert(&self, _: String, _: CacheEntry<String>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
+        ready(Ok(InsertOutcome::Accepted))
     }
 
-    async fn invalidate(&self, _: &String) -> Result<(), Error> {
-        Ok(())
+    fn invalidate(&self, _: &String) -> impl Future<Output = Result<(), Error>> + Send {
+        ready(Ok(()))
     }
 
-    async fn clear(&self) -> Result<(), Error> {
-        Ok(())
+    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
+        ready(Ok(()))
     }
 }
 

--- a/crates/cachet/examples/refresh.rs
+++ b/crates/cachet/examples/refresh.rs
@@ -4,7 +4,12 @@
 //! Time-to-refresh: return stale data immediately, refresh in background.
 //! Keeps cache warm and avoids latency spikes from cache misses.
 
-use std::future::ready;
+#![allow(unknown_lints, reason = "the pinned and latest Clippy versions expose different async lints")]
+#![expect(
+    clippy::unused_async_trait_impl,
+    reason = "examples are written for a human reader, and a plain `async fn` shows the shape of a tier impl better than `impl Future` plus `std::future::ready`"
+)]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -26,16 +31,16 @@ impl CacheTier<String, String> for Database {
         Ok(Some(CacheEntry::new(format!("{key}_v{v}"))))
     }
 
-    fn insert(&self, _: String, _: CacheEntry<String>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
-        ready(Ok(InsertOutcome::Accepted))
+    async fn insert(&self, _: String, _: CacheEntry<String>) -> Result<InsertOutcome, Error> {
+        Ok(InsertOutcome::Accepted)
     }
 
-    fn invalidate(&self, _: &String) -> impl Future<Output = Result<(), Error>> + Send {
-        ready(Ok(()))
+    async fn invalidate(&self, _: &String) -> Result<(), Error> {
+        Ok(())
     }
 
-    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
-        ready(Ok(()))
+    async fn clear(&self) -> Result<(), Error> {
+        Ok(())
     }
 }
 

--- a/crates/cachet/examples/service_as_storage.rs
+++ b/crates/cachet/examples/service_as_storage.rs
@@ -6,8 +6,13 @@
 //! This pattern is useful for remote caches (Redis, Memcached) where
 //! you want to add middleware (retry, timeout) to the underlying service.
 
+#![allow(unknown_lints, reason = "the pinned and latest Clippy versions expose different async lints")]
+#![expect(
+    clippy::unused_async_trait_impl,
+    reason = "examples are written for a human reader, and a plain `async fn` shows the shape of a service impl better than `impl Future` plus `std::future::ready`"
+)]
+
 use std::collections::HashMap;
-use std::future::ready;
 
 use cachet::{Cache, CacheEntry, CacheOperation, CacheResponse, GetRequest, InsertOutcome, InsertRequest, InvalidateRequest};
 use layered::Service;
@@ -22,8 +27,8 @@ struct RemoteCache {
 impl Service<CacheOperation<String, String>> for RemoteCache {
     type Out = Result<CacheResponse<String>, cachet::Error>;
 
-    fn execute(&self, input: CacheOperation<String, String>) -> impl Future<Output = Self::Out> + Send {
-        ready(match input {
+    async fn execute(&self, input: CacheOperation<String, String>) -> Self::Out {
+        match input {
             CacheOperation::Get(GetRequest { key }) => Ok(CacheResponse::Get(self.data.get(&key).cloned())),
             CacheOperation::Insert(InsertRequest { key, entry }) => {
                 // Note: simplified - real impl would mutate
@@ -35,7 +40,7 @@ impl Service<CacheOperation<String, String>> for RemoteCache {
                 Ok(CacheResponse::Invalidate)
             }
             CacheOperation::Clear => Ok(CacheResponse::Clear),
-        })
+        }
     }
 }
 

--- a/crates/cachet/examples/service_as_storage.rs
+++ b/crates/cachet/examples/service_as_storage.rs
@@ -7,6 +7,7 @@
 //! you want to add middleware (retry, timeout) to the underlying service.
 
 use std::collections::HashMap;
+use std::future::ready;
 
 use cachet::{Cache, CacheEntry, CacheOperation, CacheResponse, GetRequest, InsertOutcome, InsertRequest, InvalidateRequest};
 use layered::Service;
@@ -21,8 +22,8 @@ struct RemoteCache {
 impl Service<CacheOperation<String, String>> for RemoteCache {
     type Out = Result<CacheResponse<String>, cachet::Error>;
 
-    async fn execute(&self, input: CacheOperation<String, String>) -> Self::Out {
-        match input {
+    fn execute(&self, input: CacheOperation<String, String>) -> impl Future<Output = Self::Out> + Send {
+        ready(match input {
             CacheOperation::Get(GetRequest { key }) => Ok(CacheResponse::Get(self.data.get(&key).cloned())),
             CacheOperation::Insert(InsertRequest { key, entry }) => {
                 // Note: simplified - real impl would mutate
@@ -34,7 +35,7 @@ impl Service<CacheOperation<String, String>> for RemoteCache {
                 Ok(CacheResponse::Invalidate)
             }
             CacheOperation::Clear => Ok(CacheResponse::Clear),
-        }
+        })
     }
 }
 

--- a/crates/cachet/examples/stampede_protection.rs
+++ b/crates/cachet/examples/stampede_protection.rs
@@ -4,7 +4,12 @@
 //! Stampede protection prevents multiple concurrent requests for the same key
 //! from all hitting the backend. Only one request fetches; others wait and share the result.
 
-use std::future::ready;
+#![allow(unknown_lints, reason = "the pinned and latest Clippy versions expose different async lints")]
+#![expect(
+    clippy::unused_async_trait_impl,
+    reason = "examples are written for a human reader, and a plain `async fn` shows the shape of a tier impl better than `impl Future` plus `std::future::ready`"
+)]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -24,16 +29,16 @@ impl CacheTier<String, String> for SlowBackend {
         Ok(Some(CacheEntry::new(format!("value_for_{key}"))))
     }
 
-    fn insert(&self, _: String, _: CacheEntry<String>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
-        ready(Ok(InsertOutcome::Accepted))
+    async fn insert(&self, _: String, _: CacheEntry<String>) -> Result<InsertOutcome, Error> {
+        Ok(InsertOutcome::Accepted)
     }
 
-    fn invalidate(&self, _: &String) -> impl Future<Output = Result<(), Error>> + Send {
-        ready(Ok(()))
+    async fn invalidate(&self, _: &String) -> Result<(), Error> {
+        Ok(())
     }
 
-    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
-        ready(Ok(()))
+    async fn clear(&self) -> Result<(), Error> {
+        Ok(())
     }
 }
 

--- a/crates/cachet/examples/stampede_protection.rs
+++ b/crates/cachet/examples/stampede_protection.rs
@@ -4,6 +4,7 @@
 //! Stampede protection prevents multiple concurrent requests for the same key
 //! from all hitting the backend. Only one request fetches; others wait and share the result.
 
+use std::future::ready;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -23,16 +24,16 @@ impl CacheTier<String, String> for SlowBackend {
         Ok(Some(CacheEntry::new(format!("value_for_{key}"))))
     }
 
-    async fn insert(&self, _: String, _: CacheEntry<String>) -> Result<InsertOutcome, Error> {
-        Ok(InsertOutcome::Accepted)
+    fn insert(&self, _: String, _: CacheEntry<String>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
+        ready(Ok(InsertOutcome::Accepted))
     }
 
-    async fn invalidate(&self, _: &String) -> Result<(), Error> {
-        Ok(())
+    fn invalidate(&self, _: &String) -> impl Future<Output = Result<(), Error>> + Send {
+        ready(Ok(()))
     }
 
-    async fn clear(&self) -> Result<(), Error> {
-        Ok(())
+    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
+        ready(Ok(()))
     }
 }
 

--- a/crates/cachet/tests/cache.rs
+++ b/crates/cachet/tests/cache.rs
@@ -9,6 +9,8 @@
 // tracing initialization does not run here. Install it directly. See docs/tracing-tests.md.
 testing_aids::init_tracing!();
 
+use std::future::ready;
+
 use cachet::{Cache, CacheEntry, Error, InsertOutcome, InsertPolicy};
 use cachet_tier::MockCache;
 use tick::Clock;
@@ -656,21 +658,21 @@ async fn stampede_protection_converts_panic_to_error() {
     }
 
     impl CacheTier<String, i32> for PanickingCache {
-        async fn get(&self, _key: &String) -> Result<Option<CacheEntry<i32>>, Error> {
+        fn get(&self, _key: &String) -> impl Future<Output = Result<Option<CacheEntry<i32>>, Error>> + Send {
             assert!(self.panicked.swap(true, Ordering::SeqCst), "simulated panic in cache tier");
-            Ok(None)
+            ready(Ok(None))
         }
 
-        async fn insert(&self, _key: String, _entry: CacheEntry<i32>) -> Result<InsertOutcome, Error> {
-            Ok(InsertOutcome::Accepted)
+        fn insert(&self, _key: String, _entry: CacheEntry<i32>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
+            ready(Ok(InsertOutcome::Accepted))
         }
 
-        async fn invalidate(&self, _key: &String) -> Result<(), Error> {
-            Ok(())
+        fn invalidate(&self, _key: &String) -> impl Future<Output = Result<(), Error>> + Send {
+            ready(Ok(()))
         }
 
-        async fn clear(&self) -> Result<(), Error> {
-            Ok(())
+        fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
+            ready(Ok(()))
         }
     }
 
@@ -871,8 +873,8 @@ mod service_tests {
     impl Service<CacheOperation<String, i32>> for InMemoryService {
         type Out = Result<CacheResponse<i32>, Error>;
 
-        async fn execute(&self, input: CacheOperation<String, i32>) -> Self::Out {
-            match input {
+        fn execute(&self, input: CacheOperation<String, i32>) -> impl Future<Output = Self::Out> + Send {
+            ready(match input {
                 CacheOperation::Get(req) => Ok(CacheResponse::Get(self.data.lock().get(&req.key).cloned())),
                 CacheOperation::Insert(req) => {
                     self.data.lock().insert(req.key, req.entry);
@@ -886,7 +888,7 @@ mod service_tests {
                     self.data.lock().clear();
                     Ok(CacheResponse::Clear)
                 }
-            }
+            })
         }
     }
 

--- a/crates/cachet_memory/src/tier.rs
+++ b/crates/cachet_memory/src/tier.rs
@@ -9,6 +9,7 @@
 // Use foldhash::fast for high-performance hashing of cache keys.
 // The `fast` variant prioritizes speed over statistical quality, which is
 // ideal for hash table lookups where we only need good bucket distribution.
+use std::future::ready;
 use std::hash::{BuildHasher, Hash};
 use std::time::{Duration, Instant};
 
@@ -208,13 +209,13 @@ where
         Ok(())
     }
 
-    async fn clear(&self) -> Result<(), Error> {
+    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
         self.inner.invalidate_all();
-        Ok(())
+        ready(Ok(()))
     }
 
-    async fn len(&self) -> Result<u64, SizeError> {
-        Ok(self.inner.entry_count())
+    fn len(&self) -> impl Future<Output = Result<u64, SizeError>> + Send {
+        ready(Ok(self.inner.entry_count()))
     }
 }
 

--- a/crates/cachet_service/src/adapter.rs
+++ b/crates/cachet_service/src/adapter.rs
@@ -7,6 +7,7 @@
 //! and `CacheTier`, enabling remote cache services (Redis, Memcached) to be used
 //! as cache storage backends.
 
+use std::future::ready;
 use std::hash::Hash;
 use std::marker::PhantomData;
 
@@ -95,9 +96,9 @@ where
         }
     }
 
-    async fn len(&self) -> Result<u64, SizeError> {
+    fn len(&self) -> impl Future<Output = Result<u64, SizeError>> + Send {
         // Service-based tiers typically don't expose length information
-        Err(SizeError::unsupported())
+        ready(Err(SizeError::unsupported()))
     }
 }
 
@@ -112,8 +113,8 @@ mod tests {
     impl Service<CacheOperation<String, i32>> for MockService {
         type Out = Result<CacheResponse<i32>, Error>;
 
-        async fn execute(&self, input: CacheOperation<String, i32>) -> Self::Out {
-            match input {
+        fn execute(&self, input: CacheOperation<String, i32>) -> impl Future<Output = Self::Out> + Send {
+            ready(match input {
                 CacheOperation::Get(req) => {
                     if req.key == "existing" {
                         Ok(CacheResponse::Get(Some(CacheEntry::new(42))))
@@ -124,7 +125,7 @@ mod tests {
                 CacheOperation::Insert(_) => Ok(CacheResponse::Insert(InsertOutcome::Accepted)),
                 CacheOperation::Invalidate(_) => Ok(CacheResponse::Invalidate),
                 CacheOperation::Clear => Ok(CacheResponse::Clear),
-            }
+            })
         }
     }
 
@@ -164,13 +165,13 @@ mod tests {
         impl Service<CacheOperation<String, i32>> for RejectingService {
             type Out = Result<CacheResponse<i32>, Error>;
 
-            async fn execute(&self, input: CacheOperation<String, i32>) -> Self::Out {
-                match input {
+            fn execute(&self, input: CacheOperation<String, i32>) -> impl Future<Output = Self::Out> + Send {
+                ready(match input {
                     CacheOperation::Insert(_) => Ok(CacheResponse::Insert(InsertOutcome::Rejected)),
                     CacheOperation::Get(_) => Ok(CacheResponse::Get(None)),
                     CacheOperation::Invalidate(_) => Ok(CacheResponse::Invalidate),
                     CacheOperation::Clear => Ok(CacheResponse::Clear),
-                }
+                })
             }
         }
 
@@ -224,15 +225,15 @@ mod tests {
     impl Service<CacheOperation<String, i32>> for WrongResponseService {
         type Out = Result<CacheResponse<i32>, Error>;
 
-        async fn execute(&self, input: CacheOperation<String, i32>) -> Self::Out {
-            match input {
+        fn execute(&self, input: CacheOperation<String, i32>) -> impl Future<Output = Self::Out> + Send {
+            ready(match input {
                 // Returns Clear response for Insert requests (wrong type)
                 CacheOperation::Insert(_) => Ok(CacheResponse::Clear),
                 // Returns Insert response for Get/Invalidate requests (wrong type)
                 CacheOperation::Get(_) | CacheOperation::Invalidate(_) => Ok(CacheResponse::Insert(InsertOutcome::Accepted)),
                 // Returns Get response for Clear requests (wrong type)
                 CacheOperation::Clear => Ok(CacheResponse::Get(None)),
-            }
+            })
         }
     }
 

--- a/crates/cachet_service/src/ext.rs
+++ b/crates/cachet_service/src/ext.rs
@@ -61,6 +61,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::future::ready;
+
     use super::*;
 
     // A correct service that returns expected response types
@@ -70,13 +72,13 @@ mod tests {
     impl Service<CacheOperation<String, i32>> for CorrectService {
         type Out = Result<CacheResponse<i32>, Error>;
 
-        async fn execute(&self, input: CacheOperation<String, i32>) -> Self::Out {
-            match input {
+        fn execute(&self, input: CacheOperation<String, i32>) -> impl Future<Output = Self::Out> + Send {
+            ready(match input {
                 CacheOperation::Get(_) => Ok(CacheResponse::Get(Some(CacheEntry::new(42)))),
                 CacheOperation::Insert(_) => Ok(CacheResponse::Insert(InsertOutcome::Accepted)),
                 CacheOperation::Invalidate(_) => Ok(CacheResponse::Invalidate),
                 CacheOperation::Clear => Ok(CacheResponse::Clear),
-            }
+            })
         }
     }
 
@@ -87,12 +89,12 @@ mod tests {
     impl Service<CacheOperation<String, i32>> for WrongResponseService {
         type Out = Result<CacheResponse<i32>, Error>;
 
-        async fn execute(&self, input: CacheOperation<String, i32>) -> Self::Out {
-            match input {
+        fn execute(&self, input: CacheOperation<String, i32>) -> impl Future<Output = Self::Out> + Send {
+            ready(match input {
                 CacheOperation::Insert(_) => Ok(CacheResponse::Clear),
                 CacheOperation::Get(_) | CacheOperation::Invalidate(_) => Ok(CacheResponse::Insert(InsertOutcome::Accepted)),
                 CacheOperation::Clear => Ok(CacheResponse::Get(None)),
-            }
+            })
         }
     }
 

--- a/crates/cachet_service/tests/adapter.rs
+++ b/crates/cachet_service/tests/adapter.rs
@@ -4,6 +4,7 @@
 //! Integration tests for `ServiceAdapter`.
 
 use std::collections::HashMap;
+use std::future::ready;
 use std::sync::Mutex;
 
 use cachet_service::{CacheOperation, CacheResponse, GetRequest, InsertRequest, InvalidateRequest, ServiceAdapter};
@@ -31,8 +32,8 @@ where
 {
     type Out = Result<CacheResponse<V>, Error>;
 
-    async fn execute(&self, input: CacheOperation<K, V>) -> Self::Out {
-        match input {
+    fn execute(&self, input: CacheOperation<K, V>) -> impl Future<Output = Self::Out> + Send {
+        ready(match input {
             CacheOperation::Get(req) => {
                 let data = self.data.lock().expect("lock poisoned");
                 Ok(CacheResponse::Get(data.get(&req.key).cloned()))
@@ -52,7 +53,7 @@ where
                 data.clear();
                 Ok(CacheResponse::Clear)
             }
-        }
+        })
     }
 }
 

--- a/crates/cachet_tier/src/testing.rs
+++ b/crates/cachet_tier/src/testing.rs
@@ -7,6 +7,7 @@
 //! records all operations and supports failure injection for testing error paths.
 
 use std::collections::HashMap;
+use std::future::ready;
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -226,54 +227,54 @@ where
     K: Clone + Eq + Hash + Send + Sync,
     V: Clone + Send + Sync,
 {
-    async fn get(&self, key: &K) -> Result<Option<CacheEntry<V>>, Error> {
+    fn get(&self, key: &K) -> impl Future<Output = Result<Option<CacheEntry<V>>, Error>> + Send {
         let op = CacheOp::Get(key.clone());
         if self.should_fail(&op) {
             self.record(op);
-            return Err(Error::from_message("mock: get failed"));
+            return ready(Err(Error::from_message("mock: get failed")));
         }
         self.record(op);
-        Ok(self.data.lock().get(key).cloned())
+        ready(Ok(self.data.lock().get(key).cloned()))
     }
 
-    async fn insert(&self, key: K, entry: CacheEntry<V>) -> Result<InsertOutcome, Error> {
+    fn insert(&self, key: K, entry: CacheEntry<V>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
         let op = CacheOp::Insert {
             key: key.clone(),
             entry: entry.clone(),
         };
         if self.should_fail(&op) {
             self.record(op);
-            return Err(Error::from_message("mock: insert failed"));
+            return ready(Err(Error::from_message("mock: insert failed")));
         }
         self.record(op);
         self.data.lock().insert(key, entry);
-        Ok(InsertOutcome::Accepted)
+        ready(Ok(InsertOutcome::Accepted))
     }
 
-    async fn invalidate(&self, key: &K) -> Result<(), Error> {
+    fn invalidate(&self, key: &K) -> impl Future<Output = Result<(), Error>> + Send {
         let op = CacheOp::Invalidate(key.clone());
         if self.should_fail(&op) {
             self.record(op);
-            return Err(Error::from_message("mock: invalidate failed"));
+            return ready(Err(Error::from_message("mock: invalidate failed")));
         }
         self.record(op);
         self.data.lock().remove(key);
-        Ok(())
+        ready(Ok(()))
     }
 
-    async fn clear(&self) -> Result<(), Error> {
+    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
         let op = CacheOp::Clear;
         if self.should_fail(&op) {
             self.record(op);
-            return Err(Error::from_message("mock: clear failed"));
+            return ready(Err(Error::from_message("mock: clear failed")));
         }
         self.record(op);
         self.data.lock().clear();
-        Ok(())
+        ready(Ok(()))
     }
 
-    async fn len(&self) -> Result<u64, SizeError> {
-        Ok(self.data.lock().len() as u64)
+    fn len(&self) -> impl Future<Output = Result<u64, SizeError>> + Send {
+        ready(Ok(self.data.lock().len() as u64))
     }
 }
 

--- a/crates/cachet_tier/tests/tier.rs
+++ b/crates/cachet_tier/tests/tier.rs
@@ -4,6 +4,7 @@
 //! Integration tests for `CacheTier` trait default implementations.
 
 use std::collections::HashMap;
+use std::future::ready;
 use std::sync::Mutex;
 
 #[cfg(feature = "test-util")]
@@ -28,23 +29,23 @@ where
     K: Clone + Eq + std::hash::Hash + Send + Sync,
     V: Clone + Send + Sync,
 {
-    async fn get(&self, key: &K) -> Result<Option<CacheEntry<V>>, Error> {
-        Ok(self.data.lock().expect("lock poisoned").get(key).cloned())
+    fn get(&self, key: &K) -> impl Future<Output = Result<Option<CacheEntry<V>>, Error>> + Send {
+        ready(Ok(self.data.lock().expect("lock poisoned").get(key).cloned()))
     }
 
-    async fn insert(&self, key: K, entry: CacheEntry<V>) -> Result<InsertOutcome, Error> {
+    fn insert(&self, key: K, entry: CacheEntry<V>) -> impl Future<Output = Result<InsertOutcome, Error>> + Send {
         self.data.lock().expect("lock poisoned").insert(key, entry);
-        Ok(InsertOutcome::Accepted)
+        ready(Ok(InsertOutcome::Accepted))
     }
 
-    async fn invalidate(&self, key: &K) -> Result<(), Error> {
+    fn invalidate(&self, key: &K) -> impl Future<Output = Result<(), Error>> + Send {
         self.data.lock().expect("lock poisoned").remove(key);
-        Ok(())
+        ready(Ok(()))
     }
 
-    async fn clear(&self) -> Result<(), Error> {
+    fn clear(&self) -> impl Future<Output = Result<(), Error>> + Send {
         self.data.lock().expect("lock poisoned").clear();
-        Ok(())
+        ready(Ok(()))
     }
 }
 

--- a/crates/fetch/tests/telemetry_scope.rs
+++ b/crates/fetch/tests/telemetry_scope.rs
@@ -239,7 +239,7 @@ struct OkHandler {
 impl Service<HttpRequest> for OkHandler {
     type Out = fetch::Result<HttpResponse>;
 
-    async fn execute(&self, _request: HttpRequest) -> Self::Out {
-        HttpResponseBuilder::new(&self.body_builder).status(StatusCode::OK).build()
+    fn execute(&self, _request: HttpRequest) -> impl Future<Output = Self::Out> + Send {
+        std::future::ready(HttpResponseBuilder::new(&self.body_builder).status(StatusCode::OK).build())
     }
 }

--- a/crates/fetch_hyper/src/connection/hyper_handler.rs
+++ b/crates/fetch_hyper/src/connection/hyper_handler.rs
@@ -192,9 +192,7 @@ mod tests {
     use bytes::Bytes;
     use fetch_options::{ConnectionLifetime, PoolIndex, RequestFilter};
     use http::Version;
-    use http_body_util::BodyExt as _;
     use http_extensions::{HttpBodyBuilder, HttpRequestBuilder};
-    use layered::Service as _;
 
     use super::*;
     use crate::HyperTransport;

--- a/crates/fundle/tests/bundle_setters.rs
+++ b/crates/fundle/tests/bundle_setters.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(unknown_lints, reason = "the pinned and latest Clippy versions expose different async lints")]
 #![allow(
     unused_attributes,
     clippy::empty_structs_with_brackets,

--- a/crates/fundle/tests/bundle_setters.rs
+++ b/crates/fundle/tests/bundle_setters.rs
@@ -7,6 +7,7 @@
     clippy::redundant_type_annotations,
     clippy::items_after_statements,
     clippy::unused_async,
+    clippy::unused_async_trait_impl,
     clippy::unnecessary_wraps,
     missing_docs,
     reason = "Unit tests"

--- a/crates/layered/src/service.rs
+++ b/crates/layered/src/service.rs
@@ -60,6 +60,8 @@ where
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod tests {
+    use std::future::ready;
+
     use futures::executor::block_on;
 
     use super::*;
@@ -70,8 +72,8 @@ mod tests {
     impl Service<String> for EchoService {
         type Out = String;
 
-        async fn execute(&self, input: String) -> Self::Out {
-            input
+        fn execute(&self, input: String) -> impl Future<Output = Self::Out> + Send {
+            ready(input)
         }
     }
 

--- a/crates/layered/src/testing.rs
+++ b/crates/layered/src/testing.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::future::ready;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -42,7 +43,7 @@ impl TowerService<String> for MockService {
 impl Service<String> for MockService {
     type Out = Result<String, String>;
 
-    async fn execute(&self, _input: String) -> Self::Out {
-        self.call_response.clone()
+    fn execute(&self, _input: String) -> impl Future<Output = Self::Out> + Send {
+        ready(self.call_response.clone())
     }
 }

--- a/crates/multitude/src/arena/alloc_growable.rs
+++ b/crates/multitude/src/arena/alloc_growable.rs
@@ -427,8 +427,7 @@ impl<A: Allocator + Clone> Arena<A> {
             return Err(FromUtf16Error::new());
         }
         let mut out = self.alloc_string_with_capacity(bytes.len() / 2);
-        let units = bytes.chunks_exact(2).map(|pair| {
-            let raw = [pair[0], pair[1]];
+        let units = bytes.as_chunks::<2>().0.iter().map(|&raw| {
             if big_endian {
                 u16::from_be_bytes(raw)
             } else {
@@ -449,8 +448,7 @@ impl<A: Allocator + Clone> Arena<A> {
     /// Fallible variant of [`Self::alloc_string_from_utf16_bytes_lossy`].
     fn try_alloc_string_from_utf16_bytes_lossy(&self, bytes: &[u8], big_endian: bool) -> Result<String<'_, A>, AllocError> {
         let mut out = self.try_alloc_string_with_capacity(bytes.len() / 2 + 1)?;
-        let units = bytes.chunks_exact(2).map(|pair| {
-            let raw = [pair[0], pair[1]];
+        let units = bytes.as_chunks::<2>().0.iter().map(|&raw| {
             if big_endian {
                 u16::from_be_bytes(raw)
             } else {

--- a/crates/observed/benches/observed_benchmarks.rs
+++ b/crates/observed/benches/observed_benchmarks.rs
@@ -209,8 +209,11 @@ fn make_log_processor_with(redaction_engine: data_privacy::RedactionEngine) -> (
 struct NoOpLogExporter;
 
 impl opentelemetry_sdk::logs::LogExporter for NoOpLogExporter {
-    async fn export(&self, _batch: opentelemetry_sdk::logs::LogBatch<'_>) -> opentelemetry_sdk::error::OTelSdkResult {
-        Ok(())
+    fn export(
+        &self,
+        _batch: opentelemetry_sdk::logs::LogBatch<'_>,
+    ) -> impl Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send {
+        std::future::ready(Ok(()))
     }
 
     fn shutdown_with_timeout(&self, _timeout: std::time::Duration) -> opentelemetry_sdk::error::OTelSdkResult {

--- a/crates/rest_over_grpc/src/stream.rs
+++ b/crates/rest_over_grpc/src/stream.rs
@@ -388,8 +388,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures_util::StreamExt as _;
-
     use super::*;
     use crate::handling::Code;
 

--- a/crates/seatbelt/benches/observability.rs
+++ b/crates/seatbelt/benches/observability.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #![expect(missing_docs, reason = "benchmark code")]
+use std::future::ready;
 use std::time::Duration;
 
 use alloc_tracker::{Allocator, Session};
@@ -99,8 +100,8 @@ impl From<Input> for Output {
 struct EmptyExporter;
 
 impl PushMetricExporter for EmptyExporter {
-    async fn export(&self, _metrics: &ResourceMetrics) -> OTelSdkResult {
-        Ok(())
+    fn export(&self, _metrics: &ResourceMetrics) -> impl Future<Output = OTelSdkResult> + Send {
+        ready(Ok(()))
     }
 
     fn force_flush(&self) -> OTelSdkResult {

--- a/crates/seatbelt/benches/observability_cg.rs
+++ b/crates/seatbelt/benches/observability_cg.rs
@@ -34,6 +34,7 @@ fn main() {
 
 #[cfg(target_os = "linux")]
 mod linux {
+    use std::future::ready;
     use std::hint::black_box;
     use std::time::Duration;
 
@@ -63,8 +64,8 @@ mod linux {
     struct EmptyExporter;
 
     impl PushMetricExporter for EmptyExporter {
-        async fn export(&self, _metrics: &ResourceMetrics) -> OTelSdkResult {
-            Ok(())
+        fn export(&self, _metrics: &ResourceMetrics) -> impl Future<Output = OTelSdkResult> + Send {
+            ready(Ok(()))
         }
 
         fn force_flush(&self) -> OTelSdkResult {


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

## What

Rust 1.98 ships a new pedantic lint, [`clippy::unused_async_trait_impl`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#unused_async_trait_impl), which fires on an `async fn` inside an `impl` block whose body contains no `.await`. The workspace enables `clippy::pedantic` and `anvil-clippy` runs with `-D warnings`, so every one of these is a hard build failure.

This is currently blocking unrelated PRs. #698 is a documentation-only change, but its affected-package set pulls in `cachet_tier`, so `anvil-pr / pr-fast` fails on it with 5 errors in code the PR does not touch. This PR carries the lint fixes on their own so those PRs can go green.

## Lints fixed

| Lint | Sites |
|---|---|
| `clippy::unused_async_trait_impl` (new in 1.98) | 55, across 22 files |
| `clippy::chunks_exact_to_as_chunks` | 2, in `multitude` |
| `unused_imports` (rustc) | 3 `use ... as _;` trait imports |

## How

For genuine trait impls, apply clippy's own suggestion: drop `async` and return `impl Future<Output = ...>` built from `std::future::ready`. The traits (`CacheTier`, `layered::Service`, `bytesbuf_io::Read` / `Write`, the OTel exporter traits) already declare a future return type, so this is not a public API change, and the bodies were already synchronous.

Two places keep `async` instead:

* The inherent `pub async fn` mirrors in `bytesbuf_io::testing` (`Null`, `FakeRead`, `FakeWrite`) already carry `#[expect(clippy::unused_async, reason = "API compatibility between trait and inherent fn")]`. The `async` there is deliberate and the signatures are public API, so the new lint name was added to the existing `expect` list rather than changing them.
* `fundle/tests/bundle_setters.rs` has a crate-level allow list that already includes `clippy::unused_async`; the new lint name was added alongside it.

The `#[expect]` entries name a lint that does not exist before 1.98. That matches existing repo practice — `tick`'s `UnixSeconds::MAX` already `#[expect]`s `clippy::duration_suboptimal_units` the same way.

`multitude`'s `as_chunks::<2>()` change also removes the manual `let raw = [pair[0], pair[1]];` rebuild, since the iterator now yields `[u8; 2]` directly. `as_chunks` is stable since 1.88, below the 1.93.1 MSRV.

## Effects

* `anvil-fmt` and `anvil-clippy` (`--workspace --all-targets --all-features -- -D warnings`) both pass on Rust 1.98.0; before this change the workspace produced 60 clippy errors.
* Tests pass for all 13 touched packages (`--all-features`): 106 suites, 0 failures.
* The three removed imports were verified to still compile on the pinned `RUST_LATEST` 1.96.1 and on the 1.93.1 MSRV — 1.96.1 does not report them as unused, so their removal is a 1.98-only detection improvement rather than a resolution change.
* No public API changes: every rewritten signature is a trait impl whose shape the trait already fixes.
* Behaviour is unchanged apart from the timing inherent in clippy's suggested fix — the (synchronous, non-blocking) body now runs when the method is called rather than when the returned future is first polled. Every one of these methods is awaited at its call site.

## Not in scope

Lint fixes only. No refactors and no unrelated cleanups; `crates/ohno_macros/docs/` is untouched.

---

## Update — 25b3cceb

The claim above that a bare `#[expect]` naming a 1.98-only lint "matches existing repo practice" was wrong, and CI proved it:

* `static-analysis` and `anvil-pr / pr-fast (linux)` run the pinned `RUST_LATEST` 1.96.1, where `clippy::unused_async_trait_impl` does not exist. Naming it makes `unknown_lints` fire, and `-D warnings` turned that into 6 hard errors in `bytesbuf_io`. The `tick` precedent cited above does not transfer. The idiom that does is the `#![allow(unknown_lints)]` guard already carried by `rest_over_grpc_examples` and `rest_over_grpc_tests` for this exact toolchain split, now applied to `bytesbuf_io::testing` and the `fundle` setter test.
* The lint also fires on **inherent** `impl` blocks, not only trait impls, so the lint names themselves have to stay — the `bytesbuf_io` inherent mirrors genuinely need them.
* `anvil-pr / pr-fast (linux-arm)` runs 1.98 and reached `seatbelt/benches/observability_cg.rs`, which the first commit missed: the whole benchmark is `#[cfg(target_os = "linux")]`, so it never compiles on Windows. It now carries the same rewrite as its wall-clock twin `observability.rs`.

Verified locally on both toolchains: `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes on stable 1.98.0 **and** on 1.96.1. `observability_cg.rs` remains unverifiable locally (Linux-only, no cross C toolchain here); it is a line-for-line mirror of the already-passing `observability.rs`.

---

## Update — 0c69a477

Review feedback from @martintmk: an example is read by a human, so `impl Future<Output = ...>` plus `std::future::ready` costs more in readability than the lint is worth there.

The five `cachet` examples are restored to plain `async fn`, and `clippy::unused_async_trait_impl` is suppressed at each example's crate root instead — behind the same `#![allow(unknown_lints)]` guard, since the pinned 1.96.1 gates do not know the lint name.

Non-example code (library `src/`, tests, benches) keeps the `impl Future` rewrite.