### PR TITLE
docs(observed): correct example and benchmark commentary

### DIFF
--- a/crates/observed/benches/observed_benchmarks.rs
+++ b/crates/observed/benches/observed_benchmarks.rs
@@ -357,7 +357,8 @@ fn bench_emit_with_body(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc
 /// owns a meter or records an instrument, so what it captures is the cost of
 /// log mapping for an event whose descriptor also carries metric metadata -
 /// the field visit yields metric descriptors the processor then skips.
-/// Comparing it against `log_4_fields` isolates that extra descriptor work.
+/// Use it as a full-pipeline log baseline for that event shape rather than as
+/// an isolated metric-descriptor comparison.
 fn bench_emit_log_of_metric_event(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc_tracker::Session, time: &all_the_time::Session) {
     const ID: &str = "log_of_metric_event";
     let (processor, _provider) = make_log_processor();
@@ -381,9 +382,8 @@ fn bench_emit_log_of_metric_event(group: &mut BenchmarkGroup<'_, WallTime>, allo
 
 /// Benchmarks emitting an event whose fields are classified strings.
 ///
-/// This is the redaction hot path: each field is rendered through the
-/// redaction engine and stored as a string `Value`, so the benchmark measures
-/// exactly the allocations that path costs per emit.
+/// This is a full emit-pipeline case in which each field is rendered through
+/// the redaction engine and stored as a string `Value`.
 fn bench_emit_redacted_strings(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc_tracker::Session, time: &all_the_time::Session) {
     const ID: &str = "log_2_redacted_strings";
     let (processor, _provider) = make_log_processor_with(replacing_engine());
@@ -733,10 +733,10 @@ fn bench_redacted_value_creation(group: &mut BenchmarkGroup<'_, WallTime>, alloc
     });
 }
 
-/// Benchmarks the full emit pipeline at enrichment depths 0 and 5 to quantify
-/// the per-enrichment allocation cost. Those two points bracket the range: the
-/// difference between them divided by five is the marginal cost of one
-/// enrichment level, which is what identifies the breakeven point for pooling.
+/// Benchmarks the full emit pipeline at enrichment depths 0 and 5, providing
+/// representative low- and higher-depth baselines for the current
+/// implementation. These endpoints show aggregate overhead for those cases,
+/// not a per-level marginal cost or a pooling breakeven point.
 fn bench_emit_varying_enrichment_depth(
     group: &mut BenchmarkGroup<'_, WallTime>,
     allocs: &alloc_tracker::Session,

--- a/crates/observed/examples/enrichments.rs
+++ b/crates/observed/examples/enrichments.rs
@@ -123,7 +123,7 @@ impl observed::processing::EventProcessor for SimpleLogProcessor {
 fn handle_request(sink: &Sink) {
     // Batch enrichment - adds multiple attributes to all nested events.
     (|| {
-        // Inner enrichment - stacks on top of the span.
+        // Inner enrichment - stacks on top of the outer enrichment scope.
         (|| {
             emit!(sink, DbQuery { rows_returned: 42 });
             emit!(sink, CacheHit { key_count: 3 });

--- a/crates/observed/examples/event_routing.rs
+++ b/crates/observed/examples/event_routing.rs
@@ -5,8 +5,8 @@
 //!
 //! Events carry compile-time signal metadata (`is_log`, `contains_metrics`, `is_disabled`)
 //! and metric instrument descriptions in their `EventDescription`.
-//! Each `EventProcessor` inspects these in `process()` to decide whether
-//! to accept the event.
+//! Each `EventProcessor` inspects these in `is_interested()` to decide whether
+//! to accept the event; `process()` handles an already accepted delivery.
 //!
 //! This example shows:
 //!
@@ -66,7 +66,7 @@ fn main() {
         }
     );
 
-    // HttpError: LOG + METRIC -> Log processor + Metric processor (UpDownCounter)
+    // HttpError: LOG + METRIC -> Log processor + Metric processor (Counter)
     emit!(sink, HttpError { route: 1 });
 
     // MemoryUsage: METRIC only (exclude_from_logs) -> Metric processor only

--- a/crates/observed/examples/event_type_matching.rs
+++ b/crates/observed/examples/event_type_matching.rs
@@ -43,7 +43,7 @@ fn main() {
                 engine: passthrough_engine(),
             }),
             Arc::new(NameRoutingProcessor::new(
-                // Accept only events whose name starts with "http."
+                // Accept only these exact event names.
                 &["http.request", "http.error"],
                 Arc::clone(&name_log),
             )),

--- a/crates/observed/examples/layered_app/db.rs
+++ b/crates/observed/examples/layered_app/db.rs
@@ -3,9 +3,10 @@
 
 //! Database layer with its own telemetry events and metrics.
 //!
-//! All events in this module are emitted via `emit!()` and delivered to the DB
-//! sink. Global enrichments (like `service.name`) are excluded from the lib
-//! processor - only per-sink enrichments (like `db.pool`) are attached.
+//! All events in this module are emitted through the DB composite, so they fan
+//! out to both the application and DB sink leaves. The isolated DB leaf ignores
+//! global enrichments (like `service.name`) and receives only targeted per-sink
+//! enrichments (like `db.pool`).
 
 use data_privacy::classified;
 use observed::enrichment::EnrichFnExt;
@@ -102,7 +103,8 @@ pub(crate) fn query_users(sink: &Sink, table_id: i64) -> i64 {
         let rows_returned = 42;
         let query_ms = 4.7;
 
-        // Emit the query event to the DB sink only.
+        // Emit the query event through the DB composite; targeted enrichments
+        // stay visible only to the isolated DB leaf.
         emit!(
             sink,
             DbQuery {

--- a/crates/observed/examples/layered_app/token_issuer.rs
+++ b/crates/observed/examples/layered_app/token_issuer.rs
@@ -3,10 +3,10 @@
 
 //! Authentication layer with its own telemetry events and metrics.
 //!
-//! All events in this module are emitted via `emit!()` and delivered to the
-//! token issuer sink. Global enrichments are excluded from the lib
-//! processor - only per-sink enrichments (like `token.issuer.version`)
-//! are attached.
+//! All events in this module are emitted through the token-issuer composite, so
+//! they fan out to both the application and token-issuer sink leaves. The
+//! token-issuer leaf is isolated: it ignores global enrichments and receives
+//! only targeted per-sink enrichments (like `token.issuer.version`).
 
 use data_privacy::{DataClass, classified};
 use observed::enrichment::EnrichFnExt;

--- a/crates/observed/examples/sink_pipeline.rs
+++ b/crates/observed/examples/sink_pipeline.rs
@@ -5,7 +5,8 @@
 //!
 //! Events flow through a [`Sink`] that dispatches to one or more
 //! [`EventProcessor`]s. Each processor has its own redaction engine and
-//! receives pre-redacted events.
+//! applies it lazily while extracting only the field and enrichment values it
+//! exports.
 //!
 //! Field routing (which fields go to logs vs metric dimensions) is declared
 //! inside `#[event(...)]` attributes. Fields are log attributes by default;

--- a/crates/observed/examples/tokio_multithread.rs
+++ b/crates/observed/examples/tokio_multithread.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Verifies that `observed` works correctly with a multithreaded Tokio runtime
-//! (the default `#[tokio::main]` configuration).
+//! Demonstrates `observed` on a multithreaded Tokio runtime (the default
+//! `#[tokio::main]` configuration).
 //!
 //! This example spawns concurrent tasks that emit events with enrichment,
 //! demonstrating that context propagation via `EnrichFutureExt::enrich`
-//! (which wraps the future so enrichment is pushed on every poll) survives
-//! cross-thread `.await` points.
+//! (which wraps the future so enrichment is pushed on every poll) works on a
+//! runtime where task migration is permitted but not asserted.
 //!
 //! Run with:
 //! ```sh
@@ -85,7 +85,7 @@ async fn main() {
     );
 
     // 2. Spawn tasks inside an enrichment scope - each task wraps its future
-    //    with `.enrich()` so the enrichment survives cross-thread migrations.
+    //    with `.enrich()` so the enrichment is restored on every poll.
     let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(4));
     let mut handles = Vec::new();
 
@@ -97,7 +97,8 @@ async fn main() {
                 // Synchronize so all tasks are running concurrently.
                 b.wait().await;
 
-                // Yield several times to allow thread migration.
+                // Yield several times to exercise repeated polls; Tokio may
+                // resume the task on the same or a different worker thread.
                 for i in 0..3 {
                     tokio::task::yield_now().await;
                     emit!(task_emitter, TaskCompleted { task_id, result: i });


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

## Problem

Example programs and the benchmark suite carry comments that describe behavior the surrounding code does not have. Examples are read as specification, so a wrong comment next to correct code teaches the wrong model. Benchmark comments additionally state conclusions the measurements cannot support.

## What changes

Comments and module documentation only. No code, no benchmark identifiers, no measured behavior.

**Examples**

- `event_routing.rs` said each processor decides acceptance in `process()`. The decision is `is_interested()`, taken before the event is built; `process()` receives an accepted delivery.
- `sink_pipeline.rs` said processors receive pre-redacted events. Each processor applies its own redactor lazily, as it extracts the values it exports.
- `event_type_matching.rs` said the processor accepts names starting with `http.`. It holds an allowlist and compares exact names.
- `layered_app/db.rs` said events go to the DB sink only. They go through a composite and reach both the application and DB leaves; the DB leaf is isolated, so only targeted entries reach it. `layered_app/token_issuer.rs` had the same two problems and used the undefined term "lib processor".
- `event_routing.rs` called the `HttpError` metric an `UpDownCounter`; it is declared as a counter.
- `enrichments.rs` referred to a span; the enclosing scope is an enrichment, not a span.
- `tokio_multithread.rs` claimed it verifies that enrichment survives cross-thread migration. It yields to allow migration but never asserts one happened. It now claims only what it demonstrates.

**Benchmarks**

- The metric-descriptor case claimed isolation by comparison against `log_4_fields`, a baseline that does not exist.
- The redaction case claimed it measures exactly the redaction allocations; it measures the whole emit pipeline, including log-record creation and exporter work.
- The enrichment-depth case derived a per-level marginal cost and a pooling breakeven from two endpoints, with no pooled alternative measured.

## Effects

- Examples describe the routing, redaction and enrichment model the runtime implements.
- Benchmark comments state what is measured instead of conclusions the data does not support.
- No behavior, output, timing or benchmark identifier changes.

## Validation

`just anvil-fmt`, `just anvil-clippy`, `cargo +1.96.1 build --examples`, and `cargo +1.96.1 check --benches` all pass.