### PR TITLE
docs(observed): align documentation with the runtime contract

### DIFF
--- a/crates/observed/DESIGN.md
+++ b/crates/observed/DESIGN.md
@@ -33,10 +33,10 @@ Rust services and libraries need structured telemetry that is:
    NOTE: logs and metrics ship today; the trace signal is
    [planned](#planned-not-implemented).
 
-1. **Privacy-by-construction via redaction.** All non-primitive attribute values - whether
-   defined on the event struct or added by enrichment - must pass through a **redaction engine**
-   before reaching any exporter. The type system makes it impossible to accidentally emit
-   classified data. See Appendix #1.
+1. **Privacy-by-construction via redaction.** Non-primitive attribute values should carry an
+   explicit classification decision. Default and `data_class` paths pass through a redactor
+   before reaching exporters; explicit bypasses such as `unredacted` and unclassified enrichment
+   are caller-controlled. See Appendix #1.
 
 1. **Scoped, automatic enrichment.** Attributes attach to all events within a scope and propagate
    through nested calls - including across `.await` points and thread migrations.
@@ -59,7 +59,7 @@ Rust services and libraries need structured telemetry that is:
 1. **Zero-cost when inactive.** Emitting must have zero overhead in the following scenarios:
 
 - No exporters are configured.
-- The event is disabled and no processor opts in to it.
+- The event is disabled and no processor interested in that metadata accepts it.
 - Low severity: severity pre-filtering skips event construction entirely - no field extraction, no allocation, no redaction call.
   Implemented in the processor: `EventProcessor::is_interested` runs before construction, and the `observed_destination`
   log processor answers it from the `OTel` logger's `event_enabled` check.
@@ -101,8 +101,10 @@ Rust services and libraries need structured telemetry that is:
    threads in the process.
    NOTE: We cannot guarantee that users' interceptors/callbacks will not do any of this. The only thing that is not allowed is making async calls from `emit!`.
 
-1. **No globals/statics.** Global state leads to unexpected behavior, complicates testing,
-   and breaks when multiple versions of the crate coexist in the dependency tree.
+1. **No globals/statics for telemetry configuration.** Global state leads to unexpected behavior,
+   complicates testing, and breaks when multiple versions of the crate coexist in the dependency
+   tree. The one shipped exception is a thread-local recursion guard used only while processors
+   run; it drops nested emissions thread-wide across sinks to prevent cross-sink cycles.
 
 ## *Nice-to-have* requirements
 
@@ -174,13 +176,14 @@ Rust services and libraries need structured telemetry that is:
 
 ### Privacy
 
-1. **Redaction-by-construction.** The core privacy guarantee: attribute values cannot reach an exporter without an explicit classification decision.
+1. **Redaction-by-construction.** The core privacy guarantee: attribute values should reach an exporter only after an explicit classification decision.
    Every field in `#[event(...)]` and `#[derive(Enrichment)]` follows one of three paths:
    - **Default** - the type must implement `RedactedDisplay` (e.g. via `#[classified(...)]`). If it doesn't, compilation fails.
    - **`data_class = <expr>`** - wraps the value in `Sensitive::new(value, expr)` before redaction, for types that don't carry their own classification.
-   - **`unredacted`** - bypasses redaction entirely; the type must implement `Into<Value>`. Used for primitives and other inherently non-sensitive values.
+   - **`unredacted`** - bypasses redaction entirely; the type must implement `Into<Value>`. Used for primitives and other values the caller has already deemed safe to emit.
 
-   `data_class` and `unredacted` are mutually exclusive (compile error if both specified).
+   `data_class` and `unredacted` are mutually exclusive (compile error if both specified). `EnrichmentEntry::unclassified`
+   and adaptor-provided dynamic values are also caller-controlled and are not redacted by `observed`.
 
 1. **Data classification annotations.** Attributes carrying personal or sensitive data must be labeled with an appropriate `DataClass`.
    This annotation feeds into the redaction engine's policy decisions.
@@ -257,7 +260,7 @@ Each event uses per-signal attributes at the struct level; both the severity att
 
 | Annotation | Effect |
 | --- | --- |
-| `#[event("...")]` | **Required.** Declares the canonical event name used for routing and identification. Add `disabled` (`#[event("...", disabled)]`) to mark the event as opt-in: the flag is surfaced to processors as `EventDescription::is_disabled` rather than enforced by the sink, and the processors shipped in `observed_destination` skip such events unless they explicitly opt in. |
+| `#[event("...")]` | **Required.** Declares the canonical event name used for identification and processor interest checks. Add `disabled` (`#[event("...", disabled)]`) to surface disabled metadata to processors; the sink does not enforce it, and processors normally interpret it in `EventProcessor::is_interested`. |
 | A severity attribute - `#[trace]`, `#[debug]`, `#[info]`, `#[warning]`, `#[error]`, or `#[fatal]` (optionally with a message: `#[info("...")]`) | Declares the event as a log. `name` defaults to the event name; the message is optional. |
 | One of `#[counter(...)]`, `#[updown_counter(field, ...)]`, `#[gauge(field, ...)]`, `#[histogram(field, ...)]` | Declares an event-level metric instrument. `name` defaults to the event name. A bare `#[counter]` may be fieldless and records `1` per emission; the others require a leading positional field naming the struct field that supplies the metric value. |
 
@@ -299,8 +302,8 @@ A **Sink** is a composable event dispatcher identified by a `SinkId`. It is the 
 - **Clock** - the `tick::SimpleClock` used to stamp dispatched events. All processors on one leaf see the same instant, and a frozen clock keeps
   tests deterministic.
 
-- **Enrichment isolation** - By default, a sink receives both global enrichments (from `.enrich()`) and targeted enrichments (from `.enrich_for()`).
-  When isolation is enabled, the sink only sees targeted enrichments addressed to its id.
+- **Enrichment isolation** - By default, a sink receives untargeted entries present in its own slot (from `.enrich()`) plus targeted enrichments addressed to its id (from `.enrich_for()`).
+  When isolation is enabled, the sink ignores untargeted entries and only sees targeted enrichments addressed to its id.
   This lets library authors keep their internal telemetry independent of the hosting application's enrichment context.
 
 #### Composite sinks
@@ -333,25 +336,32 @@ Sink::composite([sink_a, sink_b])
 before the future yields, which keeps it from leaking into unrelated tasks sharing the worker thread.
 
 **Contract.** An integration that adds entries of its own should carry them *inside* the transfer, with
-`Transfer::with_enrichment` (global) or `Transfer::with_enrichment_for` (visible only to one `SinkId`,
+`Transfer::with_enrichment` (untargeted within the captured sink slots) or `Transfer::with_enrichment_for` (visible only to one `SinkId`,
 mirroring `enrich_for`). Entries carried this way are independent of wrapper order, so they survive the
 future being boxed or attached again further out - both of which integrations do. Wrapping `enrich`
 *around* an attached future is supported only for a single `attach` on a plain, non-boxed future;
-other compositions are outside the guarantee and silently lose the entries.
+other compositions are outside the guarantee and may lose entries when the enrichment and transfer
+operate on the same captured sink slot.
 
 **Technical details.** Applying a transfer *replaces* each captured slot's chain rather than layering
 onto it - that is what stops a transferred scope inheriting the target thread's ambient context. So
-`Enriched<Transferred<F>>` loses its entries: the inner transfer overwrites what the outer wrapper
-pushed. The inherent `Transferred::enrich` / `enrich_for` restore the intuitive result by re-ordering
+`Enriched<Transferred<F>>` loses entries that were pushed into a slot captured by the inner transfer:
+the transfer overwrites what the outer wrapper pushed. The inherent `Transferred::enrich` / `enrich_for` restore the intuitive result by re-ordering
 the wrappers, and win over the `EnrichFutureExt` blanket impl because a type's inherent methods are
 searched before its traits. That selection is why the guarantee is narrow: it needs the receiver's
 statically-known type to be exactly `Transferred<_>`, and it re-orders one wrapper deep, so nested
 transfers, boxed or type-erased receivers, explicit trait dispatch, and generic `F: EnrichFutureExt`
-receivers all fall back to the losing shape.
+receivers all fall back to the unsupported shape for overlapping captured slots.
 
 ### Processing of emitted event
 
 In v1, processing will be done on the same thread that calls `emit!`.
+
+A thread-wide recursion guard is held while processors run. Any nested emission
+made during `EventProcessor::process` is silently dropped, even if it targets a
+different sink; processors should report their own failures through a
+non-`observed` diagnostics channel. Each loaded crate version owns a separate
+thread-local guard flag.
 
 :::mermaid
 flowchart TD
@@ -409,10 +419,10 @@ Values are exporter-neutral; each exporter maps these to its own wire format.
 | **Sink** | A named event dispatcher identified by a `SinkId`. Holds one or more `EventProcessor` values, a clock, and enrichment configuration (slot, isolation flag). |
 | **SinkId** | A `&'static str` label identifying a sink. Two ids are equal when their labels are equal. |
 | **Composite sink** | A `Sink` built by `Sink::composite` that dispatches one `emit!()` through several leaf sinks, each keeping its own id, processors, and enrichment. |
-| **Attribute** | A key-value pair on an emitted event. Attributes come from two sources: event-defined (struct fields via `#[event(...)]`) and enrichment. Both are subject to the same redaction rules and end up as key-value pairs on the exported record. |
+| **Attribute** | A key-value pair on an emitted event. Attributes come from two sources: event-defined (struct fields via `#[event(...)]`) and enrichment. Classified paths use processor-supplied redaction; explicit unredacted and unclassified paths are caller-controlled. |
 | **Enrichment** | The process of attaching attributes to all events within a scope |
 | **Event** | A Rust struct implementing the `Event` trait (via `#[event(...)]`). Represents a single telemetry occurrence with typed attributes, optional severity, and routing metadata. |
-| **EventDescription** | The compile-time metadata constant generated by `#[event(...)]`: event name, type id, log and metric signal descriptions, and the `disabled` flag. Handed to `EventProcessor::is_interested` to decide routing. |
+| **EventDescription** | Metadata describing an event: event name, optional Rust type id, log and metric signal descriptions, and the `disabled` flag. Typed events provide it as a compile-time constant; dynamic adaptors build it at runtime and usually set `type_id` to `None`. Handed to `EventProcessor::is_interested` to decide routing; match the canonical name when one processor must accept both typed and dynamic sources. |
 | **EventProcessor** | A destination-facing handler that declares interest in an event and then pulls the fields it needs from an `EventView`, redacting them through its own engine. |
 | **RedactionEngine** | The `data_privacy` crate's engine for applying data-classification-aware redaction to field values. Implements `Redactor`. |
 | **Redactor** | The `data_privacy_core` trait that applies redaction for a given data class. Field getters take `&dyn Redactor`, so any redaction strategy works, not only a full engine. |

--- a/crates/observed/DESIGN.md
+++ b/crates/observed/DESIGN.md
@@ -183,7 +183,10 @@ Rust services and libraries need structured telemetry that is:
    - **`unredacted`** - bypasses redaction entirely; the type must implement `Into<Value>`. Used for primitives and other values the caller has already deemed safe to emit.
 
    `data_class` and `unredacted` are mutually exclusive (compile error if both specified). `EnrichmentEntry::unclassified`
-   and adaptor-provided dynamic values are also caller-controlled and are not redacted by `observed`.
+   is a further caller-controlled bypass: the value is stored pre-converted and no redactor ever sees it. A `DynEvent` adaptor
+   is a different case - its field getters receive the same per-processor `&dyn Redactor` as typed events, so its fields are
+   redacted when it applies that redactor; what `observed` cannot do is enforce it, because the adaptor writes the getter.
+   The dynamic event *body* is the genuine exception and reaches exporters verbatim.
 
 1. **Data classification annotations.** Attributes carrying personal or sensitive data must be labeled with an appropriate `DataClass`.
    This annotation feeds into the redaction engine's policy decisions.

--- a/crates/observed/FEATURES.md
+++ b/crates/observed/FEATURES.md
@@ -14,15 +14,15 @@
 
 ## Context & Enrichment
 
-- **Explicit sink passing** - `emit!(sink, event)` takes an `&Sink` as first argument; no ambient/global state
-- **Scoped enrichment** - `.enrich(&sink, entries)` on closures/futures attaches key-value context to all events in a scope
+- **Explicit sink passing** - `emit!(sink, event)` takes an `&Sink` as first argument; no ambient/global event or enrichment state
+- **Scoped enrichment** - `.enrich(&sink, entries)` on closures/futures attaches untargeted key-value context to events emitted through that sink's scope
 - **Per-sink thread-local storage** - each `Sink` owns a per-thread enrichment slot backed by `thread_local` crate;
   enrichments are pushed onto a per-thread linked list with RAII guards
 - **Typed enrichment structs** - `#[derive(Enrichment)]` converts structs into enrichment entries with the same field-level
   attributes as `Event` (`#[dimension(...)]`, `#[if_none(...)]`, `#[data_class]`, `#[unredacted]`);
   enrichment can opt into metric dimensions via `#[dimension(metric = "...")]` but cannot define a metric instrument
 - **Per-sink enrichment** - `.enrich_for(&sink, target, entries)` targets context to a specific sink
-- **Enrichment isolation** - library sinks can opt out of global enrichments via `Sink::new_isolated(ID, processors, clock)`
+- **Enrichment isolation** - library sinks can ignore untargeted enrichments via `Sink::new_isolated(ID, processors, clock)`
 - **Cross-thread context transfer** - `sink.transfer_context()` captures enrichment state for cross-thread propagation
 
 ## Sink Lifecycle
@@ -34,8 +34,8 @@
 
 ## Emission & Routing
 
-- **Processor-based dispatch** - `emit!(sink, ...)` sends to the sink's processors via `EventProcessor::process`
-- **Lazy event views** - each processor receives an `EventView` and pulls only the fields it needs; skipped fields never invoke their redaction closure (zero cost for rejected fields). Laziness past construction is per field, not per signal - see `emit!`'s "What emitting costs"
+- **Processor-based dispatch** - `emit!(sink, ...)` sends to the sink's interested processors via `EventProcessor::process`
+- **Lazy event views** - each processor receives an `EventView` and pulls only the fields it needs; skipped getters do not evaluate, convert, or redact their values, but field enumeration and visitor work still occur. Laziness past construction is per field, not per signal - see `emit!`'s "What emitting costs"
 - **Allocation-free static keys** - all field, enrichment, and interop keys are `&'static str`, so `Key`/`FieldDescriptor`/`LogFieldEntry`/`MetricFieldEntry` are `Copy` and snapshotting consumers (e.g. snapshotting/replay processors) retain keys with zero allocation. The `tracing` bridge forwards `tracing`'s `&'static` field/target/file names directly instead of cloning them.
 - **Interest-based lazy construction** - processors implement the required `is_interested(&EventDescription)`; if all return `false` the event closure is never called. It runs both as the construction gate and again while routing, so it may be called more than once per emission - keep it cheap, and keep the answer stable across those calls
 - **Per-processor filtering** - a processor that answers `false` from `is_interested` never receives the event, even when a peer accepted it
@@ -48,7 +48,7 @@
   1. **Default** - the type must implement `RedactedDisplay` (e.g. via `#[classified(...)]`). Compilation fails if it doesn't.
   2. **`data_class = <expr>`** - wraps the value in `Sensitive::new(value, expr)` before redaction, for types without built-in classification.
   3. **`unredacted`** - bypasses redaction entirely; the type must implement `Into<Value>`.
-- **Redaction** - `Sensitive<T>` + `RedactionEngine` enforce privacy-by-construction
+- **Redaction** - `Sensitive<T>` + `RedactionEngine` apply classification-aware redaction; explicit `#[unredacted]`, unclassified enrichment, and dynamic adaptor values bypass it and are caller-controlled
 - **Per-processor redaction** - each processor owns its own `RedactionEngine` privately, passing it to getter closures during `visit_fields`/`visit_enrichments`; the getters accept any `&dyn Redactor`
 
 ```text
@@ -64,7 +64,7 @@ emit!(sink, MyEvent { a: expensive() })
   │
   ├── resolve enrichments: walk per-sink TLS linked list
   │
-  ├── build EventView(event, enrichments) - zero-cost, just a pair of references
+  ├── build EventView(event, enrichments) - cheap snapshot of event and enrichment state
   │
   └── for each interested processor:
         └── processor.process(&event_view)

--- a/crates/observed/README.md
+++ b/crates/observed/README.md
@@ -20,9 +20,9 @@ The `observed` crate provides a unified telemetry API that:
 * Emits **structured, typed events** via `#[event(...)]` and the [`emit!`][__link0] macro
 * Supports **enrichment** - scoped, stackable, context-propagated entries
   attached to all events in scope (via RAII guards and `#[derive(Enrichment)]` structs)
-* Supports **redaction** - classified fields are extracted through a
-  [`RedactionEngine`][__link1], while explicit
-  unredacted paths remain caller-controlled
+* Redacts **by default** - a field is extracted through a
+  [`RedactionEngine`][__link1] unless the author opts it
+  out field by field with the `#[unredacted]` escape hatch
 * Provides **per-field routing** - one event struct can produce logs and metrics with
   independent field subsets per signal
 * Integrates with **OpenTelemetry** through pluggable [`EventProcessor`][__link2] implementations
@@ -155,7 +155,7 @@ collects all visible entries and passes them to processors along with the event.
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/observed">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbDoHxnkIwhM4buYzhGhT1-CAbaQenmYC82tgbXesL7Z9_3J1hZIKCbGRhdGFfcHJpdmFjeWYwLjEyLjSCaG9ic2VydmVkZjAuMjUuMA
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQblg9c8nzy72Ib8lRCGd_qnWUbXdWEHoHbtoYbho8yOV_HoGNhZIKCbGRhdGFfcHJpdmFjeWYwLjEyLjSCaG9ic2VydmVkZjAuMjUuMA
  [__link0]: `emit!`
  [__link1]: https://docs.rs/data_privacy/0.12.4/data_privacy/?search=RedactionEngine
  [__link10]: https://docs.rs/observed/0.25.0/observed/?search=enrichment::EnrichFutureExt::enrich

--- a/crates/observed/README.md
+++ b/crates/observed/README.md
@@ -20,8 +20,9 @@ The `observed` crate provides a unified telemetry API that:
 * Emits **structured, typed events** via `#[event(...)]` and the [`emit!`][__link0] macro
 * Supports **enrichment** - scoped, stackable, context-propagated entries
   attached to all events in scope (via RAII guards and `#[derive(Enrichment)]` structs)
-* Enforces **redaction** - data-classification metadata on every field, redaction
-  applied through a [`RedactionEngine`][__link1]
+* Supports **redaction** - classified fields are extracted through a
+  [`RedactionEngine`][__link1], while explicit
+  unredacted paths remain caller-controlled
 * Provides **per-field routing** - one event struct can produce logs and metrics with
   independent field subsets per signal
 * Integrates with **OpenTelemetry** through pluggable [`EventProcessor`][__link2] implementations
@@ -154,7 +155,7 @@ collects all visible entries and passes them to processors along with the event.
 This crate was developed as part of <a href="https://github.com/microsoft/oxidizer">The Oxidizer Project</a>. Browse this crate's <a href="https://github.com/microsoft/oxidizer/tree/main/crates/observed">source code</a>.
 </sub>
 
- [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQb68x7sQbVDdYbwXFbW_bB1wAb0GrV6MyUj6kbkecovaJAvyFhZIKCbGRhdGFfcHJpdmFjeWYwLjEyLjSCaG9ic2VydmVkZjAuMjUuMA
+ [__cargo_doc2readme_dependencies_info]: ggGmYW0CYXZlMC43LjJhdIQb11VxC_uAPOQbtUn4Wx2-BfAbid3Nt1Y27Pobprn8Z6FjFy9hYvRhcoQbDoHxnkIwhM4buYzhGhT1-CAbaQenmYC82tgbXesL7Z9_3J1hZIKCbGRhdGFfcHJpdmFjeWYwLjEyLjSCaG9ic2VydmVkZjAuMjUuMA
  [__link0]: `emit!`
  [__link1]: https://docs.rs/data_privacy/0.12.4/data_privacy/?search=RedactionEngine
  [__link10]: https://docs.rs/observed/0.25.0/observed/?search=enrichment::EnrichFutureExt::enrich

--- a/crates/observed/src/context/transfer.rs
+++ b/crates/observed/src/context/transfer.rs
@@ -57,8 +57,8 @@ impl Transfer {
     /// captured by [`Transfer`], so it is visible on every thread the
     /// transfer is applied to.
     ///
-    /// The entries are **global**: every non-isolated sink that observes this
-    /// transfer sees them. Use
+    /// The entries are **untargeted**: every non-isolated captured sink slot
+    /// that observes this transfer sees them. Use
     /// [`with_enrichment_for`](Self::with_enrichment_for) to restrict them to a
     /// single sink.
     pub fn with_enrichment(mut self, additional_enrichment: impl Enrichment) -> Self {

--- a/crates/observed/src/context/transferred.rs
+++ b/crates/observed/src/context/transferred.rs
@@ -70,9 +70,10 @@ impl<T: Future> Transferred<T> {
     /// receiver's statically-known type is exactly `Transferred<_>` and its
     /// inner type is not itself a `Transferred<_>`.
     ///
-    /// In every other shape the blanket trait impl is selected instead, or the
-    /// re-ordering does not reach deep enough, and the entries are still
-    /// dropped on every poll:
+    /// In other wrapper shapes the blanket trait impl may be selected instead,
+    /// or the re-ordering may not reach deep enough. Entries are unsupported
+    /// there and may be lost when the enrichment and transfer operate on the
+    /// same captured sink slot:
     ///
     /// - explicit trait dispatch, `EnrichFutureExt::enrich(fut.attach(t), &sink, e)`;
     /// - generic code whose receiver is only known as `F: EnrichFutureExt`,
@@ -113,8 +114,9 @@ impl<T: Future> Transferred<T> {
     ///
     /// The escape hatch differs, though.
     /// [`Transfer::with_enrichment`](crate::context::Transfer::with_enrichment)
-    /// is **not** a substitute here: it produces global entries, so a targeted
-    /// entry routed through it would be widened to every non-isolated sink.
+    /// is **not** a substitute here: it produces untargeted entries, so a
+    /// targeted entry routed through it would be widened to every non-isolated
+    /// sink in the captured transfer.
     /// Use
     /// [`Transfer::with_enrichment_for`](crate::context::Transfer::with_enrichment_for),
     /// which preserves the target and is likewise order-independent, or enrich

--- a/crates/observed/src/enrichment/entry.rs
+++ b/crates/observed/src/enrichment/entry.rs
@@ -39,9 +39,9 @@ impl fmt::Debug for UnredactedValue {
 
 /// A single enrichment entry: a key-value pair with data classification.
 ///
-/// Every enrichment carries privacy metadata so that string values are redacted
-/// through the [`data_privacy::RedactionEngine`] at emission time, matching the
-/// privacy guarantees of event fields.
+/// Classified enrichment values are redacted through the processor-supplied
+/// redactor at extraction time. Unclassified values are stored directly,
+/// including strings, and must already be appropriate to emit.
 ///
 /// For classified newtypes (`#[classified(...)]`), use [`new()`](Self::new) -
 /// no `Into<Value>` impl required. For dynamically classified values, use
@@ -59,7 +59,8 @@ pub struct EnrichmentEntry {
     /// Metric dimensions are opt-in via `#[dimension]`, mirroring events.
     metric_key: Option<Key>,
     /// If `Some`, this entry only applies to the specified sink (targeted enrichment).
-    /// If `None`, this is a global enrichment visible to all emitters.
+    /// If `None`, this is an untargeted entry visible within the containing sink
+    /// scope, subject to the sink's isolation setting.
     target: Option<SinkId>,
 }
 

--- a/crates/observed/src/event.rs
+++ b/crates/observed/src/event.rs
@@ -13,7 +13,7 @@ use crate::processing::FieldVisitorFn;
 /// Every event type implements this trait - typically via the `#[event(...)]`
 /// attribute macro. Default and `#[data_class(<expr>)]` fields are extracted
 /// through the processor-supplied redactor. Fields marked `#[unredacted]`,
-/// unclassified enrichment values, and values supplied by dynamic adaptors are
+/// unclassified enrichment values, and values supplied by a dynamic adaptor are
 /// caller-controlled and must already be appropriate to emit.
 ///
 /// # Attribute macro

--- a/crates/observed/src/event.rs
+++ b/crates/observed/src/event.rs
@@ -12,9 +12,13 @@ use crate::processing::FieldVisitorFn;
 ///
 /// Every event type implements this trait - typically via the `#[event(...)]`
 /// attribute macro. Default and `#[data_class(<expr>)]` fields are extracted
-/// through the processor-supplied redactor. Fields marked `#[unredacted]`,
-/// unclassified enrichment values, and values supplied by a dynamic adaptor are
-/// caller-controlled and must already be appropriate to emit.
+/// through the processor-supplied redactor. Fields marked `#[unredacted]` and
+/// unclassified enrichment values bypass it and must already be appropriate to
+/// emit. Fields supplied by a [`DynEvent`](crate::interop::DynEvent) adaptor are
+/// not a bypass: their getters receive the same per-processor redactor, but the
+/// adaptor writes those getters, so applying redaction is its responsibility
+/// rather than something this crate enforces. Only the dynamic event body skips
+/// the redactor outright.
 ///
 /// # Attribute macro
 ///

--- a/crates/observed/src/event.rs
+++ b/crates/observed/src/event.rs
@@ -11,12 +11,10 @@ use crate::processing::FieldVisitorFn;
 /// A structured telemetry event.
 ///
 /// Every event type implements this trait - typically via the `#[event(...)]`
-/// attribute macro. All events are processed through a single, redaction-safe
-/// pipeline: field values pass through a [`data_privacy::RedactionEngine`] for
-/// privacy-safe extraction.
-///
-/// This ensures that all emitted telemetry - whether routed to logs, metrics,
-/// or both - has consistent privacy-compliant behavior.
+/// attribute macro. Default and `#[data_class(<expr>)]` fields are extracted
+/// through the processor-supplied redactor. Fields marked `#[unredacted]`,
+/// unclassified enrichment values, and values supplied by dynamic adaptors are
+/// caller-controlled and must already be appropriate to emit.
 ///
 /// # Attribute macro
 ///

--- a/crates/observed/src/lib.rs
+++ b/crates/observed/src/lib.rs
@@ -17,8 +17,9 @@
 //! - Emits **structured, typed events** via `#[event(...)]` and the [`emit!`] macro
 //! - Supports **enrichment** - scoped, stackable, context-propagated entries
 //!   attached to all events in scope (via RAII guards and `#[derive(Enrichment)]` structs)
-//! - Enforces **redaction** - data-classification metadata on every field, redaction
-//!   applied through a [`RedactionEngine`](data_privacy::RedactionEngine)
+//! - Supports **redaction** - classified fields are extracted through a
+//!   [`RedactionEngine`](data_privacy::RedactionEngine), while explicit
+//!   unredacted paths remain caller-controlled
 //! - Provides **per-field routing** - one event struct can produce logs and metrics with
 //!   independent field subsets per signal
 //! - Integrates with **OpenTelemetry** through pluggable [`EventProcessor`](processing::EventProcessor) implementations
@@ -331,8 +332,8 @@ pub use observed_macros::Enrichment;
 ///
 /// | Attribute | Required | Description |
 /// |-----------|----------|-------------|
-/// | `#[event("...")]` | **yes** | Canonical event name used for routing and identification. Add `disabled` (`#[event("...", disabled)]`) to mark the event as opt-in only; processors must explicitly enable it. |
-/// | `#[<severity>]` | no | Opt into log emission, where `<severity>` is one of `trace`, `debug`, `info`, `warning`, `error`, `fatal`. At most one may be present. (The `warn` level is spelled `warning` because `warn` is a built-in attribute.) The optional positional string is the log body; an optional `name = "..."` overrides the log name (defaults to the event name). |
+/// | `#[event("...")]` | **yes** | Canonical event name used for identification and processor interest checks. Add `disabled` (`#[event("...", disabled)]`) to surface disabled metadata to processors; the sink does not enforce it. |
+/// | `#[<severity>]` | no | Opt into log emission, where `<severity>` is one of `trace`, `debug`, `info`, `warning`, `error`, `fatal`. At most one may be present. (The `warn` level is spelled `warning` because `warn` is a built-in attribute.) The optional positional string is the log body; `{key}` placeholders name effective log keys after raw-identifier normalization, `#[dimension(log = "...")]` renames, and `#[dimension(log = exclude)]` exclusions. `{{` escapes an opening brace; empty `{}` and unmatched `{` are accepted as literal text. An optional `name = "..."` overrides the log name (defaults to the event name). |
 /// | `#[<kind>(...)]` | no | Declare a metric instrument (`<kind>` = `counter`, `updown_counter`, `gauge`, or `histogram`). See [Metric instruments](#metric-instruments). |
 ///
 /// # Metric instruments

--- a/crates/observed/src/lib.rs
+++ b/crates/observed/src/lib.rs
@@ -17,9 +17,9 @@
 //! - Emits **structured, typed events** via `#[event(...)]` and the [`emit!`] macro
 //! - Supports **enrichment** - scoped, stackable, context-propagated entries
 //!   attached to all events in scope (via RAII guards and `#[derive(Enrichment)]` structs)
-//! - Supports **redaction** - classified fields are extracted through a
-//!   [`RedactionEngine`](data_privacy::RedactionEngine), while explicit
-//!   unredacted paths remain caller-controlled
+//! - Redacts **by default** - a field is extracted through a
+//!   [`RedactionEngine`](data_privacy::RedactionEngine) unless the author opts it
+//!   out field by field with the `#[unredacted]` escape hatch
 //! - Provides **per-field routing** - one event struct can produce logs and metrics with
 //!   independent field subsets per signal
 //! - Integrates with **OpenTelemetry** through pluggable [`EventProcessor`](processing::EventProcessor) implementations
@@ -229,7 +229,7 @@ pub use key::Key;
 /// | `#[dimension(metric)]` | Opt the field in as a metric dimension keyed by the field's own name. |
 /// | `#[dimension(metric = "...")]` | Opt the field in as a metric dimension under the given key. |
 /// | `#[dimension(log = "...", metric = "...")]` | Route both signals with independent keys. Either side may be omitted (but not both); `log = exclude` omits the field from logs, and a bare `metric` uses the field name. |
-/// | `#[unredacted]` | Bypass redaction; the type must implement `Into<Value>`, or be a directly spelled borrowed `&str`. |
+/// | `#[unredacted]` | Escape hatch: bypass redaction for a value that carries no user data. Never implicit. The type must implement `Into<Value>`, or be a directly spelled borrowed `&str`. |
 /// | `#[data_class(<expr>)]` | Wrap the value in `Sensitive::new(value, <expr>)` for classification. |
 /// | `#[if_none(drop)]` / `#[if_none("...")]` | Control how a `None` `Option<T>` is recorded. The default is `#[if_none("n/a")]`. |
 ///
@@ -251,8 +251,11 @@ pub use key::Key;
 ///    as a trait object and redacted at emission time.
 /// 2. **`#[data_class(<expr>)]`** - wraps the value in `Sensitive::new(value, <expr>)`
 ///    before storing, for types without built-in classification.
-/// 3. **`#[unredacted]`** - bypasses redaction entirely; the type must implement
-///    `Into<Value>`. A borrowed `&str` is the one exception: it has no
+/// 3. **`#[unredacted]`** - the escape hatch: bypasses redaction entirely, so it
+///    is reserved for values that carry no user data, such as counters, status
+///    codes and other constants. It is never applied implicitly - a field only
+///    leaves the engine when its author writes the attribute. The type must
+///    implement `Into<Value>`. A borrowed `&str` is the one exception: it has no
 ///    `Into<Value>` and is copied into an `Arc<str>` instead. Like `Option<T>`,
 ///    it is detected from the field's spelling, so an aliased `&str` is not
 ///    recognized and needs an explicit `Arc::<str>::from(s)`.
@@ -417,7 +420,7 @@ pub use observed_macros::Enrichment;
 /// | `#[dimension(metric)]` | Register the field as a metric dimension keyed by the field's own name. |
 /// | `#[dimension(metric = "...")]` | Register the field as a metric dimension with the given key. |
 /// | `#[dimension(log = "...", metric = "...")]` | Route both signals with independent keys. Either side may be omitted (but not both); `log = exclude` omits the field from logs, and a bare `metric` uses the field name. |
-/// | `#[unredacted]` | Bypass redaction; the type must implement `Into<Value>`. |
+/// | `#[unredacted]` | Escape hatch: bypass redaction for a value that carries no user data. Never implicit. The type must implement `Into<Value>`. |
 /// | `#[data_class(<expr>)]` | Wrap the value in `Sensitive::new(value, <expr>)` for classification. |
 /// | `#[if_none(drop)]` / `#[if_none("...")]` | Control how a `None` `Option<T>` is recorded. The default is `#[if_none("n/a")]`. |
 ///

--- a/crates/observed/src/metadata/event.rs
+++ b/crates/observed/src/metadata/event.rs
@@ -11,8 +11,8 @@ use crate::metadata::metric::MetricDescription;
 /// Description of a telemetry event type.
 ///
 /// Available as a `const` on every type that implements [`crate::Event`],
-/// providing compile-time metadata about the event's shape. Dynamic adaptors
-/// construct the same description at runtime and may omit Rust type identity.
+/// providing compile-time metadata about the event's shape. A dynamic adaptor
+/// constructs the same description at runtime and may omit Rust type identity.
 ///
 /// The event name is shared across all signals; per-signal metadata lives
 /// in `log` / `metric`.

--- a/crates/observed/src/metadata/event.rs
+++ b/crates/observed/src/metadata/event.rs
@@ -8,10 +8,11 @@ use std::any::TypeId;
 use crate::metadata::log::LogDescription;
 use crate::metadata::metric::MetricDescription;
 
-/// Static description of a telemetry event type.
+/// Description of a telemetry event type.
 ///
 /// Available as a `const` on every type that implements [`crate::Event`],
-/// providing compile-time metadata about the event's shape.
+/// providing compile-time metadata about the event's shape. Dynamic adaptors
+/// construct the same description at runtime and may omit Rust type identity.
 ///
 /// The event name is shared across all signals; per-signal metadata lives
 /// in `log` / `metric`.
@@ -84,8 +85,9 @@ impl EventDescription {
 
     /// Returns `true` if this event is disabled by default.
     ///
-    /// Disabled events are neither logs nor metrics unless a processor
-    /// explicitly opts in via `is_interested` and/or filters in `process()`.
+    /// The sink does not enforce this flag. Processors interpret it, normally
+    /// from [`EventProcessor::is_interested`](crate::processing::EventProcessor::is_interested);
+    /// `process` can only discard an event after accepting delivery.
     #[must_use]
     #[inline]
     pub const fn is_disabled(&self) -> bool {

--- a/crates/observed/src/metadata/metric.rs
+++ b/crates/observed/src/metadata/metric.rs
@@ -39,7 +39,7 @@ impl std::fmt::Display for InstrumentKind {
 pub struct MetricDescription {
     /// The `OTel` instrument name (e.g. `"http.server.request.duration"`).
     instrument_name: &'static str,
-    /// The instrument kind (histogram, gauge, or counter).
+    /// The instrument kind.
     kind: InstrumentKind,
     /// Human-readable description of what the instrument measures. Empty if unset.
     description: &'static str,

--- a/crates/observed/src/processing/event_view.rs
+++ b/crates/observed/src/processing/event_view.rs
@@ -5,8 +5,9 @@
 //!
 //! An [`EventView`] wraps a `&dyn DynEvent` together with a snapshot of the
 //! enrichment context active at emit time. Processors pull only the data
-//! they need - fields that are skipped never invoke their redaction
-//! closure, achieving zero cost for rejected fields.
+//! they need. Skipped getters never evaluate, convert, or redact their values
+//! and avoid the associated allocations, while field enumeration and visitor
+//! work still occur.
 //!
 //! The view does **not** retain a reference to the [`Sink`](crate::Sink) that produced
 //! it. The enrichment chain head is captured as a cheap [`Arc`] snapshot
@@ -94,8 +95,8 @@ impl EventEnrichment {
 /// A lazy, pull-based view of an event and its enrichments.
 ///
 /// Processors receive this from [`EventProcessor::process`](super::EventProcessor::process)
-/// and pull only the fields/enrichments they need. Skipped fields never
-/// invoke their redaction closure.
+/// and pull only the fields/enrichments they need. Skipped getters never
+/// evaluate, convert, or redact their values.
 ///
 /// The enrichment context is captured as a snapshot at view construction.
 /// Concurrent enrichment pushes after that point are not visible to this
@@ -149,10 +150,11 @@ impl<'a> EventView<'a> {
         }
     }
 
-    /// Returns the wall-clock timestamp captured when this view was created.
+    /// Returns the timestamp associated with this event.
     ///
-    /// All processors sharing this view see the same instant, avoiding
-    /// per-destination timestamp drift.
+    /// Live sink dispatch uses the sink clock; synthetic views return the
+    /// timestamp supplied to [`new_synthetic`](Self::new_synthetic). All
+    /// processors sharing one view see the same instant.
     #[must_use]
     #[inline]
     pub fn timestamp(&self) -> SystemTime {
@@ -166,12 +168,10 @@ impl<'a> EventView<'a> {
         self.event.name()
     }
 
-    /// Returns the event severity (only meaningful for log-producing events).
+    /// Returns the severity declared by the event's log description.
     ///
-    /// Derived from the log signal on [`description`](Self::description), which
-    /// is the single statement that decides both routing and the exported
-    /// level - an event cannot be routed as a log at one severity and exported
-    /// at another.
+    /// Processors decide how that metadata maps to their destination record and
+    /// may ignore or remap it.
     #[must_use]
     #[inline]
     pub fn severity(&self) -> Option<Severity> {
@@ -212,7 +212,11 @@ impl<'a> EventView<'a> {
         self.event.source_crate()
     }
 
-    /// Returns the compile-time event description (signals, metrics, etc.).
+    /// Returns the event description (signals, metrics, etc.).
+    ///
+    /// Typed events expose their compile-time description; dynamic events may
+    /// construct this metadata at runtime and omit Rust type identity. Match on
+    /// the canonical name when one processor must accept both sources.
     #[must_use]
     #[inline]
     pub fn description(&self) -> EventDescription {
@@ -223,7 +227,9 @@ impl<'a> EventView<'a> {
     ///
     /// For each field, the visitor receives a [`FieldDescriptor`] and a getter
     /// closure. The getter is only invoked if the processor wants the value -
-    /// it takes a `&dyn Redactor` and returns the redacted [`Value`].
+    /// it takes a `&dyn Redactor` and returns the redacted [`Value`]. Skipping
+    /// it avoids value evaluation, conversion, redaction, and their allocations,
+    /// but enumeration and visitor calls still happen until iteration stops.
     ///
     /// The visitor returns [`ControlFlow::Continue`] to keep iterating or
     /// [`ControlFlow::Break`] to stop early.
@@ -238,6 +244,8 @@ impl<'a> EventView<'a> {
     ///
     /// Same pattern as [`visit_fields`](Self::visit_fields) - the getter
     /// closure is only invoked if the processor wants the enrichment value.
+    /// Enumeration still constructs descriptors and getter closures for
+    /// surviving entries before the visitor can reject them.
     ///
     /// Entries are yielded outermost-first. Isolation and targeting rules
     /// captured at view-construction time are applied inline. If duplicate

--- a/crates/observed/src/sink/core.rs
+++ b/crates/observed/src/sink/core.rs
@@ -80,7 +80,7 @@ impl Sink {
     /// frozen clock (`SimpleClock::new_frozen()`) for deterministic, Miri-safe
     /// timestamps.
     ///
-    /// The sink receives both untargeted (global) and targeted enrichments.
+    /// The sink receives both untargeted and targeted enrichments.
     /// For a sink that ignores untargeted entries (the library-isolation
     /// pattern), use [`Sink::new_isolated`].
     ///
@@ -92,7 +92,7 @@ impl Sink {
     }
 
     /// Like [`Sink::new`], but configures the sink to ignore untargeted
-    /// (global) enrichments. Only entries explicitly targeted at this
+    /// enrichments. Only entries explicitly targeted at this
     /// sink's id (via `enrich_for(ID, …)`) are visible.
     ///
     /// Useful for library emitters that must not inherit application-level
@@ -293,7 +293,8 @@ impl Sink {
         }
     }
 
-    /// Builds an event via `build` and emits it to every registered processor.
+    /// Builds an event via `build` when at least one processor is interested
+    /// and dispatches it to each interested processor.
     ///
     /// Called by the [`emit!`](crate::emit!) macro with the captured
     /// [`SourceLocation`]; prefer that macro over calling this directly.

--- a/crates/observed/src/text.rs
+++ b/crates/observed/src/text.rs
@@ -12,9 +12,10 @@ use std::{fmt, hash};
 ///
 /// Two representations cover every call site:
 ///
-/// - `Static` for compile-time literals, which is what almost every event field
-///   is - free to store and free to clone,
-/// - `Shared` for an [`Arc<str>`], cloned by bumping a refcount.
+/// - `Static` for values that reach `Text` as compile-time literals - free to
+///   store and free to clone,
+/// - `Shared` for owned, dynamic, or non-empty redacted text, cloned by bumping
+///   a refcount.
 ///
 /// Both clone in O(1), which matters because an enrichment's stored value is
 /// cloned on every event that sees it. An owned `Box<str>` variant would let a

--- a/crates/observed_testing/Cargo.toml
+++ b/crates/observed_testing/Cargo.toml
@@ -19,10 +19,11 @@ include = { workspace = true }
 # public surface intentionally re-exposes the observed/data_privacy types it is
 # a test harness for.
 #
-# This is NOT redundant with INTERNAL_CRATES membership: that list is only read
-# by scripts/check-external-types.rs (the `external-type-exposure` job). The
-# `anvil-external-types` recipe behind `pr-fast` scopes itself from cargo
-# metadata and never consults it, so without this block that job fails.
+# This is NOT redundant with INTERNAL_CRATES membership: that list suppresses
+# scripts/check-external-types.rs and is also used by mutation-test
+# orchestration. The `anvil-external-types` recipe behind `pr-fast` scopes
+# itself from cargo metadata and never consults it, so without this block that
+# job fails.
 allowed_external_types = ["*"]
 
 [dependencies]

--- a/crates/observed_testing/tests/disabled_events.rs
+++ b/crates/observed_testing/tests/disabled_events.rs
@@ -5,7 +5,8 @@
 //!
 //! Covers DESIGN.md requirements:
 //! - Events can be disabled by default (`#[event("...", disabled)]`)
-//! - Disabled events are not emitted unless a processor explicitly opts in
+//! - Disabled is processor-controlled metadata; the sink still delivers to
+//!   processors whose `is_interested` returns `true`
 
 use std::sync::Arc;
 


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

## Problem

Public documentation for `observed` states guarantees the implementation does not make. Each statement below was checked against the code on `main` and found to be wrong, not merely imprecise. A reader who trusts them writes a processor that pays costs it expects to avoid, or that relies on an invariant nothing enforces.

## What changes

Only prose changes. No code, no public API, no test behavior.

- **Redaction.** The docs said every event goes through one redaction-safe pipeline. In fact each processor supplies its own redactor at extraction time, and `#[unredacted]` fields plus unclassified enrichment values bypass it entirely. The guarantee is now scoped to classified values.
- **Routing.** `Sink::emit` said it emits to every registered processor. It builds the event only when a processor is interested and dispatches only to interested processors.
- **Disabled events.** Documented as suppressed unless a processor opts in. The sink has no such gate; the flag is metadata a processor reads in `is_interested`.
- **Severity.** Documented as a single statement fixing both routing and the exported level. A processor may remap or drop it.
- **Laziness.** "Zero cost for rejected fields" overstates the guarantee. Skipping a getter avoids evaluation, conversion, redaction and their allocations, but enumeration and visitor calls still happen. Now stated that way.
- **Enrichment scope.** "Global enrichment" implied process-wide reach. Entries live in a sink's own slot; the real distinction is targeted vs untargeted.
- **Event identity.** `EventDescription` was described as compile-time only. Dynamic events build it at runtime and then carry no Rust `TypeId`, so name matching is the portable choice.
- **Timestamps.** `EventView::timestamp` was documented as captured at view creation; synthetic views supply their own.
- **Transfer ordering.** The wrapper-order caveat claimed entries are dropped in every unsupported shape. Loss requires the enrichment and the transfer to overlap on the same captured slot.
- **Smaller corrections.** `Text::Static` is not "almost every field"; the instrument-kind list omitted `UpDownCounter`; the log-body placeholder keys and brace grammar were undocumented; the `INTERNAL_CRATES` comment named the wrong consumer; the no-globals rule did not admit the recursion guard.

`crates/observed/README.md` is regenerated from `src/lib.rs`, not hand-edited.

## Effects

- Documentation matches observed behavior, so a processor author can rely on it.
- The redaction wording no longer implies unclassified and `#[unredacted]` values are protected.
- "Zero cost" no longer appears as an unqualified claim.
- No behavior, API surface or test outcome changes.

## Validation

`just anvil-readme-check`, `just anvil-fmt`, `just anvil-clippy`, `just anvil-spellcheck`, `cargo +1.96.1 doc --no-deps`, and `cargo +1.96.1 test -p observed -p observed_testing` all pass.