### PR TITLE
fix(observed_utils): raise minimum const-hex to 1.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ chrono = { version = "0.4.40", default-features = false }
 chrono-tz = { version = "0.10.4", default-features = false }
 chumsky = { version = "0.13.0", default-features = false }
 clap = { version = "4.6.4", default-features = false }
-const-hex = { version = "1.14.0", default-features = false }
+const-hex = { version = "1.15.0", default-features = false }
 criterion = { version = "0.8.1", default-features = false }
 ctor = { version = "1.0.8", default-features = false, features = ["proc_macro"] }
 darling = { version = "0.24.0", default-features = false }


### PR DESCRIPTION
🤖 Authored by an agent on behalf of @AdomasBekeras.

## Problem

`observed_utils` calls `const_hex::display()` in `format_any_value.rs`, but the workspace declared a const-hex floor of `1.14.0`. `display()` was only added in const-hex **1.15.0**, so the declared minimum is wrong.

Consumers that resolve dependencies at their minimum versions fail to compile the published `observed_utils 0.1.0`:

```
error[E0425]: cannot find function `display` in crate `const_hex`
  --> observed_utils-0.1.0/src/format_any_value.rs:74:62
error: could not compile `observed_utils` (lib) due to 1 previous error
```

This broke the `Build (minimum)` stage of the internal ox-sdk nightly pipeline, which pins every dependency to its declared minimum.

## Fix

Raise the workspace floor to `1.15.0`, the version that actually introduced `display()`.

The committed `Cargo.lock` already resolves const-hex 1.19.1, so `--locked` builds here are unaffected — this only corrects the declared requirement that gets baked into the published manifest.

## Notes

Republishing `observed_utils 0.1.x` was judged unnecessary: consumers only need a newer const-hex, which normal (non-minimal) resolution already picks. This bump is so the **next** published version carries the correct floor. Discussed with @EvgeniiShutov.

No changelog entry added — dependency-floor entries in this repo appear to be generated by the release tooling from PR titles, and `observed_utils`'s `[Unreleased]` section currently holds its initial-release notes. Happy to add one if that's the wrong read.
