### PR TITLE
fix(rallocator): keep stack-grouped allocations on a single call site

### DIFF
--- a/crates/rallocator/tests/telemetry.rs
+++ b/crates/rallocator/tests/telemetry.rs
@@ -220,13 +220,27 @@ fn thread_heap_hint_remains_usable_after_its_owner_exits() {
     );
 }
 
+/// Allocates one sample block from a call site the optimizer cannot duplicate.
+///
+/// Call stacks are recorded as raw return addresses, so grouping by stack only holds while every
+/// sample allocates through the same instruction. A loop with a compile-time trip count is fully
+/// unrolled in the release profile, which gives each sample its own call site and its own return
+/// address; keeping the allocation behind a non-inlined callee preserves one stack for all samples.
+#[inline(never)]
+fn allocate_stack_sample(value: u8) -> Box<[u8; 777]> {
+    std::hint::black_box(Box::new([value; 777]))
+}
+
 #[test]
 fn snapshot_encodes_allocations_by_stack() {
+    const SAMPLES: u8 = 4;
+
     let _test = test_lock();
     track_callers(false);
     track_callers(true);
-    for value in 0..4 {
-        drop(Box::new([value as u8; 777]));
+    // The opaque bound keeps the optimizer from unrolling the loop into one call site per sample.
+    for value in 0..std::hint::black_box(SAMPLES) {
+        drop(allocate_stack_sample(value));
     }
     track_callers(false);
 
@@ -243,7 +257,7 @@ fn snapshot_encodes_allocations_by_stack() {
         .iter()
         .filter(|event| event.kind == EventKind::Allocated && event.call_stack == *target_stack)
         .count();
-    assert_eq!(allocation_count, 4);
+    assert_eq!(allocation_count, usize::from(SAMPLES));
 }
 
 #[test]


### PR DESCRIPTION
## Root cause

`OxidizerGitHub.PublishEachCommit` is red on `main`. The `Cargo test` step fails in the **release** profile on both Linux and Windows (dev passes), with one failing test out of ~7,700:

```
FAIL rallocator::telemetry snapshot_encodes_allocations_by_stack
assertion `left == right` failed
  left: 1
 right: 4
```

The last green and the first red run used the same toolchain (`1.97.1-ms-20260901.3`), so this is a code regression, not a tooling migration:

| Build | Commit | Result |
| --- | --- | --- |
| 20260910.1 | 70bd5aaf (#744) | succeeded |
| 20260910.2 | 8624f907 (#733) | **first failing build** |
| 20260910.3 | 03e3dfed (#722) | failed, unrelated to the triggering commit |

`snapshot_encodes_allocations_by_stack` allocates in a loop with a compile-time trip count and asserts that all four samples share one call stack. Call stacks are recorded as raw return addresses in `capture_platform_stack`, and the release profile fully unrolls that loop, so each sample allocates from its own call site. Instrumenting the test confirms all four allocations are recorded, but their stacks differ in exactly one frame - the return address inside the test function, stepping by a fixed instruction offset per iteration:

```
stack = [140702813012151, 140702812954602, 140702813025904, ...]
stack = [140702813012151, 140702812954684, 140702813025904, ...]
stack = [140702813012151, 140702812954766, 140702813025904, ...]
stack = [140702813012151, 140702812954848, 140702813025904, ...]
```

The grouping filter therefore matches 1 event instead of 4. The allocations are not elided, they are split across four stack buckets. #733 reworked the allocation path and changed inlining enough to tip this loop into being unrolled; the test has never been protected against release codegen. This is the same class of fragility as #666 (`fix(rallocator): preserve allocation effects in release tests`), where LLVM elided unprotected test allocations.

## Fix

Route every sample through a single `#[inline(never)]` helper and make the loop bound opaque, so all samples allocate from one instruction and record one shared call stack. `black_box` alone would not fix this, since the allocations do occur - the call site itself has to stay singular.

## Validation

Against the exact CI toolchain (`ms-prod-1.97@llvm`, `1.97.1-ms-20260901.3`):

- `cargo test --release --all-features -p rallocator --test telemetry` - fails on `main` before the change, 19/19 pass after it
- `cargo test --all-features -p rallocator --test telemetry` (dev profile) - 19/19 pass
- `cargo clippy --release --all-features -p rallocator --all-targets -- -D warnings` - clean
- `cargo +nightly-2026-05-30 fmt -p rallocator -- --check` - clean
- `just anvil-spellcheck` - clean

Also reproduced and verified on 1.96.1; the failure does not reproduce on 1.95.0.

Bug: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7866558
Failing build: https://dev.azure.com/O365Exchange/O365%20Core/_build/results?buildId=40955158&view=results
First failing build: https://dev.azure.com/O365Exchange/O365%20Core/_build/results?buildId=40907883&view=results
