### PR TITLE
docs(arty): document panic handling

### DIFF
--- a/crates/arty/docs/DESIGN.md
+++ b/crates/arty/docs/DESIGN.md
@@ -2,3 +2,10 @@
 
 Arty is a single-threaded, thread-aware runtime. Stable external I/O integration contracts live
 in `arty_io_core`.
+
+Runtime shutdown is fail-fast for ordinary application work. The first task panic starts
+shutdown, after which non-critical tasks stop being polled. Critical tasks continue until they
+finish so specialized shutdown work, such as telemetry flushing, can complete.
+
+Criticality is inherited through task spawning. A task spawned within a critical task's context
+is also critical, including further descendants.

--- a/crates/arty/docs/PANICS.md
+++ b/crates/arty/docs/PANICS.md
@@ -3,12 +3,14 @@
 Arty types must be unwind-safe unless documented otherwise. Foundational I/O contracts in
 `arty_io_core` must also be panic-safe.
 
-Every spawned task has a join handle whose result includes a `JoinError` when the task does not
-complete normally. The error distinguishes a task panic from a task that stopped because the
-runtime shut down.
+Every spawned task has a join handle that returns a `JoinError` when the task does not complete
+normally. The error distinguishes a task panic from a task that stopped because the runtime shut
+down.
 
-The first task panic encountered by the runtime starts runtime shutdown. The panic remains
-observable through the panicking task's join handle.
+The first task panic encountered by the runtime starts runtime shutdown. The panicking task's
+join handle retains the panic form of `JoinError`, so the runtime host or a critical task that
+awaits it can inspect the cause. Tasks stopped by the resulting shutdown instead return the
+shutdown form of `JoinError`.
 
 ## Critical tasks
 

--- a/crates/arty/docs/PANICS.md
+++ b/crates/arty/docs/PANICS.md
@@ -1,5 +1,21 @@
 # Panics
 
-Arty types must be unwind-safe unless documented otherwise. The runtime catches task panics and
-re-raises them when the task result is awaited. Unobserved task panics are reported to a runtime
-panic handler. Foundational I/O contracts in `arty_io_core` must also be panic-safe.
+Arty types must be unwind-safe unless documented otherwise. Foundational I/O contracts in
+`arty_io_core` must also be panic-safe.
+
+Every spawned task has a join handle whose result includes a `JoinError` when the task does not
+complete normally. The error distinguishes a task panic from a task that stopped because the
+runtime shut down.
+
+The first task panic encountered by the runtime starts runtime shutdown. The panic remains
+observable through the panicking task's join handle.
+
+## Critical tasks
+
+Most tasks are non-critical. Once shutdown starts, the runtime stops polling non-critical tasks
+and their join handles complete with the shutdown form of `JoinError`.
+
+Critical tasks are reserved for specialized, high-value operations that must finish before
+shutdown completes, such as flushing telemetry. The runtime continues polling critical tasks
+during shutdown. A task spawned from within a critical task's context is automatically critical,
+so the entire operation can finish without each child task being marked separately.

--- a/crates/arty/docs/STABILIZATION.md
+++ b/crates/arty/docs/STABILIZATION.md
@@ -3,7 +3,7 @@
 Every dependency whose API Arty re-exports or exposes must be stable before Arty stabilizes.
 Public I/O integration contracts in `arty_io_core` must also be stable.
 
-Arty exposes and uses the telemetry emitter API now provided by `observed`, including its
-`Sink` and `emit!` surface. This API originated in `observer_core` and is treated as a highly
-stable dependency surface. Changes to it must preserve the compatibility expected of Arty's
-public runtime API.
+Arty's planned runtime surface exposes and uses the telemetry emitter API now provided by
+`observed`, including its `Sink` and `emit!` surface. This API previously lived in
+`observer_core` and is treated as a highly stable dependency surface. Changes to it must preserve
+the compatibility expected of Arty's public runtime API.

--- a/crates/arty/docs/STABILIZATION.md
+++ b/crates/arty/docs/STABILIZATION.md
@@ -2,3 +2,8 @@
 
 Every dependency whose API Arty re-exports or exposes must be stable before Arty stabilizes.
 Public I/O integration contracts in `arty_io_core` must also be stable.
+
+Arty exposes and uses the telemetry emitter API now provided by `observed`, including its
+`Sink` and `emit!` surface. This API originated in `observer_core` and is treated as a highly
+stable dependency surface. Changes to it must preserve the compatibility expected of Arty's
+public runtime API.


### PR DESCRIPTION
## Summary

- document `JoinError` outcomes for task panics and runtime shutdown
- define first-panic shutdown and inherited critical-task behavior
- record the stable telemetry emitter surface now provided by `observed`

## Validation

- `just package=arty format`
- `just package=arty readme`
- `just package=arty spellcheck`
- `just package=arty clippy`
- GitHub required checks passed
- Codecov project and patch coverage passed at 100%

## Review

- completed independent Opus, Sonnet, and GPT review passes
- clarified that the runtime contracts are planned and who can inspect panic join errors during shutdown
- retained the requested `observer_core` provenance statement; automation reviewers could not verify it from this repository history