### PR TITLE
fix(observed_macros): resolve renamed dependencies and reject mutable-reference fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,6 +3381,7 @@ name = "observed_macros_impl"
 version = "0.24.0"
 dependencies = [
  "insta",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 3.0.3",

--- a/crates/observed_macros_impl/CHANGELOG.md
+++ b/crates/observed_macros_impl/CHANGELOG.md
@@ -20,3 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `proc-macro-crate` instead of emitting a hard-coded `::observed`. A crate that
   renames its dependency (`telemetry = { package = "observed", ... }`) can now
   use `#[event(...)]` and `#[derive(Enrichment)]`.
+- `#[event(...)]` now rejects a field holding a mutable reference (`&mut T` or
+  `Option<&mut T>`) while parsing, naming the offending field, rather than
+  accepting it and failing later inside the generated code. Event fields are read
+  through `&self` when the event is visited, so only shared references work.

--- a/crates/observed_macros_impl/CHANGELOG.md
+++ b/crates/observed_macros_impl/CHANGELOG.md
@@ -13,3 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `observed` procedural macros (`#[event(...)]` and `#[derive(Enrichment)]`).
   `observed_macros` is now a thin `proc-macro` shim that delegates here. Use the
   re-exports from `observed` rather than depending on this crate directly.
+
+### Fixed
+
+- Both generators now resolve the `observed` runtime crate through
+  `proc-macro-crate` instead of emitting a hard-coded `::observed`. A crate that
+  renames its dependency (`telemetry = { package = "observed", ... }`) can now
+  use `#[event(...)]` and `#[derive(Enrichment)]`.

--- a/crates/observed_macros_impl/Cargo.toml
+++ b/crates/observed_macros_impl/Cargo.toml
@@ -27,6 +27,7 @@ allowed_external_types = ["proc_macro2::*", "syn::*"]
 all-features = true
 
 [dependencies]
+proc-macro-crate = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = [

--- a/crates/observed_macros_impl/src/enrichment.rs
+++ b/crates/observed_macros_impl/src/enrichment.rs
@@ -124,13 +124,13 @@ fn parse_enrichment_field_def(field: &Field) -> Result<EnrichmentFieldDef> {
 // ================================================================================================
 
 /// Entry point: generates the `Enrichment` trait implementation from `DeriveInput`.
-pub(crate) fn derive_enrichment(input: &DeriveInput) -> Result<TokenStream> {
+pub(crate) fn derive_enrichment(input: &DeriveInput, runtime: &TokenStream) -> Result<TokenStream> {
     let def = parse_enrichment_def(input)?;
-    Ok(generate_enrichment_impl(&def))
+    Ok(generate_enrichment_impl(&def, runtime))
 }
 
 /// Generates the complete `Enrichment` trait implementation.
-fn generate_enrichment_impl(def: &EnrichmentDef) -> TokenStream {
+fn generate_enrichment_impl(def: &EnrichmentDef, runtime: &TokenStream) -> TokenStream {
     let struct_ident = &def.ident;
 
     // Spell out the obligations the generated `into_entries` body relies on, so
@@ -146,19 +146,20 @@ fn generate_enrichment_impl(def: &EnrichmentDef) -> TokenStream {
                 &field.ty,
                 field.shared.redaction.as_ref().unwrap_or(&FieldRedaction::Default),
                 &params,
+                runtime,
             )
         })
         .collect();
     crate::field_attrs::extend_where_clause(&mut generics, predicates);
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let entry_stmts: Vec<TokenStream> = def.fields.iter().map(generate_entry_stmt).collect();
+    let entry_stmts: Vec<TokenStream> = def.fields.iter().map(|field| generate_entry_stmt(field, runtime)).collect();
     let field_count = def.fields.len();
 
     quote! {
         const _: () = {
-            impl #impl_generics ::observed::enrichment::Enrichment for #struct_ident #ty_generics #where_clause {
-                fn into_entries(self) -> ::std::vec::Vec<::observed::__private::EnrichmentEntry> {
+            impl #impl_generics #runtime::enrichment::Enrichment for #struct_ident #ty_generics #where_clause {
+                fn into_entries(self) -> ::std::vec::Vec<#runtime::__private::EnrichmentEntry> {
                     let mut entries = ::std::vec::Vec::with_capacity(#field_count);
                     #(#entry_stmts)*
                     entries
@@ -173,7 +174,7 @@ fn generate_enrichment_impl(def: &EnrichmentDef) -> TokenStream {
 /// `Option<T>` fields behave like in `#[event(...)]`: on `None`,
 /// `#[if_none(...)]` decides whether the entry is dropped or filled with
 /// a placeholder string (default `"n/a"`).
-fn generate_entry_stmt(field: &EnrichmentFieldDef) -> TokenStream {
+fn generate_entry_stmt(field: &EnrichmentFieldDef, runtime: &TokenStream) -> TokenStream {
     let field_ident = &field.ident;
     // Unraw-ed so a field written as `r#type` is exported under the domain key
     // `type`; `field_ident` keeps the raw form because it addresses the field.
@@ -202,11 +203,20 @@ fn generate_entry_stmt(field: &EnrichmentFieldDef) -> TokenStream {
             exclude,
             metric_key.as_deref(),
             borrowed_str,
+            runtime,
         );
         return quote! { entries.push(#entry); };
     }
 
-    let some_entry = entry_ctor(&key, redaction, &quote! { __val }, exclude, metric_key.as_deref(), borrowed_str);
+    let some_entry = entry_ctor(
+        &key,
+        redaction,
+        &quote! { __val },
+        exclude,
+        metric_key.as_deref(),
+        borrowed_str,
+        runtime,
+    );
 
     // On `None`, `#[if_none(...)]` decides whether the entry is dropped
     // or filled with a placeholder string (default `"n/a"`).
@@ -225,6 +235,7 @@ fn generate_entry_stmt(field: &EnrichmentFieldDef) -> TokenStream {
                 metric_key.as_deref(),
                 // The placeholder is a literal, so it is stored without copying.
                 false,
+                runtime,
             );
             quote! {
                 match self.#field_ident {
@@ -246,30 +257,31 @@ fn entry_ctor(
     exclude: bool,
     metric_key: Option<&str>,
     borrowed_str: bool,
+    runtime: &TokenStream,
 ) -> TokenStream {
     let constructor = match redaction {
         // A borrowed `&str` cannot be stored by reference, so the macro spells
         // out the copy that `Value` has no `From<&str>` impl to hide.
         FieldRedaction::Unredacted if borrowed_str => quote! {
-            ::observed::__private::EnrichmentEntry::unclassified(
+            #runtime::__private::EnrichmentEntry::unclassified(
                 #key,
-                ::observed::Value::from(::std::sync::Arc::<str>::from(#value)),
+                #runtime::Value::from(::std::sync::Arc::<str>::from(#value)),
             )
         },
         // Unredacted: bypass redaction, type must impl `Into<Value>`.
         FieldRedaction::Unredacted => quote! {
-            ::observed::__private::EnrichmentEntry::unclassified(#key, #value)
+            #runtime::__private::EnrichmentEntry::unclassified(#key, #value)
         },
         // `data_class`: wrap in `Sensitive` before storing.
         FieldRedaction::DataClass(data_class_expr) => quote! {
-            ::observed::__private::EnrichmentEntry::new(
+            #runtime::__private::EnrichmentEntry::new(
                 #key,
-                ::observed::__private::Sensitive::new(#value, #data_class_expr),
+                #runtime::__private::Sensitive::new(#value, #data_class_expr),
             )
         },
         // Default: type must impl `RedactedDisplay`.
         FieldRedaction::Default => quote! {
-            ::observed::__private::EnrichmentEntry::new(#key, #value)
+            #runtime::__private::EnrichmentEntry::new(#key, #value)
         },
     };
     let exclude_chain = exclude.then(|| quote! { .exclude_from_logs() });

--- a/crates/observed_macros_impl/src/event.rs
+++ b/crates/observed_macros_impl/src/event.rs
@@ -21,7 +21,8 @@ use syn::punctuated::Punctuated;
 use syn::{Attribute, Error, Field, Fields, Generics, Ident, ItemStruct, LitStr, Meta, Result, Token};
 
 use crate::field_attrs::{
-    Dimension, FieldRedaction, IfNone, LogRouting, MetricRouting, SharedFieldAttrs, is_borrowed_str, is_reference_type, option_inner_type,
+    Dimension, FieldRedaction, IfNone, LogRouting, MetricRouting, SharedFieldAttrs, is_borrowed_str, is_mutable_reference_type,
+    is_reference_type, option_inner_type,
 };
 
 // ================================================================================================
@@ -722,6 +723,13 @@ fn parse_field_def(field: &Field) -> Result<FieldDef> {
         return Err(Error::new_spanned(field, "`#[if_none(...)]` is only valid on `Option<T>` fields"));
     }
 
+    // A field is read through `&self` while the event is visited, so an exclusive
+    // borrow can never be handed out. Rejecting it here names the field; letting it
+    // through fails later inside the expansion, against generated code the author
+    // never wrote. `Option<&mut T>` is checked too, because the inner type is what
+    // the visit body dereferences.
+    reject_mutable_reference(field)?;
+
     Ok(FieldDef {
         ident,
         ty: field.ty.clone(),
@@ -731,6 +739,23 @@ fn parse_field_def(field: &Field) -> Result<FieldDef> {
         redaction: shared.redaction.unwrap_or_default(),
         if_none: shared.if_none.unwrap_or_default(),
     })
+}
+
+/// Rejects an event field that is (or wraps) a mutable reference.
+fn reject_mutable_reference(field: &Field) -> Result<()> {
+    let inner = option_inner_type(&field.ty);
+    let inspected = inner.unwrap_or(&field.ty);
+    if !is_mutable_reference_type(inspected) {
+        return Ok(());
+    }
+    let wrapper = if inner.is_some() { "`Option<&mut T>` field" } else { "field" };
+    Err(Error::new_spanned(
+        &field.ty,
+        format!(
+            "an event {wrapper} cannot hold a mutable reference; event fields are read through `&self` when the event is \
+             visited, so they support only shared references. Use `&T` instead of `&mut T`",
+        ),
+    ))
 }
 
 // ================================================================================================

--- a/crates/observed_macros_impl/src/event.rs
+++ b/crates/observed_macros_impl/src/event.rs
@@ -745,7 +745,7 @@ fn parse_field_def(field: &Field) -> Result<FieldDef> {
 /// helper attributes never need to resolve as real macros. (The `warn` severity
 /// is spelled `#[warning(...)]` to avoid the built-in `warn` lint attribute,
 /// which rustc validates before macro expansion.)
-pub(crate) fn event_attr(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
+pub(crate) fn event_attr(attr: TokenStream, item: TokenStream, runtime: &TokenStream) -> Result<TokenStream> {
     let args: EventArgs = syn::parse2(attr)?;
     let item_struct: ItemStruct = syn::parse2(item)?;
     let impl_tokens = generate_event(
@@ -754,6 +754,7 @@ pub(crate) fn event_attr(attr: TokenStream, item: TokenStream) -> Result<TokenSt
         &item_struct.attrs,
         &item_struct.fields,
         &args,
+        runtime,
     )?;
     let cleaned = strip_helper_attrs(item_struct);
     Ok(quote! {
@@ -769,10 +770,11 @@ pub(crate) fn generate_event(
     attrs: &[Attribute],
     fields: &Fields,
     args: &EventArgs,
+    runtime: &TokenStream,
 ) -> Result<TokenStream> {
     let def = parse_event_def(ident, generics, attrs, fields, args)?;
     validate_message_placeholders(&def)?;
-    Ok(generate_event_impl(&def))
+    Ok(generate_event_impl(&def, runtime))
 }
 
 /// Returns whether `attr` is a struct-level helper consumed by `#[event]`
@@ -856,7 +858,7 @@ fn validate_message_placeholders(def: &EventDef) -> Result<()> {
 
 /// Builds the `Option<LogDescription>` expression for the event's log signal
 /// (or `None` when the event declares no severity attribute).
-fn log_description_expr(def: &EventDef) -> TokenStream {
+fn log_description_expr(def: &EventDef, runtime: &TokenStream) -> TokenStream {
     let Some(log) = &def.log else {
         return quote! { ::core::option::Option::None };
     };
@@ -869,9 +871,9 @@ fn log_description_expr(def: &EventDef) -> TokenStream {
     };
     quote! {
         ::core::option::Option::Some(
-            ::observed::metadata::LogDescription::new(
+            #runtime::metadata::LogDescription::new(
                 #log_name,
-                ::observed::Severity::#severity,
+                #runtime::Severity::#severity,
                 #body_expr,
             )
         )
@@ -901,13 +903,13 @@ fn field_reaches_signal(field: &FieldDef, has_log: bool) -> bool {
 /// The redaction bounds are added only for fields that reach a signal, since a
 /// field routed nowhere generates no code to bound - which a metric-only event
 /// does to every one of its non-dimension fields.
-fn event_predicates(def: &EventDef) -> Vec<syn::WherePredicate> {
+fn event_predicates(def: &EventDef, runtime: &TokenStream) -> Vec<syn::WherePredicate> {
     let params = crate::field_attrs::type_param_idents(&def.generics);
     let has_log = def.log.is_some();
     let mut predicates = Vec::new();
     for field in &def.fields {
         if field_reaches_signal(field, has_log) {
-            predicates.extend(crate::field_attrs::field_predicates(&field.ty, &field.redaction, &params));
+            predicates.extend(crate::field_attrs::field_predicates(&field.ty, &field.redaction, &params, runtime));
         }
         let ty = &field.ty;
         if crate::field_attrs::mentions_any_type_param(ty, &params) {
@@ -917,7 +919,7 @@ fn event_predicates(def: &EventDef) -> Vec<syn::WherePredicate> {
     predicates
 }
 
-fn generate_event_impl(def: &EventDef) -> TokenStream {
+fn generate_event_impl(def: &EventDef, runtime: &TokenStream) -> TokenStream {
     let struct_ident = &def.ident;
 
     // Event identity comes from the required `#[event("...")]` attribute.
@@ -937,7 +939,7 @@ fn generate_event_impl(def: &EventDef) -> TokenStream {
     // Spell out the obligations the generated body relies on, so a generic event
     // reports them against the caller's type instead of failing inside the
     // expansion.
-    crate::field_attrs::extend_where_clause(&mut generics_with_static, event_predicates(def));
+    crate::field_attrs::extend_where_clause(&mut generics_with_static, event_predicates(def, runtime));
 
     let (impl_generics, ty_generics, where_clause) = generics_with_static.split_for_impl();
 
@@ -970,7 +972,7 @@ fn generate_event_impl(def: &EventDef) -> TokenStream {
         )
     };
 
-    let log_expr = log_description_expr(def);
+    let log_expr = log_description_expr(def, runtime);
 
     let metric_expr = if let Some(metric) = &def.metric {
         let instrument_name = metric.name.clone().unwrap_or_else(|| def.event_name.clone());
@@ -979,9 +981,9 @@ fn generate_event_impl(def: &EventDef) -> TokenStream {
         // A fieldless event-level metric is always a counter (records `1`).
         quote! {
             ::core::option::Option::Some(
-                ::observed::metadata::MetricDescription::new(
+                #runtime::metadata::MetricDescription::new(
                     #instrument_name,
-                    ::observed::metadata::InstrumentKind::Counter,
+                    #runtime::metadata::InstrumentKind::Counter,
                     #description,
                     #unit,
                 )
@@ -995,13 +997,13 @@ fn generate_event_impl(def: &EventDef) -> TokenStream {
     let disabled = def.disabled;
     let has_log = def.log.is_some();
 
-    let visit_fields_body = generate_visit_fields_body(&def.fields, has_log);
+    let visit_fields_body = generate_visit_fields_body(&def.fields, has_log, runtime);
 
     quote! {
         const _: () = {
-            impl #impl_generics ::observed::Event for #struct_ident #ty_generics #where_clause {
-                const DESCRIPTION: ::observed::metadata::EventDescription =
-                    ::observed::metadata::EventDescription::new(
+            impl #impl_generics #runtime::Event for #struct_ident #ty_generics #where_clause {
+                const DESCRIPTION: #runtime::metadata::EventDescription =
+                    #runtime::metadata::EventDescription::new(
                         #event_name,
                         #type_id_expr,
                         #log_expr,
@@ -1012,7 +1014,7 @@ fn generate_event_impl(def: &EventDef) -> TokenStream {
 
                 fn visit_fields(
                     &self,
-                    visitor: &mut ::observed::processing::FieldVisitorFn<'_>,
+                    visitor: &mut #runtime::processing::FieldVisitorFn<'_>,
                 ) -> ::core::ops::ControlFlow<()> {
                     #visit_fields_body
                     ::core::ops::ControlFlow::Continue(())
@@ -1022,12 +1024,12 @@ fn generate_event_impl(def: &EventDef) -> TokenStream {
     }
 }
 
-fn generate_visit_fields_body(fields: &[FieldDef], has_log: bool) -> TokenStream {
-    let visits: Vec<TokenStream> = fields.iter().map(|f| generate_field_visit(f, has_log)).collect();
+fn generate_visit_fields_body(fields: &[FieldDef], has_log: bool, runtime: &TokenStream) -> TokenStream {
+    let visits: Vec<TokenStream> = fields.iter().map(|f| generate_field_visit(f, has_log, runtime)).collect();
     quote! { #(#visits)* }
 }
 
-fn generate_field_visit(field: &FieldDef, has_log: bool) -> TokenStream {
+fn generate_field_visit(field: &FieldDef, has_log: bool, runtime: &TokenStream) -> TokenStream {
     let field_ident = &field.ident;
     // Unraw-ed so a field written as `r#type` is exported under the domain key
     // `type`; `field_ident` keeps the raw form because it addresses the field.
@@ -1036,7 +1038,7 @@ fn generate_field_visit(field: &FieldDef, has_log: bool) -> TokenStream {
     // Log routing
     let log_key = if has_log { field.log_key() } else { None };
     let log_entry = if let Some(key) = &log_key {
-        quote! { ::core::option::Option::Some(::observed::metadata::LogFieldEntry::new(#key)) }
+        quote! { ::core::option::Option::Some(#runtime::metadata::LogFieldEntry::new(#key)) }
     } else {
         quote! { ::core::option::Option::None }
     };
@@ -1048,18 +1050,18 @@ fn generate_field_visit(field: &FieldDef, has_log: bool) -> TokenStream {
         let description = decl.description.as_deref().unwrap_or("");
         let unit = decl.unit.as_deref().unwrap_or("");
         quote! {
-            ::core::option::Option::Some(::observed::metadata::MetricFieldEntry::instrument(
+            ::core::option::Option::Some(#runtime::metadata::MetricFieldEntry::instrument(
                 #default_key,
-                ::observed::metadata::MetricDescription::new(
+                #runtime::metadata::MetricDescription::new(
                     #name,
-                    ::observed::metadata::InstrumentKind::#kind,
+                    #runtime::metadata::InstrumentKind::#kind,
                     #description,
                     #unit,
                 ),
             ))
         }
     } else if let Some(key) = field.metric_dimension.resolve_key(&default_key) {
-        quote! { ::core::option::Option::Some(::observed::metadata::MetricFieldEntry::dimension(#key)) }
+        quote! { ::core::option::Option::Some(#runtime::metadata::MetricFieldEntry::dimension(#key)) }
     } else {
         quote! { ::core::option::Option::None }
     };
@@ -1071,14 +1073,14 @@ fn generate_field_visit(field: &FieldDef, has_log: bool) -> TokenStream {
     }
 
     let field_desc = quote! {
-        const FIELD_DESC: ::observed::metadata::FieldDescriptor =
-            ::observed::metadata::FieldDescriptor::new(#default_key, #log_entry, #metric_entry);
+        const FIELD_DESC: #runtime::metadata::FieldDescriptor =
+            #runtime::metadata::FieldDescriptor::new(#default_key, #log_entry, #metric_entry);
     };
 
     // `Option<T>` fields dispatch on `#[if_none(...)]`: a `None` value is
     // either dropped or replaced with a placeholder string (default `"n/a"`).
     if let Some(inner_ty) = option_inner_type(&field.ty) {
-        return generate_option_field_visit(field, inner_ty, &field_desc);
+        return generate_option_field_visit(field, inner_ty, &field_desc, runtime);
     }
 
     let owned = quote! { self.#field_ident.clone() };
@@ -1090,7 +1092,14 @@ fn generate_field_visit(field: &FieldDef, has_log: bool) -> TokenStream {
         // Field is an owned type, so `&self.field` produces `&T`.
         quote! { &self.#field_ident }
     };
-    let value = value_expr(&field.redaction, &owned, &by_ref, &quote! { engine }, is_borrowed_str(&field.ty));
+    let value = value_expr(
+        &field.redaction,
+        &owned,
+        &by_ref,
+        &quote! { engine },
+        is_borrowed_str(&field.ty),
+        runtime,
+    );
     let getter = if matches!(field.redaction, FieldRedaction::Unredacted) {
         quote! { |_| #value }
     } else {
@@ -1105,7 +1114,8 @@ fn generate_field_visit(field: &FieldDef, has_log: bool) -> TokenStream {
     }
 }
 
-/// Builds the `::observed::Value::…` expression for a field value.
+/// Builds the `Value::…` expression for a field value, rooted at the resolved
+/// `observed` runtime path.
 ///
 /// All generated paths are fully qualified: the consumer's `#[data_class(...)]`
 /// expression is interpolated into this output, so importing `Value` here would
@@ -1122,25 +1132,26 @@ fn value_expr(
     by_ref: &TokenStream,
     engine: &TokenStream,
     borrowed_str: bool,
+    runtime: &TokenStream,
 ) -> TokenStream {
     match redaction {
         // A borrowed `&str` cannot be stored by reference, so the macro spells
         // out the copy that `Value` has no `From<&str>` impl to hide.
         FieldRedaction::Unredacted if borrowed_str => {
-            quote! { ::observed::Value::from(::std::sync::Arc::<str>::from(#by_ref)) }
+            quote! { #runtime::Value::from(::std::sync::Arc::<str>::from(#by_ref)) }
         }
-        FieldRedaction::Unredacted => quote! { ::observed::Value::from(#owned) },
+        FieldRedaction::Unredacted => quote! { #runtime::Value::from(#owned) },
         // `Sensitive<T>` is `RedactedDisplay` whenever `T: Display`, and a
         // reference to a `Display` type is itself `Display`, so the classified
         // value can be borrowed rather than cloned. `from_redacted` only
         // borrows the temporary `Sensitive`, so nothing needs to own the value.
         FieldRedaction::DataClass(expr) => quote! {
-            ::observed::Value::from_redacted(
-                &::observed::__private::Sensitive::new(#by_ref, #expr),
+            #runtime::Value::from_redacted(
+                &#runtime::__private::Sensitive::new(#by_ref, #expr),
                 #engine)
         },
         FieldRedaction::Default => quote! {
-            ::observed::Value::from_redacted(#by_ref, #engine)
+            #runtime::Value::from_redacted(#by_ref, #engine)
         },
     }
 }
@@ -1153,7 +1164,7 @@ fn value_expr(
 ///   [`Drop`](IfNone::Drop) skips the field entirely (`visitor` is never
 ///   called), while [`Fill`](IfNone::Fill) records the placeholder string
 ///   in place of the missing value.
-fn generate_option_field_visit(field: &FieldDef, inner_ty: &syn::Type, field_desc: &TokenStream) -> TokenStream {
+fn generate_option_field_visit(field: &FieldDef, inner_ty: &syn::Type, field_desc: &TokenStream, runtime: &TokenStream) -> TokenStream {
     let field_ident = &field.ident;
     let inner_is_ref = is_reference_type(inner_ty);
     let engine = quote! { _engine };
@@ -1167,7 +1178,7 @@ fn generate_option_field_visit(field: &FieldDef, inner_ty: &syn::Type, field_des
     } else {
         (quote! { __val.clone() }, quote! { __val })
     };
-    let some_value = value_expr(&field.redaction, &val_owned, &val_ref, &engine, is_borrowed_str(inner_ty));
+    let some_value = value_expr(&field.redaction, &val_owned, &val_ref, &engine, is_borrowed_str(inner_ty), runtime);
 
     match &field.if_none {
         // `drop`: omit the field entirely when `None`.
@@ -1186,7 +1197,7 @@ fn generate_option_field_visit(field: &FieldDef, inner_ty: &syn::Type, field_des
                         visitor(&FIELD_DESC, &|_engine| #some_value )?;
                     }
                     ::core::option::Option::None => {
-                        visitor(&FIELD_DESC, &|_| ::observed::Value::from(#placeholder))?;
+                        visitor(&FIELD_DESC, &|_| #runtime::Value::from(#placeholder))?;
                     }
                 }
             }

--- a/crates/observed_macros_impl/src/field_attrs.rs
+++ b/crates/observed_macros_impl/src/field_attrs.rs
@@ -431,7 +431,12 @@ fn walk_tokens(token: &proc_macro2::TokenTree, params: &[Ident], found: &mut boo
 /// `&impl RedactedDisplay`.
 ///
 /// Returns an empty vector for field types that do not mention `params`.
-pub(crate) fn field_predicates(ty: &syn::Type, redaction: &FieldRedaction, params: &[Ident]) -> Vec<syn::WherePredicate> {
+pub(crate) fn field_predicates(
+    ty: &syn::Type,
+    redaction: &FieldRedaction,
+    params: &[Ident],
+    runtime: &proc_macro2::TokenStream,
+) -> Vec<syn::WherePredicate> {
     let owned = option_inner_type(ty).unwrap_or(ty);
     if !mentions_any_type_param(owned, params) {
         return Vec::new();
@@ -441,7 +446,7 @@ pub(crate) fn field_predicates(ty: &syn::Type, redaction: &FieldRedaction, param
     match redaction {
         FieldRedaction::Unredacted => vec![
             syn::parse_quote!(#owned: ::core::clone::Clone),
-            syn::parse_quote!(::observed::Value: ::core::convert::From<#owned>),
+            syn::parse_quote!(#runtime::Value: ::core::convert::From<#owned>),
         ],
         FieldRedaction::DataClass(_) => {
             // The value is borrowed, not cloned, so the bound is `Display` on
@@ -450,7 +455,7 @@ pub(crate) fn field_predicates(ty: &syn::Type, redaction: &FieldRedaction, param
             vec![syn::parse_quote!(#by_ref: ::core::fmt::Display)]
         }
         FieldRedaction::Default => {
-            vec![syn::parse_quote!(#by_ref: ::observed::__private::RedactedDisplay)]
+            vec![syn::parse_quote!(#by_ref: #runtime::__private::RedactedDisplay)]
         }
     }
 }
@@ -463,7 +468,12 @@ pub(crate) fn field_predicates(ty: &syn::Type, redaction: &FieldRedaction, param
 /// is why they additionally require `Send + Sync + 'static`.
 ///
 /// Returns an empty vector for field types that do not mention `params`.
-pub(crate) fn enrichment_field_predicates(ty: &syn::Type, redaction: &FieldRedaction, params: &[Ident]) -> Vec<syn::WherePredicate> {
+pub(crate) fn enrichment_field_predicates(
+    ty: &syn::Type,
+    redaction: &FieldRedaction,
+    params: &[Ident],
+    runtime: &proc_macro2::TokenStream,
+) -> Vec<syn::WherePredicate> {
     let owned = option_inner_type(ty).unwrap_or(ty);
     if !mentions_any_type_param(owned, params) {
         return Vec::new();
@@ -471,16 +481,16 @@ pub(crate) fn enrichment_field_predicates(ty: &syn::Type, redaction: &FieldRedac
 
     match redaction {
         FieldRedaction::Unredacted => {
-            vec![syn::parse_quote!(#owned: ::core::convert::Into<::observed::Value>)]
+            vec![syn::parse_quote!(#owned: ::core::convert::Into<#runtime::Value>)]
         }
         FieldRedaction::DataClass(_) => vec![syn::parse_quote!(
-            ::observed::__private::Sensitive<#owned>: ::observed::__private::RedactedDisplay
+            #runtime::__private::Sensitive<#owned>: #runtime::__private::RedactedDisplay
                 + ::core::marker::Send
                 + ::core::marker::Sync
                 + 'static
         )],
         FieldRedaction::Default => vec![syn::parse_quote!(
-            #owned: ::observed::__private::RedactedDisplay
+            #owned: #runtime::__private::RedactedDisplay
                 + ::core::marker::Send
                 + ::core::marker::Sync
                 + 'static

--- a/crates/observed_macros_impl/src/field_attrs.rs
+++ b/crates/observed_macros_impl/src/field_attrs.rs
@@ -317,6 +317,17 @@ pub(crate) fn is_reference_type(ty: &syn::Type) -> bool {
     matches!(unwrap_groups(ty), syn::Type::Reference(_))
 }
 
+/// Returns whether `ty` is, or borrows through, a mutable reference.
+///
+/// The recursion matches [`strip_reference`], so a nested `&&mut T` is caught as
+/// well as a bare `&mut T`.
+pub(crate) fn is_mutable_reference_type(ty: &syn::Type) -> bool {
+    match unwrap_groups(ty) {
+        syn::Type::Reference(reference) => reference.mutability.is_some() || is_mutable_reference_type(&reference.elem),
+        _ => false,
+    }
+}
+
 /// Returns the inner type `T` if `ty` is syntactically `Option<T>`.
 ///
 /// This is a purely syntactic match (the same approach `serde`/`clap`/`templated_uri`

--- a/crates/observed_macros_impl/src/lib.rs
+++ b/crates/observed_macros_impl/src/lib.rs
@@ -21,17 +21,37 @@
 mod enrichment;
 mod event;
 mod field_attrs;
+mod resolver;
 
 use proc_macro2::TokenStream;
 use syn::{DeriveInput, Result};
 
 /// Expands the `#[event(...)]` attribute macro.
 pub fn event(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
-    event::event_attr(attr, item)
+    event_with_runtime_path(attr, item, &resolver::runtime_path())
 }
 
 /// Expands the `#[derive(Enrichment)]` derive macro.
 pub fn derive_enrichment(input: TokenStream) -> Result<TokenStream> {
+    derive_enrichment_with_runtime_path(input, &resolver::runtime_path())
+}
+
+/// Expands `#[event(...)]` against an explicit path to the `observed` runtime crate.
+///
+/// The production entry point resolves that path from the manifest of the crate
+/// being compiled, which a test cannot vary. This hook takes it as an argument so
+/// the expansion tests can prove that a renamed `observed` dependency reaches the
+/// generated code. It is not part of the supported surface.
+#[doc(hidden)]
+pub fn event_with_runtime_path(attr: TokenStream, item: TokenStream, runtime: &TokenStream) -> Result<TokenStream> {
+    event::event_attr(attr, item, runtime)
+}
+
+/// Expands `#[derive(Enrichment)]` against an explicit path to the `observed`
+/// runtime crate. The counterpart of [`event_with_runtime_path`], and equally
+/// not part of the supported surface.
+#[doc(hidden)]
+pub fn derive_enrichment_with_runtime_path(input: TokenStream, runtime: &TokenStream) -> Result<TokenStream> {
     let input: DeriveInput = syn::parse2(input)?;
-    enrichment::derive_enrichment(&input)
+    enrichment::derive_enrichment(&input, runtime)
 }

--- a/crates/observed_macros_impl/src/resolver.rs
+++ b/crates/observed_macros_impl/src/resolver.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resolution of the `observed` runtime crate path that both generators emit into.
+//!
+//! The generated code has to name the runtime crate, and a consumer is free to
+//! rename its dependency:
+//!
+//! ```toml
+//! telemetry = { package = "observed", version = "0.24" }
+//! ```
+//!
+//! after which `::observed` names nothing in that crate. [`runtime_path`] asks
+//! Cargo what the dependency is actually called in the crate currently being
+//! compiled, so the expansion reaches the runtime under whichever name the
+//! consumer chose.
+
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+
+/// The path the generated code uses to reach the `observed` runtime crate.
+pub(crate) fn runtime_path() -> TokenStream {
+    runtime_path_for(crate_name("observed").ok())
+}
+
+/// Turns a resolution result into the leading path segment of the runtime crate.
+///
+/// [`FoundCrate::Itself`] is the `observed` crate expanding its own events; it
+/// keeps `::observed`, which resolves through the `extern crate self as observed`
+/// declaration in that crate's root. `None` is the no-manifest case (a caller
+/// Cargo cannot tell us about, such as a direct `syn` test harness), where
+/// `::observed` is the only sensible guess and matches the historical behavior.
+fn runtime_path_for(found: Option<FoundCrate>) -> TokenStream {
+    match found {
+        Some(FoundCrate::Name(name)) => {
+            // Cargo permits `-` in a dependency alias, which is not a Rust identifier;
+            // an alias that collides with a keyword needs the raw form.
+            let name = name.replace('-', "_");
+            let ident = syn::parse_str::<Ident>(&name)
+                .or_else(|_| syn::parse_str::<Ident>(&format!("r#{name}")))
+                .expect("Cargo dependency aliases are valid Rust identifiers, possibly requiring raw syntax");
+            quote! { ::#ident }
+        }
+        Some(FoundCrate::Itself) | None => quote! { ::observed },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_renamed_dependency_is_reached_under_the_name_the_consumer_chose() {
+        assert_eq!(
+            runtime_path_for(Some(FoundCrate::Name("telemetry".to_owned()))).to_string(),
+            ":: telemetry"
+        );
+    }
+
+    #[test]
+    fn a_dependency_alias_spelled_with_dashes_becomes_the_module_name_cargo_gives_it() {
+        assert_eq!(
+            runtime_path_for(Some(FoundCrate::Name("my-observed".to_owned()))).to_string(),
+            ":: my_observed"
+        );
+    }
+
+    #[test]
+    fn a_dependency_alias_that_is_a_keyword_is_escaped_as_a_raw_identifier() {
+        assert_eq!(runtime_path_for(Some(FoundCrate::Name("type".to_owned()))).to_string(), ":: r#type");
+    }
+
+    #[test]
+    fn the_runtime_crate_expanding_its_own_events_keeps_the_canonical_path() {
+        // `observed` reaches itself through `extern crate self as observed`.
+        assert_eq!(runtime_path_for(Some(FoundCrate::Itself)).to_string(), ":: observed");
+    }
+
+    #[test]
+    fn a_caller_cargo_cannot_resolve_falls_back_to_the_canonical_path() {
+        assert_eq!(runtime_path_for(None).to_string(), ":: observed");
+    }
+
+    #[test]
+    fn the_production_resolver_always_yields_a_path() {
+        assert!(!runtime_path().is_empty());
+    }
+}

--- a/crates/observed_macros_impl/tests/expansion.rs
+++ b/crates/observed_macros_impl/tests/expansion.rs
@@ -790,3 +790,47 @@ fn a_renamed_observed_dependency_is_named_throughout_both_expansions() {
     ]);
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn an_event_field_may_not_hold_a_mutable_reference() {
+    // Fields are read through `&self` while the event is visited, so an exclusive borrow
+    // can never be handed out. Rejecting it during parsing names the offending field;
+    // without the check the input is accepted and fails later inside generated code the
+    // author never wrote. The optional form is checked separately because the visit body
+    // dereferences the inner type rather than the field type.
+    let output = report(
+        [
+            "#[unredacted] v: &mut u64",
+            "#[unredacted] v: Option<&mut u64>",
+            "v: &mut Classified",
+            "#[unredacted] v: &'a mut u64",
+            // A shared reference to a mutable one still cannot be handed out.
+            "#[unredacted] v: &&mut u64",
+        ]
+        .into_iter()
+        .map(|field| {
+            let item = format!("#[info] struct Subject<'a> {{ {field} }}");
+            (event_source(r#""e""#, &item), event_error(r#""e""#, &item))
+        }),
+    );
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn an_event_field_may_hold_a_shared_reference() {
+    // The guard above must not catch the shared references the macro has always accepted.
+    insta::assert_snapshot!(expand_event(
+        r#""shared.refs""#,
+        r"
+        #[info]
+        struct SharedRefs<'a> {
+            #[unredacted]
+            plain: &'a u64,
+            #[unredacted]
+            nested: &'a &'a u64,
+            #[unredacted]
+            optional: Option<&'a u64>,
+        }
+        ",
+    ));
+}

--- a/crates/observed_macros_impl/tests/expansion.rs
+++ b/crates/observed_macros_impl/tests/expansion.rs
@@ -21,7 +21,7 @@
 
 #![cfg(not(miri))]
 
-use observed_macros_impl::{derive_enrichment, event};
+use observed_macros_impl::{derive_enrichment, derive_enrichment_with_runtime_path, event, event_with_runtime_path};
 use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
 use quote::quote;
 use testing_aids::{render_expansion, tokenize};
@@ -42,6 +42,23 @@ fn event_error(attr: &str, item: &str) -> String {
 
 fn enrichment_error(item: &str) -> String {
     derive_enrichment(tokenize(item)).expect_err("the derive is rejected").to_string()
+}
+
+/// The path a consumer that renamed its `observed` dependency reaches the runtime under.
+///
+/// The production entry points resolve this from the manifest of the crate being compiled,
+/// which these tests cannot vary, so they drive the generators through the hooks that take
+/// the path as an argument.
+fn renamed_runtime() -> TokenStream {
+    quote! { ::telemetry }
+}
+
+fn expand_event_renamed(attr: &str, item: &str) -> String {
+    render_expansion(&event_with_runtime_path(tokenize(attr), tokenize(item), &renamed_runtime()).expect("the event attribute expands"))
+}
+
+fn expand_enrichment_renamed(item: &str) -> String {
+    render_expansion(&derive_enrichment_with_runtime_path(tokenize(item), &renamed_runtime()).expect("the derive expands"))
 }
 
 /// The source a user would write to reach `#[event(...)]`, for the input side of a report row.
@@ -723,5 +740,53 @@ fn both_macros_validate_the_shared_field_attributes_identically() {
             ]
         }),
     );
+    insta::assert_snapshot!(output);
+}
+
+// ============================================================================================
+// Resolution of the `observed` runtime crate
+// ============================================================================================
+
+#[test]
+fn a_renamed_observed_dependency_is_named_throughout_both_expansions() {
+    // A consumer may rename its dependency (`telemetry = { package = "observed", ... }`),
+    // after which `::observed` names nothing in that crate. Every path the generators emit
+    // has to follow the rename -- the trait, the descriptors, `Value`, the visitor function
+    // type, the `__private` items, and the bounds spelled into the `where` clause -- so a
+    // single hard-coded `::observed` left anywhere shows up in this snapshot. Both entry
+    // points are covered in one snapshot so a divergence reads as a diff between them.
+    let event_item = r#"
+        #[info("{user} on {shard}")]
+        #[counter(requests, name = "requests")]
+        struct Renamed<'a, T> {
+            #[data_class(DataTaxonomy::Euii)]
+            user: T,
+            #[dimension(metric = "shard")]
+            #[unredacted]
+            shard: u64,
+            #[unredacted]
+            requests: u64,
+            #[unredacted]
+            borrowed: &'a str,
+            optional: Option<ClassifiedString>,
+        }
+    "#;
+    let enrichment_item = r"
+        struct RenamedEnrichment<T> {
+            #[data_class(DataTaxonomy::Euii)]
+            user: T,
+            #[unredacted]
+            region: String,
+            #[if_none(drop)]
+            tenant: Option<ClassifiedString>,
+        }
+    ";
+    let output = report([
+        (
+            event_source(r#""renamed""#, event_item),
+            expand_event_renamed(r#""renamed""#, event_item),
+        ),
+        (enrichment_source(enrichment_item), expand_enrichment_renamed(enrichment_item)),
+    ]);
     insta::assert_snapshot!(output);
 }

--- a/crates/observed_macros_impl/tests/snapshots/expansion__a_renamed_observed_dependency_is_named_throughout_both_expansions.snap
+++ b/crates/observed_macros_impl/tests/snapshots/expansion__a_renamed_observed_dependency_is_named_throughout_both_expansions.snap
@@ -1,0 +1,198 @@
+---
+source: crates/observed_macros_impl/tests/expansion.rs
+expression: output
+---
+---- input ----
+#[event("renamed")]
+#[info("{user} on {shard}")]
+        #[counter(requests, name = "requests")]
+        struct Renamed<'a, T> {
+            #[data_class(DataTaxonomy::Euii)]
+            user: T,
+            #[dimension(metric = "shard")]
+            #[unredacted]
+            shard: u64,
+            #[unredacted]
+            requests: u64,
+            #[unredacted]
+            borrowed: &'a str,
+            optional: Option<ClassifiedString>,
+        }
+
+---- yields ----
+struct Renamed<'a, T> {
+    user: T,
+    shard: u64,
+    requests: u64,
+    borrowed: &'a str,
+    optional: Option<ClassifiedString>,
+}
+const _: () = {
+    impl<'a, T: 'static> ::telemetry::Event for Renamed<'a, T>
+    where
+        T: ::core::fmt::Display,
+        T: ::core::marker::Send + ::core::marker::Sync,
+    {
+        const DESCRIPTION: ::telemetry::metadata::EventDescription = ::telemetry::metadata::EventDescription::new(
+            "renamed",
+            ::core::option::Option::Some(
+                ::core::any::TypeId::of::<Renamed<'static, T>>(),
+            ),
+            ::core::option::Option::Some(
+                ::telemetry::metadata::LogDescription::new(
+                    "renamed",
+                    ::telemetry::Severity::Info,
+                    ::core::option::Option::Some("{user} on {shard}"),
+                ),
+            ),
+            ::core::option::Option::None,
+            true,
+            false,
+        );
+        fn visit_fields(
+            &self,
+            visitor: &mut ::telemetry::processing::FieldVisitorFn<'_>,
+        ) -> ::core::ops::ControlFlow<()> {
+            {
+                const FIELD_DESC: ::telemetry::metadata::FieldDescriptor = ::telemetry::metadata::FieldDescriptor::new(
+                    "user",
+                    ::core::option::Option::Some(
+                        ::telemetry::metadata::LogFieldEntry::new("user"),
+                    ),
+                    ::core::option::Option::None,
+                );
+                visitor(
+                    &FIELD_DESC,
+                    &|engine| ::telemetry::Value::from_redacted(
+                        &::telemetry::__private::Sensitive::new(
+                            &self.user,
+                            DataTaxonomy::Euii,
+                        ),
+                        engine,
+                    ),
+                )?;
+            }
+            {
+                const FIELD_DESC: ::telemetry::metadata::FieldDescriptor = ::telemetry::metadata::FieldDescriptor::new(
+                    "shard",
+                    ::core::option::Option::Some(
+                        ::telemetry::metadata::LogFieldEntry::new("shard"),
+                    ),
+                    ::core::option::Option::Some(
+                        ::telemetry::metadata::MetricFieldEntry::dimension("shard"),
+                    ),
+                );
+                visitor(&FIELD_DESC, &|_| ::telemetry::Value::from(self.shard.clone()))?;
+            }
+            {
+                const FIELD_DESC: ::telemetry::metadata::FieldDescriptor = ::telemetry::metadata::FieldDescriptor::new(
+                    "requests",
+                    ::core::option::Option::Some(
+                        ::telemetry::metadata::LogFieldEntry::new("requests"),
+                    ),
+                    ::core::option::Option::Some(
+                        ::telemetry::metadata::MetricFieldEntry::instrument(
+                            "requests",
+                            ::telemetry::metadata::MetricDescription::new(
+                                "requests",
+                                ::telemetry::metadata::InstrumentKind::Counter,
+                                "",
+                                "",
+                            ),
+                        ),
+                    ),
+                );
+                visitor(
+                    &FIELD_DESC,
+                    &|_| ::telemetry::Value::from(self.requests.clone()),
+                )?;
+            }
+            {
+                const FIELD_DESC: ::telemetry::metadata::FieldDescriptor = ::telemetry::metadata::FieldDescriptor::new(
+                    "borrowed",
+                    ::core::option::Option::Some(
+                        ::telemetry::metadata::LogFieldEntry::new("borrowed"),
+                    ),
+                    ::core::option::Option::None,
+                );
+                visitor(
+                    &FIELD_DESC,
+                    &|_| ::telemetry::Value::from(
+                        ::std::sync::Arc::<str>::from(self.borrowed),
+                    ),
+                )?;
+            }
+            {
+                const FIELD_DESC: ::telemetry::metadata::FieldDescriptor = ::telemetry::metadata::FieldDescriptor::new(
+                    "optional",
+                    ::core::option::Option::Some(
+                        ::telemetry::metadata::LogFieldEntry::new("optional"),
+                    ),
+                    ::core::option::Option::None,
+                );
+                match self.optional.as_ref() {
+                    ::core::option::Option::Some(__val) => {
+                        visitor(
+                            &FIELD_DESC,
+                            &|_engine| ::telemetry::Value::from_redacted(__val, _engine),
+                        )?;
+                    }
+                    ::core::option::Option::None => {
+                        visitor(&FIELD_DESC, &|_| ::telemetry::Value::from("n/a"))?;
+                    }
+                }
+            }
+            ::core::ops::ControlFlow::Continue(())
+        }
+    }
+};
+
+---- input ----
+#[derive(Enrichment)]
+struct RenamedEnrichment<T> {
+            #[data_class(DataTaxonomy::Euii)]
+            user: T,
+            #[unredacted]
+            region: String,
+            #[if_none(drop)]
+            tenant: Option<ClassifiedString>,
+        }
+
+---- yields ----
+const _: () = {
+    impl<T> ::telemetry::enrichment::Enrichment for RenamedEnrichment<T>
+    where
+        ::telemetry::__private::Sensitive<
+            T,
+        >: ::telemetry::__private::RedactedDisplay + ::core::marker::Send
+            + ::core::marker::Sync + 'static,
+    {
+        fn into_entries(
+            self,
+        ) -> ::std::vec::Vec<::telemetry::__private::EnrichmentEntry> {
+            let mut entries = ::std::vec::Vec::with_capacity(3usize);
+            entries
+                .push(
+                    ::telemetry::__private::EnrichmentEntry::new(
+                        "user",
+                        ::telemetry::__private::Sensitive::new(
+                            self.user,
+                            DataTaxonomy::Euii,
+                        ),
+                    ),
+                );
+            entries
+                .push(
+                    ::telemetry::__private::EnrichmentEntry::unclassified(
+                        "region",
+                        self.region,
+                    ),
+                );
+            if let ::core::option::Option::Some(__val) = self.tenant {
+                entries
+                    .push(::telemetry::__private::EnrichmentEntry::new("tenant", __val));
+            }
+            entries
+        }
+    }
+};

--- a/crates/observed_macros_impl/tests/snapshots/expansion__an_event_field_may_hold_a_shared_reference.snap
+++ b/crates/observed_macros_impl/tests/snapshots/expansion__an_event_field_may_hold_a_shared_reference.snap
@@ -1,0 +1,75 @@
+---
+source: crates/observed_macros_impl/tests/expansion.rs
+expression: "expand_event(r#\"\"shared.refs\"\"#,\nr\"\n        #[info]\n        struct SharedRefs<'a> {\n            #[unredacted]\n            plain: &'a u64,\n            #[unredacted]\n            nested: &'a &'a u64,\n            #[unredacted]\n            optional: Option<&'a u64>,\n        }\n        \",)"
+---
+struct SharedRefs<'a> {
+    plain: &'a u64,
+    nested: &'a &'a u64,
+    optional: Option<&'a u64>,
+}
+const _: () = {
+    impl<'a> ::observed::Event for SharedRefs<'a> {
+        const DESCRIPTION: ::observed::metadata::EventDescription = ::observed::metadata::EventDescription::new(
+            "shared.refs",
+            ::core::option::Option::Some(
+                ::core::any::TypeId::of::<SharedRefs<'static>>(),
+            ),
+            ::core::option::Option::Some(
+                ::observed::metadata::LogDescription::new(
+                    "shared.refs",
+                    ::observed::Severity::Info,
+                    ::core::option::Option::None,
+                ),
+            ),
+            ::core::option::Option::None,
+            false,
+            false,
+        );
+        fn visit_fields(
+            &self,
+            visitor: &mut ::observed::processing::FieldVisitorFn<'_>,
+        ) -> ::core::ops::ControlFlow<()> {
+            {
+                const FIELD_DESC: ::observed::metadata::FieldDescriptor = ::observed::metadata::FieldDescriptor::new(
+                    "plain",
+                    ::core::option::Option::Some(
+                        ::observed::metadata::LogFieldEntry::new("plain"),
+                    ),
+                    ::core::option::Option::None,
+                );
+                visitor(&FIELD_DESC, &|_| ::observed::Value::from(self.plain.clone()))?;
+            }
+            {
+                const FIELD_DESC: ::observed::metadata::FieldDescriptor = ::observed::metadata::FieldDescriptor::new(
+                    "nested",
+                    ::core::option::Option::Some(
+                        ::observed::metadata::LogFieldEntry::new("nested"),
+                    ),
+                    ::core::option::Option::None,
+                );
+                visitor(&FIELD_DESC, &|_| ::observed::Value::from(self.nested.clone()))?;
+            }
+            {
+                const FIELD_DESC: ::observed::metadata::FieldDescriptor = ::observed::metadata::FieldDescriptor::new(
+                    "optional",
+                    ::core::option::Option::Some(
+                        ::observed::metadata::LogFieldEntry::new("optional"),
+                    ),
+                    ::core::option::Option::None,
+                );
+                match self.optional.as_ref() {
+                    ::core::option::Option::Some(__val) => {
+                        visitor(
+                            &FIELD_DESC,
+                            &|_engine| ::observed::Value::from(*__val),
+                        )?;
+                    }
+                    ::core::option::Option::None => {
+                        visitor(&FIELD_DESC, &|_| ::observed::Value::from("n/a"))?;
+                    }
+                }
+            }
+            ::core::ops::ControlFlow::Continue(())
+        }
+    }
+};

--- a/crates/observed_macros_impl/tests/snapshots/expansion__an_event_field_may_not_hold_a_mutable_reference.snap
+++ b/crates/observed_macros_impl/tests/snapshots/expansion__an_event_field_may_not_hold_a_mutable_reference.snap
@@ -1,0 +1,38 @@
+---
+source: crates/observed_macros_impl/tests/expansion.rs
+expression: output
+---
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { #[unredacted] v: &mut u64 }
+
+---- yields ----
+an event field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`
+
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { #[unredacted] v: Option<&mut u64> }
+
+---- yields ----
+an event `Option<&mut T>` field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`
+
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { v: &mut Classified }
+
+---- yields ----
+an event field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`
+
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { #[unredacted] v: &'a mut u64 }
+
+---- yields ----
+an event field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`
+
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { #[unredacted] v: &&mut u64 }
+
+---- yields ----
+an event field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

Two independent hygiene fixes in the `observed` procedural macros, both in `crates/observed_macros_impl`. One commit each, so they can be reviewed separately.

## Resolve a renamed `observed` dependency in generated paths (AB#7757619)

Both generators emitted a hard-coded `::observed` into every path they produce. `extern crate self as observed` in the runtime crate only helps expansions inside that crate, so a consumer that renames its dependency:

```toml
telemetry = { package = "observed", version = "0.24" }
```

had no `observed` in scope and failed to compile for both `#[event(...)]` and `#[derive(Enrichment)]`.

The runtime crate is now resolved once through `proc-macro-crate` and the resolved path is threaded through event generation, enrichment generation and the `where`-clause predicates the two share. The new `resolver` module follows the local pattern in `routerama_build::macro_impl::resolver`, including its handling of `FoundCrate::Itself`.

Behaviour is unchanged for every crate that does not rename the dependency: `FoundCrate::Itself` (the runtime crate expanding its own events, which reaches itself via `extern crate self as observed`) and an unreadable manifest both keep `::observed`. All 32 pre-existing expansion snapshots pass untouched, which is the evidence for that.

Coverage: a new expansion snapshot drives both entry points against a renamed path and pins every emitted path — the trait, the descriptors, `Value`, the visitor function type, the `__private` items and the spelled-out bounds — so a single hard-coded `::observed` left anywhere would show up in it. Unit tests cover the path derivation itself (rename, dash-containing alias, keyword alias needing a raw identifier, `Itself`, unresolvable). Hidden `*_with_runtime_path` entry points exist only so the tests can vary a path the production entry points read from the caller's manifest.

## Reject mutable-reference event fields (AB#7757620)

`is_reference_type` matched any `syn::Type::Reference` and never inspected `TypeReference::mutability`, so `#[event(...)]` accepted a `&mut T` field and generated a visit body for it. An event is visited through `&self`, so that body cannot hand out the exclusive borrow it asks for — the input was rejected only later, by the compiler, against generated code the author never wrote.

Mutability is now checked during field parsing and reported against the offending field type, saying that event fields support only shared references. `Option<&mut T>` is checked too, because the visit body dereferences the inner type rather than the field type, and the check recurses through nested references so `&&mut T` is caught as well. A companion snapshot proves shared references (`&'a T`, `&'a &'a T`, `Option<&'a T>`) still expand exactly as before.

## Deliberately not fixed here

`AB#7757617` ("Expose fields of signal-less events to name-based processors") lives in the same file — `field_reaches_signal` in `src/event.rs` — but needs a design decision about what the contract for signal-less fields should be. It is left untouched, and the `expansion__an_event_with_no_signal_at_all_visits_nothing` snapshot is unchanged.

## Validation

Run for `observed`, `observed_macros`, `observed_macros_impl` and `observed_testing`:

| Check | Result |
| --- | --- |
| `cargo +nightly-2026-05-30 fmt --check` | pass |
| `cargo +1.96.1 clippy --all-targets` (`-D warnings`) | pass |
| `cargo +1.96.1 test` | pass (all suites, incl. doctests) |

No pre-existing snapshot was re-blessed; the only new `.snap` files are the three added by the new tests.