### PR TITLE
fix(ohno_macros): correct the syntax context of a rewritten unit struct and the `#[automatically_derived]` placements

### DIFF
--- a/crates/ohno/examples/default_constructors.rs
+++ b/crates/ohno/examples/default_constructors.rs
@@ -6,6 +6,7 @@
 use ohno::{Error, OhnoCore};
 
 #[derive(Error)]
+#[display("cannot open {path}")]
 struct MyError {
     path: String,
     inner: OhnoCore,

--- a/crates/ohno/examples/derive_with_fields.rs
+++ b/crates/ohno/examples/derive_with_fields.rs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Prints `InvalidQuery`
+//! Prints an `InvalidQuery` through both `Display` and `Debug`.
 
 use ohno::{Error, OhnoCore};
 
 #[derive(Error)]
+#[display("invalid query: {operation} on {table}")]
 struct InvalidQuery {
     operation: String,
     table: String,

--- a/crates/ohno/examples/from_attribute.rs
+++ b/crates/ohno/examples/from_attribute.rs
@@ -6,7 +6,9 @@
 #[ohno::error]
 #[from(std::io::Error, std::fmt::Error)]
 struct MyError {
+    #[expect(dead_code, reason = "the example shows that #[from] fills the remaining fields")]
     optional_field: Option<String>,
+    #[expect(dead_code, reason = "the example shows that #[from] fills the remaining fields")]
     count: u32,
 }
 

--- a/crates/ohno/examples/multiple_core_fields.rs
+++ b/crates/ohno/examples/multiple_core_fields.rs
@@ -7,6 +7,7 @@ use ohno::{Error, OhnoCore};
 
 #[derive(Error)]
 struct MyError {
+    #[expect(dead_code, reason = "carried as data; the example is about disambiguating the core")]
     metadata: OhnoCore,
     #[error] // Mark the primary error field
     main_error: OhnoCore,

--- a/crates/ohno/tests/constructor_integration.rs
+++ b/crates/ohno/tests/constructor_integration.rs
@@ -28,6 +28,8 @@ fn test_complex_error_constructors() {
     }
 
     let db_err = DatabaseError::new("users", "SELECT");
+    assert_eq!(db_err.table, "users");
+    assert_eq!(db_err.operation, "SELECT");
     assert_error_message!(db_err, "DatabaseError");
 
     let db_err_with_error = DatabaseError::caused_by("users", "SELECT", "Table not found");

--- a/crates/ohno/tests/debug_implementation_comparison.rs
+++ b/crates/ohno/tests/debug_implementation_comparison.rs
@@ -19,7 +19,9 @@ fn test_named_struct_debug_structure() {
     pub(crate) struct TestNamedStruct {
         #[error]
         pub inner: OhnoCore,
+        #[expect(dead_code, reason = "read only by the generated Debug")]
         pub code: i32,
+        #[expect(dead_code, reason = "read only by the generated Debug")]
         pub message: String,
     }
 
@@ -46,7 +48,11 @@ fn test_tuple_struct_debug_structure() {
     pub(crate) struct RefTupleStruct(pub OhnoCore, pub String, pub i32);
 
     #[derive(Error)]
-    pub(crate) struct TestTupleStruct(#[error] pub OhnoCore, pub String, pub i32);
+    pub(crate) struct TestTupleStruct(
+        #[error] pub OhnoCore,
+        #[expect(dead_code, reason = "read only by the generated Debug")] pub String,
+        #[expect(dead_code, reason = "read only by the generated Debug")] pub i32,
+    );
 
     let ref_struct = RefTupleStruct(OhnoCore::from("error_content"), "additional_info".to_string(), 42);
 
@@ -103,6 +109,7 @@ fn test_struct_with_enum_field_debug_structure() {
     struct TestEnumFieldStruct {
         #[error]
         error: OhnoCore,
+        #[expect(dead_code, reason = "read only by the generated Debug")]
         status: TestStatus,
     }
 

--- a/crates/ohno/tests/derive_auto_debug.rs
+++ b/crates/ohno/tests/derive_auto_debug.rs
@@ -23,7 +23,10 @@ struct MultiFieldError {
 
 // Test tuple struct with automatic Debug
 #[derive(Error)]
-struct TupleError(String, #[error] OhnoCore);
+struct TupleError(
+    #[expect(dead_code, reason = "read only by the generated Debug")] String,
+    #[error] OhnoCore,
+);
 
 // Test unit struct conversion with automatic Debug
 #[derive(Error)]

--- a/crates/ohno_macros/docs/design.md
+++ b/crates/ohno_macros/docs/design.md
@@ -254,6 +254,14 @@ Two values recur below: the core field's member, and the type's name as a string
 literal — the default message the runtime falls back to when nothing else
 renders.
 
+`#[automatically_derived]` follows one rule as well, with an exception on each
+side of it. The attribute marks an `impl` as machine-written, which makes
+dead-code analysis skip the field reads inside it, and `rustc` accepts it only on
+a trait `impl`. Every generated trait `impl` therefore carries it except `Debug`,
+which wants those field reads counted; and the inherent `impl` holding the
+constructors carries it on neither ground, being no trait `impl` at all — `rustc`
+warns there today and states it will become a hard error.
+
 **`Display`** delegates to the core, passing the lowered message as an override
 when there is one. `OhnoCore::format_error` appends `caused by:`, the enrichment
 lines and the backtrace, so the generated code decides only the message. The
@@ -278,7 +286,7 @@ error type becomes infallible.
 including the core, so it iterates the full field list and branches once on
 style, into `debug_struct` for a named struct or `debug_tuple` for a tuple one.
 
-It is one of the two generated items that are **not** `#[automatically_derived]`.
+It is the one generated trait `impl` without `#[automatically_derived]`.
 Dead-code analysis ignores field reads inside a derived `Debug`, so marking this
 one would make every field that only `Debug` reads look unused in the user's own
 crate.
@@ -289,10 +297,6 @@ parameters plus a source error and builds the core from it. Both iterate the
 non-core fields, so the core is skipped and declaration order is kept, and both
 take each parameter as `impl Into<_>` of the field's type. `pub(crate)` is fixed
 by R1.4, settled by ADO 7675155.
-
-Their `impl` block is the other item that is **not** `#[automatically_derived]`,
-because that attribute is accepted only on a trait `impl` and this one is
-inherent. `rustc` warns on it today and states it will become a hard error.
 
 **`From<T>`** is emitted once per conversion, zipping the non-core fields with
 that conversion's initializers and building the core from the source error. The

--- a/crates/ohno_macros/docs/design.md
+++ b/crates/ohno_macros/docs/design.md
@@ -250,16 +250,11 @@ trait `impl` carries all three, as does the single inherent `impl` holding the
 constructors. That covers lifetimes, type parameters and where clauses in one
 rule, which is what R1.3's "all of them carry the input's generics" asks for.
 
+Every generated trait `impl` but `Debug` carries `#[automatically_derived]`.
+
 Two values recur below: the core field's member, and the type's name as a string
 literal — the default message the runtime falls back to when nothing else
 renders.
-
-`#[automatically_derived]` follows one rule as well, with an exception on each
-side of it. The attribute marks an `impl` as machine-written, which makes
-dead-code analysis skip the field reads inside it, and it is accepted only on a
-trait `impl`. Every generated trait `impl` therefore carries it except `Debug`,
-which wants those field reads counted, and the inherent `impl` holding the
-constructors cannot carry it at all.
 
 **`Display`** delegates to the core, passing the lowered message as an override
 when there is one. `OhnoCore::format_error` appends `caused by:`, the enrichment
@@ -285,8 +280,8 @@ error type becomes infallible.
 including the core, so it iterates the full field list and branches once on
 style, into `debug_struct` for a named struct or `debug_tuple` for a tuple one.
 
-It is the one generated trait `impl` without `#[automatically_derived]`.
-Dead-code analysis ignores field reads inside a derived `Debug`, so marking this
+It is the one generated trait `impl` without `#[automatically_derived]`, because
+dead-code analysis ignores field reads inside a derived `Debug`, and marking this
 one would make every field that only `Debug` reads look unused in the user's own
 crate.
 

--- a/crates/ohno_macros/docs/design.md
+++ b/crates/ohno_macros/docs/design.md
@@ -278,7 +278,7 @@ error type becomes infallible.
 including the core, so it iterates the full field list and branches once on
 style, into `debug_struct` for a named struct or `debug_tuple` for a tuple one.
 
-It is the one generated item that is **not** `#[automatically_derived]`.
+It is one of the two generated items that are **not** `#[automatically_derived]`.
 Dead-code analysis ignores field reads inside a derived `Debug`, so marking this
 one would make every field that only `Debug` reads look unused in the user's own
 crate.
@@ -289,6 +289,10 @@ parameters plus a source error and builds the core from it. Both iterate the
 non-core fields, so the core is skipped and declaration order is kept, and both
 take each parameter as `impl Into<_>` of the field's type. `pub(crate)` is fixed
 by R1.4, settled by ADO 7675155.
+
+Their `impl` block is the other item that is **not** `#[automatically_derived]`,
+because that attribute is accepted only on a trait `impl` and this one is
+inherent. `rustc` warns on it today and states it will become a hard error.
 
 **`From<T>`** is emitted once per conversion, zipping the non-core fields with
 that conversion's initializers and building the core from the source error. The

--- a/crates/ohno_macros/docs/design.md
+++ b/crates/ohno_macros/docs/design.md
@@ -256,11 +256,10 @@ renders.
 
 `#[automatically_derived]` follows one rule as well, with an exception on each
 side of it. The attribute marks an `impl` as machine-written, which makes
-dead-code analysis skip the field reads inside it, and `rustc` accepts it only on
-a trait `impl`. Every generated trait `impl` therefore carries it except `Debug`,
-which wants those field reads counted; and the inherent `impl` holding the
-constructors carries it on neither ground, being no trait `impl` at all — `rustc`
-warns there today and states it will become a hard error.
+dead-code analysis skip the field reads inside it, and it is accepted only on a
+trait `impl`. Every generated trait `impl` therefore carries it except `Debug`,
+which wants those field reads counted, and the inherent `impl` holding the
+constructors cannot carry it at all.
 
 **`Display`** delegates to the core, passing the lowered message as an override
 when there is one. `OhnoCore::format_error` appends `caused by:`, the enrichment

--- a/crates/ohno_macros/docs/design.md
+++ b/crates/ohno_macros/docs/design.md
@@ -250,7 +250,7 @@ trait `impl` carries all three, as does the single inherent `impl` holding the
 constructors. That covers lifetimes, type parameters and where clauses in one
 rule, which is what R1.3's "all of them carry the input's generics" asks for.
 
-Every generated trait `impl` but `Debug` carries `#[automatically_derived]`.
+Every generated trait `impl` carries `#[automatically_derived]`.
 
 Two values recur below: the core field's member, and the type's name as a string
 literal — the default message the runtime falls back to when nothing else
@@ -280,10 +280,12 @@ error type becomes infallible.
 including the core, so it iterates the full field list and branches once on
 style, into `debug_struct` for a named struct or `debug_tuple` for a tuple one.
 
-It is the one generated trait `impl` without `#[automatically_derived]`, because
-dead-code analysis ignores field reads inside a derived `Debug`, and marking this
-one would make every field that only `Debug` reads look unused in the user's own
-crate.
+`Debug` carries `#[rustc_trivial_field_reads]`, so marking this impl
+`#[automatically_derived]` makes dead-code analysis discard its field reads. A
+field that nothing but `Debug` reads is then reported, which is the answer
+`#[derive(Debug)]` gives too. The core and any field the `#[display]` template
+names stay live, because the other generated impls read them and their traits
+carry no such attribute.
 
 **Constructors** are emitted unless the model suppresses them. `new` takes one
 parameter per non-core field and defaults the core; `caused_by` takes the same

--- a/crates/ohno_macros_impl/src/derive_error/generate/constructors.rs
+++ b/crates/ohno_macros_impl/src/derive_error/generate/constructors.rs
@@ -7,9 +7,6 @@
 //! convenience for the crate that owns the error, not part of its public API, so adding a field is
 //! not a breaking change for callers. An error type that needs a public constructor declares one by
 //! hand, under `#[no_constructors]`.
-//!
-//! Their `impl` block carries no `#[automatically_derived]`. That attribute is accepted only on a
-//! trait `impl`, and `rustc` warns that using it on an inherent one will become a hard error.
 
 use proc_macro2::TokenStream;
 use quote::quote;

--- a/crates/ohno_macros_impl/src/derive_error/generate/constructors.rs
+++ b/crates/ohno_macros_impl/src/derive_error/generate/constructors.rs
@@ -7,6 +7,9 @@
 //! convenience for the crate that owns the error, not part of its public API, so adding a field is
 //! not a breaking change for callers. An error type that needs a public constructor declares one by
 //! hand, under `#[no_constructors]`.
+//!
+//! Their `impl` block carries no `#[automatically_derived]`. That attribute is accepted only on a
+//! trait `impl`, and `rustc` warns that using it on an inherent one will become a hard error.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -37,7 +40,6 @@ pub(crate) fn generate(model: &Model) -> TokenStream {
     let caused_by_body = construct(&model.shape, &initializers(model, &quote!(#core::from(error))));
 
     quote! {
-        #[automatically_derived]
         impl #impl_generics #ident #ty_generics #where_clause {
             /// Creates the error with no source.
             #[allow(dead_code, reason = "generated for every error type, used at the author's discretion")]

--- a/crates/ohno_macros_impl/src/derive_error/generate/traits.rs
+++ b/crates/ohno_macros_impl/src/derive_error/generate/traits.rs
@@ -149,9 +149,7 @@ pub(crate) fn debug(model: &Model) -> TokenStream {
     };
 
     quote! {
-        // Not `#[automatically_derived]`: dead-code analysis skips field reads in a derived
-        // `Debug`, so marking this one would make every field that only `Debug` reads look unused
-        // in the user's own crate.
+        #[automatically_derived]
         impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 #body

--- a/crates/ohno_macros_impl/src/error_attr/mod.rs
+++ b/crates/ohno_macros_impl/src/error_attr/mod.rs
@@ -101,10 +101,10 @@ fn inject_core(item: &mut ItemStruct) {
         }
         Fields::Unnamed(fields) => fields.unnamed.push(unnamed_core(&marker)),
         Fields::Unit => {
-            // The synthesized delimiters take the declaration's own span, so the rewritten struct
-            // keeps the caller's syntax context. Call-site tokens would place the item in this
-            // macro's context, where `rustc` discards `dead_code` on it as external-macro code and
-            // a caller's `#[expect(dead_code)]` can never be fulfilled.
+            // Both tokens take the declaration's own span, so the rewritten struct stays in the
+            // caller's syntax context. Under call-site spans it would sit in this macro's context,
+            // where `dead_code` on it is discarded as external-macro code and a caller's
+            // `#[expect(dead_code)]` can never be fulfilled.
             let span = item.ident.span();
             let mut unnamed = FieldsUnnamed {
                 paren_token: syn::token::Paren(span),

--- a/crates/ohno_macros_impl/src/error_attr/mod.rs
+++ b/crates/ohno_macros_impl/src/error_attr/mod.rs
@@ -101,13 +101,18 @@ fn inject_core(item: &mut ItemStruct) {
         }
         Fields::Unnamed(fields) => fields.unnamed.push(unnamed_core(&marker)),
         Fields::Unit => {
+            // The synthesized delimiters take the declaration's own span, so the rewritten struct
+            // keeps the caller's syntax context. Call-site tokens would place the item in this
+            // macro's context, where `rustc` discards `dead_code` on it as external-macro code and
+            // a caller's `#[expect(dead_code)]` can never be fulfilled.
+            let span = item.ident.span();
             let mut unnamed = FieldsUnnamed {
-                paren_token: syn::token::Paren::default(),
+                paren_token: syn::token::Paren(span),
                 unnamed: syn::punctuated::Punctuated::new(),
             };
             unnamed.unnamed.push(unnamed_core(&marker));
             item.fields = Fields::Unnamed(unnamed);
-            item.semi_token = Some(<syn::Token![;]>::default());
+            item.semi_token = Some(syn::Token![;](span));
         }
     }
 }

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_from_attribute_generates_its_conversions.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_from_attribute_generates_its_conversions.snap
@@ -47,7 +47,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -141,7 +140,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -245,7 +243,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -339,7 +336,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -427,7 +423,6 @@ impl ::core::fmt::Debug for T {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -514,7 +509,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_from_attribute_generates_its_conversions.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_from_attribute_generates_its_conversions.snap
@@ -39,6 +39,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -132,6 +133,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -235,6 +237,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -328,6 +331,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -418,6 +422,7 @@ impl ::ohno::ErrorExt for T {
         self.1.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
@@ -500,6 +505,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_numeric_argument_roots_at_a_tuple_field.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_numeric_argument_roots_at_a_tuple_field.snap
@@ -49,6 +49,7 @@ impl ::ohno::ErrorExt for T {
         self.1.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
@@ -133,6 +134,7 @@ impl ::ohno::ErrorExt for T {
         self.1.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
@@ -221,6 +223,7 @@ impl ::ohno::ErrorExt for T {
         self.1.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_numeric_argument_roots_at_a_tuple_field.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_numeric_argument_roots_at_a_tuple_field.snap
@@ -54,7 +54,6 @@ impl ::core::fmt::Debug for T {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -139,7 +138,6 @@ impl ::core::fmt::Debug for T {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -228,7 +226,6 @@ impl ::core::fmt::Debug for T {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_positional_argument_is_scoped_to_self.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_positional_argument_is_scoped_to_self.snap
@@ -62,7 +62,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -171,7 +170,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -280,7 +278,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -389,7 +386,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -498,7 +494,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -607,7 +602,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -712,7 +706,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -821,7 +814,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_positional_argument_is_scoped_to_self.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_positional_argument_is_scoped_to_self.snap
@@ -53,6 +53,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -161,6 +162,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -269,6 +271,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -377,6 +380,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -485,6 +489,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -593,6 +598,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -697,6 +703,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -805,6 +812,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_template_lowers_to_a_literal_or_a_format_call.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_template_lowers_to_a_literal_or_a_format_call.snap
@@ -53,6 +53,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -153,6 +154,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -261,6 +263,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -365,6 +368,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -465,6 +469,7 @@ impl ::ohno::ErrorExt for T {
         self.1.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
@@ -556,6 +561,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__a_template_lowers_to_a_literal_or_a_format_call.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__a_template_lowers_to_a_literal_or_a_format_call.snap
@@ -62,7 +62,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -163,7 +162,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -272,7 +270,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -377,7 +374,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -474,7 +470,6 @@ impl ::core::fmt::Debug for T {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -569,7 +564,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__an_argument_may_call_a_method_of_self.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__an_argument_may_call_a_method_of_self.snap
@@ -66,7 +66,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -175,7 +174,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -280,7 +278,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__an_argument_may_call_a_method_of_self.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__an_argument_may_call_a_method_of_self.snap
@@ -57,6 +57,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -165,6 +166,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -269,6 +271,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__every_struct_shape_generates_its_items.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__every_struct_shape_generates_its_items.snap
@@ -46,7 +46,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -123,7 +122,6 @@ impl ::core::fmt::Debug for T {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -196,7 +194,6 @@ impl ::core::fmt::Debug for T {
         f.debug_struct("T").field("inner", &self.inner).finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -278,7 +275,6 @@ impl ::core::fmt::Debug for T {
             .finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(
@@ -365,7 +361,6 @@ impl ::core::fmt::Debug for T {
         f.debug_struct("T").field("path", &self.path).field("mine", &self.mine).finish()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__every_struct_shape_generates_its_items.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__every_struct_shape_generates_its_items.snap
@@ -38,6 +38,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -117,6 +118,7 @@ impl ::ohno::ErrorExt for T {
         self.1.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("T").field(&self.0).field(&self.1).finish()
@@ -189,6 +191,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T").field("inner", &self.inner).finish()
@@ -266,6 +269,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -356,6 +360,7 @@ impl ::ohno::ErrorExt for T {
         self.mine.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T").field("path", &self.path).field("mine", &self.mine).finish()

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__generics_thread_through_every_impl.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__generics_thread_through_every_impl.snap
@@ -39,6 +39,7 @@ impl<A, B> ::ohno::ErrorExt for T<A, B> {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl<A, B> ::core::fmt::Debug for T<A, B> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -128,6 +129,7 @@ impl<'a> ::ohno::ErrorExt for T<'a> {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl<'a> ::core::fmt::Debug for T<'a> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T")
@@ -225,6 +227,7 @@ where
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl<A> ::core::fmt::Debug for T<A>
 where
     A: Clone,

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__generics_thread_through_every_impl.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__generics_thread_through_every_impl.snap
@@ -48,7 +48,6 @@ impl<A, B> ::core::fmt::Debug for T<A, B> {
             .finish()
     }
 }
-#[automatically_derived]
 impl<A, B> T<A, B> {
     /// Creates the error with no source.
     #[allow(
@@ -137,7 +136,6 @@ impl<'a> ::core::fmt::Debug for T<'a> {
             .finish()
     }
 }
-#[automatically_derived]
 impl<'a> T<'a> {
     /// Creates the error with no source.
     #[allow(
@@ -235,7 +233,6 @@ where
         f.debug_struct("T").field("a", &self.a).field("inner", &self.inner).finish()
     }
 }
-#[automatically_derived]
 impl<A> T<A>
 where
     A: Clone,

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__the_suppressing_flags_remove_their_items.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__the_suppressing_flags_remove_their_items.snap
@@ -38,7 +38,6 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
-#[automatically_derived]
 impl T {
     /// Creates the error with no source.
     #[allow(

--- a/crates/ohno_macros_impl/tests/snapshots/public_api__the_suppressing_flags_remove_their_items.snap
+++ b/crates/ohno_macros_impl/tests/snapshots/public_api__the_suppressing_flags_remove_their_items.snap
@@ -109,6 +109,7 @@ impl ::ohno::ErrorExt for T {
         self.inner.backtrace()
     }
 }
+#[automatically_derived]
 impl ::core::fmt::Debug for T {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("T").field("inner", &self.inner).finish()


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

Three fixes to `#[ohno::error]` / `#[derive(ohno::Error)]`. The third changes what consumers see — please read that part first.

## 1. A unit struct is emitted in the macro's syntax context

An error type declared as a **unit struct** is never reported by `dead_code`, even when nothing in the crate constructs or names it. A caller who writes `#[expect(dead_code)]` on such a type gets `unfulfilled_lint_expectations` instead, which fails a `-D warnings` gate with nothing pointing at ohno as the cause.

```rust
#[expect(dead_code, reason = "kept for a later change")]
#[ohno::error]
pub(crate) struct XsoError;      // warning: this lint expectation is unfulfilled
```

### Cause

`#[ohno::error]` gives a unit struct room for the `OhnoCore` field by turning it into a tuple struct. The parentheses and the semicolon it synthesises for that came from `Paren::default()` and `<Token![;]>::default()`, both of which carry `Span::call_site()`, so the rewritten item landed in the macro's syntax context rather than the caller's.

`rustc_passes::dead` reports a struct at `ident_span.with_ctxt(def_span.ctxt())` — the identifier's span re-tagged with the *item's* context — and `lint_level` cancels any lint whose primary span sits in an external macro expansion. The `dead_code` diagnostic was therefore dropped before it could fulfil the expectation.

Only the unit shape is affected. The named and tuple shapes push a field onto delimiters the author wrote, and `#[derive(ohno::Error)]` never rebuilds the item at all.

### Fix

Take the synthesised spans from the declaration's own identifier. Measured against a consumer crate declaring all four forms with `#[expect(dead_code)]`, on rustc 1.97 (`ok` = the expectation is fulfilled):

| form | before | after |
|---|---|---|
| `#[ohno::error] struct E;` | unfulfilled | ok |
| `#[ohno::error] struct E(u32);` | ok | ok |
| `#[ohno::error] struct E { n: u32 }` | ok | ok |
| `#[derive(ohno::Error)] struct E(#[error] OhnoCore);` | ok | ok |

### Why there is no regression test

A test would have to assert that a `#[expect(dead_code)]` is fulfilled, which means denying `unfulfilled_lint_expectations`. That cannot pass on the repo's MSRV: rustc kept an error type alive through the `#[allow(dead_code)]` on its generated constructors until [rust-lang/rust#154377](https://github.com/rust-lang/rust/pull/154377) landed in **1.97**, and `RUST_MSRV` is `1.95`. Such a test becomes possible once the MSRV reaches 1.97.

That rustc bug is a **separate, second** cause of the same symptom: on 1.93–1.96 every shape is affected, including the derive form, and no change to ohno avoids it. This PR fixes the part that is ohno's, and is the part still reproducible on 1.97 and later.

## 2. `#[automatically_derived]` on the inherent constructors impl

That attribute is accepted only on a trait `impl`. The derive put it on the inherent `impl` holding `new` and `caused_by`, where `rustc` answers:

```
warning: `#[automatically_derived]` attribute cannot be used on inherent impl blocks
  = warning: this was previously accepted by the compiler but is being phased out;
             it will become a hard error in a future release!
```

No consumer sees that warning, because lints raised inside an external macro expansion are discarded. The unit-struct fix above does **not** change that — those tokens come from the derive rather than from the caller's declaration, which was verified by reverting the attribute independently and re-running a consumer crate. The defect is latent: it costs nothing until the release that promotes it to an error, at which point it breaks every `#[ohno::error]` and `#[derive(ohno::Error)]` user at once.

Removing it changes no behaviour. The constructors carry their own `#[allow(dead_code)]` and never relied on it.

## 3. The generated `Debug` now carries `#[automatically_derived]`

**This one changes what consumers see.** `Debug` carries `#[rustc_trivial_field_reads]`, so an `#[automatically_derived]` `Debug` impl has its field reads discarded by dead-code analysis. The generated impl went without the attribute deliberately, to avoid making a field that only `Debug` reads look unused.

It does make it look unused — and that is the correct answer. Such a field *is* unused, `#[derive(Debug)]` reports it, and the remedy belongs to the author: `#[allow(dead_code)]`, an accessor, or a place in the `#[display]` message. Withholding the attribute suppressed that report for every error type in every consumer crate, so a field left behind by a refactor was never flagged.

The suppression was also wider than the original reasoning assumed. `Display`, `Error`, `Enrichable` and `ErrorExt` are **not** `#[rustc_trivial_field_reads]`, so their reads still count. Measured on one crate carrying all four cases, rustc 1.95:

| field is read by | reported? |
|---|---|
| `#[display("cannot open {path}")]` | no |
| a user accessor | no |
| the generated `Debug` only | **yes** |
| nothing — it is the core | no |

So the core stays live through the other four impls, and a field named by the `#[display]` template stays live through `Display`. Only a genuinely unused field is reported.

### Effect on this repo

A workspace check surfaced **9** such fields, all in `ohno`'s own examples and tests, none in any other crate. Each is handled on its merits rather than silenced:

- `default_constructors` and `derive_with_fields` gain the `#[display]` message they should always have had, which reads the fields and makes the examples print something other than the type name.
- `constructor_integration` now asserts the values the constructor stored, which the sibling test already did.
- The rest carry `#[expect(dead_code)]` with a reason — fields that exist to demonstrate a struct shape, or to be compared through `Debug`.

### Effect on consumers

A consumer with an error field that nothing reads but `Debug` will get a new `dead_code` warning, and a build failure under `-D warnings`. That is the point of the change, but it is a visible break and worth a release note.

## Validation

`cargo test --all-features` for `ohno`, `ohno_macros` and `ohno_macros_impl` passes on MSRV 1.95 — 49 + 53 unit tests, 12 trybuild UI tests, all insta snapshots — as do `just anvil-fmt`, `just anvil-clippy`, the nightly `unstable-rustfmt.toml` check, and a clean `cargo check --workspace --all-targets`.

## Related

Reported internally as AB#7829355, whose original diagnosis blamed the constructors' `#[allow(dead_code)]`; that work item now carries the corrected analysis. Real-world instance: AssistantsOxide PR 5605707 deleted an `#[expect(dead_code)]` purely to work around part 1. That removal remains necessary there until the repo moves off `ms-prod-1.95`, because the rustc half applies regardless of this PR.