### PR TITLE
chore: raise MSRV to Rust 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/*"]
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.93.1"
+rust-version = "1.95"
 authors = ["The Oxidizer Project Authors"]
 license = "MIT"
 homepage = "https://github.com/microsoft/oxidizer"

--- a/constants.env
+++ b/constants.env
@@ -6,7 +6,7 @@
 # Rust toolchain versions
 
 # used for testing, ensures the MSRV promise is kept; must match Cargo.toml [workspace.package].rust-version
-RUST_MSRV=1.93.1
+RUST_MSRV=1.95
 # used for static analysis & mutation testing
 RUST_LATEST=1.96.1
 # used for coverage and extended analysis; update on a regular basis

--- a/crates/bytesbuf/src/view_get.rs
+++ b/crates/bytesbuf/src/view_get.rs
@@ -175,11 +175,11 @@ impl BytesView {
     ///
     /// let mut view = BytesView::copied_from_slice(b"Hello", &memory);
     ///
-    /// let mut buffer: [MaybeUninit<u8>; 5] = [const { MaybeUninit::uninit() }; 5];
-    /// view.copy_to_uninit_slice(&mut buffer);
+    /// let mut buffer = MaybeUninit::<[u8; 5]>::uninit();
+    /// view.copy_to_uninit_slice(buffer.as_mut());
     ///
     /// // SAFETY: The buffer has been fully initialized by copy_to_uninit_slice.
-    /// let buffer: [u8; 5] = unsafe { std::mem::transmute(buffer) };
+    /// let buffer = unsafe { buffer.assume_init() };
     /// assert_eq!(&buffer, b"Hello");
     /// # }
     /// # }
@@ -352,11 +352,11 @@ mod tests {
         let memory = TransparentMemory::new();
         let mut view = BytesView::copied_from_slice(&[1, 2, 3, 4], &memory);
 
-        let mut dst = [MaybeUninit::<u8>::uninit(); 4];
-        view.copy_to_uninit_slice(&mut dst);
+        let mut dst = MaybeUninit::<[u8; 4]>::uninit();
+        view.copy_to_uninit_slice(dst.as_mut());
 
         // SAFETY: It has now been initialized.
-        let dst = unsafe { std::mem::transmute::<[MaybeUninit<u8>; 4], [u8; 4]>(dst) };
+        let dst = unsafe { dst.assume_init() };
 
         assert_eq!(dst, [1, 2, 3, 4]);
         assert!(view.is_empty());
@@ -367,11 +367,11 @@ mod tests {
         let memory = TransparentMemory::new();
         let mut view = BytesView::copied_from_slice(&[1, 2, 3, 4], &memory);
 
-        let mut dst = [MaybeUninit::<u8>::uninit(); 3];
-        view.copy_to_uninit_slice(&mut dst);
+        let mut dst = MaybeUninit::<[u8; 3]>::uninit();
+        view.copy_to_uninit_slice(dst.as_mut());
 
         // SAFETY: It has now been initialized.
-        let dst = unsafe { std::mem::transmute::<[MaybeUninit<u8>; 3], [u8; 3]>(dst) };
+        let dst = unsafe { dst.assume_init() };
 
         assert_eq!(dst, [1, 2, 3]);
         assert_eq!(view.len(), 1);
@@ -412,12 +412,12 @@ mod tests {
         let view_part2 = BytesView::copied_from_slice(&data_part2, &memory);
         let mut view_combined = BytesView::from_views([view_part1, view_part2]);
 
-        let mut dst = [MaybeUninit::<u8>::uninit(); 5];
-        view_combined.copy_to_uninit_slice(&mut dst);
+        let mut dst = MaybeUninit::<[u8; 5]>::uninit();
+        view_combined.copy_to_uninit_slice(dst.as_mut());
         assert!(view_combined.is_empty());
 
         // SAFETY: It has now been initialized.
-        let dst = unsafe { std::mem::transmute::<[MaybeUninit<u8>; 5], [u8; 5]>(dst) };
+        let dst = unsafe { dst.assume_init() };
 
         assert_eq!(dst, [10_u8, 20, 30, 40, 50]);
     }

--- a/crates/multitude/src/allocator_impl.rs
+++ b/crates/multitude/src/allocator_impl.rs
@@ -38,11 +38,9 @@ unsafe impl<A: Allocator + Clone> Allocator for &Arena<A> {
             return Err(AllocError);
         }
         // Zero-byte allocations need a non-null, well-aligned pointer but no
-        // chunk state (mirroring `std::alloc::Global`). `without_provenance_mut`
-        // keeps it strict-provenance-clean — ZSTs are never dereferenced.
+        // chunk state (mirroring `std::alloc::Global`).
         if layout.size() == 0 {
-            // SAFETY: `layout.align()` is a non-zero power of two.
-            let dangling = unsafe { NonNull::new_unchecked(ptr::without_provenance_mut::<u8>(layout.align())) };
+            let dangling = layout.dangling_ptr();
             return Ok(NonNull::slice_from_raw_parts(dangling, 0));
         }
         // Refill / oversized hint includes one alignment slack so

--- a/crates/multitude/src/internal/chunk_mutator.rs
+++ b/crates/multitude/src/internal/chunk_mutator.rs
@@ -42,11 +42,6 @@ fn mark_local_reference(marker: &Cell<bool>) {
     }
 }
 
-/// Branch-layout hint for the uncommon chunk-exhaustion path. The workspace
-/// Rust 1.93 MSRV predates `core::hint::cold_path`.
-#[cold]
-fn allocation_miss() {}
-
 /// Owns one strong reference to a chunk and tracks the bump cursor.
 ///
 /// Hot-path layout stores only `chunk`, `bump`, and `end`; cold paths
@@ -228,7 +223,7 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
         // `size.max(1)` probes that byte without changing the ZST bump.
         let probe_end = aligned_addr.checked_add(size.max(1))?;
         if probe_end > limit_addr {
-            allocation_miss();
+            hint::cold_path();
             return None;
         }
         // SAFETY: `probe_end <= limit_addr`, so both `aligned_ptr`
@@ -299,7 +294,7 @@ impl<A: Allocator + Clone> ChunkMutator<A> {
         hint_chunk_cur_addr_nonnull(cur_addr);
         let end_addr = cur_addr.checked_add(len)?;
         if end_addr > limit_addr {
-            allocation_miss();
+            hint::cold_path();
             return None;
         }
         // SAFETY: `end_addr <= limit_addr`.

--- a/crates/multitude/tests/arena.rs
+++ b/crates/multitude/tests/arena.rs
@@ -1499,9 +1499,7 @@ mod fast_path_correctness {
         }
         // Verify no two allocations overlap (each is 8 bytes)
         ptrs.sort_by_key(|&(_, addr)| addr);
-        for window in ptrs.windows(2) {
-            let (_, a) = window[0];
-            let (_, b) = window[1];
+        for &[(_, a), (_, b)] in ptrs.array_windows() {
             assert!(a + size_of::<u64>() <= b, "Allocations overlap: {a:#x} + 8 > {b:#x}");
         }
     }
@@ -1512,13 +1510,8 @@ mod fast_path_correctness {
         let handles: Vec<_> = (0..200_u64).map(|i| arena.alloc_arc(i)).collect();
         let mut addrs: Vec<usize> = handles.iter().map(|arc| &raw const **arc as usize).collect();
         addrs.sort_unstable();
-        for window in addrs.windows(2) {
-            assert!(
-                window[0] + size_of::<u64>() <= window[1],
-                "Arc allocations overlap: {:#x} + 8 > {:#x}",
-                window[0],
-                window[1]
-            );
+        for &[a, b] in addrs.array_windows() {
+            assert!(a + size_of::<u64>() <= b, "Arc allocations overlap: {a:#x} + 8 > {b:#x}");
         }
     }
 

--- a/crates/rallocator_telemetry/src/lib.rs
+++ b/crates/rallocator_telemetry/src/lib.rs
@@ -1159,11 +1159,7 @@ fn read_string_in_section(reader: &mut Reader<'_>, section_id: u16) -> Result<St
 }
 
 fn read_bool(reader: &mut Reader<'_>, section_id: u16) -> Result<bool, Error> {
-    match reader.read_u8()? {
-        0 => Ok(false),
-        1 => Ok(true),
-        _ => Err(Error::malformed_section(section_id)),
-    }
+    bool::try_from(reader.read_u8()?).map_err(|_| Error::malformed_section(section_id))
 }
 
 fn count(value: usize) -> Result<u32, Error> {

--- a/crates/rest_over_grpc/src/transcode/overlay.rs
+++ b/crates/rest_over_grpc/src/transcode/overlay.rs
@@ -466,7 +466,7 @@ fn insert_query_node<'a>(
     let node = if let Some((_, node)) = map.iter_mut().find(|(existing, _)| existing == key) {
         node
     } else {
-        map.push((
+        let (_, node) = map.push_mut((
             key.to_owned(),
             if has_more {
                 QueryNode::Map(Vec::new())
@@ -474,7 +474,7 @@ fn insert_query_node<'a>(
                 QueryNode::Leaf(SmallVec::new())
             },
         ));
-        &mut map.last_mut().expect("entry was pushed immediately above").1
+        node
     };
     if has_more {
         match node {

--- a/crates/routerama_build/src/codegen.rs
+++ b/crates/routerama_build/src/codegen.rs
@@ -554,8 +554,8 @@ fn emit_leaves(leaves: &[Leaf], any_verb: bool, route_enum: &Ident) -> TokenStre
         let group = if let Some((_, entries)) = groups.iter_mut().find(|(m, _)| *m == leaf.method) {
             entries
         } else {
-            groups.push((leaf.method.clone(), Vec::new()));
-            &mut groups.last_mut().expect("just pushed").1
+            let (_, entries) = groups.push_mut((leaf.method.clone(), Vec::new()));
+            entries
         };
         if !group.iter().any(|existing| existing.verb == leaf.verb) {
             group.push(leaf);


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The workspace can raise its minimum supported Rust version from 1.93.1 to 1.95. The newer standard library provides dedicated APIs that replace several local workarounds, impossible-state branches, and unsafe memory constructions.

## Changes

- Raises the workspace MSRV and the toolchain used by MSRV checks to Rust 1.95.
- Uses the stabilized branch-layout, collection insertion, slice-window, and checked Boolean conversion APIs where they directly simplify existing code.
- Uses `Layout::dangling_ptr` for zero-sized allocations, removing manual pointer construction and its unsafe block.
- Uses `MaybeUninit` array views in byte-buffer examples and tests, removing array type-punning conversions.

The changes preserve existing runtime behavior and API contracts.
