### PR TITLE
test(ohno_macros_impl): restore the rich signature-preservation case

### DIFF
--- a/crates/ohno_macros_impl/tests/public_api.rs
+++ b/crates/ohno_macros_impl/tests/public_api.rs
@@ -758,6 +758,12 @@ fn the_enrich_attribute_wraps_the_body_and_enriches_the_error() {
                 // the whole `syn::Signature` and only swaps the block, so an omission anywhere in
                 // it — a dropped `unsafe`, ABI, receiver or doc attribute — is a silent
                 // regression unless the snapshot carries one of each.
+                //
+                // The receiver is one of those components rather than an oversight: an attribute
+                // on a method inside an `impl` block reaches the macro as an `Item::Fn` whose
+                // signature carries it, which is how `crates/ohno/tests/enrich_err.rs` applies
+                // the attribute to `fn do_something(&mut self, ..)`. Nothing else about the case
+                // needs to be a compilable free item, since the assertion is over tokens.
                 quote! {
                     /// Documented.
                     pub(crate) unsafe extern "C" fn load<A: Clone>(

--- a/crates/ohno_macros_impl/tests/public_api.rs
+++ b/crates/ohno_macros_impl/tests/public_api.rs
@@ -754,8 +754,17 @@ fn the_enrich_attribute_wraps_the_body_and_enriches_the_error() {
             "the signature survives untouched",
             enriched(
                 TokenStream::new(),
+                // Deliberately loaded with the rarer signature components. The wrapper re-emits
+                // the whole `syn::Signature` and only swaps the block, so an omission anywhere in
+                // it — a dropped `unsafe`, ABI, receiver or doc attribute — is a silent
+                // regression unless the snapshot carries one of each.
                 quote! {
-                    pub(crate) fn load<A: Clone>(path: &str, count: usize) -> Result<A, MyError>
+                    /// Documented.
+                    pub(crate) unsafe extern "C" fn load<A: Clone>(
+                        &mut self,
+                        path: &str,
+                        count: usize,
+                    ) -> Result<A, MyError>
                     where
                         A: Send,
                     {

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__the_enrich_attribute_wraps_the_body_and_enriches_the_error.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__the_enrich_attribute_wraps_the_body_and_enriches_the_error.snap
@@ -149,7 +149,12 @@ fn load(&self) -> Result<(), MyError> {
 // ======== the signature survives untouched ========
 
 #[enrich_err]
-pub(crate) fn load<A: Clone>(path: &str, count: usize) -> Result<A, MyError>
+/// Documented.
+pub(crate) unsafe extern "C" fn load<A: Clone>(
+    &mut self,
+    path: &str,
+    count: usize,
+) -> Result<A, MyError>
 where
     A: Send,
 {
@@ -157,7 +162,12 @@ where
 }
 // ---- expands to ----
 
-pub(crate) fn load<A: Clone>(path: &str, count: usize) -> Result<A, MyError>
+/// Documented.
+pub(crate) unsafe extern "C" fn load<A: Clone>(
+    &mut self,
+    path: &str,
+    count: usize,
+) -> Result<A, MyError>
 where
     A: Send,
 {


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

Restores signature coverage that #683 dropped when the per-module `enrich_err` snapshots were folded into the grouped public-API suite.

## Context

The pre-#683 snapshot `the_signature_survives_untouched` pinned one function carrying a doc attribute, `pub`, `unsafe`, an explicit `extern "C"` ABI, a `&mut self` receiver, generics and a where clause. The grouped case that inherited the label covers only visibility, generics, ordinary parameters and the where clause.

`enrich_err` parses the input as a `syn::ItemFn`, replaces the block, and re-emits the function, so every attribute and every `syn::Signature` component is expected to survive verbatim. The reduced case no longer holds most of them.

Nothing else in the workspace closes the gap: `git grep 'unsafe extern'` over `crates/ohno*` returns no matches, and the consumer tests reach only a shared `&self` receiver.

## Change

The existing case keeps its label and gains one instance of each omitted component, rather than a second case being added — the grouped suite stays the same size. The snapshot confirms the expansion reproduces all of them.

## Effects

- A regression that drops a doc attribute, `unsafe`, an ABI or a receiver from an enriched function now fails `the_enrich_attribute_wraps_the_body_and_enriches_the_error` instead of reaching a consumer compilation test.
- The case still exercises restricted visibility (`pub(crate)`), two ordinary parameters, generics and a where clause, so nothing the previous input covered is given up.

## Validation

`just anvil-fmt`, `just anvil-clippy`, `cargo test -p ohno_macros_impl --test public_api` (20 passed), and `cargo +nightly-2026-05-30 fmt --config-path ./unstable-rustfmt.toml --check` on the changed file.

AB#7776891