### PR TITLE
perf(observed): benchmark emit paths with the production clock

### DIFF
--- a/crates/observed/benches/observed_benchmarks.rs
+++ b/crates/observed/benches/observed_benchmarks.rs
@@ -311,7 +311,7 @@ fn entrypoint(c: &mut Criterion) {
 fn bench_emit_simple_log(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc_tracker::Session, time: &all_the_time::Session) {
     const ID: &str = "simple_log_2_fields";
     let (processor, _provider) = make_log_processor();
-    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
     bench_with_tracking(group, allocs, time, ID, || {
         observed::emit!(&sink, SimpleLogEvent { status: 200, retries: 0 });
@@ -321,7 +321,7 @@ fn bench_emit_simple_log(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &allo
 fn bench_emit_many_fields(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc_tracker::Session, time: &all_the_time::Session) {
     const ID: &str = "log_8_fields";
     let (processor, _provider) = make_log_processor();
-    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
     bench_with_tracking(group, allocs, time, ID, || {
         observed::emit!(
@@ -343,7 +343,7 @@ fn bench_emit_many_fields(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &all
 fn bench_emit_with_body(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc_tracker::Session, time: &all_the_time::Session) {
     const ID: &str = "log_with_body";
     let (processor, _provider) = make_log_processor();
-    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
     bench_with_tracking(group, allocs, time, ID, || {
         observed::emit!(&sink, BodyEvent { code: 42 });
@@ -362,7 +362,7 @@ fn bench_emit_with_body(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc
 fn bench_emit_log_of_metric_event(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc_tracker::Session, time: &all_the_time::Session) {
     const ID: &str = "log_of_metric_event";
     let (processor, _provider) = make_log_processor();
-    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
     bench_with_tracking(group, allocs, time, ID, || {
         observed::emit!(
@@ -387,7 +387,7 @@ fn bench_emit_log_of_metric_event(group: &mut BenchmarkGroup<'_, WallTime>, allo
 fn bench_emit_redacted_strings(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc_tracker::Session, time: &all_the_time::Session) {
     const ID: &str = "log_2_redacted_strings";
     let (processor, _provider) = make_log_processor_with(replacing_engine());
-    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
     bench_with_tracking(group, allocs, time, ID, || {
         observed::emit!(
@@ -403,7 +403,7 @@ fn bench_emit_redacted_strings(group: &mut BenchmarkGroup<'_, WallTime>, allocs:
 fn bench_emit_with_enrichments(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc_tracker::Session, time: &all_the_time::Session) {
     const ID: &str = "emit_with_3_enrichments";
     let (processor, _provider) = make_log_processor();
-    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
     // Establish an enrichment context, then benchmark emission within it.
     (|| {
@@ -428,7 +428,7 @@ fn bench_emit_deeply_nested_enrichments(
 ) {
     const ID: &str = "emit_with_10_nested_enrichments";
     let (processor, _provider) = make_log_processor();
-    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
     // Create 10 nested enrichment levels to stress the Arc-linked list resolution.
     (|| {
@@ -479,8 +479,13 @@ fn bench_construct_processor_free_sink(
     const ID: &str = "construct_processor_free_sink";
     const EMPTY_PROCESSORS: Vec<Arc<dyn observed::processing::EventProcessor>> = Vec::new();
 
+    // The clock is built once and cloned per iteration: an application owns its
+    // clock and hands it to every sink, so clock construction is not part of the
+    // sink-construction cost this benchmark reports.
+    let clock = tick::SimpleClock::new_system();
+
     bench_with_tracking(group, allocs, time, ID, || {
-        let sink = Sink::new("bench", EMPTY_PROCESSORS, tick::SimpleClock::new_frozen());
+        let sink = Sink::new("bench", EMPTY_PROCESSORS, clock.clone());
         drop(sink);
     });
 }
@@ -512,7 +517,7 @@ fn bench_emit_to_noop_sink(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &al
 fn bench_enrichment_vec_collect(group: &mut BenchmarkGroup<'_, WallTime>, allocs: &alloc_tracker::Session, time: &all_the_time::Session) {
     const ID: &str = "enrichment_vec_collect_3";
     let (processor, _provider) = make_log_processor();
-    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+    let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
     // Single enrich scope with 3 entries - measures the Vec allocation
     // and EnrichmentEntry cloning that happens on every emit.
@@ -680,7 +685,7 @@ fn bench_pending_enriched_future_polls(
     });
 
     let children: Vec<Sink> = (0..COMPOSITE_CHILDREN)
-        .map(|_| Sink::new("bench", EMPTY_PROCESSORS, tick::SimpleClock::new_frozen()))
+        .map(|_| Sink::new("bench", EMPTY_PROCESSORS, tick::SimpleClock::new_system()))
         .collect();
     let composite = Sink::composite(children);
     bench_with_tracking(group, allocs, time, ID_COMPOSITE, || {
@@ -749,7 +754,7 @@ fn bench_emit_varying_enrichment_depth(
     {
         const ID: &str = "emit_depth_0";
         let (processor, _provider) = make_log_processor();
-        let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+        let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
         bench_with_tracking(group, allocs, time, ID, || {
             observed::emit!(&sink, SimpleLogEvent { status: 200, retries: 0 });
@@ -760,7 +765,7 @@ fn bench_emit_varying_enrichment_depth(
     {
         const ID: &str = "emit_depth_5";
         let (processor, _provider) = make_log_processor();
-        let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_frozen());
+        let sink = Sink::new("bench", vec![Arc::new(processor)], tick::SimpleClock::new_system());
 
         (|| {
             bench_with_tracking(group, allocs, time, ID, || {

--- a/crates/observed/benches/observed_benchmarks.rs
+++ b/crates/observed/benches/observed_benchmarks.rs
@@ -479,13 +479,14 @@ fn bench_construct_processor_free_sink(
     const ID: &str = "construct_processor_free_sink";
     const EMPTY_PROCESSORS: Vec<Arc<dyn observed::processing::EventProcessor>> = Vec::new();
 
-    // The clock is built once and cloned per iteration: an application owns its
+    // The clock is built once and passed by reference: an application owns its
     // clock and hands it to every sink, so clock construction is not part of the
-    // sink-construction cost this benchmark reports.
+    // sink-construction cost this benchmark reports. `Sink::new` clones it
+    // internally, so a reference keeps that at exactly one clone per iteration.
     let clock = tick::SimpleClock::new_system();
 
     bench_with_tracking(group, allocs, time, ID, || {
-        let sink = Sink::new("bench", EMPTY_PROCESSORS, clock.clone());
+        let sink = Sink::new("bench", EMPTY_PROCESSORS, &clock);
         drop(sink);
     });
 }


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

## What this changes

These benchmarks exist to answer one question: what does it cost to emit an event in production? They did not measure that. Every benchmark sink was built with `tick::SimpleClock::new_frozen()`, the test clock. This change builds them with `tick::SimpleClock::new_system()`, the clock production uses. Refs AB#7757582.

## Why the clock matters

A sink stamps a timestamp on every event it dispatches. The clock therefore sits in the emit hot path, and its cost lands in every emit measurement.

The two clocks reach the time differently. `new_system()` is a stateless enum variant that reads OS time directly. `new_frozen()` wraps a `ClockControl`, which holds its state in an `Arc<Mutex<State>>` (`crates/tick/src/clock_control.rs`). The frozen clock thus replaces a real OS time read with mutex locking. Neither cost resembles the other, so the published numbers described the test clock rather than the production emit path.

One case was plainly wrong, not merely unrepresentative. `construct_processor_free_sink` built a fresh frozen clock **inside** the measured closure. It allocated an `Arc<Mutex<..>>` per iteration and counted that as sink-construction cost. Production never makes that allocation.

`Sink::new` already documents the split: pass the application clock in production, pass a frozen clock in tests for deterministic, Miri-safe timestamps (`crates/observed/src/sink/core.rs`). Benchmarks are not tests. None of these reads a timestamp value, so none belonged on the test side of that line.

## Details

- 12 sink constructions now use `SimpleClock::new_system()`: `simple_log_2_fields`, `log_8_fields`, `log_with_body`, `log_of_metric_event`, `log_2_redacted_strings`, `emit_with_3_enrichments`, `emit_with_10_nested_enrichments`, `enrichment_vec_collect_3`, `emit_depth_0`, `emit_depth_5`, `construct_processor_free_sink`, and the composite children of `pending_enriched_future_8_polls_composite_3`.
- `construct_processor_free_sink` builds the clock once outside the measured closure and passes it by reference. `Sink::new` takes `impl AsRef<SimpleClock>` and clones internally, so a reference leaves exactly one clone in the closure. A comment states why the clock is hoisted: an application owns one clock and hands it to every sink, so clock construction is not part of sink construction.
- No benchmark keeps a frozen clock.
- Benchmark names, groups, event shapes, and the tracking harness are unchanged.

## Effects

- `construct_processor_free_sink` drops from 792 B / 5 allocations to 656 B / 4 allocations per iteration, and from 437.8 ns to 310.2 ns. The removed allocation is the per-iteration `Arc<Mutex<..>>` behind the frozen clock's `ClockControl`.
- Emit cost is unchanged within measurement noise. `simple_log_2_fields` moves +0.9%, inside the band set by untouched control benchmarks. The case for this change is representativeness, not a measured emit regression.
- Allocation figures for the other 22 benchmarks are byte-identical before and after.
- Saved Criterion baselines for the 12 affected IDs no longer compare like for like and should be discarded.
- Emit timings now include a real OS time read. That source is platform-dependent, so run-to-run variance may increase.
- No library code changes. The diff touches one bench target, so there is no public API or semver impact.
- `Cargo.toml` is unchanged. The `tick` `test-util` dev-feature is still required, because unit tests under `crates/observed/src` still use frozen clocks.
- Benchmark timestamps are no longer deterministic. A future benchmark that needs a fixed timestamp must opt back into a frozen clock and say why.

## Out of scope

- AB#7757571 residue: no `log_4_fields` control, no pooled-allocation alternative, no depth scaling model. The existing `emit_alloc` commentary is untouched.
- AB#7757574: whether `observed` should replace `all_the_time` with the workspace `benchmarking` crate. That decision is open.
- `crates/observed_macros*` is untouched.

## Validation

- `cargo clippy -p observed --all-targets --features test-util` with warnings denied, and `cargo fmt --check`.
- `cargo bench -p observed --features test-util --bench observed_benchmarks -- --test` runs every benchmark once with the system clock. CI does not execute benchmarks, so this confirms the target still runs rather than only compiles.
- A before-and-after run against the merge-base, with untouched control benchmarks included to size the noise floor. Full tables are in a PR comment. Caveat recorded there: this ran on a local Windows dev machine, and one 2 ns control moved 29% between the two builds, so sub-10 ns cross-build deltas from this host are not attributable.