### PR TITLE
refactor(ohno_macros_impl): let the shape place the core and the grammar split a `#[from]` entry

### DIFF
--- a/crates/ohno/tests/display_diagnostics.rs
+++ b/crates/ohno/tests/display_diagnostics.rs
@@ -53,4 +53,9 @@ fn display_diagnostics() {
 
     // An unbalanced brace is reported rather than parsed into a different, valid template.
     t.compile_fail("tests/ui/display_unbalanced_brace.rs");
+
+    // `()` names no error, so it is rejected as a source type rather than expanded into a
+    // `From<()>` that fails inside generated code. The second struct pins that one rejected entry
+    // does not discard the entry beside it.
+    t.compile_fail("tests/ui/from_unit_source.rs");
 }

--- a/crates/ohno/tests/ui/from_unit_source.rs
+++ b/crates/ohno/tests/ui/from_unit_source.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Nothing converts into an error from `()`, so a `From<()>` the derive generated could only fail
+//! to compile, against code the user never wrote. The source type is rejected instead.
+//!
+//! The entries of one `#[from(...)]` parse as a single list, so the second struct pins that the
+//! rejected entry does not take the entry beside it down with it: both faults are reported.
+
+#[derive(ohno::Error)]
+#[from(())]
+pub struct UnitSource {
+    pub path: String,
+    inner: ohno::OhnoCore,
+}
+
+#[derive(ohno::Error)]
+#[from((), std::io::Error(missing: 1))]
+pub struct UnitBesideAnotherFault {
+    pub path: String,
+    inner: ohno::OhnoCore,
+}
+
+fn main() {}

--- a/crates/ohno/tests/ui/from_unit_source.stderr
+++ b/crates/ohno/tests/ui/from_unit_source.stderr
@@ -1,0 +1,17 @@
+error: `#[from(...)]` cannot convert from `()`, which is not an error type. Name the type the conversion converts from, such as `#[from(std::io::Error)]`
+  --> tests/ui/from_unit_source.rs:11:8
+   |
+11 | #[from(())]
+   |        ^^
+
+error: `#[from(...)]` cannot convert from `()`, which is not an error type. Name the type the conversion converts from, such as `#[from(std::io::Error)]`
+  --> tests/ui/from_unit_source.rs:18:8
+   |
+18 | #[from((), std::io::Error(missing: 1))]
+   |        ^^
+
+error: unknown field `missing` in `#[from(...)]`, available fields: `path`
+  --> tests/ui/from_unit_source.rs:18:27
+   |
+18 | #[from((), std::io::Error(missing: 1))]
+   |                           ^^^^^^^

--- a/crates/ohno_macros/docs/design.md
+++ b/crates/ohno_macros/docs/design.md
@@ -147,6 +147,22 @@ diagnostics can anchor at it. The `#[from(...)]` payload keeps its field
 expressions keyed as the user wrote them; whether a key names a field is a rule,
 so it is checked in validate rather than at decode time.
 
+A `#[from(...)]` entry is a type followed by an optional `(member: expression)`
+override list, and both a parenthesized type such as `(std::io::Error)` and that
+override list open with the same token. The ambiguity is settled by *trying* the
+override list on a forked stream: it is resolved by the grammar of the two forms,
+not by a hand-written look-ahead that has to know how far a path's `::` reaches.
+Only an entry that opens with an override list is rejected, because a type is
+what an entry has to start with.
+
+An *empty* pair of parentheses is excluded from that trial, so `()` decodes as
+the unit type. It is not a type an entry may use — nothing converts from it, so a
+generated `From<()>` would fail inside code the user cannot see, which R4
+forbids — but that is a rule, and validate rejects it anchored at the `()`
+itself. Reading it as an empty override list here would instead fail as a
+decoding error, and because the entries of one attribute parse as a single list,
+that failure would discard every other entry in the attribute along with it.
+
 ### `Model`
 
 `Model` is a validated error type, ready to generate from: the identifier, the
@@ -159,6 +175,14 @@ style and the fields in declaration order, **split around** the one holding the
 core: those before it, the core itself, those after. It offers the core, every
 field in declaration order (what `Debug` prints, R1.3), and every field but the
 core (what constructors take and what a conversion initializes, R1.4 and R1.6).
+
+It also offers that same declaration order with each field carrying its
+*position*: the core marked as the core, and every other field **numbered** as
+the non-core list yields it. This is what generation walks. A generator that
+instead took the full field list and recovered the core by comparing members
+would be re-deciding, at every use, the question the split already answered —
+and one that carried its own counter alongside would hold a second alignment
+nothing checks.
 
 Splitting around the core rather than carrying an index into one list removes a
 class of check. An index can dangle, so a generator using one would have to
@@ -183,6 +207,12 @@ read is one form either way. Style is consulted by exactly two things — `Debug
 which needs `debug_struct` for a named struct and `debug_tuple` for a tuple one
 (R1.3), and the shared builder that emits `Self { .. }` or `Self(..)`, which the
 constructors and every generated `From` go through.
+
+That builder takes the core's initializer **apart from** the rest and places it
+itself, and asks its caller only for the initializer of a numbered non-core
+field. Both callers need the core built differently from every other field —
+defaulted, or built from the source error — and this is what spares each of them
+from finding the core in order to say so.
 
 ### `Message`
 
@@ -290,9 +320,11 @@ non-core fields, so the core is skipped and declaration order is kept, and both
 take each parameter as `impl Into<_>` of the field's type. `pub(crate)` is fixed
 by R1.4, settled by ADO 7675155.
 
-**`From<T>`** is emitted once per conversion, zipping the non-core fields with
-that conversion's initializers and building the core from the source error. The
-source binding is named `error`, which is the name a field expression refers to.
+**`From<T>`** is emitted once per conversion, taking that conversion's
+initializers in non-core field order and building the core from the source error.
+The source binding is named `error`, which is the name a field expression refers
+to. The initializers reach the fields by the number the builder hands out, which
+is the position of the tuple element holding the evaluated value.
 
 The data initializers are evaluated into one tuple before the struct literal is
 built. They may borrow `error` while the core consumes it, and a struct literal
@@ -463,6 +495,7 @@ would be a second copy that nothing checks.
 | R1.5 | `{` with no `}`, or `}` with no `{` | template literal |
 | R1.5 | a second `#[display(...)]` | attribute `Meta` |
 | R1.6 | `#[from]`, `#[from = "…"]`, `#[from()]` | attribute `Meta` |
+| R1.6 | `()` as a source type | the source type |
 | R1.6 | a key naming no non-core field | the key |
 | R1.6 | a key naming the core | the key |
 | R1.6 | a non-integer key on a tuple struct | the key |

--- a/crates/ohno_macros/docs/requirements.md
+++ b/crates/ohno_macros/docs/requirements.md
@@ -143,8 +143,9 @@ by field name for a named struct and by index for a tuple struct.
 The core field is built with `OhnoCore::from(error)`. Every other field takes
 its expression if one was given and `Default::default()` otherwise.
 
-Rejected: `#[from]`, `#[from()]`, `#[from = "…"]`, and a non-integer key for a
-tuple field. Several `#[from(...)]` attributes on one struct accumulate.
+Rejected: `#[from]`, `#[from()]`, `#[from = "…"]`, `()` as a source type, and a
+non-integer key for a tuple field. Several `#[from(...)]` attributes on one
+struct accumulate.
 
 ### R1.7 `#[no_debug]` and `#[no_constructors]`
 

--- a/crates/ohno_macros_impl/src/derive_error/display/mod.rs
+++ b/crates/ohno_macros_impl/src/derive_error/display/mod.rs
@@ -15,7 +15,7 @@ use quote::quote;
 use syn::{Expr, Member};
 
 use super::ast::{AstField, DisplayAttr};
-use super::parse::member_name;
+use super::member_name;
 use crate::diagnostics::Errors;
 use crate::message::Message;
 

--- a/crates/ohno_macros_impl/src/derive_error/generate/constructors.rs
+++ b/crates/ohno_macros_impl/src/derive_error/generate/constructors.rs
@@ -12,7 +12,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::construct;
-use crate::derive_error::model::Model;
+use crate::derive_error::model::{Model, ModelField};
 use crate::paths;
 
 /// The constructors, unless `#[no_constructors]` was written.
@@ -33,8 +33,8 @@ pub(crate) fn generate(model: &Model) -> TokenStream {
     });
     let parameters = parameters.collect::<Vec<_>>();
 
-    let new_body = construct(&model.shape, &initializers(model, &quote!(#core::default())));
-    let caused_by_body = construct(&model.shape, &initializers(model, &quote!(#core::from(error))));
+    let new_body = construct(&model.shape, &quote!(#core::default()), parameter_value);
+    let caused_by_body = construct(&model.shape, &quote!(#core::from(error)), parameter_value);
 
     quote! {
         #[automatically_derived]
@@ -57,20 +57,8 @@ pub(crate) fn generate(model: &Model) -> TokenStream {
     }
 }
 
-/// One initializer per field in declaration order, with `core` used for the error field.
-fn initializers(model: &Model, core: &TokenStream) -> Vec<TokenStream> {
-    let core_member = &model.shape.core().member;
-
-    model
-        .shape
-        .all()
-        .map(|field| {
-            if field.member == *core_member {
-                core.clone()
-            } else {
-                let binding = &field.binding;
-                quote!(#binding.into())
-            }
-        })
-        .collect()
+/// One non-core field's initializer: the parameter bound to it, converted into the field's type.
+fn parameter_value(field: &ModelField, _position: usize) -> TokenStream {
+    let binding = &field.binding;
+    quote!(#binding.into())
 }

--- a/crates/ohno_macros_impl/src/derive_error/generate/conversions.rs
+++ b/crates/ohno_macros_impl/src/derive_error/generate/conversions.rs
@@ -7,7 +7,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::construct;
-use crate::derive_error::model::Model;
+use crate::derive_error::model::{Conversion, Model};
 use crate::paths;
 
 /// Every conversion the derive owes.
@@ -30,29 +30,19 @@ pub(crate) fn generate(model: &Model) -> TokenStream {
 /// written. One tuple rather than one local per field, so that no generated name is in scope while
 /// a later initializer is evaluated: an initializer naming an outer item cannot be captured by a
 /// binding the derive introduced.
-fn from_type(model: &Model, conversion: &crate::derive_error::model::Conversion) -> TokenStream {
+fn from_type(model: &Model, conversion: &Conversion) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = model.generics.split_for_impl();
     let ident = &model.ident;
     let source = &conversion.source;
     let core_path = paths::ohno_core();
-    let core_member = &model.shape.core().member;
     let values = conversion.initializers();
 
-    let mut data = (0..values.len()).map(syn::Index::from);
-    let initializers: Vec<TokenStream> = model
-        .shape
-        .all()
-        .map(|field| {
-            if field.member == *core_member {
-                quote!(#core_path::from(error))
-            } else {
-                let index = data.next().expect("one tuple element per non-core field");
-                quote!(__ohno_fields.#index)
-            }
-        })
-        .collect();
-
-    let body = construct(&model.shape, &initializers);
+    // The tuple is laid out in `Shape::data` order, which is the order `construct` numbers the
+    // non-core fields in, so the position it hands out is the element that initializes the field.
+    let body = construct(&model.shape, &quote!(#core_path::from(error)), |_, position| {
+        let index = syn::Index::from(position);
+        quote!(__ohno_fields.#index)
+    });
 
     quote! {
         #[automatically_derived]

--- a/crates/ohno_macros_impl/src/derive_error/generate/mod.rs
+++ b/crates/ohno_macros_impl/src/derive_error/generate/mod.rs
@@ -17,7 +17,7 @@ use quote::quote;
 use syn::Member;
 
 use super::ast::Style;
-use super::model::{Model, Shape};
+use super::model::{Model, ModelField, Position, Shape};
 
 /// Generates every item the derive owes for `model`.
 #[must_use]
@@ -41,20 +41,37 @@ pub(crate) fn generate(model: &Model) -> TokenStream {
     }
 }
 
-/// Builds a `Self { .. }` or `Self(..)` literal from one initializer per field.
+/// Builds a `Self { .. }` or `Self(..)` literal.
 ///
-/// The initializers arrive in declaration order, so they line up with [`Shape::all`].
+/// `core` initializes the field holding the core. `data` is called once per other field, in
+/// declaration order, and is given the field together with its position among the non-core ones —
+/// the order in which a caller that laid its values out in advance holds them.
+///
+/// Taking the core's initializer apart from the rest is what keeps a generator from having to find
+/// the core again: [`Shape`] already knows which field it is, so no caller compares members and
+/// none carries an index of its own that could drift out of step with the field list.
 #[must_use]
-pub(crate) fn construct(shape: &Shape, initializers: &[TokenStream]) -> TokenStream {
+pub(crate) fn construct(shape: &Shape, core: &TokenStream, mut data: impl FnMut(&ModelField, usize) -> TokenStream) -> TokenStream {
+    // One walk, so the members and their values cannot be paired by two iterators that only happen
+    // to agree.
+    let initialized = shape.positions().map(|(field, position)| {
+        let value = match position {
+            Position::Core => core.clone(),
+            Position::Data(index) => data(field, index),
+        };
+
+        (&field.member, value)
+    });
+
     match shape.style {
         Style::Named => {
-            let assignments = shape.all().zip(initializers).map(|(field, value)| {
-                let member = &field.member;
-                quote!(#member: #value)
-            });
+            let assignments = initialized.map(|(member, value)| quote!(#member: #value));
             quote!(Self { #(#assignments,)* })
         }
-        Style::Tuple => quote!(Self(#(#initializers,)*)),
+        Style::Tuple => {
+            let values = initialized.map(|(_, value)| value);
+            quote!(Self(#(#values,)*))
+        }
     }
 }
 

--- a/crates/ohno_macros_impl/src/derive_error/generate/traits.rs
+++ b/crates/ohno_macros_impl/src/derive_error/generate/traits.rs
@@ -13,6 +13,7 @@ use syn::LitStr;
 
 use super::core_member;
 use crate::derive_error::ast::Style;
+use crate::derive_error::member_name;
 use crate::derive_error::model::Model;
 use crate::paths;
 
@@ -134,7 +135,7 @@ pub(crate) fn debug(model: &Model) -> TokenStream {
         Style::Named => {
             let fields = model.shape.all().map(|field| {
                 let member = &field.member;
-                let label = LitStr::new(&crate::derive_error::parse::member_name(member), model.ident.span());
+                let label = LitStr::new(&member_name(member), model.ident.span());
                 quote!(.field(#label, &self.#member))
             });
             quote!(f.debug_struct(#name) #(#fields)* .finish())

--- a/crates/ohno_macros_impl/src/derive_error/mod.rs
+++ b/crates/ohno_macros_impl/src/derive_error/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod parse;
 pub(crate) mod validate;
 
 use proc_macro2::TokenStream;
-use syn::DeriveInput;
+use syn::{DeriveInput, Member};
 
 use crate::diagnostics::Errors;
 
@@ -33,4 +33,16 @@ pub(crate) fn expand(input: DeriveInput) -> TokenStream {
         .map(|model| generate::generate(&model));
 
     expanded.unwrap_or_else(|| errors.into_compile_error())
+}
+
+/// Renders a member the way a diagnostic spells it, and the way `Debug` labels it: `path`, or `0`.
+///
+/// Shared by all three phases: a member reaches the user as text in a diagnostic, in a template
+/// resolution and in a `Debug` label, and the three have to agree on how it is spelled.
+#[must_use]
+pub(crate) fn member_name(member: &Member) -> String {
+    match member {
+        Member::Named(ident) => ident.to_string(),
+        Member::Unnamed(index) => index.index.to_string(),
+    }
 }

--- a/crates/ohno_macros_impl/src/derive_error/model.rs
+++ b/crates/ohno_macros_impl/src/derive_error/model.rs
@@ -11,8 +11,8 @@ use proc_macro2::Span;
 use quote::format_ident;
 use syn::{Expr, Generics, Ident, Member, Type};
 
-use super::ast::Style;
-use super::parse::member_name;
+use super::ast::{FromOverride, Style};
+use super::member_name;
 use crate::diagnostics::Errors;
 use crate::message::Message;
 
@@ -79,9 +79,30 @@ impl Shape {
         &self.core
     }
 
+    /// Every field, in declaration order, each with its [`Position`]. This is what generation walks.
+    ///
+    /// Pairing each field with its position here is what keeps "which field holds the core" a fact
+    /// of the shape. A generator that recovered it by comparing members would be re-deciding, at
+    /// every use, something the split around the core already settled.
+    pub(crate) fn positions(&self) -> impl Iterator<Item = (&ModelField, Position)> {
+        let after = self.before.len();
+
+        self.before
+            .iter()
+            .enumerate()
+            .map(|(index, field)| (field, Position::Data(index)))
+            .chain(std::iter::once((&self.core, Position::Core)))
+            .chain(
+                self.after
+                    .iter()
+                    .enumerate()
+                    .map(move |(index, field)| (field, Position::Data(after + index))),
+            )
+    }
+
     /// Every field, in declaration order. What `Debug` prints.
     pub(crate) fn all(&self) -> impl Iterator<Item = &ModelField> {
-        self.before.iter().chain(std::iter::once(&self.core)).chain(self.after.iter())
+        self.positions().map(|(field, _)| field)
     }
 
     /// Every field but the core, in declaration order.
@@ -91,6 +112,15 @@ impl Shape {
         self.before.iter().chain(self.after.iter())
     }
 }
+/// Where a field sits in a [`Shape`].
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Position {
+    /// The field holding the `OhnoCore`.
+    Core,
+    /// A field other than the core, numbered as [`Shape::data`] yields it.
+    Data(usize),
+}
+
 /// One field of a validated error type.
 #[derive(Debug)]
 pub(crate) struct ModelField {
@@ -135,27 +165,30 @@ impl Conversion {
     /// replaces. It is established here instead, once, where the field list is in hand.
     ///
     /// Returns `None` when an override names no non-core field, in which case a fault has been
-    /// recorded.
-    pub(crate) fn new(shape: &Shape, source: Type, overrides: &[(Member, Expr)], errors: &mut Errors) -> Option<Self> {
-        let mut initializers: Vec<Expr> = Vec::new();
-
-        for field in shape.data() {
-            let found = overrides.iter().find(|(key, _)| member_name(key) == member_name(&field.member));
-            initializers.push(match found {
-                Some((_, value)) => value.clone(),
-                None => syn::parse_quote!(::core::default::Default::default()),
-            });
-        }
-
+    /// recorded. The keys are checked before anything is built, so a rejected conversion costs no
+    /// initializer that is then thrown away.
+    pub(crate) fn new(shape: &Shape, source: Type, overrides: &[FromOverride], errors: &mut Errors) -> Option<Self> {
         let mut usable = true;
-        for (key, _) in overrides {
-            if !shape.data().any(|field| member_name(&field.member) == member_name(key)) {
-                errors.add(key, unknown_key(shape, key));
+        for entry in overrides {
+            if !shape.data().any(|field| field.member == entry.key) {
+                errors.add(&entry.key, unknown_key(shape, &entry.key));
                 usable = false;
             }
         }
 
-        usable.then_some(Self { source, initializers })
+        usable.then(|| {
+            let initializers = shape
+                .data()
+                .map(|field| {
+                    overrides.iter().find(|entry| entry.key == field.member).map_or_else(
+                        || syn::parse_quote!(::core::default::Default::default()),
+                        |entry| entry.value.clone(),
+                    )
+                })
+                .collect();
+
+            Self { source, initializers }
+        })
     }
 
     /// The initializers, in the order [`Shape::data`] yields its fields.
@@ -173,7 +206,7 @@ fn unknown_key(shape: &Shape, key: &Member) -> String {
         return format!("`#[from(...)]` field keys for a tuple struct are field indexes, not names, so `{name}:` names no field");
     }
 
-    if member_name(&shape.core().member) == name {
+    if shape.core().member == *key {
         return format!("`#[from(...)]` cannot initialize `{name}`, which holds the OhnoCore and is built from the source error");
     }
 

--- a/crates/ohno_macros_impl/src/derive_error/parse.rs
+++ b/crates/ohno_macros_impl/src/derive_error/parse.rs
@@ -7,11 +7,9 @@
 //! reported here and left out of the `Ast`, so validation has nothing to check for it and reports
 //! only faults it can actually see.
 
-use proc_macro2::{Delimiter, Spacing};
-use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{Attribute, Data, DeriveInput, Expr, Fields, Index, Member, Meta, Token, Type};
+use syn::{Attribute, Data, DeriveInput, Expr, Field, Fields, Index, Member, Meta, Token, Type, token};
 
 use super::ast::{Ast, AstField, DisplayAttr, FromAttr, FromOverride, Style};
 use crate::diagnostics::Errors;
@@ -52,30 +50,43 @@ pub(crate) fn parse(input: DeriveInput, errors: &mut Errors) -> Option<Ast> {
 }
 
 /// Reads the struct's own attributes into `ast`.
+///
+/// An attribute the crate does not own is left alone, whatever it says.
 fn parse_struct_attribute(attr: &Attribute, ast: &mut Ast, errors: &mut Errors) {
-    if attr.path().is_ident("display") {
-        if ast.display.is_some() {
-            errors.add(&attr.meta, "only one `#[display(...)]` may be given, and this is the second");
-            return;
-        }
+    let Some(name) = attr.path().get_ident() else {
+        return;
+    };
 
-        match attr.parse_args::<FormatArgs>() {
-            Ok(args) => {
-                ast.display = Some(DisplayAttr {
-                    template: args.template,
-                    arguments: args.arguments,
-                });
-            }
-            Err(error) => errors.combine(error),
+    match name.to_string().as_str() {
+        "display" => parse_display_attribute(attr, ast, errors),
+        "from" => parse_from_attribute(attr, ast, errors),
+        "no_debug" => {
+            check_bare_marker(attr, "no_debug", errors);
+            ast.no_debug = true;
         }
-    } else if attr.path().is_ident("from") {
-        parse_from_attribute(attr, ast, errors);
-    } else if attr.path().is_ident("no_debug") {
-        check_bare_marker(attr, "no_debug", errors);
-        ast.no_debug = true;
-    } else if attr.path().is_ident("no_constructors") {
-        check_bare_marker(attr, "no_constructors", errors);
-        ast.no_constructors = true;
+        "no_constructors" => {
+            check_bare_marker(attr, "no_constructors", errors);
+            ast.no_constructors = true;
+        }
+        _ => {}
+    }
+}
+
+/// Reads one `#[display(...)]`, of which there may be only one.
+fn parse_display_attribute(attr: &Attribute, ast: &mut Ast, errors: &mut Errors) {
+    if ast.display.is_some() {
+        errors.add(&attr.meta, "only one `#[display(...)]` may be given, and this is the second");
+        return;
+    }
+
+    match attr.parse_args::<FormatArgs>() {
+        Ok(args) => {
+            ast.display = Some(DisplayAttr {
+                template: args.template,
+                arguments: args.arguments,
+            });
+        }
+        Err(error) => errors.combine(error),
     }
 }
 
@@ -89,81 +100,76 @@ fn parse_from_attribute(attr: &Attribute, ast: &mut Ast, errors: &mut Errors) {
         return;
     }
 
-    match attr.parse_args_with(Punctuated::<FromEntry, Token![,]>::parse_terminated) {
+    match attr.parse_args_with(Punctuated::<FromAttr, Token![,]>::parse_terminated) {
         Ok(entries) if entries.is_empty() => errors.add(
             &attr.meta,
             "`#[from(...)]` needs at least one type, such as `#[from(std::io::Error)]`",
         ),
-        Ok(entries) => ast.conversions.extend(entries.into_iter().map(|entry| entry.0)),
+        Ok(entries) => ast.conversions.extend(entries),
         Err(error) => errors.combine(error),
     }
 }
 
-/// One entry of a `#[from(...)]` list: a type, optionally followed by field expressions.
-struct FromEntry(FromAttr);
-
-impl Parse for FromEntry {
+impl Parse for FromAttr {
+    /// One entry of a `#[from(...)]` list: a type, optionally followed by field overrides.
+    ///
+    /// `syn` decides where the type ends, so a generic argument list keeps its commas and a type
+    /// macro keeps its parentheses. Only an entry that *opens* with an override list has to be
+    /// rejected here, because a type is what an entry has to start with.
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let source = source_type(input)?;
+        if opens_overrides(input) {
+            return Err(input.error("expected a type"));
+        }
 
-        let overrides = if input.peek(syn::token::Paren) {
-            let content;
-            _ = syn::parenthesized!(content in input);
-            Punctuated::<FromOverrideSyntax, Token![,]>::parse_terminated(&content)?
-                .into_iter()
-                .map(|entry| entry.0)
-                .collect()
+        let source = input.parse::<Type>()?;
+        let overrides = if input.peek(token::Paren) {
+            input.parse::<Overrides>()?.0
         } else {
             Vec::new()
         };
 
-        Ok(Self(FromAttr { source, overrides }))
+        Ok(Self { source, overrides })
     }
 }
 
-/// The source type of one `#[from(...)]` entry.
+/// Whether an override list, rather than a parenthesized type, opens at `input`.
 ///
-/// `syn` decides where the type ends, so a generic argument list keeps its commas, a type macro
-/// keeps its parentheses, and a following `(member: expression)` override list is left for the
-/// caller. Only an entry that opens with that override list has to be rejected here, because a
-/// type is what an entry has to start with.
-fn source_type(input: ParseStream<'_>) -> syn::Result<Type> {
-    if holds_overrides(input) {
-        return Err(input.error("expected a type"));
+/// A parenthesized type such as `(std::io::Error)` opens with the same token, so the contents
+/// decide. Parsing them on a fork is what asks that question: an override list is exactly what
+/// [`Overrides`] accepts, and `(std::io::Error)` is not, because the `:` of a path leaves an
+/// expression that cannot be parsed behind it.
+///
+/// An *empty* list is excluded, so `()` reads as the unit type. It is a type an entry may not use,
+/// but that is a rule, and [`validate`](super::validate) reports it against the `()` itself. Read
+/// here as an empty override list instead, it would fail as "expected a type" — and because the
+/// entries of one attribute parse as a single list, that failure would take every other entry in
+/// the attribute with it.
+fn opens_overrides(input: ParseStream<'_>) -> bool {
+    input.peek(token::Paren) && input.fork().parse::<Overrides>().is_ok_and(|overrides| !overrides.0.is_empty())
+}
+
+/// The parenthesized `member: expression` list a `#[from(...)]` entry may end with.
+struct Overrides(Vec<FromOverride>);
+
+impl Parse for Overrides {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let content;
+        _ = syn::parenthesized!(content in input);
+
+        Ok(Self(
+            Punctuated::<FromOverride, Token![,]>::parse_terminated(&content)?
+                .into_iter()
+                .collect(),
+        ))
     }
-
-    input.parse::<Type>()
 }
 
-/// Whether a parenthesis group opens at `input` and holds field overrides rather than type syntax.
-///
-/// An override list opens with a member and a `:`. The `:` has to stand alone, so the `std` of a
-/// parenthesized `(std::io::Error)` does not read as a member.
-fn holds_overrides(input: ParseStream<'_>) -> bool {
-    let Some((inner, ..)) = input.cursor().group(Delimiter::Parenthesis) else {
-        return false;
-    };
-
-    let after_key = inner
-        .ident()
-        .map(|(_, rest)| rest)
-        .or_else(|| inner.literal().map(|(_, rest)| rest));
-
-    matches!(
-        after_key.and_then(Cursor::punct),
-        Some((punct, _)) if punct.as_char() == ':' && punct.spacing() == Spacing::Alone
-    )
-}
-
-/// One `key: expression` pair inside a `#[from(...)]` entry.
-struct FromOverrideSyntax(FromOverride);
-
-impl Parse for FromOverrideSyntax {
+impl Parse for FromOverride {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let key = input.parse::<Member>()?;
         _ = input.parse::<Token![:]>()?;
         let value = input.parse::<Expr>()?;
-        Ok(Self(FromOverride { key, value }))
+        Ok(Self { key, value })
     }
 }
 
@@ -200,33 +206,35 @@ fn parse_fields(ident: &syn::Ident, data: Data, errors: &mut Errors) -> Option<(
     let parsed = fields
         .into_iter()
         .enumerate()
-        .map(|(index, field)| {
-            let member = field
-                .ident
-                .clone()
-                .map_or_else(|| Member::Unnamed(Index::from(index)), Member::Named);
-
-            let mut marks = Vec::new();
-            let mut generated = false;
-            for attr in field.attrs {
-                if attr.path().is_ident("error") {
-                    check_bare_marker(&attr, "error", errors);
-                    marks.push(attr);
-                } else if marker::is_generated_marker(&attr) {
-                    generated = true;
-                }
-            }
-
-            AstField {
-                member,
-                ty: field.ty,
-                marks,
-                generated,
-            }
-        })
+        .map(|(index, field)| parse_field(index, field, errors))
         .collect();
 
     Some((style, parsed))
+}
+
+/// Reads one field, keeping every marker that may designate it as the error field.
+fn parse_field(index: usize, field: Field, errors: &mut Errors) -> AstField {
+    let Field { attrs, ident, ty, .. } = field;
+    let member = ident.map_or_else(|| Member::Unnamed(Index::from(index)), Member::Named);
+
+    let mut marks = Vec::new();
+    let mut generated = false;
+
+    for attr in attrs {
+        if attr.path().is_ident("error") {
+            check_bare_marker(&attr, "error", errors);
+            marks.push(attr);
+        } else if marker::is_generated_marker(&attr) {
+            generated = true;
+        }
+    }
+
+    AstField {
+        member,
+        ty,
+        marks,
+        generated,
+    }
 }
 
 /// Reports a bare marker attribute that carries anything beyond the bare word.
@@ -237,26 +245,4 @@ fn check_bare_marker(attr: &Attribute, name: &str, errors: &mut Errors) {
     if !matches!(attr.meta, Meta::Path(_)) {
         errors.add(&attr.meta, format!("`#[{name}]` takes no arguments"));
     }
-}
-
-/// Renders a member the way a diagnostic spells it: `path`, or `0`.
-#[must_use]
-pub(crate) fn member_name(member: &Member) -> String {
-    match member {
-        Member::Named(ident) => ident.to_string(),
-        Member::Unnamed(index) => index.index.to_string(),
-    }
-}
-
-/// Whether the last segment of the type's path is `OhnoCore`.
-///
-/// Nothing is resolved, so a core reached through a type alias or a renamed import is invisible
-/// here and has to be marked.
-#[must_use]
-pub(crate) fn is_ohno_core(ty: &Type) -> bool {
-    let Type::Path(path) = ty else {
-        return false;
-    };
-
-    path.qself.is_none() && path.path.segments.last().is_some_and(|segment| segment.ident == "OhnoCore")
 }

--- a/crates/ohno_macros_impl/src/derive_error/validate.rs
+++ b/crates/ohno_macros_impl/src/derive_error/validate.rs
@@ -11,12 +11,11 @@
 //! reserved marker, not by which field selection picked, so a struct that marks two fields still
 //! gets its template checked. A concern whose own input failed is skipped, not guessed at.
 
-use syn::{Expr, Member};
+use syn::Type;
 
 use super::ast::{Ast, AstField};
 use super::display::{self, Referenceable};
 use super::model::{Conversion, Model, ModelField, Shape};
-use super::parse::is_ohno_core;
 use crate::diagnostics::Errors;
 
 /// The diagnostic for a second field carrying `#[error]`.
@@ -24,6 +23,10 @@ const MULTIPLE_MARKED: &str = "Multiple fields marked with `#[error]`. Mark only
 
 /// The diagnostic for a second `#[error]` on one field.
 const DUPLICATE_MARKER: &str = "Duplicate `#[error]` on the same field. Mark it once";
+
+/// The diagnostic for `#[from(())]`.
+const UNIT_SOURCE: &str = "`#[from(...)]` cannot convert from `()`, which is not an error type. Name the type the \
+     conversion converts from, such as `#[from(std::io::Error)]`";
 
 /// Applies the rules to `ast`.
 ///
@@ -49,13 +52,12 @@ pub(crate) fn validate(ast: Ast, errors: &mut Errors) -> Option<Model> {
         .conversions
         .iter()
         .filter_map(|conversion| {
-            let overrides: Vec<(Member, Expr)> = conversion
-                .overrides
-                .iter()
-                .map(|entry| (entry.key.clone(), entry.value.clone()))
-                .collect();
+            if is_unit(&conversion.source) {
+                errors.add(&conversion.source, UNIT_SOURCE);
+                return None;
+            }
 
-            Conversion::new(&shape, conversion.source.clone(), &overrides, errors)
+            Conversion::new(&shape, conversion.source.clone(), &conversion.overrides, errors)
         })
         .collect();
 
@@ -83,8 +85,7 @@ fn select_core(ast: &Ast, errors: &mut Errors) -> Option<usize> {
         return Some(index);
     }
 
-    let mut marked = ast.fields.iter().enumerate().filter(|(_, field)| !field.marks.is_empty());
-    if let Some((index, _)) = marked.next() {
+    if let Some(index) = ast.fields.iter().position(|field| !field.marks.is_empty()) {
         return Some(index);
     }
 
@@ -133,5 +134,28 @@ fn report_duplicate_markers(fields: &[AstField], errors: &mut Errors) {
         for repeated in marks {
             errors.add(repeated, DUPLICATE_MARKER);
         }
+    }
+}
+
+/// Whether the last segment of the type's path is `OhnoCore`.
+///
+/// Nothing is resolved, so a core reached through a type alias or a renamed import is invisible
+/// here and has to be marked.
+fn is_ohno_core(ty: &Type) -> bool {
+    let Type::Path(path) = ty else {
+        return false;
+    };
+
+    path.qself.is_none() && path.path.segments.last().is_some_and(|segment| segment.ident == "OhnoCore")
+}
+
+/// Whether `ty` is the unit type, however many redundant parentheses surround it.
+///
+/// A one-element tuple such as `((),)` is a different type and is not matched.
+fn is_unit(ty: &Type) -> bool {
+    match ty {
+        Type::Tuple(tuple) => tuple.elems.is_empty(),
+        Type::Paren(paren) => is_unit(&paren.elem),
+        _ => false,
     }
 }

--- a/crates/ohno_macros_impl/tests/public_api.rs
+++ b/crates/ohno_macros_impl/tests/public_api.rs
@@ -133,6 +133,12 @@ fn every_struct_shape_generates_its_items() {
             }),
         ),
         (
+            "a tuple core in the middle keeps declaration order",
+            derived(quote! {
+                struct T(String, ohno::OhnoCore, u32);
+            }),
+        ),
+        (
             "a marked core need not be named OhnoCore",
             derived(quote! {
                 struct T { path: String, #[error] mine: Renamed }
@@ -485,6 +491,27 @@ fn a_from_attribute_generates_its_conversions() {
                 struct T { path: String, other: u32, inner: ohno::OhnoCore }
             }),
         ),
+        (
+            "a parenthesized source type is not an override list",
+            derived(quote! {
+                #[from((std::io::Error))]
+                struct T { path: String, inner: ohno::OhnoCore }
+            }),
+        ),
+        (
+            "a tuple source type is not an override list",
+            derived(quote! {
+                #[from((u8, u16))]
+                struct T { path: String, inner: ohno::OhnoCore }
+            }),
+        ),
+        (
+            "a parenthesized source type still takes overrides",
+            derived(quote! {
+                #[from((std::io::Error)(path: "unknown".to_owned()))]
+                struct T { path: String, inner: ohno::OhnoCore }
+            }),
+        ),
     ]);
     insta::assert_snapshot!(output);
 }
@@ -538,6 +565,27 @@ fn a_faulty_from_attribute_is_reported() {
             "a key naming the core",
             derived(quote! {
                 #[from(std::io::Error(inner: 1))]
+                struct T { path: String, inner: ohno::OhnoCore }
+            }),
+        ),
+        (
+            "the unit type is not a source an error can convert from",
+            derived(quote! {
+                #[from(())]
+                struct T { path: String, inner: ohno::OhnoCore }
+            }),
+        ),
+        (
+            "a parenthesized unit type is the same type",
+            derived(quote! {
+                #[from((()))]
+                struct T { path: String, inner: ohno::OhnoCore }
+            }),
+        ),
+        (
+            "a rejected unit entry does not swallow the entries beside it",
+            derived(quote! {
+                #[from((), std::io::Error(missing: 1))]
                 struct T { path: String, inner: ohno::OhnoCore }
             }),
         ),

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_faulty_from_attribute_is_reported.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_faulty_from_attribute_is_reported.snap
@@ -91,3 +91,48 @@ struct T {
 ::core::compile_error! {
     "`#[from(...)]` cannot initialize `inner`, which holds the OhnoCore and is built from the source error"
 }
+
+// ======== the unit type is not a source an error can convert from ========
+
+#[derive(Error)]
+#[from(())]
+struct T {
+    path: String,
+    inner: ohno::OhnoCore,
+}
+// ---- expands to ----
+
+::core::compile_error! {
+    "`#[from(...)]` cannot convert from `()`, which is not an error type. Name the type the conversion converts from, such as `#[from(std::io::Error)]`"
+}
+
+// ======== a parenthesized unit type is the same type ========
+
+#[derive(Error)]
+#[from((()))]
+struct T {
+    path: String,
+    inner: ohno::OhnoCore,
+}
+// ---- expands to ----
+
+::core::compile_error! {
+    "`#[from(...)]` cannot convert from `()`, which is not an error type. Name the type the conversion converts from, such as `#[from(std::io::Error)]`"
+}
+
+// ======== a rejected unit entry does not swallow the entries beside it ========
+
+#[derive(Error)]
+#[from((), std::io::Error(missing:1))]
+struct T {
+    path: String,
+    inner: ohno::OhnoCore,
+}
+// ---- expands to ----
+
+::core::compile_error! {
+    "`#[from(...)]` cannot convert from `()`, which is not an error type. Name the type the conversion converts from, such as `#[from(std::io::Error)]`"
+}
+::core::compile_error! {
+    "unknown field `missing` in `#[from(...)]`, available fields: `path`"
+}

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_from_attribute_generates_its_conversions.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_from_attribute_generates_its_conversions.snap
@@ -572,3 +572,285 @@ impl ::core::convert::From<::core::convert::Infallible> for T {
         ::core::unreachable!("Infallible cannot be constructed")
     }
 }
+
+// ======== a parenthesized source type is not an override list ========
+
+#[derive(Error)]
+#[from((std::io::Error))]
+struct T {
+    path: String,
+    inner: ohno::OhnoCore,
+}
+// ---- expands to ----
+
+#[automatically_derived]
+impl ::core::fmt::Display for T {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        self.inner.format_error(f, "T", ::core::option::Option::None)
+    }
+}
+#[automatically_derived]
+impl ::std::error::Error for T {
+    fn source(&self) -> ::core::option::Option<&(dyn ::std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+#[automatically_derived]
+impl ::ohno::Enrichable for T {
+    fn add_enrichment(&mut self, entry: ::ohno::EnrichmentEntry) {
+        ::ohno::Enrichable::add_enrichment(&mut self.inner, entry);
+    }
+}
+#[automatically_derived]
+impl ::ohno::ErrorExt for T {
+    fn message(&self) -> ::std::string::String {
+        self.inner.format_message("T", ::core::option::Option::None)
+    }
+    fn backtrace(&self) -> &::std::backtrace::Backtrace {
+        self.inner.backtrace()
+    }
+}
+impl ::core::fmt::Debug for T {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("T")
+            .field("path", &self.path)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+#[automatically_derived]
+impl T {
+    /// Creates the error with no source.
+    #[allow(
+        dead_code,
+        reason = "generated for every error type, used at the author's discretion"
+    )]
+    pub(crate) fn new(path: impl ::core::convert::Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            inner: ::ohno::OhnoCore::default(),
+        }
+    }
+    /// Creates the error wrapping `error` as its source.
+    #[allow(
+        dead_code,
+        reason = "generated for every error type, used at the author's discretion"
+    )]
+    pub(crate) fn caused_by(
+        path: impl ::core::convert::Into<String>,
+        error: impl ::core::convert::Into<
+            ::std::boxed::Box<
+                dyn ::std::error::Error + ::core::marker::Send + ::core::marker::Sync,
+            >,
+        >,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            inner: ::ohno::OhnoCore::from(error),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<(std::io::Error)> for T {
+    fn from(error: (std::io::Error)) -> Self {
+        let __ohno_fields = (::core::default::Default::default(),);
+        Self {
+            path: __ohno_fields.0,
+            inner: ::ohno::OhnoCore::from(error),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<::core::convert::Infallible> for T {
+    fn from(_value: ::core::convert::Infallible) -> Self {
+        ::core::unreachable!("Infallible cannot be constructed")
+    }
+}
+
+// ======== a tuple source type is not an override list ========
+
+#[derive(Error)]
+#[from((u8, u16))]
+struct T {
+    path: String,
+    inner: ohno::OhnoCore,
+}
+// ---- expands to ----
+
+#[automatically_derived]
+impl ::core::fmt::Display for T {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        self.inner.format_error(f, "T", ::core::option::Option::None)
+    }
+}
+#[automatically_derived]
+impl ::std::error::Error for T {
+    fn source(&self) -> ::core::option::Option<&(dyn ::std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+#[automatically_derived]
+impl ::ohno::Enrichable for T {
+    fn add_enrichment(&mut self, entry: ::ohno::EnrichmentEntry) {
+        ::ohno::Enrichable::add_enrichment(&mut self.inner, entry);
+    }
+}
+#[automatically_derived]
+impl ::ohno::ErrorExt for T {
+    fn message(&self) -> ::std::string::String {
+        self.inner.format_message("T", ::core::option::Option::None)
+    }
+    fn backtrace(&self) -> &::std::backtrace::Backtrace {
+        self.inner.backtrace()
+    }
+}
+impl ::core::fmt::Debug for T {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("T")
+            .field("path", &self.path)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+#[automatically_derived]
+impl T {
+    /// Creates the error with no source.
+    #[allow(
+        dead_code,
+        reason = "generated for every error type, used at the author's discretion"
+    )]
+    pub(crate) fn new(path: impl ::core::convert::Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            inner: ::ohno::OhnoCore::default(),
+        }
+    }
+    /// Creates the error wrapping `error` as its source.
+    #[allow(
+        dead_code,
+        reason = "generated for every error type, used at the author's discretion"
+    )]
+    pub(crate) fn caused_by(
+        path: impl ::core::convert::Into<String>,
+        error: impl ::core::convert::Into<
+            ::std::boxed::Box<
+                dyn ::std::error::Error + ::core::marker::Send + ::core::marker::Sync,
+            >,
+        >,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            inner: ::ohno::OhnoCore::from(error),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<(u8, u16)> for T {
+    fn from(error: (u8, u16)) -> Self {
+        let __ohno_fields = (::core::default::Default::default(),);
+        Self {
+            path: __ohno_fields.0,
+            inner: ::ohno::OhnoCore::from(error),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<::core::convert::Infallible> for T {
+    fn from(_value: ::core::convert::Infallible) -> Self {
+        ::core::unreachable!("Infallible cannot be constructed")
+    }
+}
+
+// ======== a parenthesized source type still takes overrides ========
+
+#[derive(Error)]
+#[from((std::io::Error)(path:"unknown".to_owned()))]
+struct T {
+    path: String,
+    inner: ohno::OhnoCore,
+}
+// ---- expands to ----
+
+#[automatically_derived]
+impl ::core::fmt::Display for T {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        self.inner.format_error(f, "T", ::core::option::Option::None)
+    }
+}
+#[automatically_derived]
+impl ::std::error::Error for T {
+    fn source(&self) -> ::core::option::Option<&(dyn ::std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+#[automatically_derived]
+impl ::ohno::Enrichable for T {
+    fn add_enrichment(&mut self, entry: ::ohno::EnrichmentEntry) {
+        ::ohno::Enrichable::add_enrichment(&mut self.inner, entry);
+    }
+}
+#[automatically_derived]
+impl ::ohno::ErrorExt for T {
+    fn message(&self) -> ::std::string::String {
+        self.inner.format_message("T", ::core::option::Option::None)
+    }
+    fn backtrace(&self) -> &::std::backtrace::Backtrace {
+        self.inner.backtrace()
+    }
+}
+impl ::core::fmt::Debug for T {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("T")
+            .field("path", &self.path)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+#[automatically_derived]
+impl T {
+    /// Creates the error with no source.
+    #[allow(
+        dead_code,
+        reason = "generated for every error type, used at the author's discretion"
+    )]
+    pub(crate) fn new(path: impl ::core::convert::Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            inner: ::ohno::OhnoCore::default(),
+        }
+    }
+    /// Creates the error wrapping `error` as its source.
+    #[allow(
+        dead_code,
+        reason = "generated for every error type, used at the author's discretion"
+    )]
+    pub(crate) fn caused_by(
+        path: impl ::core::convert::Into<String>,
+        error: impl ::core::convert::Into<
+            ::std::boxed::Box<
+                dyn ::std::error::Error + ::core::marker::Send + ::core::marker::Sync,
+            >,
+        >,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            inner: ::ohno::OhnoCore::from(error),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<(std::io::Error)> for T {
+    fn from(error: (std::io::Error)) -> Self {
+        let __ohno_fields = ("unknown".to_owned(),);
+        Self {
+            path: __ohno_fields.0,
+            inner: ::ohno::OhnoCore::from(error),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<::core::convert::Infallible> for T {
+    fn from(_value: ::core::convert::Infallible) -> Self {
+        ::core::unreachable!("Infallible cannot be constructed")
+    }
+}

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__every_struct_shape_generates_its_items.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__every_struct_shape_generates_its_items.snap
@@ -323,6 +323,81 @@ impl ::core::convert::From<::core::convert::Infallible> for T {
     }
 }
 
+// ======== a tuple core in the middle keeps declaration order ========
+
+#[derive(Error)]
+struct T(String, ohno::OhnoCore, u32);
+// ---- expands to ----
+
+#[automatically_derived]
+impl ::core::fmt::Display for T {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        self.1.format_error(f, "T", ::core::option::Option::None)
+    }
+}
+#[automatically_derived]
+impl ::std::error::Error for T {
+    fn source(&self) -> ::core::option::Option<&(dyn ::std::error::Error + 'static)> {
+        self.1.source()
+    }
+}
+#[automatically_derived]
+impl ::ohno::Enrichable for T {
+    fn add_enrichment(&mut self, entry: ::ohno::EnrichmentEntry) {
+        ::ohno::Enrichable::add_enrichment(&mut self.1, entry);
+    }
+}
+#[automatically_derived]
+impl ::ohno::ErrorExt for T {
+    fn message(&self) -> ::std::string::String {
+        self.1.format_message("T", ::core::option::Option::None)
+    }
+    fn backtrace(&self) -> &::std::backtrace::Backtrace {
+        self.1.backtrace()
+    }
+}
+impl ::core::fmt::Debug for T {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_tuple("T").field(&self.0).field(&self.1).field(&self.2).finish()
+    }
+}
+#[automatically_derived]
+impl T {
+    /// Creates the error with no source.
+    #[allow(
+        dead_code,
+        reason = "generated for every error type, used at the author's discretion"
+    )]
+    pub(crate) fn new(
+        param_0: impl ::core::convert::Into<String>,
+        param_2: impl ::core::convert::Into<u32>,
+    ) -> Self {
+        Self(param_0.into(), ::ohno::OhnoCore::default(), param_2.into())
+    }
+    /// Creates the error wrapping `error` as its source.
+    #[allow(
+        dead_code,
+        reason = "generated for every error type, used at the author's discretion"
+    )]
+    pub(crate) fn caused_by(
+        param_0: impl ::core::convert::Into<String>,
+        param_2: impl ::core::convert::Into<u32>,
+        error: impl ::core::convert::Into<
+            ::std::boxed::Box<
+                dyn ::std::error::Error + ::core::marker::Send + ::core::marker::Sync,
+            >,
+        >,
+    ) -> Self {
+        Self(param_0.into(), ::ohno::OhnoCore::from(error), param_2.into())
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<::core::convert::Infallible> for T {
+    fn from(_value: ::core::convert::Infallible) -> Self {
+        ::core::unreachable!("Infallible cannot be constructed")
+    }
+}
+
 // ======== a marked core need not be named OhnoCore ========
 
 #[derive(Error)]


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

Mostly an internal refactor of `ohno_macros_impl`. One input that used to be accepted is now rejected, deliberately. **No code that compiles today stops compiling** — see Compatibility below.

## The corner this is really about

A `#[from(...)]` entry is a type, optionally followed by `(field: expression, ...)` overrides. That makes a `(` in the leading position genuinely ambiguous, and these all mean different things:

```rust
#[from(std::io::Error)]                         // a path type
#[from((std::io::Error))]                       // the same type, parenthesized
#[from((u8, u16))]                              // a tuple type
#[from(std::io::Error(path: "?".to_owned()))]   // a type, plus a field override
#[from((std::io::Error)(path: "?".to_owned()))] // parenthesized, plus an override
```

Telling them apart is the parser's whole job here. Before this PR, exactly one of them had a test. All of them do now.

## What you write, and what you get

```rust
#[derive(Error)]
#[from(std::io::Error)]
struct T {
    source: String,
    inner: ohno::OhnoCore,
}
```

produces this, byte-identically before and after the change:

```rust
impl ::core::convert::From<std::io::Error> for T {
    fn from(error: std::io::Error) -> Self {
        let __ohno_fields = (::core::default::Default::default(),);
        Self {
            source: __ohno_fields.0,
            inner: ::ohno::OhnoCore::from(error),
        }
    }
}
```

so ordinary usage is untouched:

```rust
let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "test error");
let my_err: MyError = io_err.into();

assert_error_message!(my_err, "test error");
assert_eq!(my_err.code, 0); // fields you did not name are defaulted
```

Field overrides, several source types in one attribute, generic sources whose commas belong to the type rather than to the list, tuple structs, and a core field placed anywhere in the struct all produce identical output too. Every pre-existing expansion snapshot is unchanged.

## `()` is now rejected

`#[from(())]` used to be accepted by the macro. It was never *usable*: `OhnoCore::from` requires `T: Into<Box<dyn Error + Send + Sync>>`, which `()` does not satisfy, so the generated `From<()>` failed to compile — pointing into code the user never wrote, which `design.md` R4 forbids.

Before, on `main`:

```
error[E0277]: the trait bound `(): std::error::Error` is not satisfied
    = note: required for `OhnoCore` to implement `From<()>`
```

After, pointing at what you actually wrote:

```
error: `#[from(...)]` cannot convert from `()`, which is not an error type.
       Name the type the conversion converts from, such as `#[from(std::io::Error)]`
  --> tests/ui/from_unit_source.rs:11:8
   |
11 | #[from(())]
   |        ^^
```

`#[from((()))]` is the same type and gets the same message. `((),)` is a genuine one-element tuple and is left alone.

The rejection is a *rule*, checked in the validation phase, and that placement matters. `#[from(...)]` parses its entries as a single list, so had the parser instead treated `()` as an empty override list and failed at decode time, one `()` would have discarded every other entry in the attribute. A new `tests/ui` fixture pins that it does not:

```rust
#[from((), std::io::Error(missing: 1))]
```

reports **both** the `()` and the unknown field, rather than losing the second behind the first.

## Compatibility

Not a breaking change, in the sense that matters: no source that compiles against `main` fails to compile after this.

- **`#[from(())]`** — verified empirically, not assumed. `OhnoCore` has exactly one `From` impl, bounded on `Into<Box<dyn StdError + Send + Sync>>`, and `OhnoCore::from(())` is rejected by `rustc` with `E0277`. So any crate containing `#[from(())]` already failed to build. Code that did not compile still does not compile; only the diagnostic improves.
- **Public API** — unchanged. `ohno_macros_impl` exports the same three functions with the same signatures, and no type in `ohno` is touched, so `cargo-semver-checks` has nothing to report.
- **Diagnostic wording** — one message changes for a malformed override list, which both versions reject. Message text is not part of the API contract, and no pre-existing `.stderr` snapshot covered it.

| input | before | after |
| --- | --- | --- |
| `#[from(())]` | accepted, then `E0277` in generated code | rejected, message at the `()` |
| `#[from(std::io::Error(path: ))]` | rejected, ``expected a type`` | rejected, ``unexpected token, expected ")"`` |
| everything else | — | identical |

## Diagnostics you see when you get it wrong

Otherwise unchanged, message for message and span for span — the compile-fail tests that pin them are untouched:

```
error: unknown field `missing` in `#[from(...)]`, available fields: `path`
error: `#[from(...)]` cannot initialize `inner`, which holds the OhnoCore and is built from the source error
error: `#[from(...)]` field keys for a tuple struct are field indexes, not names, so `path:` names no field
error: `#[from(...)]` needs at least one type, such as `#[from(std::io::Error)]`
```

## Why touch it at all

Three things were re-derived by hand that a type or a grammar already held. The entry parser restated part of Rust's path grammar as raw token peeking, so that `(std::io::Error)` would not read as a field named `std`; it now settles the question by trying to parse an override list and seeing whether that succeeds. Both code generators re-found the core field by comparing member names, and one threaded its own index alongside that walk guarded by an `expect` — a panic path in the generation phase, which `design.md` requires not to have one; the shape now reports each field's position directly. Finally, override keys were compared by formatting both sides to `String`, where `syn::Member` already implements `PartialEq`.

Implementation source shrinks by roughly 20 lines. The rest of the diff is test coverage, plus the `design.md` and `requirements.md` updates for the `()` rejection.

## Validation

`ohno_macros_impl` and `ohno` both pass on the pinned MSRV, including the `trybuild` compile-fail tests that pin the diagnostics. Clippy is clean under `-D warnings`, and both formatting gates pass on the pinned nightly. The parser change was checked against the previous implementation with a differential probe over 68 adversarial `#[from(...)]` entries; `()` is the only input whose outcome moves.

`darling` was evaluated first and rejected: its derives parse each attribute through `NestedMeta`, which cannot represent `#[display("{a}", self.x())]`, a `#[from(...)]` entry carrying generic arguments or `key: expr` pairs, or bare markers such as `#[no_debug]`. Adopting it would have added a dependency without removing any of the code above.