### PR TITLE
fix(observed_macros): reject mutable-reference event fields

### DIFF
--- a/crates/observed_macros_impl/CHANGELOG.md
+++ b/crates/observed_macros_impl/CHANGELOG.md
@@ -13,3 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `observed` procedural macros (`#[event(...)]` and `#[derive(Enrichment)]`).
   `observed_macros` is now a thin `proc-macro` shim that delegates here. Use the
   re-exports from `observed` rather than depending on this crate directly.
+
+### Fixed
+
+- `#[event(...)]` now rejects a field holding a mutable reference (`&mut T` or
+  `Option<&mut T>`) while parsing, naming the offending field, rather than
+  accepting it and failing later inside the generated code. Event fields are read
+  through `&self` when the event is visited, so only shared references work.

--- a/crates/observed_macros_impl/src/event.rs
+++ b/crates/observed_macros_impl/src/event.rs
@@ -21,7 +21,8 @@ use syn::punctuated::Punctuated;
 use syn::{Attribute, Error, Field, Fields, Generics, Ident, ItemStruct, LitStr, Meta, Result, Token};
 
 use crate::field_attrs::{
-    Dimension, FieldRedaction, IfNone, LogRouting, MetricRouting, SharedFieldAttrs, is_borrowed_str, is_reference_type, option_inner_type,
+    Dimension, FieldRedaction, IfNone, LogRouting, MetricRouting, SharedFieldAttrs, is_borrowed_str, is_mutable_reference_type,
+    is_reference_type, option_inner_type,
 };
 
 // ================================================================================================
@@ -722,6 +723,13 @@ fn parse_field_def(field: &Field) -> Result<FieldDef> {
         return Err(Error::new_spanned(field, "`#[if_none(...)]` is only valid on `Option<T>` fields"));
     }
 
+    // A field is read through `&self` while the event is visited, so an exclusive
+    // borrow can never be handed out. Rejecting it here names the field; letting it
+    // through fails later inside the expansion, against generated code the author
+    // never wrote. `Option<&mut T>` is checked too, because the inner type is what
+    // the visit body dereferences.
+    reject_mutable_reference(field)?;
+
     Ok(FieldDef {
         ident,
         ty: field.ty.clone(),
@@ -731,6 +739,23 @@ fn parse_field_def(field: &Field) -> Result<FieldDef> {
         redaction: shared.redaction.unwrap_or_default(),
         if_none: shared.if_none.unwrap_or_default(),
     })
+}
+
+/// Rejects an event field that is (or wraps) a mutable reference.
+fn reject_mutable_reference(field: &Field) -> Result<()> {
+    let inner = option_inner_type(&field.ty);
+    let inspected = inner.unwrap_or(&field.ty);
+    if !is_mutable_reference_type(inspected) {
+        return Ok(());
+    }
+    let wrapper = if inner.is_some() { "`Option<&mut T>` field" } else { "field" };
+    Err(Error::new_spanned(
+        &field.ty,
+        format!(
+            "an event {wrapper} cannot hold a mutable reference; event fields are read through `&self` when the event is \
+             visited, so they support only shared references. Use `&T` instead of `&mut T`",
+        ),
+    ))
 }
 
 // ================================================================================================

--- a/crates/observed_macros_impl/src/field_attrs.rs
+++ b/crates/observed_macros_impl/src/field_attrs.rs
@@ -317,6 +317,17 @@ pub(crate) fn is_reference_type(ty: &syn::Type) -> bool {
     matches!(unwrap_groups(ty), syn::Type::Reference(_))
 }
 
+/// Returns whether `ty` is, or borrows through, a mutable reference.
+///
+/// The recursion matches [`strip_reference`], so a nested `&&mut T` is caught as
+/// well as a bare `&mut T`.
+pub(crate) fn is_mutable_reference_type(ty: &syn::Type) -> bool {
+    match unwrap_groups(ty) {
+        syn::Type::Reference(reference) => reference.mutability.is_some() || is_mutable_reference_type(&reference.elem),
+        _ => false,
+    }
+}
+
 /// Returns the inner type `T` if `ty` is syntactically `Option<T>`.
 ///
 /// This is a purely syntactic match (the same approach `serde`/`clap`/`templated_uri`

--- a/crates/observed_macros_impl/tests/expansion.rs
+++ b/crates/observed_macros_impl/tests/expansion.rs
@@ -725,3 +725,47 @@ fn both_macros_validate_the_shared_field_attributes_identically() {
     );
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn an_event_field_may_not_hold_a_mutable_reference() {
+    // Fields are read through `&self` while the event is visited, so an exclusive borrow
+    // can never be handed out. Rejecting it during parsing names the offending field;
+    // without the check the input is accepted and fails later inside generated code the
+    // author never wrote. The optional form is checked separately because the visit body
+    // dereferences the inner type rather than the field type.
+    let output = report(
+        [
+            "#[unredacted] v: &mut u64",
+            "#[unredacted] v: Option<&mut u64>",
+            "v: &mut Classified",
+            "#[unredacted] v: &'a mut u64",
+            // A shared reference to a mutable one still cannot be handed out.
+            "#[unredacted] v: &&mut u64",
+        ]
+        .into_iter()
+        .map(|field| {
+            let item = format!("#[info] struct Subject<'a> {{ {field} }}");
+            (event_source(r#""e""#, &item), event_error(r#""e""#, &item))
+        }),
+    );
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn an_event_field_may_hold_a_shared_reference() {
+    // The guard above must not catch the shared references the macro has always accepted.
+    insta::assert_snapshot!(expand_event(
+        r#""shared.refs""#,
+        r"
+        #[info]
+        struct SharedRefs<'a> {
+            #[unredacted]
+            plain: &'a u64,
+            #[unredacted]
+            nested: &'a &'a u64,
+            #[unredacted]
+            optional: Option<&'a u64>,
+        }
+        ",
+    ));
+}

--- a/crates/observed_macros_impl/tests/snapshots/expansion__an_event_field_may_hold_a_shared_reference.snap
+++ b/crates/observed_macros_impl/tests/snapshots/expansion__an_event_field_may_hold_a_shared_reference.snap
@@ -1,0 +1,75 @@
+---
+source: crates/observed_macros_impl/tests/expansion.rs
+expression: "expand_event(r#\"\"shared.refs\"\"#,\nr\"\n        #[info]\n        struct SharedRefs<'a> {\n            #[unredacted]\n            plain: &'a u64,\n            #[unredacted]\n            nested: &'a &'a u64,\n            #[unredacted]\n            optional: Option<&'a u64>,\n        }\n        \",)"
+---
+struct SharedRefs<'a> {
+    plain: &'a u64,
+    nested: &'a &'a u64,
+    optional: Option<&'a u64>,
+}
+const _: () = {
+    impl<'a> ::observed::Event for SharedRefs<'a> {
+        const DESCRIPTION: ::observed::metadata::EventDescription = ::observed::metadata::EventDescription::new(
+            "shared.refs",
+            ::core::option::Option::Some(
+                ::core::any::TypeId::of::<SharedRefs<'static>>(),
+            ),
+            ::core::option::Option::Some(
+                ::observed::metadata::LogDescription::new(
+                    "shared.refs",
+                    ::observed::Severity::Info,
+                    ::core::option::Option::None,
+                ),
+            ),
+            ::core::option::Option::None,
+            false,
+            false,
+        );
+        fn visit_fields(
+            &self,
+            visitor: &mut ::observed::processing::FieldVisitorFn<'_>,
+        ) -> ::core::ops::ControlFlow<()> {
+            {
+                const FIELD_DESC: ::observed::metadata::FieldDescriptor = ::observed::metadata::FieldDescriptor::new(
+                    "plain",
+                    ::core::option::Option::Some(
+                        ::observed::metadata::LogFieldEntry::new("plain"),
+                    ),
+                    ::core::option::Option::None,
+                );
+                visitor(&FIELD_DESC, &|_| ::observed::Value::from(self.plain.clone()))?;
+            }
+            {
+                const FIELD_DESC: ::observed::metadata::FieldDescriptor = ::observed::metadata::FieldDescriptor::new(
+                    "nested",
+                    ::core::option::Option::Some(
+                        ::observed::metadata::LogFieldEntry::new("nested"),
+                    ),
+                    ::core::option::Option::None,
+                );
+                visitor(&FIELD_DESC, &|_| ::observed::Value::from(self.nested.clone()))?;
+            }
+            {
+                const FIELD_DESC: ::observed::metadata::FieldDescriptor = ::observed::metadata::FieldDescriptor::new(
+                    "optional",
+                    ::core::option::Option::Some(
+                        ::observed::metadata::LogFieldEntry::new("optional"),
+                    ),
+                    ::core::option::Option::None,
+                );
+                match self.optional.as_ref() {
+                    ::core::option::Option::Some(__val) => {
+                        visitor(
+                            &FIELD_DESC,
+                            &|_engine| ::observed::Value::from(*__val),
+                        )?;
+                    }
+                    ::core::option::Option::None => {
+                        visitor(&FIELD_DESC, &|_| ::observed::Value::from("n/a"))?;
+                    }
+                }
+            }
+            ::core::ops::ControlFlow::Continue(())
+        }
+    }
+};

--- a/crates/observed_macros_impl/tests/snapshots/expansion__an_event_field_may_not_hold_a_mutable_reference.snap
+++ b/crates/observed_macros_impl/tests/snapshots/expansion__an_event_field_may_not_hold_a_mutable_reference.snap
@@ -1,0 +1,38 @@
+---
+source: crates/observed_macros_impl/tests/expansion.rs
+expression: output
+---
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { #[unredacted] v: &mut u64 }
+
+---- yields ----
+an event field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`
+
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { #[unredacted] v: Option<&mut u64> }
+
+---- yields ----
+an event `Option<&mut T>` field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`
+
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { v: &mut Classified }
+
+---- yields ----
+an event field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`
+
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { #[unredacted] v: &'a mut u64 }
+
+---- yields ----
+an event field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`
+
+---- input ----
+#[event("e")]
+#[info] struct Subject<'a> { #[unredacted] v: &&mut u64 }
+
+---- yields ----
+an event field cannot hold a mutable reference; event fields are read through `&self` when the event is visited, so they support only shared references. Use `&T` instead of `&mut T`


### PR DESCRIPTION
🤖 **Clawpilot here!** Posted automatically by Clawpilot (an AI agent), not by a human. Please verify before acting.

## What this changes

`#[event(...)]` now rejects a field that holds a mutable reference. The check runs while the macro parses fields, before it generates code. The error points at the field type. Fixes `AB#7757620`.

## What you get

A classified field was rejected before, but the error named generated code:

```rust
#[event("req")]
#[info]
struct Req<'a> {
    #[data_class(DC)]
    v: &'a mut u64,
}
```

Before — `rustc` reports `E0507` against the attribute:

```text
error[E0507]: cannot move out of value, as `self` is a captured variable in an `Fn` closure
  --> src/lib.rs:1:1
   |
1  | #[event("req")]
   | ^^^^^^^^^^^^^^^ move occurs because value has type `&mut u64`,
   |                 which does not implement the `Copy` trait
   = note: this error originates in the attribute macro `event`
```

After — the error names the field and the rule:

```text
error: an event field cannot hold a mutable reference; event fields are read
       through `&self` when the event is visited, so they support only shared
       references. Use `&T` instead of `&mut T`
 --> src/lib.rs:5:8
  |
5 |     v: &'a mut u64,
  |        ^^^^^^^^^^^
```

An `#[unredacted]` field behaves differently. It compiled before this change:

```rust
#[event("req")]
#[info]
struct Req<'a> {
    #[unredacted]
    v: &'a mut u64,   // compiled before; rejected now
}
```

The generated body read it through `self.v.clone()`, which auto-dereferences to `u64`. The exclusive borrow bought nothing, because `visit_fields` takes `&self` and never writes. This case is now rejected as well.

Fix either case by removing `mut`: `v: &'a u64`.

## Details

- `is_mutable_reference_type` inspects `syn::TypeReference::mutability`. It recurses like `strip_reference`, so `&&mut T` is caught.
- `reject_mutable_reference` runs in `parse_field_def`. It also reads the inner type of an `Option<T>` field, and names the optional form in the message.

## Effects

- `#[unredacted] v: &'a mut u64` compiled before this change and does not compile after it. An owner of such a field must write `&'a u64`.
- A classified or default-redaction `&mut T` field failed before with `E0507` spanned on `#[event(...)]`. It now fails with a message spanned on the field type.
- `Option<&mut T>` is rejected, with wording that names the optional form.
- Shared references are unchanged. `&'a T`, `&'a &'a T` and `Option<&'a T>` expand exactly as before, which a snapshot pins.
- `#[derive(Enrichment)]` is deliberately unchanged. `into_entries(self)` takes `self` by value, so a `&mut T` enrichment field still compiles. Only `#[event(...)]` gained the check.
- No new dependency and no `Cargo.lock` change.
- The `observed` public API is unchanged. Both new functions are internal to `observed_macros_impl`.

## Validation

Manual before-and-after repro, not committed: three event structs were compiled against the macro with the check disabled, then enabled. This confirmed that the `#[unredacted]` case compiled before the fix, that the classified case produced `E0507` against the attribute, and that a shared-reference classified field still compiles after the fix.
