### PR TITLE
fix(metabench_macros_impl): bound support identifier length via fixed-widh hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,6 +3243,7 @@ dependencies = [
  "gungraun-summary",
  "jiff",
  "metabench_macros",
+ "mutants",
  "nix 0.31.3",
  "serde",
  "serde_json",

--- a/crates/metabench/Cargo.toml
+++ b/crates/metabench/Cargo.toml
@@ -56,6 +56,7 @@ nix = { workspace = true, features = ["fs", "poll"] }
 
 [dev-dependencies]
 bolero = { workspace = true, features = ["std"] }
+mutants = { workspace = true }
 
 # >>> anvil-managed: anvil-lints
 [lints]

--- a/crates/metabench/src/allocation.rs
+++ b/crates/metabench/src/allocation.rs
@@ -36,6 +36,19 @@ pub fn begin() -> Option<ProcessSpan> {
     })
 }
 
+/// Resolves the lazy state behind [`begin`] ahead of any measurement.
+///
+/// [`begin`] runs inside the region a profiler collects, so leaving these
+/// `LazyLock`s cold would charge the first workload for a `getenv` call, the
+/// surrounding one-time synchronization, and the tracking session setup.
+#[cfg_attr(coverage_nightly, coverage(off))] // not exercised by the instrumented test binary; see prime()'s doc comment
+#[cfg_attr(test, mutants::skip)] // warm-up only affects timing, not any observable behavior
+pub(crate) fn prime() {
+    if *ACTIVE {
+        LazyLock::force(&SESSION);
+    }
+}
+
 pub(crate) fn write_worker_artifact() -> Result<(), Error> {
     let Some(path) = env::var_os(ARTIFACT_ENV).map(PathBuf::from) else {
         return Ok(());

--- a/crates/metabench/src/lib.rs
+++ b/crates/metabench/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![cfg_attr(all(coverage_nightly, test), feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_logo_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/metabench/logo.png")]
 #![doc(html_favicon_url = "https://media.githubusercontent.com/media/microsoft/oxidizer/refs/heads/main/crates/metabench/favicon.ico")]

--- a/crates/metabench/src/perf.rs
+++ b/crates/metabench/src/perf.rs
@@ -63,6 +63,18 @@ pub fn begin() -> Option<Guard> {
     }
 }
 
+/// Resolves the environment probe behind [`begin`] ahead of any measurement.
+///
+/// [`begin`] runs inside the region a profiler collects, so leaving its
+/// `LazyLock` cold would charge the first workload for a `getenv` call and the
+/// surrounding one-time synchronization. Callgrind attributes that to the code
+/// under test, inflating every reported instruction count by a fixed amount.
+#[cfg_attr(coverage_nightly, coverage(off))] // not exercised by the instrumented test binary; see prime()'s doc comment
+#[cfg_attr(test, mutants::skip)] // warm-up only affects timing, not any observable behavior
+pub(crate) fn prime() {
+    let _active = *ACTIVE;
+}
+
 pub(crate) fn finish_worker() -> Result<(), Error> {
     let error = ERROR.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take();
     if let Some(error) = error {

--- a/crates/metabench/src/runner.rs
+++ b/crates/metabench/src/runner.rs
@@ -98,6 +98,11 @@ pub fn run(engines: EngineSet, identities: &'static [BenchmarkIdentity], benchma
 }
 
 fn run_inner(engines: EngineSet, identities: &'static [BenchmarkIdentity], benchmark_target: &'static str) -> Result<(), Error> {
+    // Resolve the measurement gates before any engine starts collecting, so
+    // their one-time setup is not charged to the first workload invocation.
+    perf::prime();
+    allocation::prime();
+
     if env::args_os().nth(1).as_deref() == Some(OsStr::new("--gungraun-run")) {
         engines.run(Mode::Gungraun);
         return Ok(());

--- a/crates/metabench/tests/spawned_benchmark.rs
+++ b/crates/metabench/tests/spawned_benchmark.rs
@@ -211,11 +211,9 @@ fn gungraun_listing_is_forwarded() {
 
     let stdout = successful_stdout(&["--gungraun", "--list"]);
 
-    assert!(
-        stdout
-            .lines()
-            .any(|line| line.contains("__metabench_group_434845434b53554d53::__metabench_benchmark_524f4c4c494e47"))
-    );
+    assert!(stdout.lines().any(|line| {
+        line.contains("__metabench_group_d23a5d29e30556e2f3f66fae89e4544b::__metabench_benchmark_ecb5d0c1194ff78d70d02d708fc2a852")
+    }));
     assert!(!stdout.contains("Running gungraun benchmarks"));
 }
 

--- a/crates/metabench_macros/tests/ui/pass/generated_name_collisions.rs
+++ b/crates/metabench_macros/tests/ui/pass/generated_name_collisions.rs
@@ -11,7 +11,7 @@ mod contract {
     mod __metabench_criterion {}
     mod __metabench_gungraun {}
     fn __metabench_benchmark_COLLISION() {}
-    fn __metabench_benchmark_434f4c4c4953494f4e() {}
+    fn __metabench_benchmark_5ba7e6e02b0556f2d58ca7998a1efd17() {}
     const __METABENCH_IDENTITIES: () = ();
     static METABENCH_ALLOCATOR: () = ();
 

--- a/crates/metabench_macros_impl/src/benchmark.rs
+++ b/crates/metabench_macros_impl/src/benchmark.rs
@@ -359,7 +359,12 @@ fn expand_benchmark(arguments: BenchmarkArguments, mut function: ItemFn, metaben
             );
 
         #(#conditional_attributes)*
-        mod #adapter_module {
+            #[expect(
+                clippy::allow_attributes,
+                clippy::allow_attributes_without_reason,
+                reason = "the Gungraun adapter macro emits lint-control attributes"
+            )]
+            mod #adapter_module {
             use super::*;
             use #metabench::__private::gungraun;
 
@@ -491,6 +496,7 @@ mod tests {
         assert!(!output.contains("::metabench::gungraun"));
         assert_eq!(output.matches("BODY_SENTINEL").count(), 2);
         assert!(output.contains("config=config(),setup=setup,teardown=teardown"));
+        assert!(output.contains("#[expect(clippy::allow_attributes,clippy::allow_attributes_without_reason"));
     }
 
     #[test]

--- a/crates/metabench_macros_impl/src/shared.rs
+++ b/crates/metabench_macros_impl/src/shared.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::Write as _;
-
 use proc_macro_crate::FoundCrate;
 use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::{format_ident, quote};
@@ -113,11 +111,15 @@ fn too_complex_error(token: &TokenTree) -> Error {
 }
 
 pub(super) fn support_ident(kind: &str, logical_name: &str) -> Ident {
-    let mut encoded_name = String::with_capacity(logical_name.len() * 2);
+    const OFFSET_BASIS: u128 = 0x6c62_272e_07bb_0142_62b8_2175_6295_c58d;
+    const PRIME: u128 = 0x0000_0000_0100_0000_0000_0000_0000_013b;
+
+    let mut hash = OFFSET_BASIS;
     for byte in logical_name.bytes() {
-        write!(encoded_name, "{byte:02x}").expect("writing to a String is infallible");
+        hash ^= u128::from(byte);
+        hash = hash.wrapping_mul(PRIME);
     }
-    format_ident!("__metabench_{kind}_{encoded_name}", span = Span::mixed_site())
+    format_ident!("__metabench_{kind}_{hash:032x}", span = Span::mixed_site())
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -148,6 +150,27 @@ mod tests {
         assert_eq!(support_ident("native", "IDENTITY"), support_ident("native", "IDENTITY"));
         assert_ne!(support_ident("native", "IDENTITY"), support_ident("adapter", "IDENTITY"));
         assert_ne!(support_ident("native", "IDENTITY"), support_ident("native", "OTHER"));
+    }
+
+    #[test]
+    fn support_identifier_hash_matches_reference_fnv1a_128() {
+        // Pins the exact hash so a mutation to the FNV-1a algorithm (e.g.
+        // swapping `^=` for `|=` in the mixing step) is caught even though
+        // it would still produce distinct, stable, fixed-length identifiers.
+        assert_eq!(
+            support_ident("target", "IDENTITY").to_string(),
+            "__metabench_target_0838fce072659a7de8f7c5a0f94235a3"
+        );
+    }
+
+    #[test]
+    fn support_identifier_length_does_not_depend_on_logical_name_length() {
+        let expected_length = "__metabench_target_".len() + 32;
+        assert_eq!(support_ident("target", "x").to_string().len(), expected_length);
+        assert_eq!(
+            support_ident("target", &"identity:".repeat(1_000)).to_string().len(),
+            expected_length
+        );
     }
 
     #[test]


### PR DESCRIPTION
Replace the hex-encoded logical name (which grows with input length) with a fixed-width 128-bit FNV-1a hash so generated identifiers have a constant length regardless of the source name. Also silence clippy::allow_attributes lints on the Gungraun adapter module, since the macro emits lint-control attributes there.

Also make metabench's runner eagerly prime the perf and allocation `LazyLock`s (`perf::prime`, `allocation::prime`) before any engine starts collecting. `begin()` for both gates runs inside the region a profiler measures, so leaving them cold would charge the first workload with a `getenv` call and one-time synchronization/session setup, inflating every reported instruction count and allocation total by a fixed, spurious amount. This is bundled here because it was found and fixed alongside the identifier-length work above, rather than split into a separate PR. Both `prime()` functions only affect timing, not any externally observable behavior, so they are marked `#[cfg_attr(test, mutants::skip)]` rather than given behavioral tests.